### PR TITLE
chore: update dependabot default labels to new standard

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -20,33 +20,56 @@ update_configs:
           dependency_name: '@types/decamelize'
           version_requirement: '>= 2'
     version_requirement_updates: increase_versions
+    default_labels:
+      - dependency
 
   - directory: /packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel
     package_manager: dotnet:nuget
     update_schedule: daily
+    default_labels:
+      - dependency
+      - language/dotnet
 
   - directory: /packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel.UnitTests
     package_manager: dotnet:nuget
     update_schedule: daily
+    default_labels:
+      - dependency
+      - language/dotnet
 
   - directory: /packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime
     package_manager: dotnet:nuget
     update_schedule: daily
+    default_labels:
+      - dependency
+      - language/dotnet
 
   - directory: /packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests
     package_manager: dotnet:nuget
     update_schedule: daily
+    default_labels:
+      - dependency
+      - language/dotnet
 
   - directory: /packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests
     package_manager: dotnet:nuget
     update_schedule: daily
+    default_labels:
+      - dependency
+      - language/dotnet
 
   - directory: /packages/jsii-python-runtime
     package_manager: python
     update_schedule: live
     version_requirement_updates: auto
+    default_labels:
+      - dependency
+      - language/python
 
   - directory: /packages/jsii-ruby-runtime/project
     package_manager: ruby:bundler
     update_schedule: live
     version_requirement_updates: increase_versions
+    default_labels:
+      - dependency
+      - language/ruby


### PR DESCRIPTION
Updated @dependabot configuration to use new `language/<name>` labels.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
