### PR TITLE
Correct temporary directory creation

### DIFF
--- a/packages/jsii/lib/bundle.ts
+++ b/packages/jsii/lib/bundle.ts
@@ -66,7 +66,7 @@ export async function bundle(moduleRoot: string) {
                 setImmediate: false,
             },
             output: {
-                path: await fs.mkdtemp(os.tmpdir()),
+                path: await fs.mkdtemp(os.tmpdir() + path.sep),
                 filename: bundleFileName,
                 library: moduleName,
                 libraryTarget: 'var',


### PR DESCRIPTION
`fs.mkdtemp` does not append a path separator when creating the temporary
directory, and `os.tmpdir()` is not path-separator-terminated, so one needs
to manually add a path separator in order to correctly obtain a temporary
directory. This bug causes JSII builds to fail on systems where the user
is not authorized to create directories in the parent of `os.tmpdir()`.