### PR TITLE
fix(java): improve property override detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ script:
   - docker build --pull --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg COMMIT_ID="${TRAVIS_COMMIT}" -t "jsii/superchain:nightly" ./superchain
   # Building jsii itself within the Docker image
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:nightly ./build.sh
-  # Make sure the build did not change the source tree (git diff-index will return non-zero if that's the case)
-  - git update-index && git diff-index --exit-code --stat HEAD
+  # Make sure the build did not change the source tree
+  - git update-index --refresh
+  - git diff-index --exit-code --stat HEAD
   - untracked=$(git ls-files --others --exclude-standard) && echo "${untracked}" && test -z "${untracked}"
   # Publish the image to DockerHub when relevant
   - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   # Building jsii itself within the Docker image
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:nightly ./build.sh
   # Make sure the build did not change the source tree (git diff-index will return non-zero if that's the case)
-  - git diff-index --exit-code --ignore-space-at-eol --stat HEAD
+  - git diff-index --exit-code --stat HEAD
   - untracked=$(git ls-files --others --exclude-standard) && echo "${untracked}" && test -z "${untracked}"
   # Publish the image to DockerHub when relevant
   - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   # Building jsii itself within the Docker image
   - docker run --rm -it --net=host -v ${PWD}:${PWD} -w ${PWD} jsii/superchain:nightly ./build.sh
   # Make sure the build did not change the source tree (git diff-index will return non-zero if that's the case)
-  - git diff-index --exit-code --stat HEAD
+  - git update-index && git diff-index --exit-code --stat HEAD
   - untracked=$(git ls-files --others --exclude-standard) && echo "${untracked}" && test -z "${untracked}"
   # Publish the image to DockerHub when relevant
   - echo "TRAVIS_PULL_REQUEST = ${TRAVIS_PULL_REQUEST:-}"

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -491,8 +491,8 @@ public final class JsiiEngine implements JsiiCallbackHandler {
                 String methodName = method.getName();
 
                 // check if this is a property ("getXXX" or "setXXX", oh java!)
-                if (isJavaPropertyMethod(methodName)) {
-                    String propertyName = javaPropertyToJSProperty(methodName);
+                if (isJavaPropertyMethod(method)) {
+                    String propertyName = javaPropertyToJSProperty(method);
 
                     // skip if this property is already in the overrides list
                     if (overrides.containsKey(propertyName)) {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Util.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Util.java
@@ -43,8 +43,8 @@ final class Util {
 
     /**
      * Checks if the method name looks like a java property getter (getXxx).
-     * @param methodName The name of the method.
-     * @return True if the name looks like getXxx.
+     * @param method The reflected method that may be a get/setter
+     * @return true if the method is a get/setter.
      */
     static boolean isJavaPropertyMethod(final Method method) {
         final String methodName = method.getName();
@@ -73,14 +73,16 @@ final class Util {
             return getter.getReturnType().equals(returnType);
         } catch (final NoSuchMethodException nsme) {
             return declaring.equals(Object.class)
-                                                  ? false
-                                                  : isMatchingGetterPresent(getterName, returnType, declaring.getSuperclass());
+                ? false
+                : isMatchingGetterPresent(getterName,
+                                          returnType,
+                                          declaring.getSuperclass());
         }
     }
 
     /**
      * Convert a java property method name (getXxx/setXxx) to a javascript property name (xxx).
-     * @param getterSetterMethod The java method name
+     * @param method The reflected method (assumed to be a get/setter according to #isJavaPropertyMethod)
      * @return The javascript property name
      */
     static String javaPropertyToJSProperty(final Method method) {

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Util.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/Util.java
@@ -2,6 +2,7 @@ package software.amazon.jsii;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,9 +46,36 @@ final class Util {
      * @param methodName The name of the method.
      * @return True if the name looks like getXxx.
      */
-    static boolean isJavaPropertyMethod(final String methodName) {
-        return (methodName.length() > PROPERTY_METHOD_PREFIX_LEN
-                && (methodName.startsWith("get") || methodName.startsWith(("set"))));
+    static boolean isJavaPropertyMethod(final Method method) {
+        final String methodName = method.getName();
+        if (methodName.length() <= PROPERTY_METHOD_PREFIX_LEN) {
+            // Needs to have at least one character after the "get" or "set" prefix
+            return false;
+        }
+        if (methodName.startsWith("get") && method.getParameterCount() == 0) {
+            // Require something else than a lowercase letter after the "get" prefix
+            return !Character.isLowerCase(methodName.charAt(3));
+        }
+        if (methodName.startsWith("set") && method.getParameterCount() == 1) {
+            // Require something else than a lowercase letter after the "get" prefix
+            return !Character.isLowerCase(methodName.charAt(3))
+                // Require a matching getter
+                && isMatchingGetterPresent(method.getName().replaceFirst("set", "get"),
+                    method.getParameterTypes()[0],
+                    method.getDeclaringClass());
+        }
+        return false;
+    }
+
+    private static boolean isMatchingGetterPresent(final String getterName, final Class<?> returnType, final Class<?> declaring) {
+        try {
+            final Method getter = declaring.getDeclaredMethod(getterName);
+            return getter.getReturnType().equals(returnType);
+        } catch (final NoSuchMethodException nsme) {
+            return declaring.equals(Object.class)
+                                                  ? false
+                                                  : isMatchingGetterPresent(getterName, returnType, declaring.getSuperclass());
+        }
     }
 
     /**
@@ -55,8 +83,9 @@ final class Util {
      * @param getterSetterMethod The java method name
      * @return The javascript property name
      */
-    static String javaPropertyToJSProperty(final String getterSetterMethod) {
-        if (!isJavaPropertyMethod(getterSetterMethod)) {
+    static String javaPropertyToJSProperty(final Method method) {
+        final String getterSetterMethod = method.getName();
+        if (!isJavaPropertyMethod(method)) {
             throw new JsiiException("Invalid getter/setter method. Must start with get/set");
         }
 

--- a/packages/jsii-pacmak/package-lock.json
+++ b/packages/jsii-pacmak/package-lock.json
@@ -116,21 +116,6 @@
 			"dev": true,
 			"requires": {
 				"@scope/jsii-calc-base": "file:../jsii-calc-base"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				}
 			}
 		},
 		"@types/clone": {
@@ -1057,40 +1042,6 @@
 			"dev": true,
 			"requires": {
 				"fs-extra": "^8.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-					"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
 			}
 		},
 		"jsii-calc": {
@@ -1101,51 +1052,6 @@
 				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
 				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
 				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				},
-				"@scope/jsii-calc-base-of-base": {
-					"version": "file:../jsii-calc-base-of-base",
-					"dev": true
-				},
-				"@scope/jsii-calc-lib": {
-					"version": "file:../jsii-calc-lib",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base": "file:../jsii-calc-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base": {
-							"version": "file:../jsii-calc-base",
-							"dev": true,
-							"requires": {
-								"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-							},
-							"dependencies": {
-								"@scope/jsii-calc-base-of-base": {
-									"version": "file:../jsii-calc-base-of-base",
-									"dev": true
-								}
-							}
-						}
-					}
-				},
-				"jsii-calc-bundled": {
-					"version": "file:../jsii-calc-bundled",
-					"dev": true
-				}
 			}
 		},
 		"jsii-dotnet-jsonmodel": {
@@ -1157,12 +1063,6 @@
 			"dev": true,
 			"requires": {
 				"jsii-dotnet-jsonmodel": "file:../jsii-dotnet-jsonmodel"
-			},
-			"dependencies": {
-				"jsii-dotnet-jsonmodel": {
-					"version": "file:../jsii-dotnet-jsonmodel",
-					"dev": true
-				}
 			}
 		},
 		"jsii-java-runtime": {

--- a/packages/jsii-reflect/package-lock.json
+++ b/packages/jsii-reflect/package-lock.json
@@ -396,21 +396,6 @@
 			"dev": true,
 			"requires": {
 				"@scope/jsii-calc-base": "file:../jsii-calc-base"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				}
 			}
 		},
 		"@types/babel__core": {
@@ -3558,40 +3543,6 @@
 			"dev": true,
 			"requires": {
 				"fs-extra": "^8.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-					"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
 			}
 		},
 		"jsii-calc": {
@@ -3602,51 +3553,6 @@
 				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
 				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
 				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				},
-				"@scope/jsii-calc-base-of-base": {
-					"version": "file:../jsii-calc-base-of-base",
-					"dev": true
-				},
-				"@scope/jsii-calc-lib": {
-					"version": "file:../jsii-calc-lib",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base": "file:../jsii-calc-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base": {
-							"version": "file:../jsii-calc-base",
-							"dev": true,
-							"requires": {
-								"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-							},
-							"dependencies": {
-								"@scope/jsii-calc-base-of-base": {
-									"version": "file:../jsii-calc-base-of-base",
-									"dev": true
-								}
-							}
-						}
-					}
-				},
-				"jsii-calc-bundled": {
-					"version": "file:../jsii-calc-bundled",
-					"dev": true
-				}
 			}
 		},
 		"jsii-spec": {

--- a/packages/jsii-ruby-runtime/project/Gemfile.lock
+++ b/packages/jsii-ruby-runtime/project/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsii_runtime (0.14.2)
+    jsii_runtime (0.14.3)
 
 GEM
   remote: https://rubygems.org/
@@ -34,4 +34,4 @@ DEPENDENCIES
   test-unit (~> 3.3.3)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/packages/jsii-runtime/package-lock.json
+++ b/packages/jsii-runtime/package-lock.json
@@ -174,12 +174,6 @@
 			"dev": true,
 			"requires": {
 				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base-of-base": {
-					"version": "file:../jsii-calc-base-of-base",
-					"dev": true
-				}
 			}
 		},
 		"@scope/jsii-calc-lib": {
@@ -187,21 +181,6 @@
 			"dev": true,
 			"requires": {
 				"@scope/jsii-calc-base": "file:../jsii-calc-base"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				}
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -3142,40 +3121,6 @@
 			"dev": true,
 			"requires": {
 				"fs-extra": "^8.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
 			}
 		},
 		"jsii-calc": {
@@ -3186,51 +3131,6 @@
 				"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base",
 				"@scope/jsii-calc-lib": "file:../jsii-calc-lib",
 				"jsii-calc-bundled": "file:../jsii-calc-bundled"
-			},
-			"dependencies": {
-				"@scope/jsii-calc-base": {
-					"version": "file:../jsii-calc-base",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base-of-base": {
-							"version": "file:../jsii-calc-base-of-base",
-							"dev": true
-						}
-					}
-				},
-				"@scope/jsii-calc-base-of-base": {
-					"version": "file:../jsii-calc-base-of-base",
-					"dev": true
-				},
-				"@scope/jsii-calc-lib": {
-					"version": "file:../jsii-calc-lib",
-					"dev": true,
-					"requires": {
-						"@scope/jsii-calc-base": "file:../jsii-calc-base"
-					},
-					"dependencies": {
-						"@scope/jsii-calc-base": {
-							"version": "file:../jsii-calc-base",
-							"dev": true,
-							"requires": {
-								"@scope/jsii-calc-base-of-base": "file:../jsii-calc-base-of-base"
-							},
-							"dependencies": {
-								"@scope/jsii-calc-base-of-base": {
-									"version": "file:../jsii-calc-base-of-base",
-									"dev": true
-								}
-							}
-						}
-					}
-				},
-				"jsii-calc-bundled": {
-					"version": "file:../jsii-calc-bundled",
-					"dev": true
-				}
 			}
 		},
 		"jsii-kernel": {

--- a/packages/jsii/package-lock.json
+++ b/packages/jsii/package-lock.json
@@ -1033,40 +1033,6 @@
 			"dev": true,
 			"requires": {
 				"fs-extra": "^8.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-					"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
 			}
 		},
 		"jsii-spec": {

--- a/packages/oo-ascii-tree/package-lock.json
+++ b/packages/oo-ascii-tree/package-lock.json
@@ -3114,40 +3114,6 @@
 			"dev": true,
 			"requires": {
 				"fs-extra": "^8.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-					"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"universalify": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-					"dev": true
-				}
 			}
 		},
 		"json-parse-better-errors": {


### PR DESCRIPTION
The previous code only checked whether a methodd name was a get/setter
by checking if it's name started by `get` or `set` and was at least 4
characters long. This is insufficient, as a method called `settings`
would be misidentified.

Changed to expect getters to have zero parameters, and setters to have
exactly one parameter and to match a corresponding getter.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
