### PR TITLE
Don't make display-text safe, make module reference safe instead

### DIFF
--- a/packages/jsii-pacmak/lib/generators/sphinx.ts
+++ b/packages/jsii-pacmak/lib/generators/sphinx.ts
@@ -48,7 +48,7 @@ export default class SphinxDocsGenerator extends Generator {
 
         this.code.openFile(`${safeName(assm.names.js)}.rst`);
 
-        this.openSection(safeName(assm.names.js));
+        this.openSection(assm.names.js);
         this.code.line();
 
         this.assemblyName = assm.names.js;
@@ -88,7 +88,7 @@ export default class SphinxDocsGenerator extends Generator {
             this.openSection('Reference');
             this.code.line();
         }
-        this.code.line(`.. py:module:: ${nativeName}`);
+        this.code.line(`.. py:module:: ${safeName(nativeName)}`);
         this.code.line();
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
