### PR TITLE
Make execution of `pack.sh` much faster

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -6,5 +6,7 @@ packdir="$PWD/pack"
 rm -fr ${packdir}
 mkdir -p ${packdir}
 
-lerna ls | grep -v "private" | cut -d" " -f1 | xargs -n1 -I{} \
-    lerna exec --scope {} --stream -- "npm pack && mv *.tgz ${packdir}"
+scopes=$(lerna ls 2>/dev/null | grep -v "(private)" | cut -d" " -f1 | xargs -n1 -I{} echo "--scope {}" | tr "\n" " ")
+# Run pre-publish script, if any package defines one (we'll run npm-pack assuming stuff was built before)
+lerna run ${scopes} --sort --stream prepublish
+lerna exec ${scopes} --stream --parallel -- "npm pack --ignore-scripts && mv *.tgz ${packdir}"


### PR DESCRIPTION
ℹ️ This change is identical to awslabs/aws-cdk#161

Since the `pack.sh` script is supposed to be run after `build.sh` was
executed, the `prepare` script of all packages was already performed,
and  it is possible to only run the `prepublish` script, then execute
`npm pack --ignore-scripts` in parallel.

This removes the double-compilation of all packages (including
slow-to-build packages such as `aws-cdk-docs` or `@aws-cdk/resources`,
that involve expensive code generation).