### PR TITLE
chore: minor tweaks to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,15 @@ script:
   - set -eo pipefail
   - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:latest" ./superchain
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:latest ./build.sh
+  - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"
+  - echo "TRAVIS_TAG          = ${TRAVIS_TAG:-}"
+  - echo "TRAVIS_BRANCH       = ${TRAVIS_BRANCH:-}"
   - >-
-    echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST}"
     if [ ${TRAVIS_PULL_REQUEST} != false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
-      echo "TRAVIS_TAG    = ${TRAVIS_TAG:-}"
-      echo "TRAVIS_BRANCH = ${TRAVIS_BRANCH}"
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
       docker tag "jsii/superchain:latest" "jsii/superchain:${TRAVIS_BRANCH}"
       docker push "jsii/superchain:${TRAVIS_BRANCH}"
       if [ "${TRAVIS_TAG:-}" = "${TRAVIS_BRANCH}" ]; then
         docker push jsii/superchain:latest
       fi
-    else
-      echo "Skipping publishing (TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST})"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - echo "TRAVIS_TAG          = ${TRAVIS_TAG:-}"
   - echo "TRAVIS_BRANCH       = ${TRAVIS_BRANCH:-}"
   - >-
-    if [ ${TRAVIS_PULL_REQUEST} != false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
+    if [ ${TRAVIS_PULL_REQUEST} = false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
       docker tag "jsii/superchain:latest" "jsii/superchain:${TRAVIS_BRANCH}"
       docker push "jsii/superchain:${TRAVIS_BRANCH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ services:
 
 before_script:
   # Attempt to pre-cache the previous version of the image, to speed build up
-  - docker pull jsii/superchain:latest || true
+  - docker pull jsii/superchain:nightly || true
 
 script:
   - set -eo pipefail
   - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:nightly" ./superchain
-  - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:latest ./build.sh
+  - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:nightly ./build.sh
   - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"
   - echo "TRAVIS_TAG          = ${TRAVIS_TAG:-}"
   - echo "TRAVIS_BRANCH       = ${TRAVIS_BRANCH:-}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ script:
   - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:latest" ./superchain
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:latest ./build.sh
   - >-
-    if [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
+    if [ $TRAVIS_PULL_REQUEST != false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-      if [ ! -z "${TRAVIS_TAG+SET}" ]; then
+      docker push "jsii/superchain:${TRAVIS_BRANCH}"
+      echo "TRAVIS_TAG    = ${TRAVIS_TAG:-}"
+      echo "TRAVIS_BRANCH = ${TRAVIS_BRANCH}"
+      if [ "${TRAVIS_TAG:-}" = "${TRAVIS_BRANCH}" ]; then
         docker push jsii/superchain:latest
-      else
-        docker push "jsii/superchain:${TRAVIS_BRANCH}"
       fi
+    else
+      echo "Skipping publishing (TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST})"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 
 script:
   - set -eo pipefail
-  - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:latest" ./superchain
+  - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:nightly" ./superchain
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:latest ./build.sh
   - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"
   - echo "TRAVIS_TAG          = ${TRAVIS_TAG:-}"
@@ -22,9 +22,9 @@ script:
   - >-
     if [ ${TRAVIS_PULL_REQUEST} = false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-      docker tag "jsii/superchain:latest" "jsii/superchain:${TRAVIS_BRANCH}"
-      docker push "jsii/superchain:${TRAVIS_BRANCH}"
+      docker push jsii/superchain:nightly
       if [ "${TRAVIS_TAG:-}" = "${TRAVIS_BRANCH}" ]; then
+        docker tag jsii/superchain:nightly jsii/superchain:latest
         docker push jsii/superchain:latest
       fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ script:
   - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:latest" ./superchain
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:latest ./build.sh
   - >-
-    if [ $TRAVIS_PULL_REQUEST != false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
-      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-      docker push "jsii/superchain:${TRAVIS_BRANCH}"
+    echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST}"
+    if [ ${TRAVIS_PULL_REQUEST} != false ] && [ ! -z "${DOCKER_USERNAME+SET}" ] && [ ! -z "${DOCKER_PASSWORD+SET}" ]; then
       echo "TRAVIS_TAG    = ${TRAVIS_TAG:-}"
       echo "TRAVIS_BRANCH = ${TRAVIS_BRANCH}"
+      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+      docker tag "jsii/superchain:latest" "jsii/superchain:${TRAVIS_BRANCH}"
+      docker push "jsii/superchain:${TRAVIS_BRANCH}"
       if [ "${TRAVIS_TAG:-}" = "${TRAVIS_BRANCH}" ]; then
         docker push jsii/superchain:latest
       fi


### PR DESCRIPTION
More explicitly skip publishing to DockerHub if this is a PR build. Display
values of `$TRAVIS_TAG` and `$TRAVIS_BRANCH` for more information
when troubleshooting builds (if that's related to publishing).

Release builds from `master` to a `:nightly` tag while (git) tagged builds
will (also) release to `:latest`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0