### PR TITLE
Use jsii-java-runtime as a devDependency

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1180,11 +1180,10 @@ interface MavenDependency {
  * to Maven Central.
  */
 async function findJavaRuntimeLocalRepository() {
-    const localMavenRepo = path.resolve(path.join(__dirname, '..', '..', '..', 'jsii-java-runtime', 'maven-repo'));
-    if (await fs.pathExists(localMavenRepo)) {
-        logging.debug('Compiling against local jsii-java-runtime at:', localMavenRepo);
-        return localMavenRepo;
-    } else {
+    try {
+        const javaRuntime = require('jsii-java-runtime');
+        return javaRuntime.repository;
+    } catch (e) {
         return undefined;
     }
 }

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -25,11 +25,6 @@
 			"resolved": "https://registry.npmjs.org/@types/nodeunit/-/nodeunit-0.0.30.tgz",
 			"integrity": "sha1-SNLCcZoRjHcjuDMGw+gAsRor9ng="
 		},
-		"@types/semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
-		},
 		"@types/xmlbuilder": {
 			"version": "0.0.32",
 			"resolved": "https://registry.npmjs.org/@types/xmlbuilder/-/xmlbuilder-0.0.32.tgz",

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -12,7 +12,7 @@
     "build": "npm run gen && tsc && chmod +x bin/jsii-pacmak && tslint -p .",
     "watch": "tsc -w",
     "lint": "tslint -p . --force",
-    "test": "/bin/bash test/diff-test.sh",
+    "test": "/bin/bash test/diff-test.sh && /bin/bash test/build-test.sh",
     "package": "package-js"
   },
   "keywords": [
@@ -39,6 +39,7 @@
     "@types/yargs": "^11.1.1",
     "jsii-build-tools": "^0.6.2",
     "jsii-calc": "^0.6.2",
+    "jsii-java-runtime": "^0.6.2",
     "nodeunit": "^0.11.2",
     "tslint": "*",
     "typescript": "^2.9.2"

--- a/packages/jsii-pacmak/test/build-test.sh
+++ b/packages/jsii-pacmak/test/build-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+outdir=$(mktemp -d)
+bin/jsii-pacmak -o ${outdir} --recurse node_modules/jsii-calc -vv


### PR DESCRIPTION
Instead of looking up the maven repo of jsii-java-runtime in the repo structure, define it as a devDependency and attempt to `require` it.

If it exists, it adds the local maven-repo to the user.xml maven settings during build. Otherwise, it will just download from maven.

Also, adds a test to jsii-pacmak that recursively builds the entire jsii-calc stack in all languages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
