### PR TITLE
Add missing await

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1322,7 +1322,7 @@ async function readDependencies(rootDir: string, packageDeps: any, bundledDeps: 
             continue;
         }
 
-        addDependency(packageName, rootDir);
+        await addDependency(packageName, rootDir);
     }
 
     if (bundledDeps.length > 0) {


### PR DESCRIPTION
Could occasionally cause the compiler not to correctly consider all
external JSII types when validating the type closure of the currently
compiled bundle, because the compiler wouldn't wait for the external
assemblies to be read before trying to search them for types.
