### PR TITLE
Fix assembly resource paths on Windows.

### DIFF
--- a/packages/jsii-dotnet-generator/src/AWS.Jsii.Generator/AssemblyGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/AWS.Jsii.Generator/AssemblyGenerator.cs
@@ -57,8 +57,9 @@ namespace AWS.Jsii.Generator
             }
             _fileSystem.Directory.CreateDirectory(packageOutputRoot);
 
-            _fileSystem.File.Copy(tarballPath, packageOutputRoot);
-            _fileSystem.File.Copy(jsiiFile, packageOutputRoot);
+            // On Windows, the full destination path including the filename is required.
+            _fileSystem.File.Copy(tarballPath, Path.Combine(packageOutputRoot, Path.GetFileName(tarballPath)));
+            _fileSystem.File.Copy(jsiiFile, Path.Combine(packageOutputRoot, Path.GetFileName(jsiiFile)));
 
             Save(packageOutputRoot, symbols, assembly, new FileInfo(tarballPath).Name, new FileInfo(jsiiFile).Name);
         }

--- a/packages/jsii-dotnet-jsonmodel/src/AWS.Jsii.JsonModel/Spec/Method.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/AWS.Jsii.JsonModel/Spec/Method.cs
@@ -28,11 +28,6 @@ namespace AWS.Jsii.JsonModel.Spec
             Returns = returns;
             IsVariadic = isVariadic;
             IsStatic = isStatic;
-
-            if (IsVariadic == true)
-            {
-                Console.Error.WriteLine($"Warning: Method '{Name}' is marked as variadic, but variadics are not yet implemented.");
-            }
         }
 
 

--- a/packages/jsii-dotnet-jsonmodel/src/AWS.Jsii.JsonModel/Spec/Parameter.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/AWS.Jsii.JsonModel/Spec/Parameter.cs
@@ -18,11 +18,6 @@ namespace AWS.Jsii.JsonModel.Spec
             Type = type ?? throw new ArgumentNullException(nameof(type));
             Docs = docs;
             IsVariadic = isVariadic;
-
-            if (IsVariadic == true)
-            {
-                Console.Error.WriteLine($"Warning: Parameter '{Name}' is marked as variadic, but variadics are not yet implemented.");
-            }
         }
 
         [JsonProperty("name")]


### PR DESCRIPTION
`File.Copy` does not support the case where the first argument is a file, and the second is a directory. So we need to use the full path including the filename.