### PR TITLE
Include pom.xml when deploying to maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.js
 *.d.ts
 dist/
+pack/
+
 .BUILD_COMPLETED
 packages/jsii-dotnet-generator/cli/
 

--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -95,6 +95,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
                             <groupId>\${project.groupId}</groupId>
                             <artifactId>\${project.artifactId}</artifactId>
                             <version>\${project.version}</version>
+                            <pomFile>\${project.basedir}/pom.xml</pomFile>
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Otherwise, it generates an empty pom.xml file
which doesn't contain dependency definitions.
