### PR TITLE
Allow incremental build of documentation

### DIFF
--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -851,7 +851,7 @@ async function preparePackage(module: string, useCache = true) {
     }
 
     const packageRoot = findPackageRoot(module);
-    await generate('pack-only', packageRoot, staging);
+    await generate('pack-only', packageRoot, staging, true);
     const dir = path.join(staging, (await fs.readdir(staging))[0]);
     cache[module] = dir;
     return dir;

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -6,7 +6,8 @@ import { generate } from '../lib';
 const argv = yargs
     .usage('Usage: jsii-pacmak -t target -o outdir <jsii-package-dir>')
     .option('target', { alias: 't', type: 'string', desc: 'target language' })
-    .option('outdir', { alias: 'o', type: 'string', desc: 'output directory '})
+    .option('outdir', { alias: 'o', type: 'string', desc: 'output directory' })
+    .option('force', { alias: 'f', type: 'boolean', desc: 'force generation', default: false })
     .demandOption('target')
     .demandOption('outdir')
     .demandCommand(1, '<jsii-package-dir> is required')
@@ -14,9 +15,10 @@ const argv = yargs
 
 const target = argv.target;
 const outDir = argv.outdir;
+const force = argv.force;
 const packageDir = argv._[0];
 
-generate(target, packageDir, outDir).catch(err => {
+generate(target, packageDir, outDir, force).catch(err => {
     process.stderr.write(err.stack + '\n');
     process.exit(1);
 });

--- a/packages/jsii-pacmak/lib/generator.ts
+++ b/packages/jsii-pacmak/lib/generator.ts
@@ -38,6 +38,12 @@ export class GeneratorOptions {
 export interface IGenerator {
     generate(): void;
     load(jsiiFile: string): Promise<void>;
+    /**
+     * Determine if the generated artifacts for this generator are already up-to-date.
+     * @param outDir the directory where generated artifacts would be placed.
+     * @return ``true`` if no generation is necessary
+     */
+    upToDate(outDir: string): Promise<boolean>;
     save(outdir: string, tarball: string): Promise<any>;
 }
 
@@ -74,6 +80,10 @@ export abstract class Generator implements IGenerator {
             this.visit(this.assembly.nametree);
         }
         this.onEndAssembly(this.assembly);
+    }
+
+    upToDate(_: string): Promise<boolean> {
+        return Promise.resolve(false);
     }
 
     /**

--- a/packages/jsii-pacmak/lib/generators/dotnet.ts
+++ b/packages/jsii-pacmak/lib/generators/dotnet.ts
@@ -14,6 +14,10 @@ export default class DotNetGenerator implements IGenerator {
         this.jsiiFile = jsiiFile;
     }
 
+    public upToDate(_: string): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+
     public save(outdir: string, tarball: string): Promise<any> {
         const runtimeRoot = dirname(require.resolve('jsii-dotnet-generator/package.json'));
         const cliPath = `${runtimeRoot}/cli/${this.getRuntime()}/publish/AWS.Jsii.Generator.CLI`;

--- a/packages/jsii-pacmak/lib/program.ts
+++ b/packages/jsii-pacmak/lib/program.ts
@@ -20,11 +20,18 @@ async function newGeneratorForLanguage(lang: string): Promise<IGenerator> {
     return new GeneratorClass();
 }
 
-export async function generate(lang: string, packageDir: string, outDir: string) {
+export async function generate(lang: string, packageDir: string, outDir: string, force: boolean) {
     const jsiiFile = path.join(packageDir, SPEC_FILE_NAME);
 
     const generator = await newGeneratorForLanguage(lang);
     await generator.load(jsiiFile);
+
+    if (!force && await generator.upToDate(outDir)) {
+        // tslint:disable-next-line:no-console
+        console.log(`Artifacts in ${outDir} are already up-to-date (use --force to re-generate)`);
+        return;
+    }
+
     generator.generate();
 
     const tarball = await npmPack(packageDir);

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -15,6 +15,14 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/md5": {
+			"version": "2.1.32",
+			"resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.1.32.tgz",
+			"integrity": "sha1-k+I0N/zRenucqY0CqmAC6DWEL+g=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/node": {
 			"version": "9.6.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
@@ -156,6 +164,11 @@
 				"supports-color": "^2.0.0"
 			}
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
@@ -265,6 +278,11 @@
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -582,6 +600,11 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -758,6 +781,16 @@
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
+			}
+		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
 			}
 		},
 		"mem": {

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -23,12 +23,14 @@
     "fs-extra": "^4.0.3",
     "jsii-dotnet-generator": "^0.5.0-beta",
     "jsii-spec": "^0.5.0-beta",
+    "md5": "^2.2.1",
     "source-map-support": "^0.5.6",
     "yargs": "^9.0.0"
   },
   "devDependencies": {
     "@types/clone": "^0.1.30",
     "@types/fs-extra": "^4.0.8",
+    "@types/md5": "^2.1.32",
     "@types/node": "^9.6.18",
     "@types/nodeunit": "0.0.30",
     "@types/yargs": "^6.6.0",

--- a/packages/jsii-pacmak/test/expected.sphinx.jsii-calc-lib/_scope_jsii-calc-lib.rst
+++ b/packages/jsii-pacmak/test/expected.sphinx.jsii-calc-lib/_scope_jsii-calc-lib.rst
@@ -1,3 +1,5 @@
+.. @jsii-pacmak:meta@ {"fingerprint":"2fe6e23a619cd01e9de41b79f5019604"}
+
 @scope/jsii-calc-lib
 ====================
 

--- a/packages/jsii-pacmak/test/expected.sphinx.jsii-calc/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.sphinx.jsii-calc/jsii-calc.rst
@@ -1,3 +1,5 @@
+.. @jsii-pacmak:meta@ {"fingerprint":"48d0f05188c647ee97587881c59fa527"}
+
 jsii-calc
 =========
 


### PR DESCRIPTION
Building documentation is rather slow, and when working on documentation
improvements this can be a real pain. Sphinx is however smart enough to
not fully re-process files that haven't changed since the last
execution.

This change adds a fingerprint to the generated `.rst` files that allows
`jsii-pacmak` to determine if they need be re-generated or not, such
that files for which the JSII assembly hasn't changed will not be
re-written, making documentation iteration much faster.