### PR TITLE
Only include nupkg files in .NET npm packs

### DIFF
--- a/packages/jsii-dotnet-generator/.npmignore
+++ b/packages/jsii-dotnet-generator/.npmignore
@@ -1,4 +1,8 @@
-src
-test.sh
-build.sh
-prepack.sh
+# by default, exclude everything
+*
+
+# bundle only...
+!*.nupkg
+!package.json
+!index.js
+

--- a/packages/jsii-dotnet-jsonmodel/.npmignore
+++ b/packages/jsii-dotnet-jsonmodel/.npmignore
@@ -1,4 +1,8 @@
-src
-test.sh
-build.sh
-prepack.sh
+# by default, exclude everything
+*
+
+# bundle only...
+!*.nupkg
+!package.json
+!index.js
+

--- a/packages/jsii-dotnet-runtime/.npmignore
+++ b/packages/jsii-dotnet-runtime/.npmignore
@@ -1,4 +1,8 @@
-src
-test.sh
-build.sh
-prepack.sh
+# by default, exclude everything
+*
+
+# bundle only...
+!*.nupkg
+!package.json
+!index.js
+


### PR DESCRIPTION
These are the self contained artifacts that we will eventually publish to NuGet.
