### PR TITLE
deps(java): pin dependencies to current major

### DIFF
--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -52,14 +52,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>[2.9.8,)</version>
+            <version>[2.9.8,3)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.8,)</version>
+            <version>[2.9.8,3)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
@@ -73,14 +73,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>[3.0.2,)</version>
+            <version>[3.0.2,4)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>[1.3.2,)</version>
+            <version>[1.3.2,2)</version>
             <scope>provided</scope>
         </dependency>
 
@@ -88,7 +88,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.1</version>
+            <version>[5.4.1,6)</version>
             <scope>test</scope>
         </dependency>
 
@@ -96,7 +96,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.1</version>
+            <version>[5.4.1,6)</version>
             <scope>test</scope>
         </dependency>
 
@@ -104,7 +104,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.25.1</version>
+            <version>[2.25.1,3)</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -114,7 +114,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>[3.6.1,4)</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -155,12 +155,12 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>[2.22.0,3)</version>
             </plugin>
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>[2.22.0,3)</version>
             </plugin>
         </plugins>
     </build>

--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -114,7 +114,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>[3.6.1,4)</version>
+                <version>3.6.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -155,12 +155,12 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>[2.22.0,3)</version>
+                <version>2.22.0</version>
             </plugin>
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>[2.22.0,3)</version>
+                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Mitigate risks of new major versions of the JSII Java runtime causing
unexpected breakage when they release by pinning the dependencies to the
current major (`[A,B)` version spec is `A <= version < B`).

Fixes #602

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
