### PR TITLE
Add batch file wrappers for the jsii, jsii-pacmak, and jsii-runtime commands

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.bat
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.bat
@@ -1,0 +1,3 @@
+REM %~dp0 is the directory containing this batch file, with a trailing path separator.
+REM %* is all of the arguments passed to this batch file.
+node %~dp0jsii-pacmak %*

--- a/packages/jsii-runtime/bin/jsii-runtime.bat
+++ b/packages/jsii-runtime/bin/jsii-runtime.bat
@@ -1,0 +1,3 @@
+REM %~dp0 is the directory containing this batch file, with a trailing path separator.
+REM %* is all of the arguments passed to this batch file.
+node %~dp0jsii-runtime %*

--- a/packages/jsii/bin/jsii.bat
+++ b/packages/jsii/bin/jsii.bat
@@ -1,0 +1,3 @@
+REM %~dp0 is the directory containing this batch file, with a trailing path separator.
+REM %* is all of the arguments passed to this batch file.
+node %~dp0jsii %*


### PR DESCRIPTION
Our existing commands use shebangs, which is a *nix concept. This change allows Windows customers (with jsii/bin in their path) to run `jsii-pacmak` instead of `node path/to/jsii-pacmak.js`.