### PR TITLE
chore(ci): remove check against source tree from CodeBuild buildspec

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -13,7 +13,6 @@ phases:
   post_build:
     commands:
       - "[ -f .BUILD_COMPLETED ] && /bin/bash ./pack.sh"
-      - git diff-index --exit-code --ignore-space-at-eol --stat HEAD
 artifacts:
   files:
     - "**/*"


### PR DESCRIPTION
Modification to the check introduced in #668 

CodePipeline downloads the source as a zip from the source provider rather than doing a Git clone.
This means the .git folder won't be retained and git commands won't work in CodeBuild. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
