### PR TITLE
Fix issue where symbols referenced by ancestors of an interface were not added to externals.

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -273,6 +273,45 @@ export async function compileSources(entrypoint: string,
 
                 // Skip properties that are not direct members of this type.
                 if (mem.valueDeclaration.parent !== decl) {
+                    if (ts.isMethodSignature(mem.valueDeclaration)) {
+                        const methodDeclaration = symbol.valueDeclaration as ts.MethodDeclaration;
+
+                        if ((!methodDeclaration) || isHidden(methodDeclaration)) {
+                            continue;
+                        }
+
+                        if (methodDeclaration.type) {
+                            const type = typeChecker.getTypeAtLocation(methodDeclaration.type);
+                            if (type.symbol) {
+                                await getFullyQualifiedName(type.symbol!, ctx);
+                            }
+                        }
+
+                        for (const parameter of methodDeclaration.parameters) {
+                            if (parameter.type) {
+                                const type = typeChecker.getTypeAtLocation(parameter.type);
+                                if (type.symbol) {
+                                    await getFullyQualifiedName(type.symbol, ctx);
+                                }
+                            }
+                        }
+                    }
+
+                    if (mem.valueDeclaration.kind === ts.SyntaxKind.PropertySignature) {
+                        const propertyDeclaration = symbol.valueDeclaration as ts.PropertyDeclaration;
+
+                        if ((!propertyDeclaration) || isHidden(propertyDeclaration)) {
+                            continue;
+                        }
+                        
+                        if (propertyDeclaration.type) {
+                            const type = typeChecker.getTypeAtLocation(propertyDeclaration.type);
+                            if (type.symbol) {
+                                await getFullyQualifiedName(type.symbol!, ctx);
+                            }
+                        }
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
When compiling interfaces, `compiler.ts` ignores members of ancestor interfaces. This causes an issue in the following case:

    // in module mod1
    export interface Foo extends myMod2.SomeInterface {
    }

    // in module mod2
    export interface Bar {
        doSomething(): myMod2.SomeOtherType;
    }

Because the compiler ignores `doSomething`, `myMod2.SomeOtherType` is never referenced and isn't added to `mod1.externals`.

This isn't a problem when generating code for the interface. But when the interface *proxy* is generated, it needs to know the signature of all of its methods, including methods of ancestor interfaces. So when it tries to determine the native type corresponding to `myMod2.SomeOtherType`, it fails because `mod2.externals` does not contain this symbol.

See https://github.com/awslabs/aws-cdk/issues/383 for an example of this issue.