### PR TITLE
Make JSII correctly use externalTypes of deps

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1283,6 +1283,9 @@ async function readDependencies(rootDir: string, packageDeps: any, bundledDeps: 
         if (jsii.types) {
             Object.keys(jsii.types).forEach(fqn => lookup.set(fqn, jsii.types[fqn]));
         }
+        if (jsii.externalTypes) {
+            Object.keys(jsii.externalTypes).forEach(fqn => lookup.set(fqn, jsii.externalTypes![fqn]));
+        }
     }
 
     for (const packageName of Object.keys(packageDeps)) {


### PR DESCRIPTION
JSII failed to account for externalTypes of dependencies, causing
compilation errors when such types were used by the library being built.
This change makes JSII correctly inject dependencies' external types
into the lookup map, so that such types are correctly resolved when
validating assembly consistency.