### PR TITLE
fix(dotnet): use fully-qualified type names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # jsii
 
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=aws/jsii)](https://dependabot.com)
 ![Build Status](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiOThRRFVsVlRBTEhocVZOckE0bFlFWEtwNU0xUmtNUlRRclY0R2VYTGJaOXRlaVdaVnREV2lhVGtDUzQzUDRMMCtuYWpSTWo4N1FGTEV5Zm9yZ0dEb2dBPSIsIml2UGFyYW1ldGVyU3BlYyI6InFVbktYSlpDem1YN1JCeU8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+[![npm](https://img.shields.io/npm/v/jsii)](https://www.npmjs.com/package/jsii)
 
 __jsii__ allows code in any language to naturally interact with JavaScript classes.
 
@@ -281,7 +283,7 @@ jsii configuration is read from the `jsii` section in the module's
    __jsii-pacmak__. This is where target artifacts are emitted during packaging.
    Each artifact will be emitted under `<outdir>/<target>` (e.g. `dist/java`,
    `dist/js`, etc). Conventionally we use `"dist"` for outdir.
- * `tsc` - this section allows to adjust the compiler options of the generated `tsconfig.json`. 
+ * `tsc` - this section allows to adjust the compiler options of the generated `tsconfig.json`.
     Currently you can set `outDir` and `rootDir`. Setting `rootDir` automatically adjusts the `include` config.
 
 ### Java

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
@@ -37,8 +37,7 @@ namespace Amazon.JSII.Generator.UnitTests
             AssertUsings
             (
                 usings,
-                "using Amazon.JSII.Runtime.Deputy;",
-                "using MyNamespace;"
+                "using Amazon.JSII.Runtime.Deputy;"
             );
         }
 
@@ -236,7 +235,6 @@ namespace Amazon.JSII.Generator.UnitTests
             AssertUsings
             (
                 usings,
-                "using AAA;",
                 "using Amazon.JSII.Runtime.Deputy;"
             );
         }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/NamespaceSetTests.cs
@@ -25,31 +25,6 @@ namespace Amazon.JSII.Generator.UnitTests
             }
         }
 
-        [Fact(DisplayName = Prefix + nameof(CreatesUsingStatementForType))]
-        public void CreatesUsingStatementForType()
-        {
-            EnumType type = new EnumType
-            (
-                fullyQualifiedName: "myEnumFqn",
-                assembly: "myModule",
-                name: "myEnum",
-                members: new EnumMember[] { }
-            );
-
-            Symbols.MapNamespace(type.QualifiedNamespace, "MyNamespace");
-
-            NamespaceSet namespaces = new NamespaceSet(Symbols, SF.ParseName("MyCurrentNamespace"));
-            namespaces.Add(type);
-
-            SyntaxList<UsingDirectiveSyntax> usings = namespaces.GetUsings();
-            AssertUsings
-            (
-                usings,
-                "using Amazon.JSII.Runtime.Deputy;",
-                "using MyNamespace;"
-            );
-        }
-
         [Fact(DisplayName = Prefix + nameof(CreatesUsingStatementForObjectReference))]
         public void CreatesUsingStatementForObjectReference()
         {

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapExtensions.cs
@@ -70,50 +70,50 @@ namespace Amazon.JSII.Generator.UnitTests
                     var defaultName = frameworkName;
     
                     symbols
-                        .GetInterfaceProxyName(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceProxyName(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(proxyName);
                     symbols
-                        .GetInterfaceDefaultName(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceDefaultName(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(defaultName);
                     symbols
-                        .GetInterfaceProxyNameSyntaxToken(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceProxyNameSyntaxToken(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(SF.ParseToken(proxyName));
                     symbols
-                        .GetInterfaceDefaultNameSyntaxToken(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceDefaultNameSyntaxToken(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(SF.ParseToken(defaultName));
                     symbols
-                        .GetInterfaceProxyNameSyntax(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceProxyNameSyntax(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(SF.ParseName(proxyName));
                     symbols
-                        .GetInterfaceDefaultNameSyntax(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                        .GetInterfaceDefaultNameSyntax(Arg.Is<InterfaceType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                         .Returns(SF.ParseName(defaultName));
     
                     frameworkName = $"I{frameworkName}";
                     break;
             case TypeKind.Class:
                 symbols
-                    .GetAbstractClassProxyName(Arg.Is<ClassType>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                    .GetAbstractClassProxyName(Arg.Is<ClassType>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                     .Returns(proxyName);
                 break;
             }
             
             symbols
-                .GetName(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetName(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(frameworkName);
             symbols
-                .GetName(Arg.Is<string>(fqn => fqn == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetName(Arg.Is<string>(fqn => fqn == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(frameworkName);
             symbols
-                .GetNameSyntaxToken(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetNameSyntaxToken(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(SF.ParseToken(frameworkName));
             symbols
-                .GetNameSyntaxToken(Arg.Is<string>(fqn => fqn == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetNameSyntaxToken(Arg.Is<string>(fqn => fqn == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(SF.ParseToken(frameworkName));
             symbols
-                .GetNameSyntax(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetNameSyntax(Arg.Is<Type>(t => t.FullyQualifiedName == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(SF.ParseName(frameworkName));
             symbols
-                .GetNameSyntax(Arg.Is<string>(fqn => fqn == fullyQualifiedName), disambiguate: Arg.Any<bool>())
+                .GetNameSyntax(Arg.Is<string>(fqn => fqn == fullyQualifiedName), qualified: Arg.Any<bool>())
                 .Returns(SF.ParseName(frameworkName));
             symbols
                 .GetTypeSyntax(Arg.Is<TypeReference>(t => t.FullyQualifiedName == fullyQualifiedName), false)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator.UnitTests/SymbolMapTests.cs
@@ -253,87 +253,6 @@ namespace Amazon.JSII.Generator.UnitTests
                 Assert.Equal("My.Namespace2.MyType", actual2, ignoreLineEndingDifferences: true);
             }
 
-            [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfNoConflict))]
-            public void DoesNotDisambiguateTypeNameIfNoConflict()
-            {
-                Type type1 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn1",
-                    assembly: "my-package-1",
-                    name: "myType1",
-                    members: new EnumMember[] { }
-                );
-                Type type2 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn2",
-                    assembly: "my-package-2",
-                    name: "myType2",
-                    members: new EnumMember[] { }
-                );
-
-                Assembly assembly1 = new Assembly
-                (
-                    name: "my-package-1",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace1",
-                        packageId: "My.PackageId1"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type1.FullyQualifiedName, type1 } },
-                    dependencies: new Dictionary<string, PackageVersion>
-                    {
-                        {
-                            "my-package-2",
-                            new PackageVersion(
-                                version: "myVersion",
-                                targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                                    @namespace: "My.Namespace2",
-                                    packageId: "My.PackageId2"
-                                ))
-                            )
-                        }
-                    }
-                );
-                Assembly assembly2 = new Assembly
-                (
-                    name: "my-package-2",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace2",
-                        packageId: "My.PackageId2"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type2.FullyQualifiedName, type2 } }
-                );
-
-                ISymbolMap symbolMap = new SymbolMap();
-                symbolMap.Add(assembly1);
-                symbolMap.Add(assembly2);
-
-                // GetName(Type type)
-                string actual1 = symbolMap.GetName(type1, true);
-                string actual2 = symbolMap.GetName(type2, true);
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
-
-                // GetName(string fullyQualifiedName)
-                actual1 = symbolMap.GetName("myFqn1", true);
-                actual2 = symbolMap.GetName("myFqn2", true);
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
-            }
-
             [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfFlagNotSet))]
             public void DoesNotDisambiguateTypeNameIfFlagNotSet()
             {
@@ -614,88 +533,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 Assert.Equal("My.Namespace1.MyType", actual1, ignoreLineEndingDifferences: true);
                 Assert.Equal("My.Namespace2.MyType", actual2, ignoreLineEndingDifferences: true);
             }
-
-            [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfNoConflict))]
-            public void DoesNotDisambiguateTypeNameIfNoConflict()
-            {
-                Type type1 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn1",
-                    assembly: "my-package-1",
-                    name: "myType1",
-                    members: new EnumMember[] { }
-                );
-                Type type2 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn2",
-                    assembly: "my-package-2",
-                    name: "myType2",
-                    members: new EnumMember[] { }
-                );
-
-                Assembly assembly1 = new Assembly
-                (
-                    name: "my-package-1",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace1",
-                        packageId: "My.PackageId1"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type1.FullyQualifiedName, type1 } },
-                    dependencies: new Dictionary<string, PackageVersion>
-                    {
-                        {
-                            "my-package-2",
-                            new PackageVersion(
-                                version: "myVersion",
-                                targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                                    @namespace: "My.Namespace2",
-                                    packageId: "My.PackageId2"
-                                ))
-                            )
-                        }
-                    }
-                );
-                Assembly assembly2 = new Assembly
-                (
-                    name: "my-package-2",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace2",
-                        packageId: "My.PackageId2"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type2.FullyQualifiedName, type2 } }
-                );
-
-                ISymbolMap symbolMap = new SymbolMap();
-                symbolMap.Add(assembly1);
-                symbolMap.Add(assembly2);
-
-                // GetNameSyntaxToken(Type type)
-                string actual1 = symbolMap.GetNameSyntaxToken(type1, true).ToString();
-                string actual2 = symbolMap.GetNameSyntaxToken(type2, true).ToString();
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
-
-                // GetNameSyntaxToken(string fullyQualifiedName)
-                actual1 = symbolMap.GetNameSyntaxToken("myFqn1", true).ToString();
-                actual2 = symbolMap.GetNameSyntaxToken("myFqn2", true).ToString();
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
-            }
-
+            
             [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfFlagNotSet))]
             public void DoesNotDisambiguateTypeNameIfFlagNotSet()
             {
@@ -975,87 +813,6 @@ namespace Amazon.JSII.Generator.UnitTests
                 actual2 = symbolMap.GetNameSyntax("myFqn2", true).ToString();
                 Assert.Equal("My.Namespace1.MyType", actual1, ignoreLineEndingDifferences: true);
                 Assert.Equal("My.Namespace2.MyType", actual2, ignoreLineEndingDifferences: true);
-            }
-
-            [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfNoConflict))]
-            public void DoesNotDisambiguateTypeNameIfNoConflict()
-            {
-                Type type1 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn1",
-                    assembly: "my-package-1",
-                    name: "myType1",
-                    members: new EnumMember[] { }
-                );
-                Type type2 = new EnumType
-                (
-                    fullyQualifiedName: "myFqn2",
-                    assembly: "my-package-2",
-                    name: "myType2",
-                    members: new EnumMember[] { }
-                );
-
-                Assembly assembly1 = new Assembly
-                (
-                    name: "my-package-1",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace1",
-                        packageId: "My.PackageId1"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type1.FullyQualifiedName, type1 } },
-                    dependencies: new Dictionary<string, PackageVersion>
-                    {
-                        {
-                            "my-package-2",
-                            new PackageVersion(
-                                version: "myVersion",
-                                targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                                    @namespace: "My.Namespace2",
-                                    packageId: "My.PackageId2"
-                                ))
-                            )
-                        }
-                    }
-                );
-                Assembly assembly2 = new Assembly
-                (
-                    name: "my-package-2",
-                    description: "",
-                    homepage: "",
-                    repository: new Assembly.AssemblyRepository(type: "", url: ""),
-                    author: new Person(name: "", roles: new string[] { }),
-                    fingerprint: "",
-                    license: "",
-                    targets: new AssemblyTargets(dotnet: new AssemblyTargets.DotNetTarget(
-                        @namespace: "My.Namespace2",
-                        packageId: "My.PackageId2"
-                    )),
-                    version: "myVersion",
-                    types: new Dictionary<string, Type> { { type2.FullyQualifiedName, type2 } }
-                );
-
-                ISymbolMap symbolMap = new SymbolMap();
-                symbolMap.Add(assembly1);
-                symbolMap.Add(assembly2);
-
-                // GetNameSyntax(Type type)
-                string actual1 = symbolMap.GetNameSyntax(type1, true).ToString();
-                string actual2 = symbolMap.GetNameSyntax(type2, true).ToString();
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
-
-                // GetNameSyntax(string fullyQualifiedName)
-                actual1 = symbolMap.GetNameSyntax("myFqn1", true).ToString();
-                actual2 = symbolMap.GetNameSyntax("myFqn2", true).ToString();
-                Assert.Equal("MyType1", actual1, ignoreLineEndingDifferences: true);
-                Assert.Equal("MyType2", actual2, ignoreLineEndingDifferences: true);
             }
 
             [Fact(DisplayName = Prefix + nameof(DoesNotDisambiguateTypeNameIfFlagNotSet))]
@@ -1552,7 +1309,7 @@ namespace Amazon.JSII.Generator.UnitTests
                 TypeReference reference = new TypeReference("myFqn");
 
                 string actual = symbolMap.GetTypeSyntax(reference, false).ToString();
-                Assert.Equal("MyName", actual, ignoreLineEndingDifferences: true);
+                Assert.Equal("My.Namespace.MyName", actual, ignoreLineEndingDifferences: true);
 
             }
         }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
@@ -89,7 +89,6 @@ namespace Amazon.JSII.Generator.Class
                     }
                     else
                     {
-                        Namespaces.Add(Symbols.GetTypeFromFullyQualifiedName(Type.Base));
                         yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type.Base, disambiguate: true));
                     }
 
@@ -100,7 +99,6 @@ namespace Amazon.JSII.Generator.Class
 
                     foreach (var interfaceReference in Type.Interfaces)
                     {
-                        Namespaces.Add(Symbols.GetTypeFromFullyQualifiedName(interfaceReference));
                         yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, disambiguate: true));
                     }
                 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Class/ClassGenerator.cs
@@ -89,7 +89,7 @@ namespace Amazon.JSII.Generator.Class
                     }
                     else
                     {
-                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type.Base, disambiguate: true));
+                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type.Base, qualified: true));
                     }
 
                     if (Type.Interfaces == null)
@@ -99,7 +99,7 @@ namespace Amazon.JSII.Generator.Class
 
                     foreach (var interfaceReference in Type.Interfaces)
                     {
-                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, disambiguate: true));
+                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, qualified: true));
                     }
                 }
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/INamespaceSet.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/INamespaceSet.cs
@@ -9,8 +9,6 @@ namespace Amazon.JSII.Generator
     {
         SyntaxList<UsingDirectiveSyntax> GetUsings();
 
-        void Add(Type type);
-
         void Add(TypeReference typeReference);
     }
 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/ISymbolMap.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/ISymbolMap.cs
@@ -12,15 +12,15 @@ namespace Amazon.JSII.Generator
 
         string GetName(Assembly assembly);
 
-        string GetName(Type type, bool disambiguate = false);
+        string GetName(Type type, bool qualified = false);
 
-        string GetName(string fullyQualifiedName, bool disambiguate = false);
+        string GetName(string fullyQualifiedName, bool qualified = false);
         
-        string GetAbstractClassProxyName(ClassType type, bool disambiguate = false);
+        string GetAbstractClassProxyName(ClassType type, bool qualified = false);
 
-        string GetInterfaceProxyName(InterfaceType type, bool disambiguate = false);
+        string GetInterfaceProxyName(InterfaceType type, bool qualified = false);
 
-        string GetInterfaceDefaultName(InterfaceType type, bool disambiguate = false);
+        string GetInterfaceDefaultName(InterfaceType type, bool qualified = false);
 
         string GetName(Type type, Method method);
 
@@ -40,13 +40,13 @@ namespace Amazon.JSII.Generator
 
         SyntaxToken GetNameSyntaxToken(Assembly assembly);
 
-        SyntaxToken GetNameSyntaxToken(Type type, bool disambiguate = false);
+        SyntaxToken GetNameSyntaxToken(Type type, bool qualified = false);
 
-        SyntaxToken GetNameSyntaxToken(string fullyQualifiedName, bool disambiguate = false);
+        SyntaxToken GetNameSyntaxToken(string fullyQualifiedName, bool qualified = false);
 
-        SyntaxToken GetInterfaceProxyNameSyntaxToken(InterfaceType type, bool disambiguate = false);
+        SyntaxToken GetInterfaceProxyNameSyntaxToken(InterfaceType type, bool qualified = false);
 
-        SyntaxToken GetInterfaceDefaultNameSyntaxToken(InterfaceType type, bool disambiguate = false);
+        SyntaxToken GetInterfaceDefaultNameSyntaxToken(InterfaceType type, bool qualified = false);
 
         SyntaxToken GetNameSyntaxToken(Type type, Method method);
 
@@ -66,13 +66,13 @@ namespace Amazon.JSII.Generator
 
         NameSyntax GetNameSyntax(Assembly assembly);
 
-        NameSyntax GetNameSyntax(Type type, bool disambiguate = false);
+        NameSyntax GetNameSyntax(Type type, bool qualified = false);
 
-        NameSyntax GetNameSyntax(string fullyQualifiedName, bool disambiguate = false);
+        NameSyntax GetNameSyntax(string fullyQualifiedName, bool qualified = false);
 
-        NameSyntax GetInterfaceProxyNameSyntax(InterfaceType type, bool disambiguate = false);
+        NameSyntax GetInterfaceProxyNameSyntax(InterfaceType type, bool qualified = false);
 
-        NameSyntax GetInterfaceDefaultNameSyntax(InterfaceType type, bool disambiguate = false);
+        NameSyntax GetInterfaceDefaultNameSyntax(InterfaceType type, bool qualified = false);
 
         NameSyntax GetNameSyntax(Type type, Method method);
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceDefaultGenerator.cs
@@ -32,7 +32,7 @@ namespace Amazon.JSII.Generator.Interface
 
             IEnumerable<BaseTypeSyntax> CreateBaseTypes()
             {
-                yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, disambiguate: true));
+                yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, qualified: true));
             }
 
             IEnumerable<MemberDeclarationSyntax> CreateMembers()

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
@@ -68,7 +68,7 @@ namespace Amazon.JSII.Generator.Interface
                 {
                     foreach (string interfaceReference in Type.Interfaces ?? Enumerable.Empty<string>())
                     {
-                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, disambiguate: true));
+                        yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, qualified: true));
                     }
                 }
             }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/Interface/InterfaceGenerator.cs
@@ -68,7 +68,6 @@ namespace Amazon.JSII.Generator.Interface
                 {
                     foreach (string interfaceReference in Type.Interfaces ?? Enumerable.Empty<string>())
                     {
-                        Namespaces.Add(Symbols.GetTypeFromFullyQualifiedName(interfaceReference));
                         yield return SF.SimpleBaseType(Symbols.GetNameSyntax(interfaceReference, disambiguate: true));
                     }
                 }

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/NamespaceSet.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/NamespaceSet.cs
@@ -39,16 +39,11 @@ namespace Amazon.JSII.Generator
             return SF.List(usings);
         }
 
-        public void Add(Type type)
-        {
-            _referencedNamespaces.Add(_symbols.GetNamespaceSyntax(type));
-        }
-
         public void Add(TypeReference typeReference)
         {
             if (typeReference.FullyQualifiedName != null)
             {
-                _referencedNamespaces.Add(_symbols.GetNamespaceSyntax(typeReference.FullyQualifiedName));
+                // Not generating "using" statements for stuff from dependencies - we won't use those.
                 return;
             }
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/SymbolMap.cs
@@ -95,24 +95,21 @@ namespace Amazon.JSII.Generator
             return GetAssemblyName(assembly.Name);
         }
 
-        public string GetName(Type type, bool disambiguate = false)
+        public string GetName(Type type, bool qualified = false)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
 
             TypeMetadata metadata = _types[type.FullyQualifiedName];
 
-            disambiguate = disambiguate && _types.Values
-                .Any(m => m.Type.FullyQualifiedName != metadata.Type.FullyQualifiedName && m.Name == metadata.Name);
-
-            return disambiguate ? metadata.FrameworkFullyQualifiedName : metadata.Name;
+            return qualified ? metadata.FrameworkFullyQualifiedName : metadata.Name;
         }
 
-        public string GetName(string fullyQualifiedName, bool disambiguate = false)
+        public string GetName(string fullyQualifiedName, bool qualified = false)
         {
-            return GetName(GetTypeFromFullyQualifiedName(fullyQualifiedName), disambiguate);
+            return GetName(GetTypeFromFullyQualifiedName(fullyQualifiedName), qualified);
         }
 
-        public string GetAbstractClassProxyName(ClassType type, bool disambiguate = false)
+        public string GetAbstractClassProxyName(ClassType type, bool qualified = false)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
             
@@ -124,7 +121,7 @@ namespace Amazon.JSII.Generator
             throw new ArgumentException($"Cannot get proxy name for '{type.FullyQualifiedName}' because it is not an abstract class.");
         }
 
-        public string GetInterfaceProxyName(InterfaceType type, bool disambiguate = false)
+        public string GetInterfaceProxyName(InterfaceType type, bool qualified = false)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
 
@@ -136,7 +133,7 @@ namespace Amazon.JSII.Generator
             throw new ArgumentException($"Cannot get proxy name for '{type.FullyQualifiedName}' because it is not an interface.");
         }
 
-        public string GetInterfaceDefaultName(InterfaceType type, bool disambiguate = false)
+        public string GetInterfaceDefaultName(InterfaceType type, bool qualified = false)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
 
@@ -185,24 +182,24 @@ namespace Amazon.JSII.Generator
             return SF.Identifier(GetName(assembly ?? throw new ArgumentNullException(nameof(assembly))));
         }
 
-        public SyntaxToken GetNameSyntaxToken(Type type, bool disambiguate = false)
+        public SyntaxToken GetNameSyntaxToken(Type type, bool qualified = false)
         {
-            return SF.Identifier(GetName(type ?? throw new ArgumentNullException(nameof(type)), disambiguate));
+            return SF.Identifier(GetName(type ?? throw new ArgumentNullException(nameof(type)), qualified));
         }
 
-        public SyntaxToken GetNameSyntaxToken(string fullyQualifiedName, bool disambiguate = false)
+        public SyntaxToken GetNameSyntaxToken(string fullyQualifiedName, bool qualified = false)
         {
-            return GetNameSyntaxToken(GetTypeFromFullyQualifiedName(fullyQualifiedName), disambiguate);
+            return GetNameSyntaxToken(GetTypeFromFullyQualifiedName(fullyQualifiedName), qualified);
         }
 
-        public SyntaxToken GetInterfaceProxyNameSyntaxToken(InterfaceType type, bool disambiguate = false)
+        public SyntaxToken GetInterfaceProxyNameSyntaxToken(InterfaceType type, bool qualified = false)
         {
-            return SF.Identifier(GetInterfaceProxyName(type ?? throw new ArgumentNullException(nameof(type)), disambiguate));
+            return SF.Identifier(GetInterfaceProxyName(type ?? throw new ArgumentNullException(nameof(type)), qualified));
         }
 
-        public SyntaxToken GetInterfaceDefaultNameSyntaxToken(InterfaceType type, bool disambiguate = false)
+        public SyntaxToken GetInterfaceDefaultNameSyntaxToken(InterfaceType type, bool qualified = false)
         {
-            return SF.Identifier(GetInterfaceDefaultName(type ?? throw new ArgumentNullException(nameof(type)), disambiguate));
+            return SF.Identifier(GetInterfaceDefaultName(type ?? throw new ArgumentNullException(nameof(type)), qualified));
         }
 
         public SyntaxToken GetNameSyntaxToken(Type type, Method method)

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
@@ -70,7 +70,7 @@ namespace Amazon.JSII.Generator
                         yield return SF.SimpleBaseType(SF.ParseTypeName("DeputyBase"));
                     }
 
-                    yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, disambiguate: true));
+                    yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, qualified: true));
                 }
             }
 

--- a/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
+++ b/packages/jsii-dotnet-generator/src/Amazon.JSII.Generator/TypeProxyGeneratorBase.cs
@@ -70,7 +70,6 @@ namespace Amazon.JSII.Generator
                         yield return SF.SimpleBaseType(SF.ParseTypeName("DeputyBase"));
                     }
 
-                    Namespaces.Add(Type);
                     yield return SF.SimpleBaseType(Symbols.GetNameSyntax(Type, disambiguate: true));
                 }
             }

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -168,7 +168,7 @@ import { VERSION_DESC } from '../lib/version';
         // ``argv.target`` is guaranteed valid by ``yargs`` through the ``choices`` directive.
         const targetConstructor = targetConstructors[targetName];
         if (!targetConstructor) {
-            throw new Error(`Unsupported target ${targetName}`);
+            throw new Error(`Unsupported target: "${targetName}"`);
         }
 
         const target = new targetConstructor({

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProps.cs
@@ -1,10 +1,9 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     [JsiiByValue]
-    public class BaseProps : IBaseProps
+    public class BaseProps : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IBaseProps
     {
         [JsiiProperty(name: "bar", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
         public string Bar
@@ -14,7 +13,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}", isOverride: true)]
-        public Very Foo
+        public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
             get;
             set;

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BasePropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BasePropsProxy.cs
@@ -1,10 +1,9 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     [JsiiTypeProxy(nativeType: typeof(IBaseProps), fullyQualifiedName: "@scope/jsii-calc-base.BaseProps")]
-    internal sealed class BasePropsProxy : DeputyBase, IBaseProps
+    internal sealed class BasePropsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IBaseProps
     {
         private BasePropsProxy(ByRefValue reference): base(reference)
         {
@@ -17,9 +16,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}")]
-        public Very Foo
+        public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
-            get => GetInstanceProperty<Very>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     /// <summary>A base class.</summary>
     [JsiiTypeProxy(nativeType: typeof(Base), fullyQualifiedName: "@scope/jsii-calc-base.Base")]
-    internal sealed class BaseProxy : Base
+    internal sealed class BaseProxy : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base
     {
         private BaseProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IBaseInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IBaseInterfaceProxy.cs
@@ -3,7 +3,7 @@ using Amazon.JSII.Runtime.Deputy;
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     [JsiiTypeProxy(nativeType: typeof(IIBaseInterface), fullyQualifiedName: "@scope/jsii-calc-base.IBaseInterface")]
-    internal sealed class IBaseInterfaceProxy : DeputyBase, IIBaseInterface
+    internal sealed class IBaseInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IIBaseInterface
     {
         private IBaseInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IBaseProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IBaseProps.cs
@@ -1,10 +1,9 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     [JsiiInterface(nativeType: typeof(IBaseProps), fullyQualifiedName: "@scope/jsii-calc-base.BaseProps")]
-    public interface IBaseProps : IVeryBaseProps
+    public interface IBaseProps : Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.IVeryBaseProps
     {
         [JsiiProperty(name: "bar", typeJson: "{\"primitive\":\"string\"}")]
         string Bar

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IIBaseInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/IIBaseInterface.cs
@@ -1,10 +1,9 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
     [JsiiInterface(nativeType: typeof(IIBaseInterface), fullyQualifiedName: "@scope/jsii-calc-base.IBaseInterface")]
-    public interface IIBaseInterface : IIVeryBaseInterface
+    public interface IIBaseInterface : Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.IIVeryBaseInterface
     {
         [JsiiMethod(name: "bar")]
         void Bar();

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IDoublableProxy.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIDoublable), fullyQualifiedName: "@scope/jsii-calc-lib.IDoublable")]
     [System.Obsolete()]
-    internal sealed class IDoublableProxy : DeputyBase, IIDoublable
+    internal sealed class IDoublableProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIDoublable
     {
         private IDoublableProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IFriendlyProxy.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendly), fullyQualifiedName: "@scope/jsii-calc-lib.IFriendly")]
     [System.Obsolete()]
-    internal sealed class IFriendlyProxy : DeputyBase, IIFriendly
+    internal sealed class IFriendlyProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly
     {
         private IFriendlyProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIThreeLevelsInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IIThreeLevelsInterface.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
@@ -11,7 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// </remarks>
     [JsiiInterface(nativeType: typeof(IIThreeLevelsInterface), fullyQualifiedName: "@scope/jsii-calc-lib.IThreeLevelsInterface")]
     [System.Obsolete()]
-    public interface IIThreeLevelsInterface : IIBaseInterface
+    public interface IIThreeLevelsInterface : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IIBaseInterface
     {
         /// <remarks>stability: Deprecated</remarks>
         [JsiiMethod(name: "baz")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IThreeLevelsInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/IThreeLevelsInterfaceProxy.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(IIThreeLevelsInterface), fullyQualifiedName: "@scope/jsii-calc-lib.IThreeLevelsInterface")]
     [System.Obsolete()]
-    internal sealed class IThreeLevelsInterfaceProxy : DeputyBase, IIThreeLevelsInterface
+    internal sealed class IThreeLevelsInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIThreeLevelsInterface
     {
         private IThreeLevelsInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <summary>This is the first struct we have created in jsii.</summary>
     /// <remarks>stability: Deprecated</remarks>
     [JsiiByValue]
-    public class MyFirstStruct : IMyFirstStruct
+    public class MyFirstStruct : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct
     {
         /// <summary>An awesome number value.</summary>
         /// <remarks>stability: Deprecated</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStructProxy.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IMyFirstStruct), fullyQualifiedName: "@scope/jsii-calc-lib.MyFirstStruct")]
     [System.Obsolete()]
-    internal sealed class MyFirstStructProxy : DeputyBase, IMyFirstStruct
+    internal sealed class MyFirstStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct
     {
         private MyFirstStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Number.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Number), fullyQualifiedName: "@scope/jsii-calc-lib.Number", parametersJson: "[{\"name\":\"value\",\"type\":{\"primitive\":\"number\"}}]")]
     [System.Obsolete()]
-    public class Number : Value_, IIDoublable
+    public class Number : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIDoublable
     {
         /// <summary>Creates a Number object.</summary>
         /// <param name = "value">The number.</param>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Operation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Operation.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Operation), fullyQualifiedName: "@scope/jsii-calc-lib.Operation")]
     [System.Obsolete()]
-    public abstract class Operation : Value_
+    public abstract class Operation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_
     {
         protected Operation(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/OperationProxy.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(Operation), fullyQualifiedName: "@scope/jsii-calc-lib.Operation")]
     [System.Obsolete()]
-    internal sealed class OperationProxy : Operation
+    internal sealed class OperationProxy : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation
     {
         private OperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <summary>This is a struct with only optional properties.</summary>
     /// <remarks>stability: Deprecated</remarks>
     [JsiiByValue]
-    public class StructWithOnlyOptionals : IStructWithOnlyOptionals
+    public class StructWithOnlyOptionals : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals
     {
         /// <summary>The first optional!</summary>
         /// <remarks>stability: Deprecated</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionalsProxy.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IStructWithOnlyOptionals), fullyQualifiedName: "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
     [System.Obsolete()]
-    internal sealed class StructWithOnlyOptionalsProxy : DeputyBase, IStructWithOnlyOptionals
+    internal sealed class StructWithOnlyOptionalsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals
     {
         private StructWithOnlyOptionalsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/ValueProxy.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(Value_), fullyQualifiedName: "@scope/jsii-calc-lib.Value")]
     [System.Obsolete()]
-    internal sealed class ValueProxy : Value_
+    internal sealed class ValueProxy : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_
     {
         private ValueProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Value_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Value_.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
 {
@@ -7,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiClass(nativeType: typeof(Value_), fullyQualifiedName: "@scope/jsii-calc-lib.Value")]
     [System.Obsolete()]
-    public abstract class Value_ : Base
+    public abstract class Value_ : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base
     {
         protected Value_(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClass.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(AbstractClass), fullyQualifiedName: "jsii-calc.AbstractClass")]
-    public abstract class AbstractClass : AbstractClassBase, IIInterfaceImplementedByAbstractClass
+    public abstract class AbstractClass : Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceImplementedByAbstractClass
     {
         protected AbstractClass(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassBaseProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(AbstractClassBase), fullyQualifiedName: "jsii-calc.AbstractClassBase")]
-    internal sealed class AbstractClassBaseProxy : AbstractClassBase
+    internal sealed class AbstractClassBaseProxy : Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase
     {
         private AbstractClassBaseProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(AbstractClass), fullyQualifiedName: "jsii-calc.AbstractClass")]
-    internal sealed class AbstractClassProxy : AbstractClass
+    internal sealed class AbstractClassProxy : Amazon.JSII.Tests.CalculatorNamespace.AbstractClass
     {
         private AbstractClassProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AbstractClassReturner.cs
@@ -20,23 +20,23 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "returnAbstractFromProperty", typeJson: "{\"fqn\":\"jsii-calc.AbstractClassBase\"}")]
-        public virtual AbstractClassBase ReturnAbstractFromProperty
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase ReturnAbstractFromProperty
         {
-            get => GetInstanceProperty<AbstractClassBase>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase>();
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeAbstract", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.AbstractClass\"}}")]
-        public virtual AbstractClass GiveMeAbstract()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.AbstractClass GiveMeAbstract()
         {
-            return InvokeInstanceMethod<AbstractClass>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.AbstractClass>(new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IInterfaceImplementedByAbstractClass\"}}")]
-        public virtual IIInterfaceImplementedByAbstractClass GiveMeInterface()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceImplementedByAbstractClass GiveMeInterface()
         {
-            return InvokeInstanceMethod<IIInterfaceImplementedByAbstractClass>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceImplementedByAbstractClass>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Add.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Add.cs
@@ -1,18 +1,17 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The "+" binary operation.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Add), fullyQualifiedName: "jsii-calc.Add", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public class Add : BinaryOperation
+    public class Add : Amazon.JSII.Tests.CalculatorNamespace.BinaryOperation
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
         /// <remarks>stability: Experimental</remarks>
-        public Add(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        public Add(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -84,9 +83,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "enumProperty", typeJson: "{\"fqn\":\"jsii-calc.AllTypesEnum\"}")]
-        public virtual AllTypesEnum EnumProperty
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum EnumProperty
         {
-            get => GetInstanceProperty<AllTypesEnum>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum>();
             set => SetInstanceProperty(value);
         }
 
@@ -100,9 +99,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "mapProperty", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Number\"}}}")]
-        public virtual IDictionary<string, Number> MapProperty
+        public virtual IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number> MapProperty
         {
-            get => GetInstanceProperty<IDictionary<string, Number>>();
+            get => GetInstanceProperty<IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>>();
             set => SetInstanceProperty(value);
         }
 
@@ -172,9 +171,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "optionalEnumValue", typeJson: "{\"fqn\":\"jsii-calc.StringEnum\"}", isOptional: true)]
-        public virtual StringEnum? OptionalEnumValue
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.StringEnum? OptionalEnumValue
         {
-            get => GetInstanceProperty<StringEnum? >();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.StringEnum? >();
             set => SetInstanceProperty(value);
         }
 
@@ -194,9 +193,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "enumMethod", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.StringEnum\"}}", parametersJson: "[{\"name\":\"value\",\"type\":{\"fqn\":\"jsii-calc.StringEnum\"}}]")]
-        public virtual StringEnum EnumMethod(StringEnum value)
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.StringEnum EnumMethod(Amazon.JSII.Tests.CalculatorNamespace.StringEnum value)
         {
-            return InvokeInstanceMethod<StringEnum>(new object[]{value});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.StringEnum>(new object[]{value});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperation.cs
@@ -1,18 +1,17 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Represents an operation with two operands.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(BinaryOperation), fullyQualifiedName: "jsii-calc.BinaryOperation", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public abstract class BinaryOperation : Operation, IIFriendly
+    public abstract class BinaryOperation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
         /// <remarks>stability: Experimental</remarks>
-        protected BinaryOperation(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        protected BinaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
 
@@ -27,17 +26,17 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Left-hand side operand.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "lhs", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Lhs
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Lhs
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>Right-hand side operand.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "rhs", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Rhs
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Rhs
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>Say hello!</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/BinaryOperationProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Represents an operation with two operands.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(BinaryOperation), fullyQualifiedName: "jsii-calc.BinaryOperation")]
-    internal sealed class BinaryOperationProxy : BinaryOperation
+    internal sealed class BinaryOperationProxy : Amazon.JSII.Tests.CalculatorNamespace.BinaryOperation
     {
         private BinaryOperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Calculator.cs
@@ -1,6 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.composition;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System.Collections.Generic;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
@@ -8,12 +6,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>A calculator which maintains a current value and allows adding operations.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Calculator), fullyQualifiedName: "jsii-calc.Calculator", parametersJson: "[{\"name\":\"props\",\"type\":{\"fqn\":\"jsii-calc.CalculatorProps\"},\"optional\":true}]")]
-    public class Calculator : CompositeOperation_
+    public class Calculator : Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation_
     {
         /// <summary>Creates a Calculator object.</summary>
         /// <param name = "props">Initialization properties.</param>
         /// <remarks>stability: Experimental</remarks>
-        public Calculator(ICalculatorProps props): base(new DeputyProps(new object[]{props}))
+        public Calculator(Amazon.JSII.Tests.CalculatorNamespace.ICalculatorProps props): base(new DeputyProps(new object[]{props}))
         {
         }
 
@@ -28,33 +26,33 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Returns the expression.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public override Value_ Expression
+        public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Expression
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>A log of all operations.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operationsLog", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}")]
-        public virtual Value_[] OperationsLog
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[] OperationsLog
         {
-            get => GetInstanceProperty<Value_[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[]>();
         }
 
         /// <summary>A map of per operation name of all operations performed.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operationsMap", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}}")]
-        public virtual IDictionary<string, Value_[]> OperationsMap
+        public virtual IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[]> OperationsMap
         {
-            get => GetInstanceProperty<IDictionary<string, Value_[]>>();
+            get => GetInstanceProperty<IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[]>>();
         }
 
         /// <summary>The current value.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "curr", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Curr
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Curr
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
             set => SetInstanceProperty(value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Properties for Calculator.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class CalculatorProps : ICalculatorProps
+    public class CalculatorProps : Amazon.JSII.Tests.CalculatorNamespace.ICalculatorProps
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "initialValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Properties for Calculator.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ICalculatorProps), fullyQualifiedName: "jsii-calc.CalculatorProps")]
-    internal sealed class CalculatorPropsProxy : DeputyBase, ICalculatorProps
+    internal sealed class CalculatorPropsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.ICalculatorProps
     {
         private CalculatorPropsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsTheInternalInterface.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassThatImplementsTheInternalInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsTheInternalInterface")]
-    public class ClassThatImplementsTheInternalInterface : DeputyBase, IINonInternalInterface
+    public class ClassThatImplementsTheInternalInterface : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IINonInternalInterface
     {
         public ClassThatImplementsTheInternalInterface(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassThatImplementsThePrivateInterface.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassThatImplementsThePrivateInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsThePrivateInterface")]
-    public class ClassThatImplementsThePrivateInterface : DeputyBase, IINonInternalInterface
+    public class ClassThatImplementsThePrivateInterface : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IINonInternalInterface
     {
         public ClassThatImplementsThePrivateInterface(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithMutableObjectLiteralProperty.cs
@@ -20,9 +20,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "mutableObject", typeJson: "{\"fqn\":\"jsii-calc.IMutableObjectLiteral\"}")]
-        public virtual IIMutableObjectLiteral MutableObject
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIMutableObjectLiteral MutableObject
         {
-            get => GetInstanceProperty<IIMutableObjectLiteral>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IIMutableObjectLiteral>();
             set => SetInstanceProperty(value);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithPrivateConstructorAndAutomaticProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithPrivateConstructorAndAutomaticProperties.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Class that implements interface properties automatically, but using a private constructor.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ClassWithPrivateConstructorAndAutomaticProperties), fullyQualifiedName: "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties")]
-    public class ClassWithPrivateConstructorAndAutomaticProperties : DeputyBase, IIInterfaceWithProperties
+    public class ClassWithPrivateConstructorAndAutomaticProperties : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties
     {
         protected ClassWithPrivateConstructorAndAutomaticProperties(ByRefValue reference): base(reference)
         {
@@ -32,9 +32,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "create", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties\"}}", parametersJson: "[{\"name\":\"readOnlyString\",\"type\":{\"primitive\":\"string\"}},{\"name\":\"readWriteString\",\"type\":{\"primitive\":\"string\"}}]")]
-        public static ClassWithPrivateConstructorAndAutomaticProperties Create(string readOnlyString, string readWriteString)
+        public static Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties Create(string readOnlyString, string readWriteString)
         {
-            return InvokeStaticMethod<ClassWithPrivateConstructorAndAutomaticProperties>(typeof(ClassWithPrivateConstructorAndAutomaticProperties), new object[]{readOnlyString, readWriteString});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties>(typeof(ClassWithPrivateConstructorAndAutomaticProperties), new object[]{readOnlyString, readWriteString});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConstructorPassesThisOut.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConstructorPassesThisOut.cs
@@ -7,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     public class ConstructorPassesThisOut : DeputyBase
     {
         /// <remarks>stability: Experimental</remarks>
-        public ConstructorPassesThisOut(PartiallyInitializedThisConsumer consumer): base(new DeputyProps(new object[]{consumer}))
+        public ConstructorPassesThisOut(Amazon.JSII.Tests.CalculatorNamespace.PartiallyInitializedThisConsumer consumer): base(new DeputyProps(new object[]{consumer}))
         {
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Constructors.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Constructors.cs
@@ -20,51 +20,51 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
-        public static IIPublicInterface HiddenInterface()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface HiddenInterface()
         {
-            return InvokeStaticMethod<IIPublicInterface>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
-        public static IIPublicInterface[] HiddenInterfaces()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[] HiddenInterfaces()
         {
-            return InvokeStaticMethod<IIPublicInterface[]>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[]>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "hiddenSubInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
-        public static IIPublicInterface[] HiddenSubInterfaces()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[] HiddenSubInterfaces()
         {
-            return InvokeStaticMethod<IIPublicInterface[]>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[]>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeClass", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.PublicClass\"}}")]
-        public static PublicClass MakeClass()
+        public static Amazon.JSII.Tests.CalculatorNamespace.PublicClass MakeClass()
         {
-            return InvokeStaticMethod<PublicClass>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.PublicClass>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterface", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
-        public static IIPublicInterface MakeInterface()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface MakeInterface()
         {
-            return InvokeStaticMethod<IIPublicInterface>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterface2", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface2\"}}")]
-        public static IIPublicInterface2 MakeInterface2()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface2 MakeInterface2()
         {
-            return InvokeStaticMethod<IIPublicInterface2>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface2>(typeof(Constructors), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInterfaces", returnsJson: "{\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}}}")]
-        public static IIPublicInterface[] MakeInterfaces()
+        public static Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[] MakeInterfaces()
         {
-            return InvokeStaticMethod<IIPublicInterface[]>(typeof(Constructors), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface[]>(typeof(Constructors), new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ConsumersOfThisCrazyTypeSystem.cs
@@ -20,14 +20,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumeAnotherPublicInterface", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IAnotherPublicInterface\"}}]")]
-        public virtual string ConsumeAnotherPublicInterface(IIAnotherPublicInterface obj)
+        public virtual string ConsumeAnotherPublicInterface(Amazon.JSII.Tests.CalculatorNamespace.IIAnotherPublicInterface obj)
         {
             return InvokeInstanceMethod<string>(new object[]{obj});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumeNonInternalInterface", returnsJson: "{\"type\":{\"primitive\":\"any\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.INonInternalInterface\"}}]")]
-        public virtual object ConsumeNonInternalInterface(IINonInternalInterface obj)
+        public virtual object ConsumeNonInternalInterface(Amazon.JSII.Tests.CalculatorNamespace.IINonInternalInterface obj)
         {
             return InvokeInstanceMethod<object>(new object[]{obj});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DataRenderer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DataRenderer.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System.Collections.Generic;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
@@ -24,7 +23,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "render", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"data\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.MyFirstStruct\"},\"optional\":true}]")]
-        public virtual string Render(IMyFirstStruct data)
+        public virtual string Render(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct data)
         {
             return InvokeInstanceMethod<string>(new object[]{data});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Deprecated</remarks>
     [JsiiByValue]
-    public class DeprecatedStruct : IDeprecatedStruct
+    public class DeprecatedStruct : Amazon.JSII.Tests.CalculatorNamespace.IDeprecatedStruct
     {
         /// <remarks>stability: Deprecated</remarks>
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStructProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IDeprecatedStruct), fullyQualifiedName: "jsii-calc.DeprecatedStruct")]
     [System.Obsolete("it just wraps a string")]
-    internal sealed class DeprecatedStructProxy : DeputyBase, IDeprecatedStruct
+    internal sealed class DeprecatedStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDeprecatedStruct
     {
         private DeprecatedStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>A struct which derives from another struct.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class DerivedStruct : IDerivedStruct
+    public class DerivedStruct : Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherRequired", typeJson: "{\"primitive\":\"date\"}", isOverride: true)]
@@ -29,7 +28,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>An example of a non primitive property.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}", isOverride: true)]
-        public DoubleTrouble NonPrimitive
+        public Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble NonPrimitive
         {
             get;
             set;
@@ -38,7 +37,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>This is optional.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true, isOverride: true)]
-        public IDictionary<string, Value_> AnotherOptional
+        public IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_> AnotherOptional
         {
             get;
             set;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStructProxy.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>A struct which derives from another struct.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IDerivedStruct), fullyQualifiedName: "jsii-calc.DerivedStruct")]
-    internal sealed class DerivedStructProxy : DeputyBase, IDerivedStruct
+    internal sealed class DerivedStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct
     {
         private DerivedStructProxy(ByRefValue reference): base(reference)
         {
@@ -31,17 +30,17 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>An example of a non primitive property.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
-        public DoubleTrouble NonPrimitive
+        public Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble NonPrimitive
         {
-            get => GetInstanceProperty<DoubleTrouble>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>();
         }
 
         /// <summary>This is optional.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true)]
-        public IDictionary<string, Value_> AnotherOptional
+        public IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_> AnotherOptional
         {
-            get => GetInstanceProperty<IDictionary<string, Value_>>();
+            get => GetInstanceProperty<IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>>();
         }
 
         /// <remarks>stability: Experimental</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DocumentedClass.cs
@@ -34,7 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// stability: Stable
         /// </remarks>
         [JsiiMethod(name: "greet", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"greetee\",\"type\":{\"fqn\":\"jsii-calc.Greetee\"},\"optional\":true}]")]
-        public virtual double Greet(IGreetee greetee)
+        public virtual double Greet(Amazon.JSII.Tests.CalculatorNamespace.IGreetee greetee)
         {
             return InvokeInstanceMethod<double>(new object[]{greetee});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoubleTrouble.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DoubleTrouble.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(DoubleTrouble), fullyQualifiedName: "jsii-calc.DoubleTrouble")]
-    public class DoubleTrouble : DeputyBase, IIFriendlyRandomGenerator
+    public class DoubleTrouble : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIFriendlyRandomGenerator
     {
         public DoubleTrouble(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValues.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValues.cs
@@ -25,7 +25,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// stability: Experimental
         /// </remarks>
         [JsiiMethod(name: "doesKeyExist", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"opts\",\"type\":{\"fqn\":\"jsii-calc.EraseUndefinedHashValuesOptions\"}},{\"name\":\"key\",\"type\":{\"primitive\":\"string\"}}]")]
-        public static bool DoesKeyExist(IEraseUndefinedHashValuesOptions opts, string key)
+        public static bool DoesKeyExist(Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions opts, string key)
         {
             return InvokeStaticMethod<bool>(typeof(EraseUndefinedHashValues), new object[]{opts, key});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class EraseUndefinedHashValuesOptions : IEraseUndefinedHashValuesOptions
+    public class EraseUndefinedHashValuesOptions : Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "option1", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptionsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptionsProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IEraseUndefinedHashValuesOptions), fullyQualifiedName: "jsii-calc.EraseUndefinedHashValuesOptions")]
-    internal sealed class EraseUndefinedHashValuesOptionsProxy : DeputyBase, IEraseUndefinedHashValuesOptions
+    internal sealed class EraseUndefinedHashValuesOptionsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions
     {
         private EraseUndefinedHashValuesOptionsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class ExperimentalStruct : IExperimentalStruct
+    public class ExperimentalStruct : Amazon.JSII.Tests.CalculatorNamespace.IExperimentalStruct
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStructProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IExperimentalStruct), fullyQualifiedName: "jsii-calc.ExperimentalStruct")]
-    internal sealed class ExperimentalStructProxy : DeputyBase, IExperimentalStruct
+    internal sealed class ExperimentalStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IExperimentalStruct
     {
         private ExperimentalStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class ExtendsInternalInterface : IExtendsInternalInterface
+    public class ExtendsInternalInterface : Amazon.JSII.Tests.CalculatorNamespace.IExtendsInternalInterface
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "boom", typeJson: "{\"primitive\":\"boolean\"}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IExtendsInternalInterface), fullyQualifiedName: "jsii-calc.ExtendsInternalInterface")]
-    internal sealed class ExtendsInternalInterfaceProxy : DeputyBase, IExtendsInternalInterface
+    internal sealed class ExtendsInternalInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IExtendsInternalInterface
     {
         private ExtendsInternalInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GiveMeStructs.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GiveMeStructs.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -21,31 +20,31 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "structLiteral", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.StructWithOnlyOptionals\"}")]
-        public virtual IStructWithOnlyOptionals StructLiteral
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals StructLiteral
         {
-            get => GetInstanceProperty<IStructWithOnlyOptionals>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals>();
         }
 
         /// <summary>Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "derivedToFirst", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.MyFirstStruct\"}}", parametersJson: "[{\"name\":\"derived\",\"type\":{\"fqn\":\"jsii-calc.DerivedStruct\"}}]")]
-        public virtual IMyFirstStruct DerivedToFirst(IDerivedStruct derived)
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct DerivedToFirst(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct derived)
         {
-            return InvokeInstanceMethod<IMyFirstStruct>(new object[]{derived});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct>(new object[]{derived});
         }
 
         /// <summary>Returns the boolean from a DerivedStruct struct.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readDerivedNonPrimitive", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.DoubleTrouble\"}}", parametersJson: "[{\"name\":\"derived\",\"type\":{\"fqn\":\"jsii-calc.DerivedStruct\"}}]")]
-        public virtual DoubleTrouble ReadDerivedNonPrimitive(IDerivedStruct derived)
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble ReadDerivedNonPrimitive(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct derived)
         {
-            return InvokeInstanceMethod<DoubleTrouble>(new object[]{derived});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(new object[]{derived});
         }
 
         /// <summary>Returns the "anumber" from a MyFirstStruct struct;</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readFirstNumber", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"first\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.MyFirstStruct\"}}]")]
-        public virtual double ReadFirstNumber(IMyFirstStruct first)
+        public virtual double ReadFirstNumber(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct first)
         {
             return InvokeInstanceMethod<double>(new object[]{first});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>These are some arguments you can pass to a method.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class Greetee : IGreetee
+    public class Greetee : Amazon.JSII.Tests.CalculatorNamespace.IGreetee
     {
         /// <summary>The name of the greetee.</summary>
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreeteeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreeteeProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>These are some arguments you can pass to a method.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IGreetee), fullyQualifiedName: "jsii-calc.Greetee")]
-    internal sealed class GreeteeProxy : DeputyBase, IGreetee
+    internal sealed class GreeteeProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IGreetee
     {
         private GreeteeProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/GreetingAugmenter.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -21,7 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "betterGreeting", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"friendly\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}]")]
-        public virtual string BetterGreeting(IIFriendly friendly)
+        public virtual string BetterGreeting(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly friendly)
         {
             return InvokeInstanceMethod<string>(new object[]{friendly});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnotherPublicInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIAnotherPublicInterface), fullyQualifiedName: "jsii-calc.IAnotherPublicInterface")]
-    internal sealed class IAnotherPublicInterfaceProxy : DeputyBase, IIAnotherPublicInterface
+    internal sealed class IAnotherPublicInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIAnotherPublicInterface
     {
         private IAnotherPublicInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDeprecatedInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDeprecatedInterfaceProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>stability: Deprecated</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIDeprecatedInterface), fullyQualifiedName: "jsii-calc.IDeprecatedInterface")]
     [System.Obsolete("useless interface")]
-    internal sealed class IDeprecatedInterfaceProxy : DeputyBase, IIDeprecatedInterface
+    internal sealed class IDeprecatedInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIDeprecatedInterface
     {
         private IDeprecatedInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDerivedStruct.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>A struct which derives from another struct.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IDerivedStruct), fullyQualifiedName: "jsii-calc.DerivedStruct")]
-    public interface IDerivedStruct : IMyFirstStruct
+    public interface IDerivedStruct : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherRequired", typeJson: "{\"primitive\":\"date\"}")]
@@ -27,7 +26,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>An example of a non primitive property.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
-        DoubleTrouble NonPrimitive
+        Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble NonPrimitive
         {
             get;
         }
@@ -35,7 +34,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>This is optional.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "anotherOptional", typeJson: "{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}", isOptional: true)]
-        IDictionary<string, Value_> AnotherOptional
+        IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_> AnotherOptional
         {
             get;
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExperimentalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExperimentalInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIExperimentalInterface), fullyQualifiedName: "jsii-calc.IExperimentalInterface")]
-    internal sealed class IExperimentalInterfaceProxy : DeputyBase, IIExperimentalInterface
+    internal sealed class IExperimentalInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIExperimentalInterface
     {
         private IExperimentalInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsPrivateInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IExtendsPrivateInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIExtendsPrivateInterface), fullyQualifiedName: "jsii-calc.IExtendsPrivateInterface")]
-    internal sealed class IExtendsPrivateInterfaceProxy : DeputyBase, IIExtendsPrivateInterface
+    internal sealed class IExtendsPrivateInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIExtendsPrivateInterface
     {
         private IExtendsPrivateInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlierProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Even friendlier classes can implement this interface.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendlier), fullyQualifiedName: "jsii-calc.IFriendlier")]
-    internal sealed class IFriendlierProxy : DeputyBase, IIFriendlier
+    internal sealed class IFriendlierProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIFriendlier
     {
         private IFriendlierProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IFriendlyRandomGeneratorProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIFriendlyRandomGenerator), fullyQualifiedName: "jsii-calc.IFriendlyRandomGenerator")]
-    internal sealed class IFriendlyRandomGeneratorProxy : DeputyBase, IIFriendlyRandomGenerator
+    internal sealed class IFriendlyRandomGeneratorProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIFriendlyRandomGenerator
     {
         private IFriendlyRandomGeneratorProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlier.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlier.cs
@@ -1,12 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>Even friendlier classes can implement this interface.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIFriendlier), fullyQualifiedName: "jsii-calc.IFriendlier")]
-    public interface IIFriendlier : IIFriendly
+    public interface IIFriendlier : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly
     {
         /// <summary>Say farewell.</summary>
         /// <remarks>stability: Experimental</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlyRandomGenerator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIFriendlyRandomGenerator.cs
@@ -1,11 +1,10 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIFriendlyRandomGenerator), fullyQualifiedName: "jsii-calc.IFriendlyRandomGenerator")]
-    public interface IIFriendlyRandomGenerator : IIRandomNumberGenerator, IIFriendly
+    public interface IIFriendlyRandomGenerator : Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly
     {
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceThatShouldNotBeADataType.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceThatShouldNotBeADataType), fullyQualifiedName: "jsii-calc.IInterfaceThatShouldNotBeADataType")]
-    public interface IIInterfaceThatShouldNotBeADataType : IIInterfaceWithMethods
+    public interface IIInterfaceThatShouldNotBeADataType : Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithMethods
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "otherValue", typeJson: "{\"primitive\":\"string\"}")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithPropertiesExtension.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIInterfaceWithPropertiesExtension.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIInterfaceWithPropertiesExtension), fullyQualifiedName: "jsii-calc.IInterfaceWithPropertiesExtension")]
-    public interface IIInterfaceWithPropertiesExtension : IIInterfaceWithProperties
+    public interface IIInterfaceWithPropertiesExtension : Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"primitive\":\"number\"}")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIJSII417Derived.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IIJSII417Derived), fullyQualifiedName: "jsii-calc.IJSII417Derived")]
-    public interface IIJSII417Derived : IIJSII417PublicBaseOfBase
+    public interface IIJSII417Derived : Amazon.JSII.Tests.CalculatorNamespace.IIJSII417PublicBaseOfBase
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "property", typeJson: "{\"primitive\":\"string\"}")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IINonInternalInterface.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IINonInternalInterface), fullyQualifiedName: "jsii-calc.INonInternalInterface")]
-    public interface IINonInternalInterface : IIAnotherPublicInterface
+    public interface IINonInternalInterface : Amazon.JSII.Tests.CalculatorNamespace.IIAnotherPublicInterface
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "b", typeJson: "{\"primitive\":\"string\"}")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IIReturnsNumber.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -9,13 +8,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "numberProp", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
-        Number NumberProp
+        Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number NumberProp
         {
             get;
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "obtainNumber", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}}")]
-        IIDoublable ObtainNumber();
+        Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIDoublable ObtainNumber();
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IImplictBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IImplictBaseOfBase.cs
@@ -1,12 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiInterface(nativeType: typeof(IImplictBaseOfBase), fullyQualifiedName: "jsii-calc.ImplictBaseOfBase")]
-    public interface IImplictBaseOfBase : IBaseProps
+    public interface IImplictBaseOfBase : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IBaseProps
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "goo", typeJson: "{\"primitive\":\"date\"}")]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClassProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceImplementedByAbstractClassProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>awslabs/jsii#220 Abstract return type.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceImplementedByAbstractClass), fullyQualifiedName: "jsii-calc.IInterfaceImplementedByAbstractClass")]
-    internal sealed class IInterfaceImplementedByAbstractClassProxy : DeputyBase, IIInterfaceImplementedByAbstractClass
+    internal sealed class IInterfaceImplementedByAbstractClassProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceImplementedByAbstractClass
     {
         private IInterfaceImplementedByAbstractClassProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceThatShouldNotBeADataTypeProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceThatShouldNotBeADataType), fullyQualifiedName: "jsii-calc.IInterfaceThatShouldNotBeADataType")]
-    internal sealed class IInterfaceThatShouldNotBeADataTypeProxy : DeputyBase, IIInterfaceThatShouldNotBeADataType
+    internal sealed class IInterfaceThatShouldNotBeADataTypeProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceThatShouldNotBeADataType
     {
         private IInterfaceThatShouldNotBeADataTypeProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithInternalProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithInternalProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithInternal), fullyQualifiedName: "jsii-calc.IInterfaceWithInternal")]
-    internal sealed class IInterfaceWithInternalProxy : DeputyBase, IIInterfaceWithInternal
+    internal sealed class IInterfaceWithInternalProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithInternal
     {
         private IInterfaceWithInternalProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithMethodsProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithMethods), fullyQualifiedName: "jsii-calc.IInterfaceWithMethods")]
-    internal sealed class IInterfaceWithMethodsProxy : DeputyBase, IIInterfaceWithMethods
+    internal sealed class IInterfaceWithMethodsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithMethods
     {
         private IInterfaceWithMethodsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithOptionalMethodArgumentsProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithOptionalMethodArguments), fullyQualifiedName: "jsii-calc.IInterfaceWithOptionalMethodArguments")]
-    internal sealed class IInterfaceWithOptionalMethodArgumentsProxy : DeputyBase, IIInterfaceWithOptionalMethodArguments
+    internal sealed class IInterfaceWithOptionalMethodArgumentsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithOptionalMethodArguments
     {
         private IInterfaceWithOptionalMethodArgumentsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesExtensionProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithPropertiesExtension), fullyQualifiedName: "jsii-calc.IInterfaceWithPropertiesExtension")]
-    internal sealed class IInterfaceWithPropertiesExtensionProxy : DeputyBase, IIInterfaceWithPropertiesExtension
+    internal sealed class IInterfaceWithPropertiesExtensionProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithPropertiesExtension
     {
         private IInterfaceWithPropertiesExtensionProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IInterfaceWithPropertiesProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIInterfaceWithProperties), fullyQualifiedName: "jsii-calc.IInterfaceWithProperties")]
-    internal sealed class IInterfaceWithPropertiesProxy : DeputyBase, IIInterfaceWithProperties
+    internal sealed class IInterfaceWithPropertiesProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties
     {
         private IInterfaceWithPropertiesProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417DerivedProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417DerivedProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJSII417Derived), fullyQualifiedName: "jsii-calc.IJSII417Derived")]
-    internal sealed class IJSII417DerivedProxy : DeputyBase, IIJSII417Derived
+    internal sealed class IJSII417DerivedProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJSII417Derived
     {
         private IJSII417DerivedProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417PublicBaseOfBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJSII417PublicBaseOfBaseProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJSII417PublicBaseOfBase), fullyQualifiedName: "jsii-calc.IJSII417PublicBaseOfBase")]
-    internal sealed class IJSII417PublicBaseOfBaseProxy : DeputyBase, IIJSII417PublicBaseOfBase
+    internal sealed class IJSII417PublicBaseOfBaseProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJSII417PublicBaseOfBase
     {
         private IJSII417PublicBaseOfBaseProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487External2Proxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii487External2), fullyQualifiedName: "jsii-calc.IJsii487External2")]
-    internal sealed class IJsii487External2Proxy : DeputyBase, IIJsii487External2
+    internal sealed class IJsii487External2Proxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJsii487External2
     {
         private IJsii487External2Proxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii487ExternalProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii487External), fullyQualifiedName: "jsii-calc.IJsii487External")]
-    internal sealed class IJsii487ExternalProxy : DeputyBase, IIJsii487External
+    internal sealed class IJsii487ExternalProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJsii487External
     {
         private IJsii487ExternalProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IJsii496Proxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIJsii496), fullyQualifiedName: "jsii-calc.IJsii496")]
-    internal sealed class IJsii496Proxy : DeputyBase, IIJsii496
+    internal sealed class IJsii496Proxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJsii496
     {
         private IJsii496Proxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteralProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IMutableObjectLiteralProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIMutableObjectLiteral), fullyQualifiedName: "jsii-calc.IMutableObjectLiteral")]
-    internal sealed class IMutableObjectLiteralProxy : DeputyBase, IIMutableObjectLiteral
+    internal sealed class IMutableObjectLiteralProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIMutableObjectLiteral
     {
         private IMutableObjectLiteralProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/INonInternalInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IINonInternalInterface), fullyQualifiedName: "jsii-calc.INonInternalInterface")]
-    internal sealed class INonInternalInterfaceProxy : DeputyBase, IINonInternalInterface
+    internal sealed class INonInternalInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IINonInternalInterface
     {
         private INonInternalInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPrivatelyImplementedProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPrivatelyImplementedProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPrivatelyImplemented), fullyQualifiedName: "jsii-calc.IPrivatelyImplemented")]
-    internal sealed class IPrivatelyImplementedProxy : DeputyBase, IIPrivatelyImplemented
+    internal sealed class IPrivatelyImplementedProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIPrivatelyImplemented
     {
         private IPrivatelyImplementedProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterface2Proxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterface2Proxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPublicInterface2), fullyQualifiedName: "jsii-calc.IPublicInterface2")]
-    internal sealed class IPublicInterface2Proxy : DeputyBase, IIPublicInterface2
+    internal sealed class IPublicInterface2Proxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface2
     {
         private IPublicInterface2Proxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IPublicInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIPublicInterface), fullyQualifiedName: "jsii-calc.IPublicInterface")]
-    internal sealed class IPublicInterfaceProxy : DeputyBase, IIPublicInterface
+    internal sealed class IPublicInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface
     {
         private IPublicInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IRandomNumberGeneratorProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>Generates random numbers.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIRandomNumberGenerator), fullyQualifiedName: "jsii-calc.IRandomNumberGenerator")]
-    internal sealed class IRandomNumberGeneratorProxy : DeputyBase, IIRandomNumberGenerator
+    internal sealed class IRandomNumberGeneratorProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator
     {
         private IRandomNumberGeneratorProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IReturnsNumberProxy.cs
@@ -1,11 +1,10 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIReturnsNumber), fullyQualifiedName: "jsii-calc.IReturnsNumber")]
-    internal sealed class IReturnsNumberProxy : DeputyBase, IIReturnsNumber
+    internal sealed class IReturnsNumberProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIReturnsNumber
     {
         private IReturnsNumberProxy(ByRefValue reference): base(reference)
         {
@@ -13,16 +12,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "numberProp", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Number\"}")]
-        public Number NumberProp
+        public Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number NumberProp
         {
-            get => GetInstanceProperty<Number>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>();
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "obtainNumber", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IDoublable\"}}")]
-        public IIDoublable ObtainNumber()
+        public Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIDoublable ObtainNumber()
         {
-            return InvokeInstanceMethod<IIDoublable>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIDoublable>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStableInterfaceProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStableInterfaceProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Stable</remarks>
     [JsiiTypeProxy(nativeType: typeof(IIStableInterface), fullyQualifiedName: "jsii-calc.IStableInterface")]
-    internal sealed class IStableInterfaceProxy : DeputyBase, IIStableInterface
+    internal sealed class IStableInterfaceProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIStableInterface
     {
         private IStableInterfaceProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternal.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternal.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementsInterfaceWithInternal), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternal")]
-    public class ImplementsInterfaceWithInternal : DeputyBase, IIInterfaceWithInternal
+    public class ImplementsInterfaceWithInternal : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithInternal
     {
         public ImplementsInterfaceWithInternal(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternalSubclass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplementsInterfaceWithInternalSubclass.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(ImplementsInterfaceWithInternalSubclass), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternalSubclass")]
-    public class ImplementsInterfaceWithInternalSubclass : ImplementsInterfaceWithInternal
+    public class ImplementsInterfaceWithInternalSubclass : Amazon.JSII.Tests.CalculatorNamespace.ImplementsInterfaceWithInternal
     {
         public ImplementsInterfaceWithInternalSubclass(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
@@ -1,12 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class ImplictBaseOfBase : IImplictBaseOfBase
+    public class ImplictBaseOfBase : Amazon.JSII.Tests.CalculatorNamespace.IImplictBaseOfBase
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "goo", typeJson: "{\"primitive\":\"date\"}", isOverride: true)]
@@ -24,7 +23,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}", isOverride: true)]
-        public Very Foo
+        public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
             get;
             set;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBaseProxy.cs
@@ -1,12 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace;
 using System;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IImplictBaseOfBase), fullyQualifiedName: "jsii-calc.ImplictBaseOfBase")]
-    internal sealed class ImplictBaseOfBaseProxy : DeputyBase, IImplictBaseOfBase
+    internal sealed class ImplictBaseOfBaseProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IImplictBaseOfBase
     {
         private ImplictBaseOfBaseProxy(ByRefValue reference): base(reference)
         {
@@ -26,9 +25,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-base-of-base.Very\"}")]
-        public Very Foo
+        public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
-            get => GetInstanceProperty<Very>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InbetweenClass.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InbetweenClass.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(InbetweenClass), fullyQualifiedName: "jsii-calc.InbetweenClass")]
-    public class InbetweenClass : PublicClass, IIPublicInterface2
+    public class InbetweenClass : Amazon.JSII.Tests.CalculatorNamespace.PublicClass, Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface2
     {
         public InbetweenClass(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417Derived.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(JSII417Derived), fullyQualifiedName: "jsii-calc.JSII417Derived", parametersJson: "[{\"name\":\"property\",\"type\":{\"primitive\":\"string\"}}]")]
-    public class JSII417Derived : JSII417PublicBaseOfBase
+    public class JSII417Derived : Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase
     {
         /// <remarks>stability: Experimental</remarks>
         public JSII417Derived(string property): base(new DeputyProps(new object[]{property}))

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417PublicBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSII417PublicBaseOfBase.cs
@@ -27,9 +27,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "makeInstance", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.JSII417PublicBaseOfBase\"}}")]
-        public static JSII417PublicBaseOfBase MakeInstance()
+        public static Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase MakeInstance()
         {
-            return InvokeStaticMethod<JSII417PublicBaseOfBase>(typeof(JSII417PublicBaseOfBase), new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase>(typeof(JSII417PublicBaseOfBase), new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralForInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralForInterface.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -21,16 +20,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeFriendly", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}")]
-        public virtual IIFriendly GiveMeFriendly()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly GiveMeFriendly()
         {
-            return InvokeInstanceMethod<IIFriendly>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly>(new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeFriendlyGenerator", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IFriendlyRandomGenerator\"}}")]
-        public virtual IIFriendlyRandomGenerator GiveMeFriendlyGenerator()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIFriendlyRandomGenerator GiveMeFriendlyGenerator()
         {
-            return InvokeInstanceMethod<IIFriendlyRandomGenerator>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IIFriendlyRandomGenerator>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNative.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/JSObjectLiteralToNative.cs
@@ -20,9 +20,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "returnLiteral", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.JSObjectLiteralToNativeClass\"}}")]
-        public virtual JSObjectLiteralToNativeClass ReturnLiteral()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass ReturnLiteral()
         {
-            return InvokeInstanceMethod<JSObjectLiteralToNativeClass>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii487Derived.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Jsii487Derived), fullyQualifiedName: "jsii-calc.Jsii487Derived")]
-    public class Jsii487Derived : DeputyBase, IIJsii487External2, IIJsii487External
+    public class Jsii487Derived : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJsii487External2, Amazon.JSII.Tests.CalculatorNamespace.IIJsii487External
     {
         public Jsii487Derived(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Jsii496Derived.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Jsii496Derived), fullyQualifiedName: "jsii-calc.Jsii496Derived")]
-    public class Jsii496Derived : DeputyBase, IIJsii496
+    public class Jsii496Derived : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IIJsii496
     {
         public Jsii496Derived(): base(new DeputyProps(new object[]{}))
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class LoadBalancedFargateServiceProps : ILoadBalancedFargateServiceProps
+    public class LoadBalancedFargateServiceProps : Amazon.JSII.Tests.CalculatorNamespace.ILoadBalancedFargateServiceProps
     {
         /// <summary>The container port of the application load balancer attached to your Fargate service.</summary>
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServicePropsProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>jsii#298: show default values in sphinx documentation, and respect newlines.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ILoadBalancedFargateServiceProps), fullyQualifiedName: "jsii-calc.LoadBalancedFargateServiceProps")]
-    internal sealed class LoadBalancedFargateServicePropsProxy : DeputyBase, ILoadBalancedFargateServiceProps
+    internal sealed class LoadBalancedFargateServicePropsProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.ILoadBalancedFargateServiceProps
     {
         private LoadBalancedFargateServicePropsProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Multiply.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Multiply.cs
@@ -1,18 +1,17 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The "*" binary operation.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Multiply), fullyQualifiedName: "jsii-calc.Multiply", parametersJson: "[{\"name\":\"lhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"rhs\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public class Multiply : BinaryOperation, IIFriendlier, IIRandomNumberGenerator
+    public class Multiply : Amazon.JSII.Tests.CalculatorNamespace.BinaryOperation, Amazon.JSII.Tests.CalculatorNamespace.IIFriendlier, Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator
     {
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name = "lhs">Left-hand side operand.</param>
         /// <param name = "rhs">Right-hand side operand.</param>
         /// <remarks>stability: Experimental</remarks>
-        public Multiply(Value_ lhs, Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        public Multiply(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ rhs): base(new DeputyProps(new object[]{lhs, rhs}))
         {
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Negate.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Negate.cs
@@ -1,15 +1,14 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The negation operation ("-value").</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Negate), fullyQualifiedName: "jsii-calc.Negate", parametersJson: "[{\"name\":\"operand\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public class Negate : UnaryOperation, IIFriendlier
+    public class Negate : Amazon.JSII.Tests.CalculatorNamespace.UnaryOperation, Amazon.JSII.Tests.CalculatorNamespace.IIFriendlier
     {
         /// <remarks>stability: Experimental</remarks>
-        public Negate(Value_ operand): base(new DeputyProps(new object[]{operand}))
+        public Negate(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ operand): base(new DeputyProps(new object[]{operand}))
         {
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefined.cs
@@ -37,7 +37,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "giveMeUndefinedInsideAnObject", parametersJson: "[{\"name\":\"input\",\"type\":{\"fqn\":\"jsii-calc.NullShouldBeTreatedAsUndefinedData\"}}]")]
-        public virtual void GiveMeUndefinedInsideAnObject(INullShouldBeTreatedAsUndefinedData input)
+        public virtual void GiveMeUndefinedInsideAnObject(Amazon.JSII.Tests.CalculatorNamespace.INullShouldBeTreatedAsUndefinedData input)
         {
             InvokeInstanceVoidMethod(new object[]{input});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class NullShouldBeTreatedAsUndefinedData : INullShouldBeTreatedAsUndefinedData
+    public class NullShouldBeTreatedAsUndefinedData : Amazon.JSII.Tests.CalculatorNamespace.INullShouldBeTreatedAsUndefinedData
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "arrayWithThreeElementsAndUndefinedAsSecondArgument", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"primitive\":\"any\"}}}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedDataProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedDataProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(INullShouldBeTreatedAsUndefinedData), fullyQualifiedName: "jsii-calc.NullShouldBeTreatedAsUndefinedData")]
-    internal sealed class NullShouldBeTreatedAsUndefinedDataProxy : DeputyBase, INullShouldBeTreatedAsUndefinedData
+    internal sealed class NullShouldBeTreatedAsUndefinedDataProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.INullShouldBeTreatedAsUndefinedData
     {
         private NullShouldBeTreatedAsUndefinedDataProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NumberGenerator.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NumberGenerator.cs
@@ -8,7 +8,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     public class NumberGenerator : DeputyBase
     {
         /// <remarks>stability: Experimental</remarks>
-        public NumberGenerator(IIRandomNumberGenerator generator): base(new DeputyProps(new object[]{generator}))
+        public NumberGenerator(Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator generator): base(new DeputyProps(new object[]{generator}))
         {
         }
 
@@ -22,15 +22,15 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "generator", typeJson: "{\"fqn\":\"jsii-calc.IRandomNumberGenerator\"}")]
-        public virtual IIRandomNumberGenerator Generator
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator Generator
         {
-            get => GetInstanceProperty<IIRandomNumberGenerator>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator>();
             set => SetInstanceProperty(value);
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "isSameGenerator", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"gen\",\"type\":{\"fqn\":\"jsii-calc.IRandomNumberGenerator\"}}]")]
-        public virtual bool IsSameGenerator(IIRandomNumberGenerator gen)
+        public virtual bool IsSameGenerator(Amazon.JSII.Tests.CalculatorNamespace.IIRandomNumberGenerator gen)
         {
             return InvokeInstanceMethod<bool>(new object[]{gen});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ObjectRefsInCollections.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ObjectRefsInCollections.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 using System.Collections.Generic;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
@@ -24,7 +23,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Returns the sum of all values.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sumFromArray", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"values\",\"type\":{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}]")]
-        public virtual double SumFromArray(Value_[] values)
+        public virtual double SumFromArray(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[] values)
         {
             return InvokeInstanceMethod<double>(new object[]{values});
         }
@@ -32,7 +31,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Returns the sum of all values in a map.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sumFromMap", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"values\",\"type\":{\"collection\":{\"kind\":\"map\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}}]")]
-        public virtual double SumFromMap(IDictionary<string, Value_> values)
+        public virtual double SumFromMap(IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_> values)
         {
             return InvokeInstanceMethod<double>(new object[]{values});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class OptionalStruct : IOptionalStruct
+    public class OptionalStruct : Amazon.JSII.Tests.CalculatorNamespace.IOptionalStruct
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "field", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructConsumer.cs
@@ -7,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     public class OptionalStructConsumer : DeputyBase
     {
         /// <remarks>stability: Experimental</remarks>
-        public OptionalStructConsumer(IOptionalStruct optionalStruct): base(new DeputyProps(new object[]{optionalStruct}))
+        public OptionalStructConsumer(Amazon.JSII.Tests.CalculatorNamespace.IOptionalStruct optionalStruct): base(new DeputyProps(new object[]{optionalStruct}))
         {
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStructProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IOptionalStruct), fullyQualifiedName: "jsii-calc.OptionalStruct")]
-    internal sealed class OptionalStructProxy : DeputyBase, IOptionalStruct
+    internal sealed class OptionalStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IOptionalStruct
     {
         private OptionalStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OverrideReturnsObject.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OverrideReturnsObject.cs
@@ -20,7 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "test", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.IReturnsNumber\"}}]")]
-        public virtual double Test(IIReturnsNumber obj)
+        public virtual double Test(Amazon.JSII.Tests.CalculatorNamespace.IIReturnsNumber obj)
         {
             return InvokeInstanceMethod<double>(new object[]{obj});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumer.cs
@@ -21,6 +21,6 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumePartiallyInitializedThis", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.ConstructorPassesThisOut\"}},{\"name\":\"dt\",\"type\":{\"primitive\":\"date\"}},{\"name\":\"ev\",\"type\":{\"fqn\":\"jsii-calc.AllTypesEnum\"}}]")]
-        public abstract string ConsumePartiallyInitializedThis(ConstructorPassesThisOut obj, DateTime dt, AllTypesEnum ev);
+        public abstract string ConsumePartiallyInitializedThis(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut obj, DateTime dt, Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum ev);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumerProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PartiallyInitializedThisConsumerProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(PartiallyInitializedThisConsumer), fullyQualifiedName: "jsii-calc.PartiallyInitializedThisConsumer")]
-    internal sealed class PartiallyInitializedThisConsumerProxy : PartiallyInitializedThisConsumer
+    internal sealed class PartiallyInitializedThisConsumerProxy : Amazon.JSII.Tests.CalculatorNamespace.PartiallyInitializedThisConsumer
     {
         private PartiallyInitializedThisConsumerProxy(ByRefValue reference): base(reference)
         {
@@ -13,7 +13,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "consumePartiallyInitializedThis", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"obj\",\"type\":{\"fqn\":\"jsii-calc.ConstructorPassesThisOut\"}},{\"name\":\"dt\",\"type\":{\"primitive\":\"date\"}},{\"name\":\"ev\",\"type\":{\"fqn\":\"jsii-calc.AllTypesEnum\"}}]")]
-        public override string ConsumePartiallyInitializedThis(ConstructorPassesThisOut obj, DateTime dt, AllTypesEnum ev)
+        public override string ConsumePartiallyInitializedThis(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut obj, DateTime dt, Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum ev)
         {
             return InvokeInstanceMethod<string>(new object[]{obj, dt, ev});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Polymorphism.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Polymorphism.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -21,7 +20,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "sayHello", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"friendly\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.IFriendly\"}}]")]
-        public virtual string SayHello(IIFriendly friendly)
+        public virtual string SayHello(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IIFriendly friendly)
         {
             return InvokeInstanceMethod<string>(new object[]{friendly});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Power.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Power.cs
@@ -1,19 +1,17 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.composition;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>The power operation.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Power), fullyQualifiedName: "jsii-calc.Power", parametersJson: "[{\"name\":\"base\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}},{\"name\":\"pow\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public class Power : CompositeOperation_
+    public class Power : Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation_
     {
         /// <summary>Creates a Power operation.</summary>
         /// <param name = "@base">The base of the power.</param>
         /// <param name = "pow">The number of times to multiply.</param>
         /// <remarks>stability: Experimental</remarks>
-        public Power(Value_ @base, Value_ pow): base(new DeputyProps(new object[]{@base, pow}))
+        public Power(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ @base, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ pow): base(new DeputyProps(new object[]{@base, pow}))
         {
         }
 
@@ -28,25 +26,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>The base of the power.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "base", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Base
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Base
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public override Value_ Expression
+        public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Expression
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>The number of times to multiply.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "pow", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Pow
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Pow
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReferenceEnumFromScopedPackage.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReferenceEnumFromScopedPackage.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
@@ -22,22 +21,22 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "foo", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"}", isOptional: true)]
-        public virtual EnumFromScopedModule? Foo
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.EnumFromScopedModule? Foo
         {
-            get => GetInstanceProperty<EnumFromScopedModule? >();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.EnumFromScopedModule? >();
             set => SetInstanceProperty(value);
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "loadFoo", returnsJson: "{\"type\":{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"},\"optional\":true}")]
-        public virtual EnumFromScopedModule? LoadFoo()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.EnumFromScopedModule? LoadFoo()
         {
-            return InvokeInstanceMethod<EnumFromScopedModule? >(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.EnumFromScopedModule? >(new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "saveFoo", parametersJson: "[{\"name\":\"value\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.EnumFromScopedModule\"}}]")]
-        public virtual void SaveFoo(EnumFromScopedModule value)
+        public virtual void SaveFoo(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.EnumFromScopedModule value)
         {
             InvokeInstanceVoidMethod(new object[]{value});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsPrivateImplementationOfInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ReturnsPrivateImplementationOfInterface.cs
@@ -24,9 +24,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "privateImplementation", typeJson: "{\"fqn\":\"jsii-calc.IPrivatelyImplemented\"}")]
-        public virtual IIPrivatelyImplemented PrivateImplementation
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIPrivatelyImplemented PrivateImplementation
         {
-            get => GetInstanceProperty<IIPrivatelyImplemented>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IIPrivatelyImplemented>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class SecondLevelStruct : ISecondLevelStruct
+    public class SecondLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.ISecondLevelStruct
     {
         /// <summary>It's long and required.</summary>
         /// <remarks>stability: Experimental</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStructProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ISecondLevelStruct), fullyQualifiedName: "jsii-calc.SecondLevelStruct")]
-    internal sealed class SecondLevelStructProxy : DeputyBase, ISecondLevelStruct
+    internal sealed class SecondLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.ISecondLevelStruct
     {
         private SecondLevelStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingleInstanceTwoTypes.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SingleInstanceTwoTypes.cs
@@ -26,16 +26,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "interface1", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.InbetweenClass\"}}")]
-        public virtual InbetweenClass Interface1()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass Interface1()
         {
-            return InvokeInstanceMethod<InbetweenClass>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass>(new object[]{});
         }
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "interface2", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IPublicInterface\"}}")]
-        public virtual IIPublicInterface Interface2()
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface Interface2()
         {
-            return InvokeInstanceMethod<IIPublicInterface>(new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IIPublicInterface>(new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Stable</remarks>
     [JsiiByValue]
-    public class StableStruct : IStableStruct
+    public class StableStruct : Amazon.JSII.Tests.CalculatorNamespace.IStableStruct
     {
         /// <remarks>stability: Stable</remarks>
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStructProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Stable</remarks>
     [JsiiTypeProxy(nativeType: typeof(IStableStruct), fullyQualifiedName: "jsii-calc.StableStruct")]
-    internal sealed class StableStructProxy : DeputyBase, IStableStruct
+    internal sealed class StableStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IStableStruct
     {
         private StableStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Statics.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Statics.cs
@@ -31,12 +31,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         = GetStaticProperty<double>(typeof(Statics));
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "ConstObj", typeJson: "{\"fqn\":\"jsii-calc.DoubleTrouble\"}")]
-        public static DoubleTrouble ConstObj
+        public static Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble ConstObj
         {
             get;
         }
 
-        = GetStaticProperty<DoubleTrouble>(typeof(Statics));
+        = GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(typeof(Statics));
         /// <summary>Jsdocs for static property.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "Foo", typeJson: "{\"primitive\":\"string\"}")]
@@ -58,9 +58,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Jsdocs for static getter. Jsdocs for static setter.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "instance", typeJson: "{\"fqn\":\"jsii-calc.Statics\"}")]
-        public static Statics Instance
+        public static Amazon.JSII.Tests.CalculatorNamespace.Statics Instance
         {
-            get => GetStaticProperty<Statics>(typeof(Statics));
+            get => GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.Statics>(typeof(Statics));
             set => SetStaticProperty(typeof(Statics), value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructPassing.cs
@@ -21,16 +21,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: External</remarks>
         [JsiiMethod(name: "howManyVarArgsDidIPass", returnsJson: "{\"type\":{\"primitive\":\"number\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"inputs\",\"variadic\":true,\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}]")]
-        public static double HowManyVarArgsDidIPass(double _positional, ITopLevelStruct inputs)
+        public static double HowManyVarArgsDidIPass(double _positional, Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct inputs)
         {
             return InvokeStaticMethod<double>(typeof(StructPassing), new object[]{_positional, inputs});
         }
 
         /// <remarks>stability: External</remarks>
         [JsiiMethod(name: "roundTrip", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}", parametersJson: "[{\"name\":\"_positional\",\"type\":{\"primitive\":\"number\"}},{\"name\":\"input\",\"type\":{\"fqn\":\"jsii-calc.TopLevelStruct\"}}]")]
-        public static ITopLevelStruct RoundTrip(double _positional, ITopLevelStruct input)
+        public static Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct RoundTrip(double _positional, Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct input)
         {
-            return InvokeStaticMethod<ITopLevelStruct>(typeof(StructPassing), new object[]{_positional, input});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct>(typeof(StructPassing), new object[]{_positional, input});
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Sum.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Sum.cs
@@ -1,13 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.composition;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation that sums multiple values.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(Sum), fullyQualifiedName: "jsii-calc.Sum")]
-    public class Sum : CompositeOperation_
+    public class Sum : Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation_
     {
         /// <remarks>stability: Experimental</remarks>
         public Sum(): base(new DeputyProps(new object[]{}))
@@ -25,17 +23,17 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public override Value_ Expression
+        public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Expression
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>The parts to sum.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "parts", typeJson: "{\"collection\":{\"kind\":\"array\",\"elementtype\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}}")]
-        public virtual Value_[] Parts
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[] Parts
         {
-            get => GetInstanceProperty<Value_[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_[]>();
             set => SetInstanceProperty(value);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStruct.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class TopLevelStruct : ITopLevelStruct
+    public class TopLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct
     {
         /// <summary>This is a required field.</summary>
         /// <remarks>stability: Experimental</remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStructProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(ITopLevelStruct), fullyQualifiedName: "jsii-calc.TopLevelStruct")]
-    internal sealed class TopLevelStructProxy : DeputyBase, ITopLevelStruct
+    internal sealed class TopLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct
     {
         private TopLevelStructProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperation.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperation.cs
@@ -1,15 +1,14 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <summary>An operation on a single operand.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(UnaryOperation), fullyQualifiedName: "jsii-calc.UnaryOperation", parametersJson: "[{\"name\":\"operand\",\"type\":{\"fqn\":\"@scope/jsii-calc-lib.Value\"}}]")]
-    public abstract class UnaryOperation : Operation
+    public abstract class UnaryOperation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation
     {
         /// <remarks>stability: Experimental</remarks>
-        protected UnaryOperation(Value_ operand): base(new DeputyProps(new object[]{operand}))
+        protected UnaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ operand): base(new DeputyProps(new object[]{operand}))
         {
         }
 
@@ -23,9 +22,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "operand", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Operand
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Operand
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnaryOperationProxy.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <summary>An operation on a single operand.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(UnaryOperation), fullyQualifiedName: "jsii-calc.UnaryOperation")]
-    internal sealed class UnaryOperationProxy : UnaryOperation
+    internal sealed class UnaryOperationProxy : Amazon.JSII.Tests.CalculatorNamespace.UnaryOperation
     {
         private UnaryOperationProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiByValue]
-    public class UnionProperties : IUnionProperties
+    public class UnionProperties : Amazon.JSII.Tests.CalculatorNamespace.IUnionProperties
     {
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "bar", typeJson: "{\"union\":{\"types\":[{\"primitive\":\"string\"},{\"primitive\":\"number\"},{\"fqn\":\"jsii-calc.AllTypes\"}]}}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionPropertiesProxy.cs
@@ -4,7 +4,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 {
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(IUnionProperties), fullyQualifiedName: "jsii-calc.UnionProperties")]
-    internal sealed class UnionPropertiesProxy : DeputyBase, IUnionProperties
+    internal sealed class UnionPropertiesProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IUnionProperties
     {
         private UnionPropertiesProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseCalcBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UseCalcBase.cs
@@ -1,5 +1,4 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace
 {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UsesInterfaceWithProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UsesInterfaceWithProperties.cs
@@ -7,7 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     public class UsesInterfaceWithProperties : DeputyBase
     {
         /// <remarks>stability: Experimental</remarks>
-        public UsesInterfaceWithProperties(IIInterfaceWithProperties obj): base(new DeputyProps(new object[]{obj}))
+        public UsesInterfaceWithProperties(Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties obj): base(new DeputyProps(new object[]{obj}))
         {
         }
 
@@ -21,9 +21,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "obj", typeJson: "{\"fqn\":\"jsii-calc.IInterfaceWithProperties\"}")]
-        public virtual IIInterfaceWithProperties Obj
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties Obj
         {
-            get => GetInstanceProperty<IIInterfaceWithProperties>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithProperties>();
         }
 
         /// <remarks>stability: Experimental</remarks>
@@ -35,7 +35,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
         /// <remarks>stability: Experimental</remarks>
         [JsiiMethod(name: "readStringAndNumber", returnsJson: "{\"type\":{\"primitive\":\"string\"}}", parametersJson: "[{\"name\":\"ext\",\"type\":{\"fqn\":\"jsii-calc.IInterfaceWithPropertiesExtension\"}}]")]
-        public virtual string ReadStringAndNumber(IIInterfaceWithPropertiesExtension ext)
+        public virtual string ReadStringAndNumber(Amazon.JSII.Tests.CalculatorNamespace.IIInterfaceWithPropertiesExtension ext)
         {
             return InvokeInstanceMethod<string>(new object[]{ext});
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VoidCallbackProxy.cs
@@ -10,7 +10,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// stability: Experimental
     /// </remarks>
     [JsiiTypeProxy(nativeType: typeof(VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
-    internal sealed class VoidCallbackProxy : VoidCallback
+    internal sealed class VoidCallbackProxy : Amazon.JSII.Tests.CalculatorNamespace.VoidCallback
     {
         private VoidCallbackProxy(ByRefValue reference): base(reference)
         {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperationProxy.cs
@@ -1,12 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition
 {
     /// <summary>Abstract operation composed from an expression of other operations.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiTypeProxy(nativeType: typeof(CompositeOperation_), fullyQualifiedName: "jsii-calc.composition.CompositeOperation")]
-    internal sealed class CompositeOperationProxy : CompositeOperation_
+    internal sealed class CompositeOperationProxy : Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation_
     {
         private CompositeOperationProxy(ByRefValue reference): base(reference)
         {
@@ -15,9 +14,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public override Value_ Expression
+        public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Expression
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation_.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/composition/CompositeOperation_.cs
@@ -1,13 +1,11 @@
 using Amazon.JSII.Runtime.Deputy;
-using Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation;
-using Amazon.JSII.Tests.CalculatorNamespace.LibNamespace;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.composition
 {
     /// <summary>Abstract operation composed from an expression of other operations.</summary>
     /// <remarks>stability: Experimental</remarks>
     [JsiiClass(nativeType: typeof(CompositeOperation_), fullyQualifiedName: "jsii-calc.composition.CompositeOperation")]
-    public abstract class CompositeOperation_ : Operation
+    public abstract class CompositeOperation_ : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation
     {
         protected CompositeOperation_(): base(new DeputyProps(new object[]{}))
         {
@@ -24,9 +22,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         /// <summary>The expression that this operation consists of. Must be implemented by derived classes.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "expression", typeJson: "{\"fqn\":\"@scope/jsii-calc-lib.Value\"}")]
-        public virtual Value_ Expression
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_ Expression
         {
-            get => GetInstanceProperty<Value_>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Value_>();
         }
 
         /// <summary>The value.</summary>
@@ -58,9 +56,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.composition
         /// <summary>The .toString() style.</summary>
         /// <remarks>stability: Experimental</remarks>
         [JsiiProperty(name: "stringStyle", typeJson: "{\"fqn\":\"jsii-calc.composition.CompositeOperation.CompositionStringStyle\"}")]
-        public virtual CompositionStringStyle StringStyle
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation.CompositionStringStyle StringStyle
         {
-            get => GetInstanceProperty<CompositionStringStyle>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation.CompositionStringStyle>();
             set => SetInstanceProperty(value);
         }
 


### PR DESCRIPTION
Stop generating `using` statements for types referenced in a particular
file, so as to avoid running into cases where a given type (leaf) name
corresponds to a locally defined type as well as a dependent type, which
breaks compilation as `dotnet` will resolve to the local type with
higher priority than the  `using` type.

Fixes #650

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
