### PR TITLE
fix(kernel): validate presence of required struct properties

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1780,7 +1780,7 @@ export class StructPassing {
         };
     }
 
-    public static howManyVarArgsDidIPass(_positional: number, inputs: TopLevelStruct[]): number {
+    public static howManyVarArgsDidIPass(_positional: number, ...inputs: TopLevelStruct[]): number {
         return inputs.length;
     }
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -7837,13 +7837,9 @@
             {
               "name": "inputs",
               "type": {
-                "collection": {
-                  "elementtype": {
-                    "fqn": "jsii-calc.TopLevelStruct"
-                  },
-                  "kind": "array"
-                }
-              }
+                "fqn": "jsii-calc.TopLevelStruct"
+              },
+              "variadic": true
             }
           ],
           "returns": {
@@ -7851,7 +7847,8 @@
               "primitive": "number"
             }
           },
-          "static": true
+          "static": true,
+          "variadic": true
         },
         {
           "docs": {
@@ -9055,5 +9052,5 @@
     }
   },
   "version": "0.14.0",
-  "fingerprint": "FCuQcrhxNzRu5psy8XKe+fkbvJhTtFAEc2eiULxQP8w="
+  "fingerprint": "3KJr12zCrNOW5f2XkO6HxM761PQoUBbT9VLR5+foBOo="
 }

--- a/packages/jsii-kernel/test/test.kernel.ts
+++ b/packages/jsii-kernel/test/test.kernel.ts
@@ -1118,6 +1118,36 @@ defineTest('can set and retrieve union properties', async (test, sandbox) => {
     test.equal(get(sandbox, unionArray[1])('value'), 33);
 });
 
+defineTest('require presence of required properties -- top level', async (test, sandbox) => {
+    test.throws(() => {
+        sandbox.sinvoke({ fqn: 'jsii-calc.StructPassing', method: 'roundTrip', args: [
+            123,
+            { incomplete: true }
+        ]});
+    }, /Missing required properties for jsii-calc.TopLevelStruct: required,secondLevel/);
+});
+
+defineTest('require presence of required properties -- deeper level', async (test, sandbox) => {
+    test.throws(() => {
+        sandbox.sinvoke({ fqn: 'jsii-calc.StructPassing', method: 'roundTrip', args: [
+            123,
+            {
+                required: 'abc',
+                secondLevel: { alsoIncomplete: true, }
+            }
+        ]});
+    }, /Missing required properties for jsii-calc.SecondLevelStruct: deeperRequiredProp/);
+});
+
+defineTest('notice when an array is passed instead of varargs', async (test, sandbox) => {
+    test.throws(() => {
+        sandbox.sinvoke({ fqn: 'jsii-calc.StructPassing', method: 'howManyVarArgsDidIPass', args: [
+            123,
+            [ { required: 'abc', secondLevel: 6 } ]
+        ]});
+    }, /Got an array where a jsii-calc.TopLevelStruct was expected/);
+});
+
 defineTest('Object ID does not get re-allocated when the constructor passes "this" out', async (test, sandbox) => {
     sandbox.callbackHandler = makeSyncCallbackHandler((callback) => {
         test.equal(callback.invoke && callback.invoke.method, 'consumePartiallyInitializedThis');

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -7837,13 +7837,9 @@
             {
               "name": "inputs",
               "type": {
-                "collection": {
-                  "elementtype": {
-                    "fqn": "jsii-calc.TopLevelStruct"
-                  },
-                  "kind": "array"
-                }
-              }
+                "fqn": "jsii-calc.TopLevelStruct"
+              },
+              "variadic": true
             }
           ],
           "returns": {
@@ -7851,7 +7847,8 @@
               "primitive": "number"
             }
           },
-          "static": true
+          "static": true,
+          "variadic": true
         },
         {
           "docs": {
@@ -9055,5 +9052,5 @@
     }
   },
   "version": "0.14.0",
-  "fingerprint": "FCuQcrhxNzRu5psy8XKe+fkbvJhTtFAEc2eiULxQP8w="
+  "fingerprint": "3KJr12zCrNOW5f2XkO6HxM761PQoUBbT9VLR5+foBOo="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
@@ -19,8 +19,8 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         /// <remarks>stability: Experimental</remarks>
-        [JsiiMethod(name: "howManyVarArgsDidIPass", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"inputs\",\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}}}]")]
-        public static double HowManyVarArgsDidIPass(double _positional, ITopLevelStruct[] inputs)
+        [JsiiMethod(name: "howManyVarArgsDidIPass", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"inputs\",\"variadic\":true,\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}]")]
+        public static double HowManyVarArgsDidIPass(double _positional, ITopLevelStruct inputs)
         {
             return InvokeStaticMethod<double>(typeof(StructPassing), new object[]{_positional, inputs});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -19,8 +19,8 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Number howManyVarArgsDidIPass(final java.lang.Number _positional, final java.util.List<software.amazon.jsii.tests.calculator.TopLevelStruct> inputs) {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "howManyVarArgsDidIPass", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required"), java.util.Objects.requireNonNull(inputs, "inputs is required") });
+    public static java.lang.Number howManyVarArgsDidIPass(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct... inputs) {
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "howManyVarArgsDidIPass", java.lang.Number.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required") }), java.util.Arrays.<Object>stream(inputs)).toArray(Object[]::new));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -5341,7 +5341,7 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
 
     @jsii.member(jsii_name="howManyVarArgsDidIPass")
     @classmethod
-    def how_many_var_args_did_i_pass(cls, _positional: jsii.Number, inputs: typing.List["TopLevelStruct"]) -> jsii.Number:
+    def how_many_var_args_did_i_pass(cls, _positional: jsii.Number, *inputs: "TopLevelStruct") -> jsii.Number:
         """
         :param _positional: -
         :param inputs: -
@@ -5349,7 +5349,7 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         stability
         :stability: experimental
         """
-        return jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, inputs])
+        return jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs])
 
     @jsii.member(jsii_name="roundTrip")
     @classmethod

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -6436,12 +6436,12 @@ StructPassing
 
 
 
-   .. py:staticmethod:: howManyVarArgsDidIPass(_positional, inputs) -> number
+   .. py:staticmethod:: howManyVarArgsDidIPass(_positional, *inputs) -> number
 
       :param _positional: 
       :type _positional: number
-      :param inputs: 
-      :type inputs: :py:class:`~jsii-calc.TopLevelStruct`\ []
+      :param \*inputs: 
+      :type \*inputs: :py:class:`~jsii-calc.TopLevelStruct`\ 
       :rtype: number
 
 

--- a/packages/jsii-python-runtime/tests/test_compliance.py
+++ b/packages/jsii-python-runtime/tests/test_compliance.py
@@ -936,10 +936,10 @@ def test_passNestedScalar():
     assert output.second_level == 5
 
 def test_passStructsInVariadic():
-    output = StructPassing.how_many_var_args_did_i_pass(123, [
+    output = StructPassing.how_many_var_args_did_i_pass(123,
         TopLevelStruct(required='hello', second_level=1),
         TopLevelStruct(required='bye', second_level=SecondLevelStruct(deeper_required_prop='ciao'))
-    ])
+    )
     assert output == 2
 
 def test_structEquality():

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -1091,11 +1091,13 @@ assemblies
  │   │   ├── <initializer>() initializer (experimental)
  │   │   ├─┬ static howManyVarArgsDidIPass(_positional,inputs) method (experimental)
  │   │   │ ├── static
+ │   │   │ ├── variadic
  │   │   │ ├─┬ parameters
  │   │   │ │ ├─┬ _positional
  │   │   │ │ │ └── type: number
  │   │   │ │ └─┬ inputs
- │   │   │ │   └── type: Array<jsii-calc.TopLevelStruct>
+ │   │   │ │   ├── type: jsii-calc.TopLevelStruct
+ │   │   │ │   └── variadic
  │   │   │ └── returns: number
  │   │   └─┬ static roundTrip(_positional,input) method (experimental)
  │   │     ├── static


### PR DESCRIPTION
Detect when required struct properties are not supplied, so that
we can produce useful error messages to untyped jsii languages (in
particular, Python).

Also check for an array in place of a variadic argument, and throw
a hopefully helpful message to hint at a common misuse.

Fix the test to be actually variadic, which it wasn't :o.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
