### PR TITLE
Fix version compatibility test

### DIFF
--- a/packages/jsii-java-runtime/project/src/main/java/org/jsii/JsiiRuntime.java
+++ b/packages/jsii-java-runtime/project/src/main/java/org/jsii/JsiiRuntime.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jsii.api.Callback;
-import static org.jsii.JsiiVersion.JSII_RUNTIME_VERSION;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -15,6 +14,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Collectors;
+
+import static org.jsii.JsiiVersion.JSII_RUNTIME_VERSION;
 
 /**
  * Manages the jsii-runtime child process.
@@ -265,7 +266,7 @@ public class JsiiRuntime {
         }
 
         String runtimeVersion = helloResponse.get("hello").asText();
-        assertVersionCompatibleWith(runtimeVersion);
+        assertVersionCompatible(JSII_RUNTIME_VERSION, runtimeVersion);
     }
 
     /**
@@ -350,13 +351,14 @@ public class JsiiRuntime {
      * Asserts that a peer runtimeVersion is compatible with this Java runtime version, which means
      * they share the same version components, with the possible exception of the build number.
      *
-     * @param runtimeVersion the peer runtime's version, possibly including build number.
+     * @param expectedVersion The version this client expects from the runtime
+     * @param actualVersion   The actual version the runtime reports
      *
-     * @throws JsiiException if {@code runtimeVersion} and {@link RUNTIME_VERSION} aren't equal.
+     * @throws JsiiException if versions mismatch
      */
-    static void assertVersionCompatibleWith(final String runtimeVersion) {
-        final String shortActualVersion = runtimeVersion.replaceAll(VERSION_BUILD_PART_REGEX, "");
-        final String shortExpectedVersion = JSII_RUNTIME_VERSION.replaceAll(VERSION_BUILD_PART_REGEX, "");
+    static void assertVersionCompatible(final String expectedVersion, final String actualVersion) {
+        final String shortActualVersion = actualVersion.replaceAll(VERSION_BUILD_PART_REGEX, "");
+        final String shortExpectedVersion = expectedVersion.replaceAll(VERSION_BUILD_PART_REGEX, "");
         if (shortExpectedVersion.compareTo(shortActualVersion) != 0) {
             throw new JsiiException("Incompatible jsii-runtime version. Expecting "
                     + shortExpectedVersion

--- a/packages/jsii-java-runtime/project/src/test/java/org/jsii/JsiiVersionTest.java
+++ b/packages/jsii-java-runtime/project/src/test/java/org/jsii/JsiiVersionTest.java
@@ -1,17 +1,30 @@
 package org.jsii;
 
 import org.junit.Test;
-import org.jsii.JsiiRuntime;
+
 import static org.jsii.JsiiVersion.JSII_RUNTIME_VERSION;
 
 public final class JsiiVersionTest {
     @Test
-    public void testShortVersion() {
-        JsiiRuntime.assertVersionCompatibleWith(JSII_RUNTIME_VERSION);
+    public void compatibleVersions() {
+        JsiiRuntime.assertVersionCompatible("0.7.0", "0.7.0");
+        JsiiRuntime.assertVersionCompatible("0.7.0", "0.7.0+abcd");
+        JsiiRuntime.assertVersionCompatible("0.7.0+cdfe0", "0.7.0+abcd");
+        JsiiRuntime.assertVersionCompatible("0.7.0+cdfe0", "0.7.0+abcd111");
     }
 
-    @Test
-    public void testLongVersion() {
-        JsiiRuntime.assertVersionCompatibleWith(JSII_RUNTIME_VERSION + "+fooba0");
+    @Test(expected = JsiiException.class)
+    public void incompatibleVersions_1() {
+        JsiiRuntime.assertVersionCompatible("0.7.0", "0.7.1");
+    }
+
+    @Test(expected = JsiiException.class)
+    public void incompatibleVersions_2() {
+        JsiiRuntime.assertVersionCompatible("0.7.0", "0.7");
+    }
+
+    @Test(expected = JsiiException.class)
+    public void incompatibleVersions_3() {
+        JsiiRuntime.assertVersionCompatible("0.7.0+abcd", "1.2.0+abcd");
     }
 }


### PR DESCRIPTION
The test assumed JSII_RUNTIME_VERSION doesn't have
a "+build" postfix, so it appended one, which 
resulted in "0.1.2.3+xxxx+yyyy", which failed
the compatibility test since it's malformed.

By submitting this pull request, I confirm that my contribution is made under
the terms of the beta license.
