### PR TITLE
fix: fix usage of "external" stability

### DIFF
--- a/packages/codemaker/package-lock.json
+++ b/packages/codemaker/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemaker",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-build-tools/package-lock.json
+++ b/packages/jsii-build-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-build-tools",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1771,6 +1771,11 @@ export interface SecondLevelStruct {
     readonly deeperOptionalProp?: string;
 }
 
+/**
+ * Just because we can.
+ *
+ * @stability external
+ */
 export class StructPassing {
     public static roundTrip(_positional: number, input: TopLevelStruct): TopLevelStruct {
         return {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -7808,23 +7808,24 @@
     "jsii-calc.StructPassing": {
       "assembly": "jsii-calc",
       "docs": {
-        "stability": "experimental"
+        "stability": "external",
+        "summary": "Just because we can."
       },
       "fqn": "jsii-calc.StructPassing",
       "initializer": {},
       "kind": "class",
       "locationInModule": {
         "filename": "lib/compliance.ts",
-        "line": 1774
+        "line": 1779
       },
       "methods": [
         {
           "docs": {
-            "stability": "experimental"
+            "stability": "external"
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1783
+            "line": 1788
           },
           "name": "howManyVarArgsDidIPass",
           "parameters": [
@@ -7852,11 +7853,11 @@
         },
         {
           "docs": {
-            "stability": "experimental"
+            "stability": "external"
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1775
+            "line": 1780
           },
           "name": "roundTrip",
           "parameters": [
@@ -9052,5 +9053,5 @@
     }
   },
   "version": "0.14.1",
-  "fingerprint": "+yGMmfs+WJP2iATk7OXRXw8oP6Ov+VOkOf8BaxaCbN4="
+  "fingerprint": "31WUucZoc5uXBpVM+LdQz2noSFtdRXgTdT58JECw1ow="
 }

--- a/packages/jsii-diff/package-lock.json
+++ b/packages/jsii-diff/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-diff",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -327,12 +327,6 @@
 			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
 			"dev": true
 		},
-		"case": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/case/-/case-1.6.1.tgz",
-			"integrity": "sha512-N0rDB5ftMDKANGsIBRWPWcG0VIKtirgqcXb2vKFi66ySAjXVEwbfCN7ass1mkdXO8fbol3RfbWlQ9KyBX2F/Gg==",
-			"dev": true
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -384,11 +378,6 @@
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
-		},
-		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -495,12 +484,6 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
-		"deep-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-			"dev": true
-		},
 		"default-require-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -514,18 +497,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
-		"detect-indent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
-		},
-		"detect-newline": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
 		},
 		"diff": {
@@ -1016,83 +987,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jsii": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii/-/jsii-0.14.0.tgz",
-			"integrity": "sha512-hs6LobQPIOrcaTCZ4KkhT2lTE6uaLAyXPWD1sySj7ekWs6W64DplrzK5Fg5K1y0MoegodKzt4IcX7ST6kBEFhw==",
-			"dev": true,
-			"requires": {
-				"case": "^1.6.1",
-				"colors": "^1.3.3",
-				"deep-equal": "^1.0.1",
-				"fs-extra": "^8.0.1",
-				"jsii-spec": "^0.14.0",
-				"log4js": "^4.3.1",
-				"semver": "^6.1.1",
-				"sort-json": "^2.0.0",
-				"spdx-license-list": "^6.0.0",
-				"typescript": "^3.5.2",
-				"yargs": "^13.2.4"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"semver": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-					"integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
-					"dev": true
-				}
-			}
-		},
-		"jsii-build-tools": {
-			"version": "file:../jsii-build-tools",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0"
-			}
-		},
-		"jsii-reflect": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-0.14.0.tgz",
-			"integrity": "sha512-lnOsTYe9uWi5V/Sxg8Mpr/Nd6plArulhyreqla2/mOJtKZCxsWmGG5A99lOOBduGg1Pjc+KZbmYL+JvYbHQ7Cg==",
-			"requires": {
-				"colors": "^1.3.3",
-				"fs-extra": "^8.0.1",
-				"jsii-spec": "^0.14.0",
-				"oo-ascii-tree": "^0.14.0",
-				"yargs": "^13.2.4"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				}
-			}
-		},
-		"jsii-spec": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-spec/-/jsii-spec-0.14.0.tgz",
-			"integrity": "sha512-hXSAtc4dhy9O0m41Eg6dufuvbDpVk7Kfb8Tu5xINwZe/8iXwCWS3XrnrkjzBrk82RgnPF6x+NQ9+i4lnqscJ4w==",
-			"requires": {
-				"jsonschema": "^1.2.4"
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1124,11 +1018,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -1400,11 +1289,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"oo-ascii-tree": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-0.14.0.tgz",
-			"integrity": "sha512-GkVJc1rZMapZyX/AMHciiQaLd2xMKbnCpfDD73mkqg9FJSGB6543fCRboLesnoGTpUENkpntghbmGsMRqoW4kQ=="
 		},
 		"opener": {
 			"version": "1.5.1",
@@ -1731,17 +1615,6 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
 		},
-		"sort-json": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.0.tgz",
-			"integrity": "sha512-OgXPErPJM/rBK5OhzIJ+etib/BmLQ1JY55Nb/ElhoWUec62pXNF/X6DrecHq3NW5OAGX0KxYD7m0HtgB9dvGeA==",
-			"dev": true,
-			"requires": {
-				"detect-indent": "^5.0.0",
-				"detect-newline": "^2.1.0",
-				"minimist": "^1.2.0"
-			}
-		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1810,12 +1683,6 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-			"dev": true
-		},
-		"spdx-license-list": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.0.0.tgz",
-			"integrity": "sha512-TIwgF7P7bE3MLnE5Oh1zgMNu6W0An1ASf8uoe3P3ZA3sVf4nJ9m9XDzudKYrmWVZ4TR0i/7tWfaH2AWPtc46Ag==",
 			"dev": true
 		},
 		"sprintf-js": {
@@ -2316,6 +2183,13 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
 			"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
 			"dev": true
+		},
+		"jsii-build-tools": {
+			"version": "file:../jsii-build-tools",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0"
+			}
 		}
 	}
 }

--- a/packages/jsii-dotnet-jsonmodel/package-lock.json
+++ b/packages/jsii-dotnet-jsonmodel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-dotnet-jsonmodel",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Stability.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Stability.cs
@@ -8,6 +8,7 @@ namespace Amazon.JSII.JsonModel.Spec
     {
         Stable,
         Experimental,
-        Deprecated
+        Deprecated,
+        External
     }
 }

--- a/packages/jsii-dotnet-runtime-test/package-lock.json
+++ b/packages/jsii-dotnet-runtime-test/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-dotnet-runtime-test",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-dotnet-runtime/package-lock.json
+++ b/packages/jsii-dotnet-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-dotnet-runtime",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-java-runtime/package-lock.json
+++ b/packages/jsii-java-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-java-runtime",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Stability.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Stability.java
@@ -40,6 +40,12 @@ public @interface Stability {
      * The API may emit warnings. Backward compatibility is not guaranteed. APIs annotated with the {@code Deprecated}
      * level should also be annotated with the standard {@link Deprecated} annotation.
      */
-    Deprecated
+    Deprecated,
+
+    /**
+     * This API is an representation of an API managed elsewhere and follows
+     * the other API's versioning model.
+     */
+    External
   }
 }

--- a/packages/jsii-kernel/package-lock.json
+++ b/packages/jsii-kernel/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-kernel",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-pacmak",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -109,13 +109,6 @@
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@scope/jsii-calc-lib": {
-			"version": "file:../jsii-calc-lib",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base"
 			}
 		},
 		"@types/clone": {
@@ -390,16 +383,6 @@
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
-		"codemaker": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-0.14.0.tgz",
-			"integrity": "sha512-JNeABIthDEeKk0khdnMw2aRdc7w0MFfmbB0b7HKw/4IHlw6MtNskyyEXPYqbhLEhmlMlOnVcVJH+S4AQgE8eVA==",
-			"requires": {
-				"camelcase": "^5.3.1",
-				"decamelize": "^1.2.0",
-				"fs-extra": "^8.0.1"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -418,11 +401,6 @@
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
-		},
-		"colors": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -1037,65 +1015,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jsii-build-tools": {
-			"version": "file:../jsii-build-tools",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0"
-			}
-		},
-		"jsii-calc": {
-			"version": "file:../jsii-calc",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base",
-				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
-				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
-				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			}
-		},
-		"jsii-dotnet-generator": {
-			"version": "file:../jsii-dotnet-generator",
-			"dev": true,
-			"requires": {
-				"jsii-dotnet-jsonmodel": "file:../jsii-dotnet-jsonmodel"
-			}
-		},
-		"jsii-dotnet-jsonmodel": {
-			"version": "file:../jsii-dotnet-jsonmodel",
-			"dev": true
-		},
-		"jsii-dotnet-runtime": {
-			"version": "file:../jsii-dotnet-runtime",
-			"dev": true,
-			"requires": {
-				"jsii-dotnet-jsonmodel": "file:../jsii-dotnet-jsonmodel"
-			}
-		},
-		"jsii-java-runtime": {
-			"version": "file:../jsii-java-runtime",
-			"dev": true
-		},
-		"jsii-reflect": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-0.14.0.tgz",
-			"integrity": "sha512-lnOsTYe9uWi5V/Sxg8Mpr/Nd6plArulhyreqla2/mOJtKZCxsWmGG5A99lOOBduGg1Pjc+KZbmYL+JvYbHQ7Cg==",
-			"requires": {
-				"colors": "^1.3.3",
-				"fs-extra": "^8.0.1",
-				"jsii-spec": "^0.14.0",
-				"oo-ascii-tree": "^0.14.0",
-				"yargs": "^13.2.4"
-			}
-		},
-		"jsii-spec": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-spec/-/jsii-spec-0.14.0.tgz",
-			"integrity": "sha512-hXSAtc4dhy9O0m41Eg6dufuvbDpVk7Kfb8Tu5xINwZe/8iXwCWS3XrnrkjzBrk82RgnPF6x+NQ9+i4lnqscJ4w==",
-			"requires": {
-				"jsonschema": "^1.2.4"
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1127,11 +1046,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -1397,11 +1311,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"oo-ascii-tree": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-0.14.0.tgz",
-			"integrity": "sha512-GkVJc1rZMapZyX/AMHciiQaLd2xMKbnCpfDD73mkqg9FJSGB6543fCRboLesnoGTpUENkpntghbmGsMRqoW4kQ=="
 		},
 		"opener": {
 			"version": "1.5.1",
@@ -2334,6 +2243,52 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
 			"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+			"dev": true
+		},
+		"@scope/jsii-calc-lib": {
+			"version": "file:../jsii-calc-lib",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base"
+			}
+		},
+		"jsii-build-tools": {
+			"version": "file:../jsii-build-tools",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0"
+			}
+		},
+		"jsii-calc": {
+			"version": "file:../jsii-calc",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base",
+				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
+				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
+				"jsii-calc-bundled": "file:../jsii-calc-bundled"
+			}
+		},
+		"jsii-dotnet-generator": {
+			"version": "file:../jsii-dotnet-generator",
+			"dev": true,
+			"requires": {
+				"jsii-dotnet-jsonmodel": "file:../jsii-dotnet-jsonmodel"
+			}
+		},
+		"jsii-dotnet-jsonmodel": {
+			"version": "file:../jsii-dotnet-jsonmodel",
+			"dev": true
+		},
+		"jsii-dotnet-runtime": {
+			"version": "file:../jsii-dotnet-runtime",
+			"dev": true,
+			"requires": {
+				"jsii-dotnet-jsonmodel": "file:../jsii-dotnet-jsonmodel"
+			}
+		},
+		"jsii-java-runtime": {
+			"version": "file:../jsii-java-runtime",
 			"dev": true
 		}
 	}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -7808,23 +7808,24 @@
     "jsii-calc.StructPassing": {
       "assembly": "jsii-calc",
       "docs": {
-        "stability": "experimental"
+        "stability": "external",
+        "summary": "Just because we can."
       },
       "fqn": "jsii-calc.StructPassing",
       "initializer": {},
       "kind": "class",
       "locationInModule": {
         "filename": "lib/compliance.ts",
-        "line": 1774
+        "line": 1779
       },
       "methods": [
         {
           "docs": {
-            "stability": "experimental"
+            "stability": "external"
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1783
+            "line": 1788
           },
           "name": "howManyVarArgsDidIPass",
           "parameters": [
@@ -7852,11 +7853,11 @@
         },
         {
           "docs": {
-            "stability": "experimental"
+            "stability": "external"
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1775
+            "line": 1780
           },
           "name": "roundTrip",
           "parameters": [
@@ -9052,5 +9053,5 @@
     }
   },
   "version": "0.14.1",
-  "fingerprint": "+yGMmfs+WJP2iATk7OXRXw8oP6Ov+VOkOf8BaxaCbN4="
+  "fingerprint": "31WUucZoc5uXBpVM+LdQz2noSFtdRXgTdT58JECw1ow="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
@@ -2,7 +2,8 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
-    /// <remarks>stability: Experimental</remarks>
+    /// <summary>Just because we can.</summary>
+    /// <remarks>stability: External</remarks>
     [JsiiClass(nativeType: typeof(StructPassing), fullyQualifiedName: "jsii-calc.StructPassing")]
     public class StructPassing : DeputyBase
     {
@@ -18,14 +19,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
-        /// <remarks>stability: Experimental</remarks>
+        /// <remarks>stability: External</remarks>
         [JsiiMethod(name: "howManyVarArgsDidIPass", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"inputs\",\"variadic\":true,\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}]")]
         public static double HowManyVarArgsDidIPass(double _positional, ITopLevelStruct inputs)
         {
             return InvokeStaticMethod<double>(typeof(StructPassing), new object[]{_positional, inputs});
         }
 
-        /// <remarks>stability: Experimental</remarks>
+        /// <remarks>stability: External</remarks>
         [JsiiMethod(name: "roundTrip", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"input\",\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}]")]
         public static ITopLevelStruct RoundTrip(double _positional, ITopLevelStruct input)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -1,10 +1,10 @@
 package software.amazon.jsii.tests.calculator;
 
 /**
- * EXPERIMENTAL
+ * Just because we can.
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
-@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StructPassing")
 public class StructPassing extends software.amazon.jsii.JsiiObject {
     protected StructPassing(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
@@ -16,17 +16,15 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
     }
 
     /**
-     * EXPERIMENTAL
      */
-    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
     public static java.lang.Number howManyVarArgsDidIPass(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct... inputs) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "howManyVarArgsDidIPass", java.lang.Number.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required") }), java.util.Arrays.<Object>stream(inputs)).toArray(Object[]::new));
     }
 
     /**
-     * EXPERIMENTAL
      */
-    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
     public static software.amazon.jsii.tests.calculator.TopLevelStruct roundTrip(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct input) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "roundTrip", software.amazon.jsii.tests.calculator.TopLevelStruct.class, new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required"), java.util.Objects.requireNonNull(input, "input is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -5332,10 +5332,7 @@ class StripInternal(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StripInternal"
 
 
 class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"):
-    """
-    stability
-    :stability: experimental
-    """
+    """Just because we can."""
     def __init__(self) -> None:
         jsii.create(StructPassing, self, [])
 
@@ -5345,9 +5342,6 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         """
         :param _positional: -
         :param inputs: -
-
-        stability
-        :stability: experimental
         """
         return jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs])
 
@@ -5360,9 +5354,6 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         :param required: This is a required field.
         :param second_level: A union to really stress test our serialization.
         :param optional: You don't have to pass this.
-
-        stability
-        :stability: experimental
         """
         input = TopLevelStruct(required=required, second_level=second_level, optional=optional)
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -6435,6 +6435,10 @@ StructPassing
 
 
 
+   Just because we can.
+
+
+
 
    .. py:staticmethod:: howManyVarArgsDidIPass(_positional, *inputs) -> number
 

--- a/packages/jsii-reflect/package-lock.json
+++ b/packages/jsii-reflect/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-reflect",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -391,13 +391,6 @@
 				}
 			}
 		},
-		"@scope/jsii-calc-lib": {
-			"version": "file:../jsii-calc-lib",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -648,15 +641,6 @@
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
-		},
-		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
 		},
 		"async-limiter": {
 			"version": "1.0.0",
@@ -926,12 +910,6 @@
 				"rsvp": "^4.8.4"
 			}
 		},
-		"case": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/case/-/case-1.6.1.tgz",
-			"integrity": "sha512-N0rDB5ftMDKANGsIBRWPWcG0VIKtirgqcXb2vKFi66ySAjXVEwbfCN7ass1mkdXO8fbol3RfbWlQ9KyBX2F/Gg==",
-			"dev": true
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -1138,12 +1116,6 @@
 				}
 			}
 		},
-		"date-format": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
-			"integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
-			"dev": true
-		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1162,12 +1134,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
-		},
-		"deep-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
 			"dev": true
 		},
 		"deep-is": {
@@ -1230,12 +1196,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
-		},
-		"detect-indent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
 		},
 		"detect-newline": {
@@ -1586,12 +1546,6 @@
 				"locate-path": "^3.0.0"
 			}
 		},
-		"flatted": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-			"dev": true
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1653,28 +1607,28 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
@@ -1685,14 +1639,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
@@ -1703,42 +1657,42 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "4.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"optional": true,
@@ -1748,28 +1702,28 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"dev": true,
 					"optional": true,
@@ -1779,14 +1733,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -1803,7 +1757,7 @@
 				},
 				"glob": {
 					"version": "7.1.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"dev": true,
 					"optional": true,
@@ -1818,14 +1772,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
@@ -1835,7 +1789,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"optional": true,
@@ -1845,7 +1799,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -1856,21 +1810,21 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
@@ -1880,14 +1834,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
@@ -1897,14 +1851,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"dev": true,
 					"optional": true,
@@ -1915,7 +1869,7 @@
 				},
 				"minizlib": {
 					"version": "1.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 					"dev": true,
 					"optional": true,
@@ -1925,7 +1879,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
@@ -1935,14 +1889,14 @@
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
 					"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 					"dev": true,
 					"optional": true,
@@ -1954,7 +1908,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"dev": true,
 					"optional": true,
@@ -1973,7 +1927,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -1984,14 +1938,14 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
 					"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
 					"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 					"dev": true,
 					"optional": true,
@@ -2002,7 +1956,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -2015,21 +1969,21 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
@@ -2039,21 +1993,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -2064,21 +2018,21 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
@@ -2091,7 +2045,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -2100,7 +2054,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
@@ -2116,7 +2070,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 					"dev": true,
 					"optional": true,
@@ -2126,49 +2080,49 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
@@ -2180,7 +2134,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -2190,7 +2144,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
@@ -2200,14 +2154,14 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.8",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"dev": true,
 					"optional": true,
@@ -2223,14 +2177,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
@@ -2240,14 +2194,14 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"dev": true,
 					"optional": true
@@ -3511,58 +3465,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jsii": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii/-/jsii-0.14.0.tgz",
-			"integrity": "sha512-hs6LobQPIOrcaTCZ4KkhT2lTE6uaLAyXPWD1sySj7ekWs6W64DplrzK5Fg5K1y0MoegodKzt4IcX7ST6kBEFhw==",
-			"dev": true,
-			"requires": {
-				"case": "^1.6.1",
-				"colors": "^1.3.3",
-				"deep-equal": "^1.0.1",
-				"fs-extra": "^8.0.1",
-				"jsii-spec": "^0.14.0",
-				"log4js": "^4.3.1",
-				"semver": "^6.1.1",
-				"sort-json": "^2.0.0",
-				"spdx-license-list": "^6.0.0",
-				"typescript": "^3.5.2",
-				"yargs": "^13.2.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-					"integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
-					"dev": true
-				}
-			}
-		},
-		"jsii-build-tools": {
-			"version": "file:../jsii-build-tools",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0"
-			}
-		},
-		"jsii-calc": {
-			"version": "file:../jsii-calc",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base",
-				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
-				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
-				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			}
-		},
-		"jsii-spec": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-spec/-/jsii-spec-0.14.0.tgz",
-			"integrity": "sha512-hXSAtc4dhy9O0m41Eg6dufuvbDpVk7Kfb8Tu5xINwZe/8iXwCWS3XrnrkjzBrk82RgnPF6x+NQ9+i4lnqscJ4w==",
-			"requires": {
-				"jsonschema": "^1.2.4"
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3603,11 +3505,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3696,36 +3593,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
-		},
-		"log4js": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
-			"integrity": "sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==",
-			"dev": true,
-			"requires": {
-				"date-format": "^2.0.0",
-				"debug": "^4.1.1",
-				"flatted": "^2.0.0",
-				"rfdc": "^1.1.4",
-				"streamroller": "^1.0.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -4104,11 +3971,6 @@
 			"requires": {
 				"wrappy": "1"
 			}
-		},
-		"oo-ascii-tree": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-0.14.0.tgz",
-			"integrity": "sha512-GkVJc1rZMapZyX/AMHciiQaLd2xMKbnCpfDD73mkqg9FJSGB6543fCRboLesnoGTpUENkpntghbmGsMRqoW4kQ=="
 		},
 		"optimist": {
 			"version": "0.6.1",
@@ -4564,12 +4426,6 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
-		"rfdc": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-			"integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
-			"dev": true
-		},
 		"rimraf": {
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -4815,17 +4671,6 @@
 				}
 			}
 		},
-		"sort-json": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.0.tgz",
-			"integrity": "sha512-OgXPErPJM/rBK5OhzIJ+etib/BmLQ1JY55Nb/ElhoWUec62pXNF/X6DrecHq3NW5OAGX0KxYD7m0HtgB9dvGeA==",
-			"dev": true,
-			"requires": {
-				"detect-indent": "^5.0.0",
-				"detect-newline": "^2.1.0",
-				"minimist": "^1.2.0"
-			}
-		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4893,12 +4738,6 @@
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
-		"spdx-license-list": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.0.0.tgz",
-			"integrity": "sha512-TIwgF7P7bE3MLnE5Oh1zgMNu6W0An1ASf8uoe3P3ZA3sVf4nJ9m9XDzudKYrmWVZ4TR0i/7tWfaH2AWPtc46Ag==",
-			"dev": true
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4957,47 +4796,6 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
-		},
-		"streamroller": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.6.tgz",
-			"integrity": "sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==",
-			"dev": true,
-			"requires": {
-				"async": "^2.6.2",
-				"date-format": "^2.0.0",
-				"debug": "^3.2.6",
-				"fs-extra": "^7.0.1",
-				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
 		},
 		"string-length": {
 			"version": "2.0.0",
@@ -5514,6 +5312,30 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
+			}
+		},
+		"@scope/jsii-calc-lib": {
+			"version": "file:../jsii-calc-lib",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base"
+			}
+		},
+		"jsii-build-tools": {
+			"version": "file:../jsii-build-tools",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0"
+			}
+		},
+		"jsii-calc": {
+			"version": "file:../jsii-calc",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base",
+				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
+				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
+				"jsii-calc-bundled": "file:../jsii-calc-bundled"
 			}
 		}
 	}

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -1086,10 +1086,10 @@ assemblies
  │   │   ├── <initializer>() initializer (experimental)
  │   │   └─┬ youSeeMe property (experimental)
  │   │     └── type: string
- │   ├─┬ class StructPassing (experimental)
+ │   ├─┬ class StructPassing
  │   │ └─┬ members
- │   │   ├── <initializer>() initializer (experimental)
- │   │   ├─┬ static howManyVarArgsDidIPass(_positional,inputs) method (experimental)
+ │   │   ├── <initializer>() initializer
+ │   │   ├─┬ static howManyVarArgsDidIPass(_positional,inputs) method
  │   │   │ ├── static
  │   │   │ ├── variadic
  │   │   │ ├─┬ parameters
@@ -1099,7 +1099,7 @@ assemblies
  │   │   │ │   ├── type: jsii-calc.TopLevelStruct
  │   │   │ │   └── variadic
  │   │   │ └── returns: number
- │   │   └─┬ static roundTrip(_positional,input) method (experimental)
+ │   │   └─┬ static roundTrip(_positional,input) method
  │   │     ├── static
  │   │     ├─┬ parameters
  │   │     │ ├─┬ _positional

--- a/packages/jsii-ruby-runtime/package-lock.json
+++ b/packages/jsii-ruby-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-ruby-runtime",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-runtime",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -167,20 +167,6 @@
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@scope/jsii-calc-base": {
-			"version": "file:../jsii-calc-base",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-			}
-		},
-		"@scope/jsii-calc-lib": {
-			"version": "file:../jsii-calc-lib",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -978,7 +964,8 @@
 		"chownr": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -1900,14 +1887,6 @@
 			"resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
 			"integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
 			"dev": true
-		},
-		"fs-minipass": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
-			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
-			"requires": {
-				"minipass": "^2.2.1"
-			}
 		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
@@ -3109,41 +3088,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jsii-build-tools": {
-			"version": "file:../jsii-build-tools",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0"
-			}
-		},
-		"jsii-calc": {
-			"version": "file:../jsii-calc",
-			"dev": true,
-			"requires": {
-				"@scope/jsii-calc-base": "file:../jsii-calc-base",
-				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
-				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
-				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			}
-		},
-		"jsii-kernel": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-kernel/-/jsii-kernel-0.14.0.tgz",
-			"integrity": "sha512-cOQkhzQ6CaeFUuFqppt7PWA3dAQaGQ/zzR9VqND/wyUOQpjZAhZi4NuImoxXet+wNpXJVTnXQyOKIGy6tleMFQ==",
-			"requires": {
-				"jsii-spec": "^0.14.0",
-				"source-map": "^0.7.3",
-				"tar": "^4.4.10"
-			}
-		},
-		"jsii-spec": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-spec/-/jsii-spec-0.14.0.tgz",
-			"integrity": "sha512-hXSAtc4dhy9O0m41Eg6dufuvbDpVk7Kfb8Tu5xINwZe/8iXwCWS3XrnrkjzBrk82RgnPF6x+NQ9+i4lnqscJ4w==",
-			"requires": {
-				"jsonschema": "^1.2.4"
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3176,11 +3120,6 @@
 			"requires": {
 				"minimist": "^1.2.0"
 			}
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -3474,6 +3413,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -3482,16 +3422,9 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
-			}
-		},
-		"minizlib": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-			"requires": {
-				"minipass": "^2.2.1"
 			}
 		},
 		"mississippi": {
@@ -3537,6 +3470,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -3544,7 +3478,8 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
 				}
 			}
 		},
@@ -4409,7 +4344,8 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -4652,7 +4588,8 @@
 		"source-map": {
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+			"dev": true
 		},
 		"source-map-loader": {
 			"version": "0.2.4",
@@ -5015,27 +4952,6 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
-		},
-		"tar": {
-			"version": "4.4.10",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
-			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
-			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.5",
-				"minizlib": "^1.2.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.3"
-			},
-			"dependencies": {
-				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
-				}
-			}
 		},
 		"terser": {
 			"version": "4.1.2",
@@ -5758,6 +5674,37 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
 			"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
 			"dev": true
+		},
+		"@scope/jsii-calc-base": {
+			"version": "file:../jsii-calc-base",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
+			}
+		},
+		"@scope/jsii-calc-lib": {
+			"version": "file:../jsii-calc-lib",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base"
+			}
+		},
+		"jsii-build-tools": {
+			"version": "file:../jsii-build-tools",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0"
+			}
+		},
+		"jsii-calc": {
+			"version": "file:../jsii-calc",
+			"dev": true,
+			"requires": {
+				"@scope/jsii-calc-base": "file:../jsii-calc-base",
+				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
+				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
+				"jsii-calc-bundled": "file:../jsii-calc-bundled"
+			}
 		}
 	}
 }

--- a/packages/jsii-spec/package-lock.json
+++ b/packages/jsii-spec/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii-spec",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/jsii/package-lock.json
+++ b/packages/jsii/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jsii",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1028,21 +1028,6 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
-		"jsii-build-tools": {
-			"version": "file:../jsii-build-tools",
-			"dev": true,
-			"requires": {
-				"fs-extra": "^8.1.0"
-			}
-		},
-		"jsii-spec": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/jsii-spec/-/jsii-spec-0.14.0.tgz",
-			"integrity": "sha512-hXSAtc4dhy9O0m41Eg6dufuvbDpVk7Kfb8Tu5xINwZe/8iXwCWS3XrnrkjzBrk82RgnPF6x+NQ9+i4lnqscJ4w==",
-			"requires": {
-				"jsonschema": "^1.2.4"
-			}
-		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1074,11 +1059,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonschema": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-			"integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -2283,6 +2263,13 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
 			"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
 			"dev": true
+		},
+		"jsii-build-tools": {
+			"version": "file:../jsii-build-tools",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^8.1.0"
+			}
 		}
 	}
 }

--- a/packages/oo-ascii-tree/package-lock.json
+++ b/packages/oo-ascii-tree/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "oo-ascii-tree",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Stabilities have representations in runtimes, and the .NET
generator has an enum that also had to be updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
