### PR TITLE
Model license in JSII Assemblies & allow signing of Java artifacts

### DIFF
--- a/packages/jsii-calc-base/test/assembly.jsii
+++ b/packages/jsii-calc-base/test/assembly.jsii
@@ -1,5 +1,6 @@
 {
-  "fingerprint": "JYtYo+q7G8adUmsSLvMbHrmeDiHMVRdYU+iBAgcqDYs=",
+  "fingerprint": "sSxXNJ/dGt/v6Tm7/1IjgRx/oPq0wVG6WWSrZaPglLk=",
+  "license": "Apache-2.0",
   "name": "@scope/jsii-calc-base",
   "schema": "jsii/1.0",
   "targets": {

--- a/packages/jsii-calc-lib/test/assembly.jsii
+++ b/packages/jsii-calc-lib/test/assembly.jsii
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "tTyyMeA0wpOdqE9aJmKa9fhQf0MpOSDY+PF4SIE7wmM=",
+  "fingerprint": "zmdpszdkcQaxiwMA5nr+avUpv5ZGa+zrzFAdUIxnqTo=",
   "dependencies": {
     "@scope/jsii-calc-base": {
       "targets": {
@@ -20,6 +20,7 @@
       "version": "0.5.0-beta"
     }
   },
+  "license": "Apache-2.0",
   "name": "@scope/jsii-calc-lib",
   "schema": "jsii/1.0",
   "targets": {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "UZaeUlVhAy9PtnywqGQcQo4CT72A4giWdsGUTnLeZBE=",
+  "fingerprint": "YIOURB5Tj5Kj2w1IGOKGSNbNysK9fYLBJoDMCLVERII=",
   "bundled": {
     "jsii-calc-bundled": "^0.5.0-beta"
   },
@@ -43,6 +43,7 @@
       "version": "0.5.0-beta"
     }
   },
+  "license": "Apache-2.0",
   "name": "jsii-calc",
   "readme": {
     "markdown": "## JSII Calculator\n\nThis library is used to demonstrate and test the features of JSII\n"

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -3346,6 +3346,11 @@
 				}
 			}
 		},
+		"spdx-license-list": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-4.1.0.tgz",
+			"integrity": "sha512-nlyjgQUe1PgBGU0RdXIwo+N1VHI0XV/hxCBms8fhRDV7qottuPdX3gcTB4dpNnnQ/fIC3ymb/oWB6S8T6nQEnw=="
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -25,6 +25,7 @@
     "jsii-java-runtime": "^0.5.0-beta",
     "jsii-spec": "^0.5.0-beta",
     "source-map-support": "^0.5.6",
+    "spdx-license-list": "^4.1.0",
     "xmlbuilder": "^10.0.0",
     "yargs": "^12.0.0"
   },

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.Calculator.Base/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.Calculator.Base/.jsii
@@ -1,5 +1,6 @@
 {
-  "fingerprint": "JYtYo+q7G8adUmsSLvMbHrmeDiHMVRdYU+iBAgcqDYs=",
+  "fingerprint": "sSxXNJ/dGt/v6Tm7/1IjgRx/oPq0wVG6WWSrZaPglLk=",
+  "license": "Apache-2.0",
   "name": "@scope/jsii-calc-base",
   "schema": "jsii/1.0",
   "targets": {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
@@ -2,6 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Java bindings for @scope/jsii-calc-base</name>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+      <comments>An OSI-approved license</comments>
+    </license>
+  </licenses>
   <artifactId>calculator-base</artifactId>
   <groupId>com.amazonaws.jsii.tests</groupId>
   <version>0.5.0-beta</version>
@@ -80,7 +88,34 @@
   </build>
   <profiles>
     <profile>
-      <id>publishing</id>
+      <id>sign</id>
+      <activation>
+        <!-- See: https://maven.apache.org/plugins/maven-gpg-plugin/sign-mojo.html -->
+        <property>
+          <name>gpg.keyname</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>deploy</id>
       <activation>
         <property>
           <name>publish.url</name>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.Calculator.Lib/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.Calculator.Lib/.jsii
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "tTyyMeA0wpOdqE9aJmKa9fhQf0MpOSDY+PF4SIE7wmM=",
+  "fingerprint": "zmdpszdkcQaxiwMA5nr+avUpv5ZGa+zrzFAdUIxnqTo=",
   "dependencies": {
     "@scope/jsii-calc-base": {
       "targets": {
@@ -20,6 +20,7 @@
       "version": "0.5.0-beta"
     }
   },
+  "license": "Apache-2.0",
   "name": "@scope/jsii-calc-lib",
   "schema": "jsii/1.0",
   "targets": {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
@@ -2,6 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Java bindings for @scope/jsii-calc-lib</name>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+      <comments>An OSI-approved license</comments>
+    </license>
+  </licenses>
   <artifactId>calculator-lib</artifactId>
   <groupId>com.amazonaws.jsii.tests</groupId>
   <version>0.5.0-beta</version>
@@ -85,7 +93,34 @@
   </build>
   <profiles>
     <profile>
-      <id>publishing</id>
+      <id>sign</id>
+      <activation>
+        <!-- See: https://maven.apache.org/plugins/maven-gpg-plugin/sign-mojo.html -->
+        <property>
+          <name>gpg.keyname</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>deploy</id>
       <activation>
         <property>
           <name>publish.url</name>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.Calculator/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.Calculator/.jsii
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "UZaeUlVhAy9PtnywqGQcQo4CT72A4giWdsGUTnLeZBE=",
+  "fingerprint": "YIOURB5Tj5Kj2w1IGOKGSNbNysK9fYLBJoDMCLVERII=",
   "bundled": {
     "jsii-calc-bundled": "^0.5.0-beta"
   },
@@ -43,6 +43,7 @@
       "version": "0.5.0-beta"
     }
   },
+  "license": "Apache-2.0",
   "name": "jsii-calc",
   "readme": {
     "markdown": "## JSII Calculator\n\nThis library is used to demonstrate and test the features of JSII\n"

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
@@ -2,6 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Java bindings for jsii-calc</name>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <distribution>repo</distribution>
+      <comments>An OSI-approved license</comments>
+    </license>
+  </licenses>
   <artifactId>calculator</artifactId>
   <groupId>com.amazonaws.jsii.tests</groupId>
   <version>0.5.0-beta</version>
@@ -85,7 +93,34 @@
   </build>
   <profiles>
     <profile>
-      <id>publishing</id>
+      <id>sign</id>
+      <activation>
+        <!-- See: https://maven.apache.org/plugins/maven-gpg-plugin/sign-mojo.html -->
+        <property>
+          <name>gpg.keyname</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>deploy</id>
       <activation>
         <property>
           <name>publish.url</name>

--- a/packages/jsii-spec/lib/spec.ts
+++ b/packages/jsii-spec/lib/spec.ts
@@ -28,6 +28,11 @@ export interface Assembly extends Documentable {
     version: string;
 
     /**
+     * The SPDX name of the license this assembly is distributed on.
+     */
+    license: string;
+
+    /**
      * A map of target name to configuration, which is used when generating packages for
      * various languages.
      */

--- a/packages/jsii-spec/test/test.name-tree.ts
+++ b/packages/jsii-spec/test/test.name-tree.ts
@@ -14,6 +14,7 @@ export = testCase({
                 schema: spec.SchemaVersion.V1_0,
                 name: assemblyName,
                 version: '0.0.1',
+                license: 'NONE',
                 fingerprint: '<no-fingerprint>',
                 targets: {},
                 types: {

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -54,6 +54,7 @@ export async function compilePackage(packageDir: string, includeDirs = [ 'test',
         schema: spec.SchemaVersion.V1_0,
         name: pkg.name,
         version: pkg.version.replace(/\+.+$/, ''),
+        license: pkg.license,
         targets: {
             ...pkg.targets,
             // automatically add a "js" target based on the npm name.

--- a/packages/jsii/package-lock.json
+++ b/packages/jsii/package-lock.json
@@ -3304,6 +3304,11 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"spdx-license-list": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-4.1.0.tgz",
+			"integrity": "sha512-nlyjgQUe1PgBGU0RdXIwo+N1VHI0XV/hxCBms8fhRDV7qottuPdX3gcTB4dpNnnQ/fIC3ymb/oWB6S8T6nQEnw=="
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -34,6 +34,7 @@
     "sort-json": "^2.0.0",
     "source-map-loader": "^0.2.3",
     "source-map-support": "^0.5.6",
+    "spdx-license-list": "^4.1.0",
     "typescript": "^2.9.2",
     "yargs": "^11.0.0"
   },

--- a/packages/jsii/test/test.negatives.ts
+++ b/packages/jsii/test/test.negatives.ts
@@ -39,7 +39,10 @@ for (const source of fs.readdirSync(negativesDir)) {
             await compileSources(path.join(negativesDir, source),
                                  undefined /* No extra source */,
                                  undefined /* No external types */,
-                                 { schema: spec.SchemaVersion.V1_0, name: 'foo', version: 'bar', fingerprint: 'baz', targets: {}, types: {} },
+                                 {
+                                    schema: spec.SchemaVersion.V1_0, name: 'foo', version: 'bar', license: 'NONE', fingerprint: 'baz',
+                                    targets: {}, types: {}
+                                },
                                  true /* warnings as errors */);
         } catch (e) {
             for (const match of matchError) {


### PR DESCRIPTION
The License is necessary in the Maven POM in order to publish to Maven-Central. Additionally,
it is necessary that the objects are signed with a GPG key that is available on the MIT keyserver.
This change models the license as part of the JSII assemblies and requires the license to be a
valid SPDX identifier. This is translated in the Maven POM using the standard SPDX license list
(since the POM expects a full name and URL).

Additionally, POM allows signing of artifacts by setting (at least) the `gpg.keyname` property,
which can be achieved by adding `--mvn-D gpg.keyname=name@foo.bar` to the `jsii-pacmak`
invokation. The signatures are provided as `.asc` files next to the signed artifacts, as is done
by the `maven-gpg-plugin`.