### PR TITLE
Fix .npmignore to include .NET generator CLI.

### DIFF
--- a/packages/jsii-dotnet-generator/.npmignore
+++ b/packages/jsii-dotnet-generator/.npmignore
@@ -5,4 +5,5 @@
 !*.nupkg
 !package.json
 !index.js
+!cli/**/*
 


### PR DESCRIPTION
When `packages/jsii-dotnet-generator/.npmignore` was switched to opt-in, the `cli/` directory was not added to the whitelist. This breaks `jsii-pacmak` for .NET.