### PR TITLE
kernel: cross-platform untar of jsii bundle

### DIFF
--- a/packages/jsii-kernel/package-lock.json
+++ b/packages/jsii-kernel/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "jsii-kernel",
+	"version": "0.5.0-beta",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@types/fs-extra": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.8.tgz",
 			"integrity": "sha512-Z5nu9Pbxj9yNeXIK3UwGlRdJth4cZ5sCq05nI7FaI6B0oz28nxkOtp6Lsz0ZnmLHJGvOJfB/VHxSTbVq/i6ujA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -13,27 +16,41 @@
 		"@types/node": {
 			"version": "9.6.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.18.tgz",
-			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig=="
+			"integrity": "sha512-lywCnJQRSsu0kitHQ5nkb7Ay/ScdJPQjhWRtuf+G1DmNKJnPcdVyP0pYvdiDFKjzReC6NLWLgSyimno3kKfIig==",
+			"dev": true
 		},
 		"@types/nodeunit": {
 			"version": "0.0.30",
 			"resolved": "https://registry.npmjs.org/@types/nodeunit/-/nodeunit-0.0.30.tgz",
-			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng="
+			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng=",
+			"dev": true
+		},
+		"@types/tar": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
+			"integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -41,32 +58,38 @@
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+			"dev": true
 		},
 		"assert-plus": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.3",
 				"esutils": "^2.0.2",
@@ -76,12 +99,14 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
@@ -90,17 +115,20 @@
 		"bind-obj-methods": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
-			"integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw="
+			"integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw=",
+			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
 		},
 		"boom": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -109,6 +137,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -117,17 +146,20 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+			"dev": true
 		},
 		"chalk": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^2.2.1",
 				"escape-string-regexp": "^1.0.2",
@@ -136,15 +168,22 @@
 				"supports-color": "^2.0.0"
 			}
 		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
 			"requires": {
 				"color-name": "^1.1.1"
 			}
@@ -152,17 +191,20 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -170,22 +212,26 @@
 		"commander": {
 			"version": "2.15.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"coveralls": {
 			"version": "2.13.3",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
 			"integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
+			"dev": true,
 			"requires": {
 				"js-yaml": "3.6.1",
 				"lcov-parse": "0.0.10",
@@ -198,6 +244,7 @@
 					"version": "3.6.1",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
 					"integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^2.6.0"
@@ -209,6 +256,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
 			"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
@@ -218,6 +266,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"dev": true,
 			"requires": {
 				"boom": "2.x.x"
 			}
@@ -226,6 +275,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -233,7 +283,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -241,6 +292,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -248,17 +300,20 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"diff": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+			"dev": true
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0"
@@ -267,42 +322,50 @@
 		"ejs": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"esprima": {
 			"version": "2.7.3",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"events-to-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"foreground-child": {
 			"version": "1.5.6",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
 			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^4",
 				"signal-exit": "^3.0.0"
@@ -311,12 +374,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
 			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.5",
@@ -326,37 +391,51 @@
 		"fs-exists-cached": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
-			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84="
+			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs-minipass": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-loop": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
-			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw="
+			"integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
 			"requires": {
 				"is-property": "^1.0.0"
 			}
@@ -365,6 +444,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			},
@@ -372,7 +452,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -380,6 +461,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -392,12 +474,14 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
 			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+			"dev": true,
 			"requires": {
 				"chalk": "^1.1.1",
 				"commander": "^2.9.0",
@@ -409,6 +493,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -416,12 +501,14 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"hawk": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"dev": true,
 			"requires": {
 				"boom": "2.x.x",
 				"cryptiles": "2.x.x",
@@ -432,12 +519,14 @@
 		"hoek": {
 			"version": "2.16.3",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+			"dev": true
 		},
 		"http-signature": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^0.2.0",
 				"jsprim": "^1.2.2",
@@ -448,6 +537,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -456,17 +546,20 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"is-my-ip-valid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+			"dev": true
 		},
 		"is-my-json-valid": {
 			"version": "2.17.2",
 			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
 			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"dev": true,
 			"requires": {
 				"generate-function": "^2.0.0",
 				"generate-object-property": "^1.1.0",
@@ -478,37 +571,44 @@
 		"is-property": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -517,7 +617,8 @@
 				"esprima": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+					"dev": true
 				}
 			}
 		},
@@ -525,22 +626,26 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true,
 			"optional": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -548,12 +653,14 @@
 		"jsonpointer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -564,24 +671,28 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"log-driver": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
+			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -590,12 +701,14 @@
 		"mime-db": {
 			"version": "1.33.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.18",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "~1.33.0"
 			}
@@ -604,6 +717,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -611,17 +725,59 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"minipass": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+			"integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+				}
+			}
+		},
+		"minizlib": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+			"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				}
+			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"nodeunit": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/nodeunit/-/nodeunit-0.11.2.tgz",
 			"integrity": "sha512-rlr0Fgd66nLmWwgVFj40TZp5jo47/YqaPQtoHG78mt+DVQhaLhA8EJJYCf2lozgYplPv+jJMLt8bCP34zo05mQ==",
+			"dev": true,
 			"requires": {
 				"ejs": "^2.5.2",
 				"tap": "^10.0.2"
@@ -631,6 +787,7 @@
 			"version": "11.8.0",
 			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
 			"integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
+			"dev": true,
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
@@ -664,6 +821,7 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -672,62 +830,76 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"atob": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"chalk": "^1.1.3",
 						"esutils": "^2.0.2",
@@ -737,6 +909,7 @@
 				"babel-generator": {
 					"version": "6.26.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-messages": "^6.23.0",
 						"babel-runtime": "^6.26.0",
@@ -751,6 +924,7 @@
 				"babel-messages": {
 					"version": "6.23.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.22.0"
 					}
@@ -758,6 +932,7 @@
 				"babel-runtime": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -766,6 +941,7 @@
 				"babel-template": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -777,6 +953,7 @@
 				"babel-traverse": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -792,6 +969,7 @@
 				"babel-types": {
 					"version": "6.26.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -801,15 +979,18 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"base": {
 					"version": "0.11.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cache-base": "^1.0.1",
 						"class-utils": "^0.3.5",
@@ -823,6 +1004,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -830,6 +1012,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -837,6 +1020,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -844,6 +1028,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -852,17 +1037,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -871,6 +1059,7 @@
 				"braces": {
 					"version": "2.3.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -887,6 +1076,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -895,11 +1085,13 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"collection-visit": "^1.0.0",
 						"component-emitter": "^1.2.1",
@@ -914,13 +1106,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-hex": "^1.2.0",
 						"mkdirp": "^0.5.1",
@@ -930,11 +1124,13 @@
 				"camelcase": {
 					"version": "1.2.1",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
@@ -944,6 +1140,7 @@
 				"chalk": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -955,6 +1152,7 @@
 				"class-utils": {
 					"version": "0.3.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"define-property": "^0.2.5",
@@ -965,19 +1163,22 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -988,17 +1189,20 @@
 						"wordwrap": {
 							"version": "0.0.2",
 							"bundled": true,
+							"dev": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-visit": "^1.0.0",
 						"object-visit": "^1.0.0"
@@ -1006,31 +1210,38 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"core-js": {
 					"version": "2.5.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -1039,25 +1250,30 @@
 				"debug": {
 					"version": "2.6.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"strip-bom": "^2.0.0"
 					}
@@ -1065,6 +1281,7 @@
 				"define-property": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.2",
 						"isobject": "^3.0.1"
@@ -1073,6 +1290,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1080,6 +1298,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1087,6 +1306,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -1095,17 +1315,20 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -1113,21 +1336,25 @@
 				"error-ex": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -1141,6 +1368,7 @@
 						"cross-spawn": {
 							"version": "5.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -1152,6 +1380,7 @@
 				"expand-brackets": {
 					"version": "2.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -1165,6 +1394,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -1172,6 +1402,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1181,6 +1412,7 @@
 				"extend-shallow": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"assign-symbols": "^1.0.0",
 						"is-extendable": "^1.0.1"
@@ -1189,6 +1421,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -1198,6 +1431,7 @@
 				"extglob": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -1212,6 +1446,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -1219,6 +1454,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1226,6 +1462,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1233,6 +1470,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -1240,6 +1478,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -1248,13 +1487,15 @@
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"fill-range": {
 					"version": "4.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -1265,6 +1506,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -1274,6 +1516,7 @@
 				"find-cache-dir": {
 					"version": "0.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"mkdirp": "^0.5.1",
@@ -1283,17 +1526,20 @@
 				"find-up": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
@@ -1302,29 +1548,35 @@
 				"fragment-cache": {
 					"version": "0.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -1336,15 +1588,18 @@
 				},
 				"globals": {
 					"version": "9.18.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -1355,6 +1610,7 @@
 						"source-map": {
 							"version": "0.4.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
@@ -1364,17 +1620,20 @@
 				"has-ansi": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"has-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"get-value": "^2.0.6",
 						"has-values": "^1.0.0",
@@ -1383,13 +1642,15 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"kind-of": "^4.0.0"
@@ -1398,6 +1659,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -1405,6 +1667,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -1414,6 +1677,7 @@
 						"kind-of": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -1422,15 +1686,18 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -1438,37 +1705,44 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"invariant": {
 					"version": "2.2.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
@@ -1476,6 +1750,7 @@
 				"is-data-descriptor": {
 					"version": "0.1.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -1483,6 +1758,7 @@
 				"is-descriptor": {
 					"version": "0.1.6",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -1491,28 +1767,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "5.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-number": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -1520,60 +1801,72 @@
 				"is-odd": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"append-transform": "^0.4.0"
 					}
@@ -1581,6 +1874,7 @@
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"babel-generator": "^6.18.0",
 						"babel-template": "^6.16.0",
@@ -1594,6 +1888,7 @@
 				"istanbul-lib-report": {
 					"version": "1.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "^1.1.2",
 						"mkdirp": "^0.5.1",
@@ -1604,6 +1899,7 @@
 						"supports-color": {
 							"version": "3.2.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"has-flag": "^1.0.0"
 							}
@@ -1613,6 +1909,7 @@
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"istanbul-lib-coverage": "^1.1.2",
@@ -1624,6 +1921,7 @@
 						"debug": {
 							"version": "3.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -1633,21 +1931,25 @@
 				"istanbul-reports": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -1655,11 +1957,13 @@
 				"lazy-cache": {
 					"version": "1.0.4",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -1667,6 +1971,7 @@
 				"load-json-file": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -1678,6 +1983,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -1685,21 +1991,25 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.10",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"js-tokens": "^3.0.0"
 					}
@@ -1707,6 +2017,7 @@
 				"lru-cache": {
 					"version": "4.1.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -1714,11 +2025,13 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"object-visit": "^1.0.0"
 					}
@@ -1726,17 +2039,20 @@
 				"md5-hex": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -1744,19 +2060,22 @@
 				"merge-source-map": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "3.1.10",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -1775,28 +2094,33 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"for-in": "^1.0.2",
 						"is-extendable": "^1.0.1"
@@ -1805,6 +2129,7 @@
 						"is-extendable": {
 							"version": "1.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -1814,17 +2139,20 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -1842,21 +2170,25 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -1867,21 +2199,25 @@
 				"npm-run-path": {
 					"version": "2.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"copy-descriptor": "^0.1.0",
 						"define-property": "^0.2.5",
@@ -1891,6 +2227,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -1900,32 +2237,37 @@
 				"object-visit": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1933,6 +2275,7 @@
 				"optimist": {
 					"version": "0.6.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -1940,11 +2283,13 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -1953,11 +2298,13 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -1965,47 +2312,56 @@
 				"p-locate": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"path-type": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -2014,15 +2370,18 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
@@ -2030,6 +2389,7 @@
 				"pkg-dir": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					},
@@ -2037,6 +2397,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -2046,15 +2407,18 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -2064,6 +2428,7 @@
 				"read-pkg-up": {
 					"version": "1.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -2072,6 +2437,7 @@
 						"find-up": {
 							"version": "1.1.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -2081,11 +2447,13 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"regex-not": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.2",
 						"safe-regex": "^1.1.0"
@@ -2093,42 +2461,51 @@
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"repeating": {
 					"version": "2.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"right-align": {
 					"version": "0.1.3",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -2137,6 +2514,7 @@
 				"rimraf": {
 					"version": "2.6.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
@@ -2144,21 +2522,25 @@
 				"safe-regex": {
 					"version": "1.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"set-value": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -2169,6 +2551,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2178,25 +2561,30 @@
 				"shebang-command": {
 					"version": "1.2.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"base": "^0.11.1",
 						"debug": "^2.2.0",
@@ -2211,6 +2599,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -2218,6 +2607,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2227,6 +2617,7 @@
 				"snapdragon-node": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^1.0.0",
 						"isobject": "^3.0.0",
@@ -2236,6 +2627,7 @@
 						"define-property": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
@@ -2243,6 +2635,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2250,6 +2643,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2257,6 +2651,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -2265,28 +2660,33 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"atob": "^2.0.0",
 						"decode-uri-component": "^0.2.0",
@@ -2297,11 +2697,13 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -2314,6 +2716,7 @@
 				"spdx-correct": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2321,11 +2724,13 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -2333,11 +2738,13 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"split-string": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"extend-shallow": "^3.0.0"
 					}
@@ -2345,6 +2752,7 @@
 				"static-extend": {
 					"version": "0.1.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^0.2.5",
 						"object-copy": "^0.1.0"
@@ -2353,6 +2761,7 @@
 						"define-property": {
 							"version": "0.2.5",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -2362,6 +2771,7 @@
 				"string-width": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -2369,11 +2779,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -2383,6 +2795,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2390,21 +2803,25 @@
 				"strip-bom": {
 					"version": "2.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arrify": "^1.0.1",
 						"micromatch": "^3.1.8",
@@ -2415,15 +2832,18 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"braces": {
 							"version": "2.3.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -2440,6 +2860,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2449,6 +2870,7 @@
 						"expand-brackets": {
 							"version": "2.1.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -2462,6 +2884,7 @@
 								"define-property": {
 									"version": "0.2.5",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
@@ -2469,6 +2892,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2476,6 +2900,7 @@
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -2483,6 +2908,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -2492,6 +2918,7 @@
 								"is-data-descriptor": {
 									"version": "0.1.4",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
@@ -2499,6 +2926,7 @@
 										"kind-of": {
 											"version": "3.2.2",
 											"bundled": true,
+											"dev": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -2508,6 +2936,7 @@
 								"is-descriptor": {
 									"version": "0.1.6",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-accessor-descriptor": "^0.1.6",
 										"is-data-descriptor": "^0.1.4",
@@ -2516,13 +2945,15 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"bundled": true
+									"bundled": true,
+									"dev": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -2537,6 +2968,7 @@
 								"define-property": {
 									"version": "1.0.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
@@ -2544,6 +2976,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2553,6 +2986,7 @@
 						"fill-range": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -2563,6 +2997,7 @@
 								"extend-shallow": {
 									"version": "2.0.1",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -2572,6 +3007,7 @@
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2579,6 +3015,7 @@
 						"is-data-descriptor": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
@@ -2586,6 +3023,7 @@
 						"is-descriptor": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -2595,6 +3033,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
@@ -2602,6 +3041,7 @@
 								"kind-of": {
 									"version": "3.2.2",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -2610,15 +3050,18 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"micromatch": {
 							"version": "3.1.10",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -2639,11 +3082,13 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -2651,6 +3096,7 @@
 				"to-regex": {
 					"version": "3.0.2",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"define-property": "^2.0.2",
 						"extend-shallow": "^3.0.2",
@@ -2661,6 +3107,7 @@
 				"to-regex-range": {
 					"version": "2.1.1",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
@@ -2669,6 +3116,7 @@
 						"is-number": {
 							"version": "3.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -2677,11 +3125,13 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"bundled": true,
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -2692,6 +3142,7 @@
 						"yargs": {
 							"version": "3.10.0",
 							"bundled": true,
+							"dev": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -2705,11 +3156,13 @@
 				"uglify-to-browserify": {
 					"version": "1.0.2",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"get-value": "^2.0.6",
@@ -2720,6 +3173,7 @@
 						"extend-shallow": {
 							"version": "2.0.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -2727,6 +3181,7 @@
 						"set-value": {
 							"version": "0.4.3",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -2739,6 +3194,7 @@
 				"unset-value": {
 					"version": "1.0.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"has-value": "^0.3.1",
 						"isobject": "^3.0.0"
@@ -2747,6 +3203,7 @@
 						"has-value": {
 							"version": "0.3.1",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"get-value": "^2.0.3",
 								"has-values": "^0.1.4",
@@ -2756,6 +3213,7 @@
 								"isobject": {
 									"version": "2.1.0",
 									"bundled": true,
+									"dev": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -2764,34 +3222,40 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"use": {
 					"version": "3.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -2800,26 +3264,31 @@
 				"which": {
 					"version": "1.3.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"window-size": {
 					"version": "0.1.0",
 					"bundled": true,
+					"dev": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -2828,6 +3297,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -2835,6 +3305,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -2845,11 +3316,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -2858,15 +3331,18 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true
+					"bundled": true,
+					"dev": true
 				},
 				"yargs": {
 					"version": "11.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -2884,15 +3360,18 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						},
 						"cliui": {
 							"version": "4.1.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
@@ -2902,6 +3381,7 @@
 						"strip-ansi": {
 							"version": "4.0.0",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -2909,6 +3389,7 @@
 						"yargs-parser": {
 							"version": "9.0.2",
 							"bundled": true,
+							"dev": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							}
@@ -2918,13 +3399,15 @@
 				"yargs-parser": {
 					"version": "8.1.0",
 					"bundled": true,
+					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true
+							"bundled": true,
+							"dev": true
 						}
 					}
 				}
@@ -2933,12 +3416,14 @@
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+			"dev": true
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -2946,22 +3431,26 @@
 		"opener": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-			"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg="
+			"integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+			"dev": true
 		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"own-or": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
-			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw="
+			"integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+			"dev": true
 		},
 		"own-or-env": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
 			"integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+			"dev": true,
 			"requires": {
 				"own-or": "^1.0.0"
 			}
@@ -2969,22 +3458,26 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
@@ -2992,27 +3485,32 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"punycode": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.3.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+			"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+			"dev": true
 		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -3027,6 +3525,7 @@
 			"version": "2.79.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
 			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.6.0",
 				"aws4": "^1.2.1",
@@ -3054,6 +3553,7 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.5"
 			}
@@ -3066,17 +3566,20 @@
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"sntp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"dev": true,
 			"requires": {
 				"hoek": "2.x.x"
 			}
@@ -3090,6 +3593,7 @@
 			"version": "0.4.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
 			"requires": {
 				"source-map": "^0.5.6"
 			},
@@ -3097,19 +3601,22 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3124,19 +3631,22 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
 		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -3144,12 +3654,14 @@
 		"stringstream": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -3157,12 +3669,14 @@
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"tap": {
 			"version": "10.7.3",
 			"resolved": "https://registry.npmjs.org/tap/-/tap-10.7.3.tgz",
 			"integrity": "sha512-oS/FIq+tcmxVgYn5usKtLsX+sOHNEj+G7JIQE9SBjO5mVYB1rbaEJJiDbnYp8k0ZqY2Pe4HbYEpkvzm9jfLDyw==",
+			"dev": true,
 			"requires": {
 				"bind-obj-methods": "^1.0.0",
 				"bluebird": "^3.5.1",
@@ -3196,6 +3710,7 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
 			"integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
+			"dev": true,
 			"requires": {
 				"color-support": "^1.1.0",
 				"debug": "^2.1.3",
@@ -3212,21 +3727,45 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
 			"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+			"dev": true,
 			"requires": {
 				"events-to-array": "^1.0.1",
 				"js-yaml": "^3.2.7",
 				"readable-stream": "^2"
 			}
 		},
+		"tar": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+			"integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
+			"requires": {
+				"chownr": "^1.0.1",
+				"fs-minipass": "^1.2.5",
+				"minipass": "^2.3.3",
+				"minizlib": "^1.1.0",
+				"mkdirp": "^0.5.0",
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.2"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+				}
+			}
+		},
 		"tmatch": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
-			"integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ=="
+			"integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"dev": true,
 			"requires": {
 				"punycode": "^1.4.1"
 			}
@@ -3234,22 +3773,26 @@
 		"trivial-deferred": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
-			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM="
+			"integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+			"dev": true
 		},
 		"tsame": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
-			"integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw=="
+			"integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw==",
+			"dev": true
 		},
 		"tslib": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
+			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
+			"dev": true
 		},
 		"tslint": {
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
 			"integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+			"dev": true,
 			"requires": {
 				"babel-code-frame": "^6.22.0",
 				"builtin-modules": "^1.1.1",
@@ -3269,6 +3812,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -3277,6 +3821,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -3286,12 +3831,14 @@
 				"diff": {
 					"version": "3.5.0",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -3302,6 +3849,7 @@
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
 			"integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
 			}
@@ -3309,23 +3857,27 @@
 		"tunnel-agent": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+			"dev": true
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true,
 			"optional": true
 		},
 		"typescript": {
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"dev": true
 		},
 		"unicode-length": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
 			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+			"dev": true,
 			"requires": {
 				"punycode": "^1.3.2",
 				"strip-ansi": "^3.0.1"
@@ -3334,22 +3886,26 @@
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"uuid": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -3359,7 +3915,8 @@
 				"assert-plus": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
 				}
 			}
 		},
@@ -3367,6 +3924,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -3374,22 +3932,26 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yapool": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+			"integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+			"dev": true
 		}
 	}
 }

--- a/packages/jsii-kernel/package.json
+++ b/packages/jsii-kernel/package.json
@@ -15,6 +15,7 @@
     "@types/fs-extra": "^4.0.8",
     "@types/node": "^9.6.18",
     "@types/nodeunit": "0.0.30",
+    "@types/tar": "^4.0.0",
     "fs-extra": "^4.0.3",
     "jsii-calc": "^0.5.0-beta",
     "jsii-pacmak": "^0.5.0-beta",
@@ -24,7 +25,8 @@
   },
   "dependencies": {
     "jsii-spec": "^0.5.0-beta",
-    "source-map": "^0.7.0"
+    "source-map": "^0.7.0",
+    "tar": "^4.4.4"
   },
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
Instead of spawn("tar") use [node-tar] (from npm) so that the kernel will be cross platform.
Fixes #86

[node-tar]: https://github.com/npm/node-tar