### PR TITLE
Fix representation of enum types in the assemblies

### DIFF
--- a/packages/jsii-calc/lib/index.ts
+++ b/packages/jsii-calc/lib/index.ts
@@ -350,6 +350,12 @@ export enum AllTypesEnum {
     ThisIsGreat
 }
 
+export enum StringEnum {
+    A = 'A',
+    B = 'B',
+    C = 'C'
+}
+
 /**
  * This class includes property for all types supported by jsii. The setters will validate
  * that the value set is of the expected type and throw otherwise.
@@ -480,6 +486,7 @@ export class AllTypes {
 
     // enum
 
+    public optionalEnumValue?: StringEnum;
     private enumValue: AllTypesEnum = AllTypesEnum.ThisIsGreat;
 
     get enumProperty() {
@@ -500,6 +507,10 @@ export class AllTypes {
 
     get enumPropertyValue(): number {
         return this.enumValue.valueOf();
+    }
+
+    enumMethod(value: StringEnum) {
+        return value;
     }
 }
 

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -879,6 +879,24 @@
       "namespace": "jsii-calc",
       "name": "AllTypesEnum"
     },
+    "jsii-calc.StringEnum": {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "A"
+        },
+        {
+          "name": "B"
+        },
+        {
+          "name": "C"
+        }
+      ],
+      "fqn": "jsii-calc.StringEnum",
+      "module": "jsii-calc",
+      "namespace": "jsii-calc",
+      "name": "StringEnum"
+    },
     "jsii-calc.AllTypes": {
       "docs": {
         "comment": "This class includes property for all types supported by jsii. The setters will validate\nthat the value set is of the expected type and throw otherwise."
@@ -1024,6 +1042,13 @@
           }
         },
         {
+          "name": "optionalEnumValue",
+          "type": {
+            "fqn": "jsii-calc.StringEnum",
+            "optional": true
+          }
+        },
+        {
           "name": "enumProperty",
           "type": {
             "fqn": "jsii-calc.AllTypesEnum"
@@ -1035,6 +1060,22 @@
             "primitive": "number"
           },
           "immutable": true
+        }
+      ],
+      "methods": [
+        {
+          "parameters": [
+            {
+              "name": "value",
+              "type": {
+                "fqn": "jsii-calc.StringEnum"
+              }
+            }
+          ],
+          "name": "enumMethod",
+          "returns": {
+            "fqn": "jsii-calc.StringEnum"
+          }
         }
       ],
       "fqn": "jsii-calc.AllTypes",
@@ -2512,6 +2553,9 @@
       "AllTypesEnum": {
         "_": "jsii-calc.AllTypesEnum"
       },
+      "StringEnum": {
+        "_": "jsii-calc.StringEnum"
+      },
       "AllTypes": {
         "_": "jsii-calc.AllTypes"
       },
@@ -2600,7 +2644,7 @@
       }
     }
   },
-  "typecount": 43,
+  "typecount": 44,
   "externalTypes": {
     "@scope/jsii-calc-lib.IFriendly": {
       "docs": {


### PR DESCRIPTION
`enum` types are special union types in the TypeScript world. When an
`enum` is used in another union type (for example: an optional `enum`),
`tsc` represents it as the union of `undefined` and all the possible
`enum` values. Getting the *apparent* type of an `enum` value yields
it's *value type* (`string` or `number`), and not it's *base type*
(the `enum` type). Fortunately, the `typeChecker` provides an API to get
the base type of a litteral type (such as an `enum` value), which
correctly yields the `enum` type as desired.

This commit changes how the compiler resolves `enum`-like types for
inclusion in the assembly, and adds a couple of entries to `jsii-calc`
that advertised the incorrect behavior mentioned in #68, and that now
are correctly represented.

Fixes #68