### PR TITLE
chore: upgrade Java runtime dependencies

### DIFF
--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -51,11 +51,12 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions of the dependencies -->
         <findbugs.version>[3.0.2,3.1.0)</findbugs.version>
-        <guava.version>[27.0.1-jre,27.1)</guava.version>
-        <jackson.version>[2.9.8,2.10.0)</jackson.version>
+        <guava.version>[28.0-jre,28.1)</guava.version>
+        <jackson-core.version>[2.9.9,2.10.0)</jackson-core.version>
+        <jackson-databind.version>[2.9.9.2,2.10.0)</jackson-databind.version>
         <javax.annotations.version>[1.3.2,1.4.0)</javax.annotations.version>
-        <junit.version>[5.4.1,5.5.0)</junit.version>
-        <mockito.version>[2.25.1,2.26.0)</mockito.version>
+        <junit.version>[5.5.1,5.6.0)</junit.version>
+        <mockito.version>[3.0.0,3.1.0)</mockito.version>
     </properties>
 
     <dependencies>
@@ -63,14 +64,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>\${jackson.version}</version>
+            <version>\${jackson-core.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>\${jackson.version}</version>
+            <version>\${jackson-databind.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
@@ -111,7 +112,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+        <!-- https://mvnrepository.com/artifact/org.mjockito/mockito-core -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
Moves past certain security vulnerabilities in Jackson-databind.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
