### PR TITLE
Publish .NET Generator CLI as framework-dependent rather than self-contained

### DIFF
--- a/packages/jsii-dotnet-generator/build.sh
+++ b/packages/jsii-dotnet-generator/build.sh
@@ -7,13 +7,7 @@ set -euo pipefail
 # explicitly clear the cache as a temporary workaround.
 dotnet nuget locals all --clear
 dotnet build -c Release ./src/AWS.Jsii.Generator.sln
-
-# TODO: Publishing for all four platforms takes ~30 seconds. It might
-# be worth skipping non-linux platforms for Debug builds.
-dotnet publish -c Release src/AWS.Jsii.Generator.CLI/ -r win-x86
-dotnet publish -c Release src/AWS.Jsii.Generator.CLI/ -r win-x64
-dotnet publish -c Release src/AWS.Jsii.Generator.CLI/ -r osx-x64
-dotnet publish -c Release src/AWS.Jsii.Generator.CLI/ -r linux-x64
+dotnet publish -c Release src/AWS.Jsii.Generator.CLI/
 
 mkdir -p cli
 rsync -av ./src/AWS.Jsii.Generator.CLI/bin/Release/netcoreapp2.0/ ./cli/

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -38,8 +38,8 @@ class DotNetGenerator implements IGenerator {
 
     public save(outdir: string, tarball: string): Promise<any> {
         const runtimeRoot = dirname(require.resolve('jsii-dotnet-generator/package.json'));
-        const cliPath = `${runtimeRoot}/cli/${this.getRuntime()}/publish/AWS.Jsii.Generator.CLI`;
-        const cli = spawn(cliPath, ['--jsii', this.jsiiFile, '--tarball', tarball, '--output', outdir], { stdio: 'inherit' });
+        const cliPath = `${runtimeRoot}/cli/publish/AWS.Jsii.Generator.CLI.dll`;
+        const cli = spawn("dotnet", [cliPath, '--jsii', this.jsiiFile, '--tarball', tarball, '--output', outdir], { stdio: 'inherit' });
 
         return new Promise<number>((resolve, reject) => {
             cli.once('exit', code => {
@@ -52,47 +52,5 @@ class DotNetGenerator implements IGenerator {
 
             cli.once('error', err => reject(err));
         });
-    }
-
-    private getRuntime(): string {
-        // We don't want to require dotnet core as a pacmak dependency,
-        // so we use dotnet publish to create a standalone bundle that
-        // includes the dotnet runtime. This bundle is platform-specific,
-        // so we generate a different bundle for each platform supported
-        // by nodejs.
-        return `${this.getPlatform()}-${this.getArchitecture()}`;
-    }
-
-    private getPlatform(): string {
-        switch (process.platform) {
-            case "darwin":
-                return "osx";
-
-            case "linux":
-                return "linux";
-
-            case "win32":
-                return "win";
-
-            default:
-                throw new Error(`Unsupported platform: '${process.platform}'`);
-        }
-    }
-
-    private getArchitecture(): string {
-        switch (process.arch) {
-            case "x32":
-                if (process.platform !== "win32") {
-                    throw new Error(`x86 architecture is not supported on ${process.platform}`);
-                }
-
-                return "x86";
-
-            case "x64":
-                return "x64";
-
-            default:
-                throw new Error(`Unsupported architecture: '${process.arch}'`);
-        }
     }
 }


### PR DESCRIPTION
Previously the generator CLI was published as self-contained to avoid taking a dependency on the .NET Core runtime. However:

* A developers who wants to *build* generated source needs the .NET Core SDK anyway, which includes the runtime.
* Publishing a self-contained executable for all four platforms raises the jsii bundle size from ~6MiB to ~114MiB. This isn't just unacceptably large, it also prevents the bundle from being checked in to github repositories, which have a maximum file size of 100MiB.