### PR TITLE
Remove typescript source maps

### DIFF
--- a/packages/jsii-java-runtime-test/tsconfig.json
+++ b/packages/jsii-java-runtime-test/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-java-runtime/tsconfig.json
+++ b/packages/jsii-java-runtime/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-kernel/tsconfig.json
+++ b/packages/jsii-kernel/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
-
 import fs = require('fs-extra');
 import os = require('os');
 import path = require('path');

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -129,11 +129,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"buffer-from": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
-		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -3329,22 +3324,6 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
 		},
 		"spdx-license-list": {
 			"version": "4.1.0",

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -24,7 +24,6 @@
     "jsii-dotnet-generator": "^0.5.0-beta",
     "jsii-java-runtime": "^0.5.0-beta",
     "jsii-spec": "^0.5.0-beta",
-    "source-map-support": "^0.5.6",
     "spdx-license-list": "^4.1.0",
     "xmlbuilder": "^10.0.0",
     "yargs": "^12.0.0"

--- a/packages/jsii-pacmak/tsconfig.json
+++ b/packages/jsii-pacmak/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-runtime/lib/program.ts
+++ b/packages/jsii-runtime/lib/program.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register'
 import { KernelHost } from './host'
 import { InputOutput } from './in-out'
 

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -6836,22 +6836,6 @@
 				"urix": "^0.1.0"
 			}
 		},
-		"source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",

--- a/packages/jsii-runtime/package.json
+++ b/packages/jsii-runtime/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "jsii-kernel": "^0.5.0-beta",
-    "jsii-spec": "^0.5.0-beta",
-    "source-map-support": "^0.5.6"
+    "jsii-spec": "^0.5.0-beta"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/packages/jsii-runtime/tsconfig.json
+++ b/packages/jsii-runtime/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii-spec/tsconfig.json
+++ b/packages/jsii-spec/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
 import * as yargs from 'yargs';
 import { bundle } from '../lib/bundle';
 import { VERSION } from '../lib/version';

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -33,7 +33,6 @@
     "jsii-spec": "^0.5.0-beta",
     "sort-json": "^2.0.0",
     "source-map-loader": "^0.2.3",
-    "source-map-support": "^0.5.6",
     "spdx-license-list": "^4.1.0",
     "typescript": "^2.9.2",
     "yargs": "^11.0.0"

--- a/packages/jsii/tsconfig.json
+++ b/packages/jsii/tsconfig.json
@@ -44,8 +44,8 @@
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    // "inlineSourceMap": false,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": false,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */


### PR DESCRIPTION
Since we are not distributing the .ts files with our
modules, the source maps actually make it hard to diagnose issues
"in the field".

Developers can locally execute with source-map-support when they
are working on the jsii codebase.

Fixes #127

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
