### PR TITLE
Don't make jsii include the package name into the tempdir name

### DIFF
--- a/packages/jsii/lib/bundle.ts
+++ b/packages/jsii/lib/bundle.ts
@@ -66,7 +66,7 @@ export async function bundle(moduleRoot: string) {
                 setImmediate: false,
             },
             output: {
-                path: await fs.mkdtemp(path.join(os.tmpdir(), spec.names.js)),
+                path: await fs.mkdtemp(os.tmpdir()),
                 filename: bundleFileName,
                 library: moduleName,
                 libraryTarget: 'var',


### PR DESCRIPTION
When the package name contains a '/', this turns the path into
'/tmp/@aws-cdk/packageXV5u88', which then throws a "no such
directory" error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
