### PR TITLE
feat(java): overhauled structs with native implementation, builders, ...

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1775,6 +1775,22 @@ export interface SecondLevelStruct {
     readonly deeperOptionalProp?: string;
 }
 
+export interface DiamondInheritanceBaseLevelStruct {
+    readonly baseLevelProperty: string;
+}
+
+export interface DiamondInheritanceFirstMidLevelStruct extends DiamondInheritanceBaseLevelStruct {
+    readonly firstMidLevelProperty: string;
+}
+
+export interface DiamondInheritanceSecondMidLevelStruct extends DiamondInheritanceBaseLevelStruct {
+    readonly secondMidLevelProperty: string;
+}
+
+export interface DiamondInheritanceTopLevelStruct extends DiamondInheritanceFirstMidLevelStruct, DiamondInheritanceSecondMidLevelStruct {
+    readonly topLevelProperty: string;
+}
+
 /**
  * Just because we can.
  *

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -2583,6 +2583,140 @@
         }
       ]
     },
+    "jsii-calc.DiamondInheritanceBaseLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceBaseLevelStruct",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1778
+      },
+      "name": "DiamondInheritanceBaseLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1779
+          },
+          "name": "baseLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceFirstMidLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceFirstMidLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceBaseLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1782
+      },
+      "name": "DiamondInheritanceFirstMidLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1783
+          },
+          "name": "firstMidLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceSecondMidLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceSecondMidLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceBaseLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1786
+      },
+      "name": "DiamondInheritanceSecondMidLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1787
+          },
+          "name": "secondMidLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceTopLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceTopLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceFirstMidLevelStruct",
+        "jsii-calc.DiamondInheritanceSecondMidLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1790
+      },
+      "name": "DiamondInheritanceTopLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1791
+          },
+          "name": "topLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.DoNotOverridePrivates": {
       "assembly": "jsii-calc",
       "docs": {
@@ -7844,7 +7978,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/compliance.ts",
-        "line": 1783
+        "line": 1799
       },
       "methods": [
         {
@@ -7853,7 +7987,7 @@
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1792
+            "line": 1808
           },
           "name": "howManyVarArgsDidIPass",
           "parameters": [
@@ -7885,7 +8019,7 @@
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1784
+            "line": 1800
           },
           "name": "roundTrip",
           "parameters": [
@@ -9081,5 +9215,5 @@
     }
   },
   "version": "0.14.3",
-  "fingerprint": "Ld7vqOD5LvQ5a/I1LdRkj08XkdS+7syV580DELBDa+Y="
+  "fingerprint": "a/jxMJzoCSejg4NPvGH9qpyWwkZxCHN/zb4T5d00Cto="
 }

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -16,6 +16,7 @@ import software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutom
 import software.amazon.jsii.tests.calculator.Constructors;
 import software.amazon.jsii.tests.calculator.DataRenderer;
 import software.amazon.jsii.tests.calculator.DerivedStruct;
+import software.amazon.jsii.tests.calculator.DiamondInheritanceTopLevelStruct;
 import software.amazon.jsii.tests.calculator.DoNotOverridePrivates;
 import software.amazon.jsii.tests.calculator.DoubleTrouble;
 import software.amazon.jsii.tests.calculator.EraseUndefinedHashValues;
@@ -40,12 +41,14 @@ import software.amazon.jsii.tests.calculator.NodeStandardLibrary;
 import software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefined;
 import software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData;
 import software.amazon.jsii.tests.calculator.NumberGenerator;
+import software.amazon.jsii.tests.calculator.OptionalStruct;
 import software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer;
 import software.amazon.jsii.tests.calculator.Polymorphism;
 import software.amazon.jsii.tests.calculator.Power;
 import software.amazon.jsii.tests.calculator.PublicClass;
 import software.amazon.jsii.tests.calculator.ReferenceEnumFromScopedPackage;
 import software.amazon.jsii.tests.calculator.ReturnsPrivateImplementationOfInterface;
+import software.amazon.jsii.tests.calculator.StableStruct;
 import software.amazon.jsii.tests.calculator.Statics;
 import software.amazon.jsii.tests.calculator.Sum;
 import software.amazon.jsii.tests.calculator.SyncVirtualMethods;
@@ -214,7 +217,7 @@ public class ComplianceTest {
     @Test
     public void createObjectAndCtorOverloads() {
         new Calculator();
-        new Calculator(CalculatorProps.builder().withMaximumValue(10).build());
+        new Calculator(CalculatorProps.builder().maximumValue(10).build());
     }
 
     @Test
@@ -307,8 +310,8 @@ public class ComplianceTest {
     @Test
     public void fluentApi() {
         final Calculator calc3 = new Calculator(CalculatorProps.builder()
-                .withInitialValue(20)
-                .withMaximumValue(30)
+                .initialValue(20)
+                .maximumValue(30)
                 .build());
         calc3.add(3);
         assertEquals(23, calc3.getValue());
@@ -319,29 +322,29 @@ public class ComplianceTest {
 
         // verify we have a withXxx overload for each union type
         UnionProperties.Builder builder = UnionProperties.builder();
-        assertNotNull(builder.getClass().getMethod("withBar", java.lang.Number.class));
-        assertNotNull(builder.getClass().getMethod("withBar", String.class));
-        assertNotNull(builder.getClass().getMethod("withBar", AllTypes.class));
-        assertNotNull(builder.getClass().getMethod("withFoo", String.class));
-        assertNotNull(builder.getClass().getMethod("withFoo", java.lang.Number.class));
+        assertNotNull(builder.getClass().getMethod("bar", java.lang.Number.class));
+        assertNotNull(builder.getClass().getMethod("bar", String.class));
+        assertNotNull(builder.getClass().getMethod("bar", AllTypes.class));
+        assertNotNull(builder.getClass().getMethod("foo", String.class));
+        assertNotNull(builder.getClass().getMethod("foo", java.lang.Number.class));
 
         UnionProperties obj1 = UnionProperties.builder()
-            .withBar(12)
-            .withFoo("Hello")
+            .bar(12)
+            .foo("Hello")
             .build();
         assertEquals(12, obj1.getBar());
         assertEquals("Hello", obj1.getFoo());
 
         UnionProperties obj2 = UnionProperties.builder()
-            .withBar("BarIsString")
+            .bar("BarIsString")
             .build();
         assertEquals("BarIsString", obj2.getBar());
         assertNull(obj2.getFoo());
 
         AllTypes allTypes = new AllTypes();
         UnionProperties obj3 = UnionProperties.builder()
-            .withBar(allTypes)
-            .withFoo(999)
+            .bar(allTypes)
+            .foo(999)
             .build();
         assertSame(allTypes, obj3.getBar());
         assertEquals(999, obj3.getFoo());
@@ -350,8 +353,8 @@ public class ComplianceTest {
     @Test
     public void exceptions() {
         final Calculator calc3 = new Calculator(CalculatorProps.builder()
-            .withInitialValue(20)
-            .withMaximumValue(30).build());
+            .initialValue(20)
+            .maximumValue(30).build());
         calc3.add(3);
         assertEquals(23, calc3.getValue());
         boolean thrown = false;
@@ -746,12 +749,12 @@ public class ComplianceTest {
         DoubleTrouble nonPrim = new DoubleTrouble();
 
         DerivedStruct s = new DerivedStruct.Builder()
-                .withNonPrimitive(nonPrim)
-                .withBool(false)
-                .withAnotherRequired(someInstant)
-                .withAstring("Hello")
-                .withAnumber(1234)
-                .withFirstOptional(Arrays.asList("Hello", "World"))
+                .nonPrimitive(nonPrim)
+                .bool(false)
+                .anotherRequired(someInstant)
+                .astring("Hello")
+                .anumber(1234)
+                .firstOptional(Arrays.asList("Hello", "World"))
                 .build();
 
         assertSame(nonPrim, s.getNonPrimitive());
@@ -764,16 +767,16 @@ public class ComplianceTest {
         assertNull(s.getOptionalArray());
 
         MyFirstStruct myFirstStruct = new MyFirstStruct.Builder()
-                .withAstring("Hello")
-                .withAnumber(12)
+                .astring("Hello")
+                .anumber(12)
                 .build();
 
         assertEquals("Hello", myFirstStruct.getAstring());
         assertEquals(12, myFirstStruct.getAnumber());
 
         StructWithOnlyOptionals onlyOptionals1 = new StructWithOnlyOptionals.Builder()
-                .withOptional1("Hello")
-                .withOptional2(1)
+                .optional1("Hello")
+                .optional2(1)
                 .build();
 
         assertEquals("Hello", onlyOptionals1.getOptional1());
@@ -786,28 +789,180 @@ public class ComplianceTest {
         assertNull(onlyOptionals2.getOptional3());
     }
 
+    @Test
+    public void structs_withDiamondInheritance_correctlyDedupeProperties() {
+        DiamondInheritanceTopLevelStruct struct = DiamondInheritanceTopLevelStruct.builder()
+                                                                                  .baseLevelProperty("base")
+                                                                                  .firstMidLevelProperty("mid1")
+                                                                                  .secondMidLevelProperty("mid2")
+                                                                                  .topLevelProperty("top")
+                                                                                  .build();
+
+        assertEquals("base", struct.getBaseLevelProperty());
+        assertEquals("mid1", struct.getFirstMidLevelProperty());
+        assertEquals("mid2", struct.getSecondMidLevelProperty());
+        assertEquals("top", struct.getTopLevelProperty());
+    }
+
+    @Test
+    public void structs_nonOptionalequals() {
+        StableStruct structA = StableStruct.builder()
+                                           .readonlyProperty("one")
+                                           .build();
+
+        StableStruct structB = StableStruct.builder()
+                                           .readonlyProperty("one")
+                                           .build();
+
+        StableStruct structC = StableStruct.builder()
+                                           .readonlyProperty("two")
+                                           .build();
+
+
+        assertTrue(structA.equals(structB));
+        assertFalse(structA.equals(structC));
+    }
+
+    @Test
+    public void structs_nonOptionalhashCode() {
+        StableStruct structA = StableStruct.builder()
+                                           .readonlyProperty("one")
+                                           .build();
+
+        StableStruct structB = StableStruct.builder()
+                                           .readonlyProperty("one")
+                                           .build();
+
+        StableStruct structC = StableStruct.builder()
+                                           .readonlyProperty("two")
+                                           .build();
+
+
+        assertTrue(structA.hashCode() == structB.hashCode());
+        assertFalse(structA.hashCode() == structC.hashCode());
+    }
+
+    @Test
+    public void structs_optionalEquals() {
+        OptionalStruct structA = OptionalStruct.builder()
+                                               .field("one")
+                                               .build();
+
+        OptionalStruct structB = OptionalStruct.builder()
+                                               .field("one")
+                                               .build();
+
+        OptionalStruct structC = OptionalStruct.builder()
+                                               .field("two")
+                                               .build();
+
+        OptionalStruct structD = OptionalStruct.builder()
+                                               .build();
+
+
+        assertTrue(structA.equals(structB));
+        assertFalse(structA.equals(structC));
+        assertFalse(structA.equals(structD));
+    }
+
+    @Test
+    public void structs_optionalHashCode() {
+        OptionalStruct structA = OptionalStruct.builder()
+                                               .field("one")
+                                               .build();
+
+        OptionalStruct structB = OptionalStruct.builder()
+                                               .field("one")
+                                               .build();
+
+        OptionalStruct structC = OptionalStruct.builder()
+                                               .field("two")
+                                               .build();
+
+        OptionalStruct structD = OptionalStruct.builder()
+                                               .build();
+
+        assertTrue(structA.hashCode() == structB.hashCode());
+        assertFalse(structA.hashCode() == structC.hashCode());
+        assertFalse(structA.hashCode() == structD.hashCode());
+    }
+
+    @Test
+    public void structs_multiplePropertiesEquals() {
+        DiamondInheritanceTopLevelStruct structA = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("three")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        DiamondInheritanceTopLevelStruct structB = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("three")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        DiamondInheritanceTopLevelStruct structC = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("different")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        assertTrue(structA.equals(structB));
+        assertFalse(structA.equals(structC));
+    }
+
+    @Test
+    public void structs_multiplePropertiesHashCode() {
+        DiamondInheritanceTopLevelStruct structA = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("three")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        DiamondInheritanceTopLevelStruct structB = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("three")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        DiamondInheritanceTopLevelStruct structC = DiamondInheritanceTopLevelStruct.builder()
+                                                                                   .baseLevelProperty("one")
+                                                                                   .firstMidLevelProperty("two")
+                                                                                   .secondMidLevelProperty("different")
+                                                                                   .topLevelProperty("four")
+                                                                                   .build();
+
+        assertTrue(structA.hashCode() == structB.hashCode());
+        assertFalse(structA.hashCode() == structC.hashCode());
+    }
+
     @Test(expected = NullPointerException.class)
-    public void structs_buildersContainNullChecks() {
-        new MyFirstStruct.Builder().withAstring(null);
+    public void structs_containsNullChecks() {
+        new MyFirstStruct.Builder().build();
     }
 
     @Test
     public void structs_serializeToJsii() {
         MyFirstStruct firstStruct = MyFirstStruct.builder()
-                .withAstring("FirstString")
-                .withAnumber(999)
-                .withFirstOptional(Arrays.asList("First", "Optional"))
+                .astring("FirstString")
+                .anumber(999)
+                .firstOptional(Arrays.asList("First", "Optional"))
                 .build();
 
         DoubleTrouble doubleTrouble = new DoubleTrouble();
 
         DerivedStruct derivedStruct = DerivedStruct.builder()
-                .withNonPrimitive(doubleTrouble)
-                .withBool(false)
-                .withAnotherRequired(Instant.now())
-                .withAstring("String")
-                .withAnumber(1234)
-                .withFirstOptional(Arrays.asList("one", "two"))
+                .nonPrimitive(doubleTrouble)
+                .bool(false)
+                .anotherRequired(Instant.now())
+                .astring("String")
+                .anumber(1234)
+                .firstOptional(Arrays.asList("one", "two"))
                 .build();
 
         GiveMeStructs gms = new GiveMeStructs();
@@ -819,6 +974,23 @@ public class ComplianceTest {
         assertEquals("optional1FromStructLiteral", literal.getOptional1());
         assertEquals(false, literal.getOptional3());
         assertNull(literal.getOptional2());
+    }
+
+    @Test
+    public void structs_returnedLiteralEqualsNativeBuilt() {
+        GiveMeStructs gms = new GiveMeStructs();
+        StructWithOnlyOptionals returnedLiteral = gms.getStructLiteral();
+        StructWithOnlyOptionals nativeBuilt = StructWithOnlyOptionals.builder()
+                                                                     .optional1("optional1FromStructLiteral")
+                                                                     .optional3(false)
+                                                                     .build();
+
+        assertEquals(nativeBuilt.getOptional1(), returnedLiteral.getOptional1());
+        assertEquals(nativeBuilt.getOptional2(), returnedLiteral.getOptional2());
+        assertEquals(nativeBuilt.getOptional3(), returnedLiteral.getOptional3());
+        assertEquals(nativeBuilt, returnedLiteral);
+        assertEquals(returnedLiteral, nativeBuilt);
+        assertEquals(nativeBuilt.hashCode(), returnedLiteral.hashCode());
     }
 
     @Test
@@ -977,8 +1149,8 @@ public class ComplianceTest {
         NullShouldBeTreatedAsUndefined obj = new NullShouldBeTreatedAsUndefined("hello", null);
         obj.giveMeUndefined(null);
         obj.giveMeUndefinedInsideAnObject(NullShouldBeTreatedAsUndefinedData.builder()
-                .withThisShouldBeUndefined(null)
-                .withArrayWithThreeElementsAndUndefinedAsSecondArgument(Arrays.asList("hello", null, "boom"))
+                .thisShouldBeUndefined(null)
+                .arrayWithThreeElementsAndUndefinedAsSecondArgument(Arrays.asList("hello", null, "boom"))
                 .build());
         obj.setChangeMeToUndefined(null);
         obj.verifyPropertyIsUndefined();
@@ -1013,7 +1185,7 @@ public class ComplianceTest {
     @Test
     public void eraseUnsetDataValues() {
         EraseUndefinedHashValuesOptions opts = EraseUndefinedHashValuesOptions.builder()
-                .withOption1("option1")
+                .option1("option1")
                 .build();
 
         assertTrue(EraseUndefinedHashValues.doesKeyExist(opts, "option1"));

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiObject.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiObject.java
@@ -1,9 +1,5 @@
 package software.amazon.jsii;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.JsonNode;
-
 import javax.annotation.Nullable;
 
 /**
@@ -24,12 +20,20 @@ public class JsiiObject implements JsiiSerializable {
     /**
      * A special constructor that allows creating wrapper objects while bypassing the normal constructor
      * chain. This is used when an object was created in javascript-land and just needs a wrapper in native-land.
-     * @param initializationMode Must always be set to "Jsii".
+     * @param initializationMode Must always be set to "JSII".
      */
     protected JsiiObject(final InitializationMode initializationMode) {
-        if (initializationMode != InitializationMode.Jsii) {
-            throw new JsiiException("The only supported initialization mode is 'Jsii'");
+        if (initializationMode != InitializationMode.JSII) {
+            throw new JsiiException("The only supported initialization mode is 'JSII'");
         }
+    }
+
+    /**
+     * Used to construct a JSII object with a reference to an existing managed JSII node object.
+     * @param objRef Reference to existing managed JSII node object.
+     */
+    protected JsiiObject(final JsiiObjectRef objRef) {
+        this.objRef = objRef;
     }
 
     /**
@@ -40,7 +44,7 @@ public class JsiiObject implements JsiiSerializable {
          * Used as a way to bypass the the native constructor chain to allow classes that do not extend
          * JsiiObject directly to perform the initialization logic in javascript instead of natively.
          */
-        Jsii
+        JSII;
     }
 
     /**
@@ -145,7 +149,7 @@ public class JsiiObject implements JsiiSerializable {
      * Sets the jsii object reference for this object.
      * @param objRef The objref
      */
-    final void setObjRef(final JsiiObjectRef objRef) {
+    protected final void setObjRef(final JsiiObjectRef objRef) {
         this.objRef = objRef;
     }
 

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiObject.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiObject.java
@@ -24,7 +24,7 @@ public class JsiiObject implements JsiiSerializable {
      */
     protected JsiiObject(final InitializationMode initializationMode) {
         if (initializationMode != InitializationMode.JSII) {
-            throw new JsiiException("The only supported initialization mode is 'JSII'");
+            throw new JsiiException("The only supported initialization mode is '" + InitializationMode.JSII + "'");
         }
     }
 

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -813,7 +813,7 @@ class JavaGenerator extends Generator {
         // collect all properties from all base structs and dedupe by name. It is assumed that the generation of the
         // assembly will not permit multiple overloaded inherited properties with the same name and that this will be
         // enforced by Typescript constraints.
-        const propsByName = new Map<string, JavaProp>();
+        const propsByName: { [name: string]: JavaProp } = {};
         const self = this;
 
         function collectProps(currentIfc: spec.InterfaceType, isBaseClass = false) {
@@ -834,7 +834,7 @@ class JavaGenerator extends Generator {
                     inherited: isBaseClass,
                 };
 
-                propsByName.set(prop.propName, prop);
+                propsByName[prop.propName] = prop;
             }
 
             // add props of base struct
@@ -844,7 +844,7 @@ class JavaGenerator extends Generator {
         }
 
         collectProps(ifc);
-        const props = Array.from(propsByName.values());
+        const props = Object.values(propsByName);
 
         // Start Builder
         this.code.line('/**');

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -14,6 +14,7 @@ import { VERSION, VERSION_DESC } from '../version';
 const spdxLicenseList = require('spdx-license-list');
 
 export default class Java extends Target {
+
     public static toPackageInfos(assm: spec.Assembly): { [language: string]: PackageInfo } {
         const groupId = assm.targets!.java!.maven.groupId;
         const artifactId = assm.targets!.java!.maven.artifactId;
@@ -145,7 +146,19 @@ export default class Java extends Target {
 const MODULE_CLASS_NAME = '$Module';
 const INTERFACE_PROXY_CLASS_NAME = 'Jsii$Proxy';
 
-const JSR305_NULLABLE = '@javax.annotation.Nullable';
+interface JavaProp {
+    docs?: spec.Docs
+    spec: spec.Property
+    propName: string
+    jsiiName: string
+    fieldName: string
+    fieldJavaType: string
+    fieldJavaClass: string
+    javaTypes: string[]
+    nullable: boolean
+    inherited: boolean
+    immutable: boolean
+}
 
 class JavaGenerator extends Generator {
     /** If false, @Generated will not include generator version nor timestamp */
@@ -202,7 +215,7 @@ class JavaGenerator extends Generator {
         this.code.line(`@software.amazon.jsii.Jsii(module = ${this.moduleClass}.class, fqn = "${cls.fqn}")`);
         this.code.openBlock(`public${inner}${absPrefix} class ${cls.name}${extendsExpression}${implementsExpr}`);
 
-        this.emitJsiiInitializers(cls.name);
+        this.emitJsiiInitializers(cls);
         this.emitStaticInitializer(cls);
     }
 
@@ -219,8 +232,9 @@ class JavaGenerator extends Generator {
         this.addJavaDocs(method);
         this.emitStabilityAnnotations(method);
         this.code.openBlock(`${this.renderAccessLevel(method)} ${cls.name}(${this.renderMethodParameters(method)})`);
-        this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);');
-        this.code.line(`software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this${this.renderMethodCallArguments(method)});`);
+        this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
+        const createObjectCall = `software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this${this.renderMethodCallArguments(method)})`;
+        this.code.line(`this.setObjRef(${createObjectCall});`);
         this.code.closeBlock();
     }
 
@@ -317,11 +331,10 @@ class JavaGenerator extends Generator {
 
     protected onEndInterface(ifc: spec.InterfaceType) {
         if (ifc.datatype) {
-            this.emitInterfaceBuilder(ifc);
+            this.emitDataType(ifc);
+        } else {
+            this.emitInterfaceProxy(ifc);
         }
-
-        // emit interface proxy class
-        this.emitInterfaceProxy(ifc);
 
         this.code.closeBlock();
         this.closeFileIfNeeded(ifc);
@@ -332,6 +345,7 @@ class JavaGenerator extends Generator {
         this.addJavaDocs(method);
         this.emitStabilityAnnotations(method);
         this.code.line(`${returnType} ${method.name}(${this.renderMethodParameters(method)});`);
+        this.code.line();
     }
 
     protected onInterfaceMethodOverload(ifc: spec.InterfaceType, overload: spec.Method, _originalMethod: spec.Method) {
@@ -347,11 +361,13 @@ class JavaGenerator extends Generator {
         this.addJavaDocs(prop);
         this.emitStabilityAnnotations(prop);
         this.code.line(`${getterType} get${propName}();`);
+        this.code.line();
 
         if (!prop.immutable) {
             for (const type of setterTypes) {
                 this.addJavaDocs(prop);
                 this.code.line(`void set${propName}(final ${type} value);`);
+                this.code.line();
             }
         }
     }
@@ -622,7 +638,6 @@ class JavaGenerator extends Generator {
             this.addJavaDocs(prop);
             if (overrides) { this.code.line('@Override'); }
             this.emitStabilityAnnotations(prop);
-            if (isNullable(prop)) { this.code.line(JSR305_NULLABLE); }
             this.code.openBlock(`${access} ${statc}${getterType} get${propName}()`);
 
             let statement = 'return ';
@@ -644,8 +659,7 @@ class JavaGenerator extends Generator {
                 this.addJavaDocs(prop);
                 if (overrides) { this.code.line('@Override'); }
                 this.emitStabilityAnnotations(prop);
-                const nullable = isNullable(prop) ? `${JSR305_NULLABLE} ` : '';
-                this.code.openBlock(`${access} ${statc}void set${propName}(${nullable}final ${type} value)`);
+                this.code.openBlock(`${access} ${statc}void set${propName}(final ${type} value)`);
                 let statement = '';
 
                 if (prop.static) {
@@ -672,7 +686,6 @@ class JavaGenerator extends Generator {
         this.addJavaDocs(method);
         this.emitStabilityAnnotations(method);
         if (overrides) { this.code.line('@Override'); }
-        if (isNullable(method.returns)) { this.code.line(JSR305_NULLABLE); }
         if (method.abstract) {
             this.code.line(`${access} abstract ${signature};`);
         } else {
@@ -701,7 +714,10 @@ class JavaGenerator extends Generator {
             : `extends ${this.toNativeFqn(ifc.fqn)}`;
 
         this.code.openBlock(`final static class ${name} ${suffix}`);
-        this.emitJsiiInitializers(name);
+        this.code.openBlock(`protected ${name}(final software.amazon.jsii.JsiiObjectRef objRef)`);
+        this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
+        this.code.line('this.setObjRef(objRef);');
+        this.code.closeBlock();
 
         // compile a list of all unique methods from the current interface and all
         // base interfaces (and their bases).
@@ -779,11 +795,11 @@ class JavaGenerator extends Generator {
         }
     }
 
-    private emitInterfaceBuilder(ifc: spec.InterfaceType) {
+    private emitDataType(ifc: spec.InterfaceType) {
         const interfaceName = ifc.name;
         const builderName = 'Builder';
 
-        this.code.line();
+        // Start builder()
         this.code.line('/**');
         this.code.line(` * @return a {@link Builder} of {@link ${interfaceName}}`);
         this.code.line(' */');
@@ -791,41 +807,34 @@ class JavaGenerator extends Generator {
         this.code.openBlock(`static ${builderName} builder()`);
         this.code.line(`return new ${builderName}();`);
         this.code.closeBlock();
+        this.code.line();
+        // End builder()
 
-        interface Prop {
-            docs?: spec.Docs
-            spec: spec.Property
-            propName: string
-            fieldName: string
-            fieldJavaType: string
-            javaTypes: string[]
-            nullable: boolean
-            inherited: boolean
-            immutable: boolean
-        }
-
-        const props = new Array<Prop>();
-
-        // collect all properties from all base structs
+        // collect all properties from all base structs and dedupe by name. It is assumed that the generation of the
+        // assembly will not permit multiple overloaded inherited properties with the same name and that this will be
+        // enforced by Typescript constraints.
+        const propsByName = new Map<string, JavaProp>();
         const self = this;
 
         function collectProps(currentIfc: spec.InterfaceType, isBaseClass = false) {
             for (const property of currentIfc.properties || []) {
                 const propName = self.code.toPascalCase(property.name);
 
-                const prop: Prop = {
+                const prop: JavaProp = {
                     docs: property.docs,
                     spec: property,
                     propName,
+                    jsiiName: property.name,
                     nullable: !!property.optional,
                     fieldName: self.code.toCamelCase(property.name),
                     fieldJavaType: self.toJavaType(property.type),
+                    fieldJavaClass: `${self.toJavaType(property.type, true)}.class`,
                     javaTypes: self.toJavaTypes(property.type),
                     immutable: property.immutable || false,
                     inherited: isBaseClass,
                 };
 
-                props.push(prop);
+                propsByName.set(prop.propName, prop);
             }
 
             // add props of base struct
@@ -835,29 +844,26 @@ class JavaGenerator extends Generator {
         }
 
         collectProps(ifc);
+        const props = Array.from(propsByName.values());
 
-        this.code.line();
+        // Start Builder
         this.code.line('/**');
         this.code.line(` * A builder for {@link ${interfaceName}}`);
         this.code.line(' */');
         this.emitStabilityAnnotations(ifc);
         this.code.openBlock(`final class ${builderName}`);
+        props.forEach(prop => this.code.line(`private ${prop.fieldJavaType} ${prop.fieldName};`));
+        this.code.line();
 
         for (const prop of props) {
-            if (prop.nullable) {
-                this.code.line(JSR305_NULLABLE);
-            }
-            this.code.line(`private ${prop.fieldJavaType} _${prop.fieldName};`);
-        }
-        this.code.line();
-        for (const prop of props) {
             for (const type of prop.javaTypes) {
+                // Start property setter
                 this.code.line('/**');
                 this.code.line(` * Sets the value of ${prop.propName}`);
                 if (prop.docs && prop.docs.summary) {
-                    this.code.line(` * @param value ${prop.docs.summary}`);
+                    this.code.line(` * @param ${prop.fieldName} ${prop.docs.summary}`);
                 } else {
-                    this.code.line(` * @param value the value to be set`);
+                    this.code.line(` * @param ${prop.fieldName} the value to be set`);
                 }
                 this.code.line(` * @return {@code this}`);
                 if (prop.docs && prop.docs.deprecated) {
@@ -865,13 +871,16 @@ class JavaGenerator extends Generator {
                 }
                 this.code.line(' */');
                 this.emitStabilityAnnotations(prop.spec);
-                this.code.openBlock(`public ${builderName} with${prop.propName}(${prop.nullable ? `${JSR305_NULLABLE} ` : ''}final ${type} value)`);
-                this.code.line(`this._${prop.fieldName} = ${_validateIfNonOptional('value', prop)};`);
+                this.code.openBlock(`public ${builderName} ${prop.fieldName}(${type} ${prop.fieldName})`);
+                this.code.line(`this.${prop.fieldName} = ${prop.fieldName};`);
                 this.code.line('return this;');
                 this.code.closeBlock();
+                this.code.line();
+                // End property setter
             }
         }
-        this.code.line();
+
+        // Start build()
         this.code.line('/**');
         this.code.line(' * Builds the configured instance.');
         this.code.line(` * @return a new instance of {@link ${interfaceName}}`);
@@ -879,31 +888,66 @@ class JavaGenerator extends Generator {
         this.code.line(' */');
         this.emitStabilityAnnotations(ifc);
         this.code.openBlock(`public ${interfaceName} build()`);
-        this.code.openBlock(`return new ${interfaceName}()`);
-        for (const prop of props) {
-            if (prop.nullable) { this.code.line(JSR305_NULLABLE); }
-            // tslint:disable-next-line:max-line-length
-            this.code.line(`private${prop.immutable ? ' final' : ''} ${prop.fieldJavaType} $${prop.fieldName} = ${_validateIfNonOptional(`_${prop.fieldName}`, prop)};`);
-        }
-        for (const prop of props) {
-            this.code.line();
+        const propFields = props.map(prop => prop.fieldName).join(", ");
+        this.code.line(`return new ${INTERFACE_PROXY_CLASS_NAME}(${propFields});`);
+        this.code.closeBlock();
+        this.code.line();
+        // End build()
+
+        this.code.closeBlock();
+        this.code.line();
+        // End Builder
+
+        // Start implementation class
+        this.code.line('/**');
+        this.code.line(` * An implementation for {@link ${interfaceName}}`);
+        this.code.line(' */');
+        this.emitStabilityAnnotations(ifc);
+        this.code.openBlock(`final class ${INTERFACE_PROXY_CLASS_NAME} extends software.amazon.jsii.JsiiObject implements ${interfaceName}`);
+
+        // Immutable properties
+        props.forEach(prop => this.code.line(`private final ${prop.fieldJavaType} ${prop.fieldName};`));
+
+        // Start JSII reference constructor
+        this.code.line();
+        this.code.line('/**');
+        this.code.line(' * Constructor that initializes the object based on values retrieved from the JsiiObject.');
+        this.code.line(' * @param objRef Reference to the JSII managed object.');
+        this.code.line(' */');
+        this.code.openBlock(`protected ${INTERFACE_PROXY_CLASS_NAME}(final software.amazon.jsii.JsiiObjectRef objRef)`);
+        this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
+        this.code.line('this.setObjRef(objRef);');
+        props.forEach(prop => this.code.line(`this.${prop.fieldName} = this.jsiiGet("${prop.jsiiName}", ${prop.fieldJavaClass});`));
+        this.code.closeBlock();
+        // End JSII reference constructor
+
+        // Start literal constructor
+        this.code.line();
+        this.code.line();
+        this.code.line('/**');
+        this.code.line(' * Constructor that initializes the object based on literal property values passed by the {@link Builder}.');
+        this.code.line(' */');
+        const constructorArgs = props.map(prop => `${prop.fieldJavaType} ${prop.fieldName}`).join(", ");
+        this.code.openBlock(`private ${INTERFACE_PROXY_CLASS_NAME}(${constructorArgs})`);
+        this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
+        props.forEach(prop => {
+            this.code.line(`this.${prop.fieldName} = ${_validateIfNonOptional(prop.fieldName, prop)};`);
+        });
+        this.code.closeBlock();
+        this.code.line();
+        // End literal constructor
+
+        // Getters
+        props.forEach(prop => {
             this.code.line('@Override');
             this.code.openBlock(`public ${prop.fieldJavaType} get${prop.propName}()`);
-            this.code.line(`return this.$${prop.fieldName};`);
+            this.code.line(`return this.${prop.fieldName};`);
             this.code.closeBlock();
-            if (!prop.immutable) {
-                for (const type of prop.javaTypes) {
-                    this.code.line();
-                    this.code.line('@Override');
-                    this.code.openBlock(`public void set${prop.propName}(${prop.nullable ? `${JSR305_NULLABLE} ` : ''}final ${type} value)`);
-                    this.code.line(`this.$${prop.fieldName} = ${_validateIfNonOptional('value', prop)};`);
-                    this.code.closeBlock();
-                }
-            }
-        }
+            this.code.line();
+        });
 
         // emit $jsii$toJson which will be called to serialize this object when sent to JS
-        this.code.line();
+        this.code.line('@Override');
         this.code.openBlock(`public com.fasterxml.jackson.databind.JsonNode $jsii$toJson()`);
         this.code.line(`com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;`);
         // tslint:disable-next-line:max-line-length
@@ -916,19 +960,81 @@ class JavaGenerator extends Generator {
         }
 
         this.code.line(`return obj;`);
+        this.code.closeBlock();
+        this.code.line();
+        // End $jsii$toJson
+
+        // Generate equals() override
+        this.emitEqualsOverride(interfaceName, props);
+
+        // Generate hashCode() override
+        this.emitHashCodeOverride(props);
 
         this.code.closeBlock();
+        // End implementation class
 
-        this.code.unindent();
-        this.code.line(`};`); /* return new Foo() */
-
-        this.code.closeBlock(/* public Foo build() */);
-
-        this.code.closeBlock(/* final class Builder */);
-
-        function _validateIfNonOptional(variable: string, prop: Prop): string {
+        function _validateIfNonOptional(variable: string, prop: JavaProp): string {
             if (prop.nullable) { return variable; }
             return `java.util.Objects.requireNonNull(${variable}, "${prop.fieldName} is required")`;
+        }
+    }
+
+    private emitEqualsOverride(className: string, props: JavaProp[]) {
+        // A class without properties does not need to override equals()
+        if (props.length === 0) {
+            return;
+        }
+
+        this.code.line('@Override');
+        this.code.openBlock('public boolean equals(Object o)');
+        this.code.line('if (this == o) return true;');
+
+        this.code.line('if (o == null || getClass() != o.getClass()) return false;');
+        this.code.line();
+        this.code.line(`${className}.${INTERFACE_PROXY_CLASS_NAME} that = (${className}.${INTERFACE_PROXY_CLASS_NAME}) o;`);
+        this.code.line();
+
+        const initialProps = props.slice(0, props.length - 1);
+        const finalProp = props[props.length - 1];
+
+        initialProps.forEach(prop => {
+            const predicate = prop.nullable ?
+                `${prop.fieldName} != null ? !${prop.fieldName}.equals(that.${prop.fieldName}) : that.${prop.fieldName} != null` :
+                `!${prop.fieldName}.equals(that.${prop.fieldName})`;
+
+            this.code.line(`if (${predicate}) return false;`);
+        });
+
+        // The final (returned predicate) is the inverse of the other ones
+        const finalPredicate = finalProp.nullable ?
+            `${finalProp.fieldName} != null ? ${finalProp.fieldName}.equals(that.${finalProp.fieldName}) : that.${finalProp.fieldName} == null` :
+            `${finalProp.fieldName}.equals(that.${finalProp.fieldName})`;
+        this.code.line(`return ${finalPredicate};`);
+
+        this.code.closeBlock();
+        this.code.line();
+    }
+
+    private emitHashCodeOverride(props: JavaProp[]) {
+        // A class without properties does not need to override hashCode()
+        if (props.length === 0) {
+            return;
+        }
+
+        this.code.line('@Override');
+        this.code.openBlock('public int hashCode()');
+
+        const firstProp = props[0];
+        const remainingProps = props.slice(1);
+
+        this.code.line(`int result = ${_hashCodeForProp(firstProp)};`);
+        remainingProps.forEach(prop => this.code.line(`result = 31 * result + (${_hashCodeForProp(prop)});`));
+        this.code.line(`return result;`);
+        this.code.closeBlock();
+        this.code.line();
+
+        function _hashCodeForProp(prop: JavaProp) {
+            return prop.nullable ? `${prop.fieldName} != null ? ${prop.fieldName}.hashCode() : 0` : `${prop.fieldName}.hashCode()`;
         }
     }
 
@@ -1149,8 +1255,7 @@ class JavaGenerator extends Generator {
         const params = [];
         if (method.parameters) {
             for (const p of method.parameters) {
-                const nullable = isNullable(p) ? `${JSR305_NULLABLE} ` : '';
-                params.push(`${nullable}final ${this.toJavaType(p.type)}${p.variadic ? '...' : ''} ${p.name}`);
+                params.push(`final ${this.toJavaType(p.type)}${p.variadic ? '...' : ''} ${p.name}`);
             }
         }
         return params.join(', ');
@@ -1222,9 +1327,15 @@ class JavaGenerator extends Generator {
         return moduleClass;
     }
 
-    private emitJsiiInitializers(className: string) {
-        this.code.openBlock(`protected ${className}(final software.amazon.jsii.JsiiObject.InitializationMode mode)`);
-        this.code.line(`super(mode);`);
+    private emitJsiiInitializers(cls: spec.ClassType) {
+        this.code.line();
+        this.code.openBlock(`protected ${cls.name}(final software.amazon.jsii.JsiiObjectRef objRef)`);
+        this.code.line('super(objRef);');
+        this.code.closeBlock();
+
+        this.code.line();
+        this.code.openBlock(`protected ${cls.name}(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode)`);
+        this.code.line('super(initializationMode);');
         this.code.closeBlock();
     }
 

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -146,17 +146,39 @@ export default class Java extends Target {
 const MODULE_CLASS_NAME = '$Module';
 const INTERFACE_PROXY_CLASS_NAME = 'Jsii$Proxy';
 
+// Struct that stores metadata about a property that can be used in Java code generation.
 interface JavaProp {
+    // Documentation for the property
     docs?: spec.Docs
+
+    // The original JSII property spec this struct was derived from
     spec: spec.Property
+
+    // Canonical name of the Java property (eg: 'MyProperty')
     propName: string
+
+    // The original canonical name of the JSII property
     jsiiName: string
+
+    // Field name of the Java property (eg: 'myProperty')
     fieldName: string
+
+    // The java type for the property (eg: 'List<String>')
     fieldJavaType: string
+
+    // The raw class type of the property that can be used for marshalling (eg: 'List.class')
     fieldJavaClass: string
+
+    // List of types that the property is assignable from. Used to overload setters.
     javaTypes: string[]
+
+    // True if the property is optional.
     nullable: boolean
+
+    // True if the property has been transitively inherited from a base class.
     inherited: boolean
+
+    // True if the property is read-only once initialized.
     immutable: boolean
 }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -6,18 +6,22 @@ package software.amazon.jsii.tests.calculator.base;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.base.$Module.class, fqn = "@scope/jsii-calc-base.Base")
 public abstract class Base extends software.amazon.jsii.JsiiObject {
-    protected Base(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Base(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Base(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Base() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * @return the name of the class (to verify native type names are created for derived classes).
      */
-    @javax.annotation.Nullable
     public java.lang.Object typeName() {
         return this.jsiiCall("typeName", java.lang.Object.class);
     }
@@ -26,8 +30,9 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.base.Base {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -15,25 +15,26 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
      * A builder for {@link BaseProps}
      */
     final class Builder {
-        private java.lang.String _bar;
-        private software.amazon.jsii.tests.calculator.baseofbase.Very _foo;
+        private java.lang.String bar;
+        private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
          * Sets the value of Bar
-         * @param value the value to be set
+         * @param bar the value to be set
          * @return {@code this}
          */
-        public Builder withBar(final java.lang.String value) {
-            this._bar = java.util.Objects.requireNonNull(value, "bar is required");
+        public Builder bar(java.lang.String bar) {
+            this.bar = bar;
             return this;
         }
+
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
-        public Builder withFoo(final software.amazon.jsii.tests.calculator.baseofbase.Very value) {
-            this._foo = java.util.Objects.requireNonNull(value, "foo is required");
+        public Builder foo(software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+            this.foo = foo;
             return this;
         }
 
@@ -43,48 +44,75 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
          * @throws NullPointerException if any required attribute was not provided
          */
         public BaseProps build() {
-            return new BaseProps() {
-                private final java.lang.String $bar = java.util.Objects.requireNonNull(_bar, "bar is required");
-                private final software.amazon.jsii.tests.calculator.baseofbase.Very $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
-
-                @Override
-                public java.lang.String getBar() {
-                    return this.$bar;
-                }
-
-                @Override
-                public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
-                    return this.$foo;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("bar", om.valueToTree(this.getBar()));
-                    obj.set("foo", om.valueToTree(this.getFoo()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(bar, foo);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link BaseProps}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.base.BaseProps {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements BaseProps {
+        private final java.lang.String bar;
+        private final software.amazon.jsii.tests.calculator.baseofbase.Very foo;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.bar = this.jsiiGet("bar", java.lang.String.class);
+            this.foo = this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String bar, software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
+            this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
         }
 
         @Override
         public java.lang.String getBar() {
-            return this.jsiiGet("bar", java.lang.String.class);
+            return this.bar;
         }
 
         @Override
         public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
-            return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
+            return this.foo;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("bar", om.valueToTree(this.getBar()));
+            obj.set("foo", om.valueToTree(this.getFoo()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BaseProps.Jsii$Proxy that = (BaseProps.Jsii$Proxy) o;
+
+            if (!bar.equals(that.bar)) return false;
+            return foo.equals(that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = bar.hashCode();
+            result = 31 * result + (foo.hashCode());
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/IBaseInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/IBaseInterface.java
@@ -4,12 +4,14 @@ package software.amazon.jsii.tests.calculator.base;
 public interface IBaseInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.baseofbase.IVeryBaseInterface {
     void bar();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.base.IBaseInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -13,12 +13,14 @@ public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getDoubleValue();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IDoublable {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -17,12 +17,14 @@ public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String hello();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IFriendly {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
@@ -16,12 +16,14 @@ public interface IThreeLevelsInterface extends software.amazon.jsii.JsiiSerializ
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     void baz();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.IThreeLevelsInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -13,12 +13,14 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getAnumber();
+
     /**
      * A string value.
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String getAstring();
+
     /**
      */
     @Deprecated
@@ -40,42 +42,43 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     final class Builder {
-        private java.lang.Number _anumber;
-        private java.lang.String _astring;
-        @javax.annotation.Nullable
-        private java.util.List<java.lang.String> _firstOptional;
+        private java.lang.Number anumber;
+        private java.lang.String astring;
+        private java.util.List<java.lang.String> firstOptional;
 
         /**
          * Sets the value of Anumber
-         * @param value An awesome number value.
+         * @param anumber An awesome number value.
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withAnumber(final java.lang.Number value) {
-            this._anumber = java.util.Objects.requireNonNull(value, "anumber is required");
+        public Builder anumber(java.lang.Number anumber) {
+            this.anumber = anumber;
             return this;
         }
+
         /**
          * Sets the value of Astring
-         * @param value A string value.
+         * @param astring A string value.
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withAstring(final java.lang.String value) {
-            this._astring = java.util.Objects.requireNonNull(value, "astring is required");
+        public Builder astring(java.lang.String astring) {
+            this.astring = astring;
             return this;
         }
+
         /**
          * Sets the value of FirstOptional
-         * @param value the value to be set
+         * @param firstOptional the value to be set
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
-            this._firstOptional = value;
+        public Builder firstOptional(java.util.List<java.lang.String> firstOptional) {
+            this.firstOptional = firstOptional;
             return this;
         }
 
@@ -87,78 +90,90 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public MyFirstStruct build() {
-            return new MyFirstStruct() {
-                private final java.lang.Number $anumber = java.util.Objects.requireNonNull(_anumber, "anumber is required");
-                private final java.lang.String $astring = java.util.Objects.requireNonNull(_astring, "astring is required");
-                @javax.annotation.Nullable
-                private final java.util.List<java.lang.String> $firstOptional = _firstOptional;
-
-                @Override
-                public java.lang.Number getAnumber() {
-                    return this.$anumber;
-                }
-
-                @Override
-                public java.lang.String getAstring() {
-                    return this.$astring;
-                }
-
-                @Override
-                public java.util.List<java.lang.String> getFirstOptional() {
-                    return this.$firstOptional;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("anumber", om.valueToTree(this.getAnumber()));
-                    obj.set("astring", om.valueToTree(this.getAstring()));
-                    if (this.getFirstOptional() != null) {
-                        obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(anumber, astring, firstOptional);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link MyFirstStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.MyFirstStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements MyFirstStruct {
+        private final java.lang.Number anumber;
+        private final java.lang.String astring;
+        private final java.util.List<java.lang.String> firstOptional;
 
         /**
-         * An awesome number value.
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.anumber = this.jsiiGet("anumber", java.lang.Number.class);
+            this.astring = this.jsiiGet("astring", java.lang.String.class);
+            this.firstOptional = this.jsiiGet("firstOptional", java.util.List.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Number anumber, java.lang.String astring, java.util.List<java.lang.String> firstOptional) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.anumber = java.util.Objects.requireNonNull(anumber, "anumber is required");
+            this.astring = java.util.Objects.requireNonNull(astring, "astring is required");
+            this.firstOptional = firstOptional;
+        }
+
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getAnumber() {
-            return this.jsiiGet("anumber", java.lang.Number.class);
+            return this.anumber;
         }
 
-        /**
-         * A string value.
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.String getAstring() {
-            return this.jsiiGet("astring", java.lang.String.class);
+            return this.astring;
         }
 
-        /**
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.util.List<java.lang.String> getFirstOptional() {
-            return this.jsiiGet("firstOptional", java.util.List.class);
+            return this.firstOptional;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("anumber", om.valueToTree(this.getAnumber()));
+            obj.set("astring", om.valueToTree(this.getAstring()));
+            if (this.getFirstOptional() != null) {
+                obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            MyFirstStruct.Jsii$Proxy that = (MyFirstStruct.Jsii$Proxy) o;
+
+            if (!anumber.equals(that.anumber)) return false;
+            if (!astring.equals(that.astring)) return false;
+            return firstOptional != null ? firstOptional.equals(that.firstOptional) : that.firstOptional == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = anumber.hashCode();
+            result = 31 * result + (astring.hashCode());
+            result = 31 * result + (firstOptional != null ? firstOptional.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -8,8 +8,13 @@ package software.amazon.jsii.tests.calculator.lib;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Number")
 public class Number extends software.amazon.jsii.tests.calculator.lib.Value implements software.amazon.jsii.tests.calculator.lib.IDoublable {
-    protected Number(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Number(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Number(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a Number object.
@@ -19,8 +24,8 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public Number(final java.lang.Number value) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -8,12 +8,17 @@ package software.amazon.jsii.tests.calculator.lib;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Operation")
 public abstract class Operation extends software.amazon.jsii.tests.calculator.lib.Value {
-    protected Operation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Operation(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Operation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Operation() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -28,8 +33,9 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.lib.Operation {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -13,11 +13,13 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String getOptional1();
+
     /**
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getOptional2();
+
     /**
      */
     @Deprecated
@@ -39,44 +41,43 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.String _optional1;
-        @javax.annotation.Nullable
-        private java.lang.Number _optional2;
-        @javax.annotation.Nullable
-        private java.lang.Boolean _optional3;
+        private java.lang.String optional1;
+        private java.lang.Number optional2;
+        private java.lang.Boolean optional3;
 
         /**
          * Sets the value of Optional1
-         * @param value The first optional!
+         * @param optional1 The first optional!
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withOptional1(@javax.annotation.Nullable final java.lang.String value) {
-            this._optional1 = value;
+        public Builder optional1(java.lang.String optional1) {
+            this.optional1 = optional1;
             return this;
         }
+
         /**
          * Sets the value of Optional2
-         * @param value the value to be set
+         * @param optional2 the value to be set
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withOptional2(@javax.annotation.Nullable final java.lang.Number value) {
-            this._optional2 = value;
+        public Builder optional2(java.lang.Number optional2) {
+            this.optional2 = optional2;
             return this;
         }
+
         /**
          * Sets the value of Optional3
-         * @param value the value to be set
+         * @param optional3 the value to be set
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withOptional3(@javax.annotation.Nullable final java.lang.Boolean value) {
-            this._optional3 = value;
+        public Builder optional3(java.lang.Boolean optional3) {
+            this.optional3 = optional3;
             return this;
         }
 
@@ -88,85 +89,94 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public StructWithOnlyOptionals build() {
-            return new StructWithOnlyOptionals() {
-                @javax.annotation.Nullable
-                private final java.lang.String $optional1 = _optional1;
-                @javax.annotation.Nullable
-                private final java.lang.Number $optional2 = _optional2;
-                @javax.annotation.Nullable
-                private final java.lang.Boolean $optional3 = _optional3;
-
-                @Override
-                public java.lang.String getOptional1() {
-                    return this.$optional1;
-                }
-
-                @Override
-                public java.lang.Number getOptional2() {
-                    return this.$optional2;
-                }
-
-                @Override
-                public java.lang.Boolean getOptional3() {
-                    return this.$optional3;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getOptional1() != null) {
-                        obj.set("optional1", om.valueToTree(this.getOptional1()));
-                    }
-                    if (this.getOptional2() != null) {
-                        obj.set("optional2", om.valueToTree(this.getOptional2()));
-                    }
-                    if (this.getOptional3() != null) {
-                        obj.set("optional3", om.valueToTree(this.getOptional3()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(optional1, optional2, optional3);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link StructWithOnlyOptionals}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements StructWithOnlyOptionals {
+        private final java.lang.String optional1;
+        private final java.lang.Number optional2;
+        private final java.lang.Boolean optional3;
 
         /**
-         * The first optional!
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.optional1 = this.jsiiGet("optional1", java.lang.String.class);
+            this.optional2 = this.jsiiGet("optional2", java.lang.Number.class);
+            this.optional3 = this.jsiiGet("optional3", java.lang.Boolean.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String optional1, java.lang.Number optional2, java.lang.Boolean optional3) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.optional1 = optional1;
+            this.optional2 = optional2;
+            this.optional3 = optional3;
+        }
+
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.lang.String getOptional1() {
-            return this.jsiiGet("optional1", java.lang.String.class);
+            return this.optional1;
         }
 
-        /**
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.lang.Number getOptional2() {
-            return this.jsiiGet("optional2", java.lang.Number.class);
+            return this.optional2;
         }
 
-        /**
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.lang.Boolean getOptional3() {
-            return this.jsiiGet("optional3", java.lang.Boolean.class);
+            return this.optional3;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getOptional1() != null) {
+                obj.set("optional1", om.valueToTree(this.getOptional1()));
+            }
+            if (this.getOptional2() != null) {
+                obj.set("optional2", om.valueToTree(this.getOptional2()));
+            }
+            if (this.getOptional3() != null) {
+                obj.set("optional3", om.valueToTree(this.getOptional3()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            StructWithOnlyOptionals.Jsii$Proxy that = (StructWithOnlyOptionals.Jsii$Proxy) o;
+
+            if (optional1 != null ? !optional1.equals(that.optional1) : that.optional1 != null) return false;
+            if (optional2 != null ? !optional2.equals(that.optional2) : that.optional2 != null) return false;
+            return optional3 != null ? optional3.equals(that.optional3) : that.optional3 == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = optional1 != null ? optional1.hashCode() : 0;
+            result = 31 * result + (optional2 != null ? optional2.hashCode() : 0);
+            result = 31 * result + (optional3 != null ? optional3.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -8,12 +8,17 @@ package software.amazon.jsii.tests.calculator.lib;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.lib.$Module.class, fqn = "@scope/jsii-calc-lib.Value")
 public abstract class Value extends software.amazon.jsii.tests.calculator.base.Base {
-    protected Value(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Value(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Value(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Value() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -38,8 +43,9 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.lib.Value {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -2583,6 +2583,140 @@
         }
       ]
     },
+    "jsii-calc.DiamondInheritanceBaseLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceBaseLevelStruct",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1778
+      },
+      "name": "DiamondInheritanceBaseLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1779
+          },
+          "name": "baseLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceFirstMidLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceFirstMidLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceBaseLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1782
+      },
+      "name": "DiamondInheritanceFirstMidLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1783
+          },
+          "name": "firstMidLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceSecondMidLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceSecondMidLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceBaseLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1786
+      },
+      "name": "DiamondInheritanceSecondMidLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1787
+          },
+          "name": "secondMidLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.DiamondInheritanceTopLevelStruct": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.DiamondInheritanceTopLevelStruct",
+      "interfaces": [
+        "jsii-calc.DiamondInheritanceFirstMidLevelStruct",
+        "jsii-calc.DiamondInheritanceSecondMidLevelStruct"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1790
+      },
+      "name": "DiamondInheritanceTopLevelStruct",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1791
+          },
+          "name": "topLevelProperty",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
     "jsii-calc.DoNotOverridePrivates": {
       "assembly": "jsii-calc",
       "docs": {
@@ -7844,7 +7978,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/compliance.ts",
-        "line": 1783
+        "line": 1799
       },
       "methods": [
         {
@@ -7853,7 +7987,7 @@
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1792
+            "line": 1808
           },
           "name": "howManyVarArgsDidIPass",
           "parameters": [
@@ -7885,7 +8019,7 @@
           },
           "locationInModule": {
             "filename": "lib/compliance.ts",
-            "line": 1784
+            "line": 1800
           },
           "name": "roundTrip",
           "parameters": [
@@ -9081,5 +9215,5 @@
     }
   },
   "version": "0.14.3",
-  "fingerprint": "Ld7vqOD5LvQ5a/I1LdRkj08XkdS+7syV580DELBDa+Y="
+  "fingerprint": "a/jxMJzoCSejg4NPvGH9qpyWwkZxCHN/zb4T5d00Cto="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStruct.cs
@@ -1,0 +1,21 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue]
+    public class DiamondInheritanceBaseLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceBaseLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string BaseLevelProperty
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStructProxy.cs
@@ -1,0 +1,24 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IDiamondInheritanceBaseLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceBaseLevelStruct")]
+    internal sealed class DiamondInheritanceBaseLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceBaseLevelStruct
+    {
+        private DiamondInheritanceBaseLevelStructProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string BaseLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStruct.cs
@@ -1,0 +1,31 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue]
+    public class DiamondInheritanceFirstMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceFirstMidLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string FirstMidLevelProperty
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string BaseLevelProperty
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStructProxy.cs
@@ -1,0 +1,33 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IDiamondInheritanceFirstMidLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceFirstMidLevelStruct")]
+    internal sealed class DiamondInheritanceFirstMidLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceFirstMidLevelStruct
+    {
+        private DiamondInheritanceFirstMidLevelStructProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string FirstMidLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string BaseLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStruct.cs
@@ -1,0 +1,31 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue]
+    public class DiamondInheritanceSecondMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceSecondMidLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string SecondMidLevelProperty
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string BaseLevelProperty
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStructProxy.cs
@@ -1,0 +1,33 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IDiamondInheritanceSecondMidLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceSecondMidLevelStruct")]
+    internal sealed class DiamondInheritanceSecondMidLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceSecondMidLevelStruct
+    {
+        private DiamondInheritanceSecondMidLevelStructProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string SecondMidLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string BaseLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStruct.cs
@@ -1,0 +1,51 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue]
+    public class DiamondInheritanceTopLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceTopLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "topLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string TopLevelProperty
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string FirstMidLevelProperty
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string BaseLevelProperty
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string SecondMidLevelProperty
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStructProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStructProxy.cs
@@ -1,0 +1,51 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IDiamondInheritanceTopLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceTopLevelStruct")]
+    internal sealed class DiamondInheritanceTopLevelStructProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceTopLevelStruct
+    {
+        private DiamondInheritanceTopLevelStructProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "topLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string TopLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string FirstMidLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string BaseLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        public string SecondMidLevelProperty
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceBaseLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceBaseLevelStruct.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IDiamondInheritanceBaseLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceBaseLevelStruct")]
+    public interface IDiamondInheritanceBaseLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "baseLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        string BaseLevelProperty
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceFirstMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceFirstMidLevelStruct.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IDiamondInheritanceFirstMidLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceFirstMidLevelStruct")]
+    public interface IDiamondInheritanceFirstMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceBaseLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        string FirstMidLevelProperty
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceSecondMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceSecondMidLevelStruct.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IDiamondInheritanceSecondMidLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceSecondMidLevelStruct")]
+    public interface IDiamondInheritanceSecondMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceBaseLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        string SecondMidLevelProperty
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceTopLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IDiamondInheritanceTopLevelStruct.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IDiamondInheritanceTopLevelStruct), fullyQualifiedName: "jsii-calc.DiamondInheritanceTopLevelStruct")]
+    public interface IDiamondInheritanceTopLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceFirstMidLevelStruct, Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceSecondMidLevelStruct
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "topLevelProperty", typeJson: "{\"primitive\":\"string\"}")]
+        string TopLevelProperty
+        {
+            get;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -46,6 +46,10 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.DerivedClassHasNoProperties.Base": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base.class;
             case "jsii-calc.DerivedClassHasNoProperties.Derived": return software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Derived.class;
             case "jsii-calc.DerivedStruct": return software.amazon.jsii.tests.calculator.DerivedStruct.class;
+            case "jsii-calc.DiamondInheritanceBaseLevelStruct": return software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct.class;
+            case "jsii-calc.DiamondInheritanceFirstMidLevelStruct": return software.amazon.jsii.tests.calculator.DiamondInheritanceFirstMidLevelStruct.class;
+            case "jsii-calc.DiamondInheritanceSecondMidLevelStruct": return software.amazon.jsii.tests.calculator.DiamondInheritanceSecondMidLevelStruct.class;
+            case "jsii-calc.DiamondInheritanceTopLevelStruct": return software.amazon.jsii.tests.calculator.DiamondInheritanceTopLevelStruct.class;
             case "jsii-calc.DoNotOverridePrivates": return software.amazon.jsii.tests.calculator.DoNotOverridePrivates.class;
             case "jsii-calc.DoNotRecognizeAnyAsOptional": return software.amazon.jsii.tests.calculator.DoNotRecognizeAnyAsOptional.class;
             case "jsii-calc.DocumentedClass": return software.amazon.jsii.tests.calculator.DocumentedClass.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClass")
 public abstract class AbstractClass extends software.amazon.jsii.tests.calculator.AbstractClassBase implements software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass {
-    protected AbstractClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AbstractClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AbstractClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AbstractClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -42,8 +47,9 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.AbstractClass {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassBase")
 public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject {
-    protected AbstractClassBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AbstractClassBase(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AbstractClassBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AbstractClassBase() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -27,8 +32,9 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.AbstractClassBase {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AbstractClassReturner")
 public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
-    protected AbstractClassReturner(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AbstractClassReturner(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AbstractClassReturner(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AbstractClassReturner() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Add")
 public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
-    protected Add(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Add(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Add(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a BinaryOperation.
@@ -22,8 +27,8 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Add(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -12,19 +12,24 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AllTypes")
 public class AllTypes extends software.amazon.jsii.JsiiObject {
-    protected AllTypes(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AllTypes(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AllTypes(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AllTypes() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void anyIn(@javax.annotation.Nullable final java.lang.Object inp) {
+    public void anyIn(final java.lang.Object inp) {
         this.jsiiCall("anyIn", Void.class, new Object[] { inp });
     }
 
@@ -32,7 +37,6 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object anyOut() {
         return this.jsiiCall("anyOut", java.lang.Object.class);
     }
@@ -89,7 +93,6 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object getAnyProperty() {
         return this.jsiiGet("anyProperty", java.lang.Object.class);
     }
@@ -98,7 +101,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setAnyProperty(@javax.annotation.Nullable final java.lang.Object value) {
+    public void setAnyProperty(final java.lang.Object value) {
         this.jsiiSet("anyProperty", java.util.Objects.requireNonNull(value, "anyProperty is required"));
     }
 
@@ -338,7 +341,6 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object getUnknownProperty() {
         return this.jsiiGet("unknownProperty", java.lang.Object.class);
     }
@@ -347,7 +349,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnknownProperty(@javax.annotation.Nullable final java.lang.Object value) {
+    public void setUnknownProperty(final java.lang.Object value) {
         this.jsiiSet("unknownProperty", java.util.Objects.requireNonNull(value, "unknownProperty is required"));
     }
 
@@ -355,7 +357,6 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.StringEnum getOptionalEnumValue() {
         return this.jsiiGet("optionalEnumValue", software.amazon.jsii.tests.calculator.StringEnum.class);
     }
@@ -364,7 +365,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setOptionalEnumValue(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.StringEnum value) {
+    public void setOptionalEnumValue(final software.amazon.jsii.tests.calculator.StringEnum value) {
         this.jsiiSet("optionalEnumValue", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AllowedMethodNames")
 public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
-    protected AllowedMethodNames(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AllowedMethodNames(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AllowedMethodNames(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AllowedMethodNames() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AsyncVirtualMethods")
 public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
-    protected AsyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AsyncVirtualMethods(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AsyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AsyncVirtualMethods() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AugmentableClass")
 public class AugmentableClass extends software.amazon.jsii.JsiiObject {
-    protected AugmentableClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected AugmentableClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AugmentableClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public AugmentableClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.BinaryOperation")
 public abstract class BinaryOperation extends software.amazon.jsii.tests.calculator.lib.Operation implements software.amazon.jsii.tests.calculator.lib.IFriendly {
-    protected BinaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected BinaryOperation(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected BinaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a BinaryOperation.
@@ -22,8 +27,8 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") }));
     }
 
     /**
@@ -61,8 +66,9 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.BinaryOperation {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Calculator")
 public class Calculator extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
-    protected Calculator(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Calculator(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Calculator(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a Calculator object.
@@ -20,9 +25,9 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * @param props Initialization properties.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Calculator(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.CalculatorProps props) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props });
+    public Calculator(final software.amazon.jsii.tests.calculator.CalculatorProps props) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props }));
     }
     /**
      * Creates a Calculator object.
@@ -31,8 +36,8 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Calculator() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -142,7 +147,6 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Number getMaxValue() {
         return this.jsiiGet("maxValue", java.lang.Number.class);
     }
@@ -153,7 +157,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMaxValue(@javax.annotation.Nullable final java.lang.Number value) {
+    public void setMaxValue(final java.lang.Number value) {
         this.jsiiSet("maxValue", value);
     }
 
@@ -163,7 +167,6 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
@@ -174,7 +177,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Add value) {
+    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Add value) {
         this.jsiiSet("unionProperty", value);
     }
 
@@ -184,7 +187,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Multiply value) {
+    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", value);
     }
 
@@ -194,7 +197,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Power value) {
+    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Power value) {
         this.jsiiSet("unionProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -13,6 +13,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getInitialValue();
+
     /**
      * EXPERIMENTAL
      */
@@ -32,29 +33,28 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.Number _initialValue;
-        @javax.annotation.Nullable
-        private java.lang.Number _maximumValue;
+        private java.lang.Number initialValue;
+        private java.lang.Number maximumValue;
 
         /**
          * Sets the value of InitialValue
-         * @param value the value to be set
+         * @param initialValue the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withInitialValue(@javax.annotation.Nullable final java.lang.Number value) {
-            this._initialValue = value;
+        public Builder initialValue(java.lang.Number initialValue) {
+            this.initialValue = initialValue;
             return this;
         }
+
         /**
          * Sets the value of MaximumValue
-         * @param value the value to be set
+         * @param maximumValue the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withMaximumValue(@javax.annotation.Nullable final java.lang.Number value) {
-            this._maximumValue = value;
+        public Builder maximumValue(java.lang.Number maximumValue) {
+            this.maximumValue = maximumValue;
             return this;
         }
 
@@ -65,64 +65,80 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public CalculatorProps build() {
-            return new CalculatorProps() {
-                @javax.annotation.Nullable
-                private final java.lang.Number $initialValue = _initialValue;
-                @javax.annotation.Nullable
-                private final java.lang.Number $maximumValue = _maximumValue;
-
-                @Override
-                public java.lang.Number getInitialValue() {
-                    return this.$initialValue;
-                }
-
-                @Override
-                public java.lang.Number getMaximumValue() {
-                    return this.$maximumValue;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getInitialValue() != null) {
-                        obj.set("initialValue", om.valueToTree(this.getInitialValue()));
-                    }
-                    if (this.getMaximumValue() != null) {
-                        obj.set("maximumValue", om.valueToTree(this.getMaximumValue()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(initialValue, maximumValue);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link CalculatorProps}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.CalculatorProps {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements CalculatorProps {
+        private final java.lang.Number initialValue;
+        private final java.lang.Number maximumValue;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.initialValue = this.jsiiGet("initialValue", java.lang.Number.class);
+            this.maximumValue = this.jsiiGet("maximumValue", java.lang.Number.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Number initialValue, java.lang.Number maximumValue) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.initialValue = initialValue;
+            this.maximumValue = maximumValue;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Number getInitialValue() {
-            return this.jsiiGet("initialValue", java.lang.Number.class);
+            return this.initialValue;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Number getMaximumValue() {
-            return this.jsiiGet("maximumValue", java.lang.Number.class);
+            return this.maximumValue;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getInitialValue() != null) {
+                obj.set("initialValue", om.valueToTree(this.getInitialValue()));
+            }
+            if (this.getMaximumValue() != null) {
+                obj.set("maximumValue", om.valueToTree(this.getMaximumValue()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            CalculatorProps.Jsii$Proxy that = (CalculatorProps.Jsii$Proxy) o;
+
+            if (initialValue != null ? !initialValue.equals(that.initialValue) : that.initialValue != null) return false;
+            return maximumValue != null ? maximumValue.equals(that.maximumValue) : that.maximumValue == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = initialValue != null ? initialValue.hashCode() : 0;
+            result = 31 * result + (maximumValue != null ? maximumValue.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsTheInternalInterface")
 public class ClassThatImplementsTheInternalInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
-    protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ClassThatImplementsTheInternalInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassThatImplementsThePrivateInterface")
 public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
-    protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ClassThatImplementsThePrivateInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithDocs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithDocs.java
@@ -16,11 +16,16 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithDocs")
 public class ClassWithDocs extends software.amazon.jsii.JsiiObject {
-    protected ClassWithDocs(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ClassWithDocs(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassWithDocs(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ClassWithDocs() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithMutableObjectLiteralProperty")
 public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.JsiiObject {
-    protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ClassWithMutableObjectLiteralProperty() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties")
 public class ClassWithPrivateConstructorAndAutomaticProperties extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
-    protected ClassWithPrivateConstructorAndAutomaticProperties(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ClassWithPrivateConstructorAndAutomaticProperties(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassWithPrivateConstructorAndAutomaticProperties(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -7,15 +7,20 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ConstructorPassesThisOut")
 public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
-    protected ConstructorPassesThisOut(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ConstructorPassesThisOut(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ConstructorPassesThisOut(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ConstructorPassesThisOut(final software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(consumer, "consumer is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(consumer, "consumer is required") }));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Constructors")
 public class Constructors extends software.amazon.jsii.JsiiObject {
-    protected Constructors(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Constructors(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Constructors(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Constructors() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ConsumersOfThisCrazyTypeSystem")
 public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObject {
-    protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ConsumersOfThisCrazyTypeSystem() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -27,7 +32,6 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
         return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
@@ -9,23 +9,28 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DataRenderer")
 public class DataRenderer extends software.amazon.jsii.JsiiObject {
-    protected DataRenderer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DataRenderer(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DataRenderer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DataRenderer() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String render(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.lib.MyFirstStruct data) {
+    public java.lang.String render(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct data) {
         return this.jsiiCall("render", java.lang.String.class, new Object[] { data });
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -7,40 +7,45 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DefaultedConstructorArgument")
 public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObject {
-    protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 });
+    public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 });
+    public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(@javax.annotation.Nullable final java.lang.Number arg1) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 });
+    public DefaultedConstructorArgument(final java.lang.Number arg1) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -63,7 +68,6 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.String getArg2() {
         return this.jsiiGet("arg2", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
@@ -8,17 +8,22 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DeprecatedClass")
 public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
-    protected DeprecatedClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DeprecatedClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DeprecatedClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * @deprecated this constructor is "just" okay
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    public DeprecatedClass(final java.lang.String readonlyString, @javax.annotation.Nullable final java.lang.Number mutableNumber) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
+    public DeprecatedClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
     /**
      * @deprecated this constructor is "just" okay
@@ -26,8 +31,8 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     public DeprecatedClass(final java.lang.String readonlyString) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") }));
     }
 
     /**
@@ -53,7 +58,6 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    @javax.annotation.Nullable
     public java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
@@ -63,7 +67,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+    public void setMutableProperty(final java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -29,18 +29,18 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     final class Builder {
-        private java.lang.String _readonlyProperty;
+        private java.lang.String readonlyProperty;
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param value the value to be set
+         * @param readonlyProperty the value to be set
          * @return {@code this}
          * @deprecated well, yeah
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withReadonlyProperty(final java.lang.String value) {
-            this._readonlyProperty = java.util.Objects.requireNonNull(value, "readonlyProperty is required");
+        public Builder readonlyProperty(java.lang.String readonlyProperty) {
+            this.readonlyProperty = readonlyProperty;
             return this;
         }
 
@@ -52,41 +52,66 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public DeprecatedStruct build() {
-            return new DeprecatedStruct() {
-                private final java.lang.String $readonlyProperty = java.util.Objects.requireNonNull(_readonlyProperty, "readonlyProperty is required");
-
-                @Override
-                public java.lang.String getReadonlyProperty() {
-                    return this.$readonlyProperty;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(readonlyProperty);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link DeprecatedStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.DeprecatedStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @Deprecated
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DeprecatedStruct {
+        private final java.lang.String readonlyProperty;
 
         /**
-         * @deprecated well, yeah
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public java.lang.String getReadonlyProperty() {
-            return this.jsiiGet("readonlyProperty", java.lang.String.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String readonlyProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
+        }
+
+        @Override
+        public java.lang.String getReadonlyProperty() {
+            return this.readonlyProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DeprecatedStruct.Jsii$Proxy that = (DeprecatedStruct.Jsii$Proxy) o;
+
+            return readonlyProperty.equals(that.readonlyProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = readonlyProperty.hashCode();
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DerivedClassHasNoProperties.Base")
 public class Base extends software.amazon.jsii.JsiiObject {
-    protected Base(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Base(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Base(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Base() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
@@ -7,11 +7,16 @@ package software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DerivedClassHasNoProperties.Derived")
 public class Derived extends software.amazon.jsii.tests.calculator.DerivedClassHasNoProperties.Base {
-    protected Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Derived(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Derived() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -13,11 +13,13 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.time.Instant getAnotherRequired();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getBool();
+
     /**
      * An example of a non primitive property.
      * 
@@ -25,6 +27,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive();
+
     /**
      * This is optional.
      * 
@@ -32,11 +35,13 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getOptionalAny();
+
     /**
      * EXPERIMENTAL
      */
@@ -56,111 +61,115 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.time.Instant _anotherRequired;
-        private java.lang.Boolean _bool;
-        private software.amazon.jsii.tests.calculator.DoubleTrouble _nonPrimitive;
-        @javax.annotation.Nullable
-        private java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> _anotherOptional;
-        @javax.annotation.Nullable
-        private java.lang.Object _optionalAny;
-        @javax.annotation.Nullable
-        private java.util.List<java.lang.String> _optionalArray;
-        private java.lang.Number _anumber;
-        private java.lang.String _astring;
-        @javax.annotation.Nullable
-        private java.util.List<java.lang.String> _firstOptional;
+        private java.time.Instant anotherRequired;
+        private java.lang.Boolean bool;
+        private software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive;
+        private java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional;
+        private java.lang.Object optionalAny;
+        private java.util.List<java.lang.String> optionalArray;
+        private java.lang.Number anumber;
+        private java.lang.String astring;
+        private java.util.List<java.lang.String> firstOptional;
 
         /**
          * Sets the value of AnotherRequired
-         * @param value the value to be set
+         * @param anotherRequired the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withAnotherRequired(final java.time.Instant value) {
-            this._anotherRequired = java.util.Objects.requireNonNull(value, "anotherRequired is required");
+        public Builder anotherRequired(java.time.Instant anotherRequired) {
+            this.anotherRequired = anotherRequired;
             return this;
         }
+
         /**
          * Sets the value of Bool
-         * @param value the value to be set
+         * @param bool the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withBool(final java.lang.Boolean value) {
-            this._bool = java.util.Objects.requireNonNull(value, "bool is required");
+        public Builder bool(java.lang.Boolean bool) {
+            this.bool = bool;
             return this;
         }
+
         /**
          * Sets the value of NonPrimitive
-         * @param value An example of a non primitive property.
+         * @param nonPrimitive An example of a non primitive property.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withNonPrimitive(final software.amazon.jsii.tests.calculator.DoubleTrouble value) {
-            this._nonPrimitive = java.util.Objects.requireNonNull(value, "nonPrimitive is required");
+        public Builder nonPrimitive(software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive) {
+            this.nonPrimitive = nonPrimitive;
             return this;
         }
+
         /**
          * Sets the value of AnotherOptional
-         * @param value This is optional.
+         * @param anotherOptional This is optional.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withAnotherOptional(@javax.annotation.Nullable final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> value) {
-            this._anotherOptional = value;
+        public Builder anotherOptional(java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional) {
+            this.anotherOptional = anotherOptional;
             return this;
         }
+
         /**
          * Sets the value of OptionalAny
-         * @param value the value to be set
+         * @param optionalAny the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withOptionalAny(@javax.annotation.Nullable final java.lang.Object value) {
-            this._optionalAny = value;
+        public Builder optionalAny(java.lang.Object optionalAny) {
+            this.optionalAny = optionalAny;
             return this;
         }
+
         /**
          * Sets the value of OptionalArray
-         * @param value the value to be set
+         * @param optionalArray the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withOptionalArray(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
-            this._optionalArray = value;
+        public Builder optionalArray(java.util.List<java.lang.String> optionalArray) {
+            this.optionalArray = optionalArray;
             return this;
         }
+
         /**
          * Sets the value of Anumber
-         * @param value An awesome number value.
+         * @param anumber An awesome number value.
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withAnumber(final java.lang.Number value) {
-            this._anumber = java.util.Objects.requireNonNull(value, "anumber is required");
+        public Builder anumber(java.lang.Number anumber) {
+            this.anumber = anumber;
             return this;
         }
+
         /**
          * Sets the value of Astring
-         * @param value A string value.
+         * @param astring A string value.
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withAstring(final java.lang.String value) {
-            this._astring = java.util.Objects.requireNonNull(value, "astring is required");
+        public Builder astring(java.lang.String astring) {
+            this.astring = astring;
             return this;
         }
+
         /**
          * Sets the value of FirstOptional
-         * @param value the value to be set
+         * @param firstOptional the value to be set
          * @return {@code this}
          */
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public Builder withFirstOptional(@javax.annotation.Nullable final java.util.List<java.lang.String> value) {
-            this._firstOptional = value;
+        public Builder firstOptional(java.util.List<java.lang.String> firstOptional) {
+            this.firstOptional = firstOptional;
             return this;
         }
 
@@ -171,190 +180,161 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public DerivedStruct build() {
-            return new DerivedStruct() {
-                private final java.time.Instant $anotherRequired = java.util.Objects.requireNonNull(_anotherRequired, "anotherRequired is required");
-                private final java.lang.Boolean $bool = java.util.Objects.requireNonNull(_bool, "bool is required");
-                private final software.amazon.jsii.tests.calculator.DoubleTrouble $nonPrimitive = java.util.Objects.requireNonNull(_nonPrimitive, "nonPrimitive is required");
-                @javax.annotation.Nullable
-                private final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> $anotherOptional = _anotherOptional;
-                @javax.annotation.Nullable
-                private final java.lang.Object $optionalAny = _optionalAny;
-                @javax.annotation.Nullable
-                private final java.util.List<java.lang.String> $optionalArray = _optionalArray;
-                private final java.lang.Number $anumber = java.util.Objects.requireNonNull(_anumber, "anumber is required");
-                private final java.lang.String $astring = java.util.Objects.requireNonNull(_astring, "astring is required");
-                @javax.annotation.Nullable
-                private final java.util.List<java.lang.String> $firstOptional = _firstOptional;
-
-                @Override
-                public java.time.Instant getAnotherRequired() {
-                    return this.$anotherRequired;
-                }
-
-                @Override
-                public java.lang.Boolean getBool() {
-                    return this.$bool;
-                }
-
-                @Override
-                public software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive() {
-                    return this.$nonPrimitive;
-                }
-
-                @Override
-                public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
-                    return this.$anotherOptional;
-                }
-
-                @Override
-                public java.lang.Object getOptionalAny() {
-                    return this.$optionalAny;
-                }
-
-                @Override
-                public java.util.List<java.lang.String> getOptionalArray() {
-                    return this.$optionalArray;
-                }
-
-                @Override
-                public java.lang.Number getAnumber() {
-                    return this.$anumber;
-                }
-
-                @Override
-                public java.lang.String getAstring() {
-                    return this.$astring;
-                }
-
-                @Override
-                public java.util.List<java.lang.String> getFirstOptional() {
-                    return this.$firstOptional;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("anotherRequired", om.valueToTree(this.getAnotherRequired()));
-                    obj.set("bool", om.valueToTree(this.getBool()));
-                    obj.set("nonPrimitive", om.valueToTree(this.getNonPrimitive()));
-                    if (this.getAnotherOptional() != null) {
-                        obj.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
-                    }
-                    if (this.getOptionalAny() != null) {
-                        obj.set("optionalAny", om.valueToTree(this.getOptionalAny()));
-                    }
-                    if (this.getOptionalArray() != null) {
-                        obj.set("optionalArray", om.valueToTree(this.getOptionalArray()));
-                    }
-                    obj.set("anumber", om.valueToTree(this.getAnumber()));
-                    obj.set("astring", om.valueToTree(this.getAstring()));
-                    if (this.getFirstOptional() != null) {
-                        obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(anotherRequired, bool, nonPrimitive, anotherOptional, optionalAny, optionalArray, anumber, astring, firstOptional);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link DerivedStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.DerivedStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DerivedStruct {
+        private final java.time.Instant anotherRequired;
+        private final java.lang.Boolean bool;
+        private final software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive;
+        private final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional;
+        private final java.lang.Object optionalAny;
+        private final java.util.List<java.lang.String> optionalArray;
+        private final java.lang.Number anumber;
+        private final java.lang.String astring;
+        private final java.util.List<java.lang.String> firstOptional;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.anotherRequired = this.jsiiGet("anotherRequired", java.time.Instant.class);
+            this.bool = this.jsiiGet("bool", java.lang.Boolean.class);
+            this.nonPrimitive = this.jsiiGet("nonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class);
+            this.anotherOptional = this.jsiiGet("anotherOptional", java.util.Map.class);
+            this.optionalAny = this.jsiiGet("optionalAny", java.lang.Object.class);
+            this.optionalArray = this.jsiiGet("optionalArray", java.util.List.class);
+            this.anumber = this.jsiiGet("anumber", java.lang.Number.class);
+            this.astring = this.jsiiGet("astring", java.lang.String.class);
+            this.firstOptional = this.jsiiGet("firstOptional", java.util.List.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.time.Instant anotherRequired, java.lang.Boolean bool, software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive, java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional, java.lang.Object optionalAny, java.util.List<java.lang.String> optionalArray, java.lang.Number anumber, java.lang.String astring, java.util.List<java.lang.String> firstOptional) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.anotherRequired = java.util.Objects.requireNonNull(anotherRequired, "anotherRequired is required");
+            this.bool = java.util.Objects.requireNonNull(bool, "bool is required");
+            this.nonPrimitive = java.util.Objects.requireNonNull(nonPrimitive, "nonPrimitive is required");
+            this.anotherOptional = anotherOptional;
+            this.optionalAny = optionalAny;
+            this.optionalArray = optionalArray;
+            this.anumber = java.util.Objects.requireNonNull(anumber, "anumber is required");
+            this.astring = java.util.Objects.requireNonNull(astring, "astring is required");
+            this.firstOptional = firstOptional;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.time.Instant getAnotherRequired() {
-            return this.jsiiGet("anotherRequired", java.time.Instant.class);
+            return this.anotherRequired;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getBool() {
-            return this.jsiiGet("bool", java.lang.Boolean.class);
+            return this.bool;
         }
 
-        /**
-         * An example of a non primitive property.
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive() {
-            return this.jsiiGet("nonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class);
+            return this.nonPrimitive;
         }
 
-        /**
-         * This is optional.
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
-            return this.jsiiGet("anotherOptional", java.util.Map.class);
+            return this.anotherOptional;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Object getOptionalAny() {
-            return this.jsiiGet("optionalAny", java.lang.Object.class);
+            return this.optionalAny;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.util.List<java.lang.String> getOptionalArray() {
-            return this.jsiiGet("optionalArray", java.util.List.class);
+            return this.optionalArray;
         }
 
-        /**
-         * An awesome number value.
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.Number getAnumber() {
-            return this.jsiiGet("anumber", java.lang.Number.class);
+            return this.anumber;
         }
 
-        /**
-         * A string value.
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public java.lang.String getAstring() {
-            return this.jsiiGet("astring", java.lang.String.class);
+            return this.astring;
         }
 
-        /**
-         */
         @Override
-        @Deprecated
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.util.List<java.lang.String> getFirstOptional() {
-            return this.jsiiGet("firstOptional", java.util.List.class);
+            return this.firstOptional;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("anotherRequired", om.valueToTree(this.getAnotherRequired()));
+            obj.set("bool", om.valueToTree(this.getBool()));
+            obj.set("nonPrimitive", om.valueToTree(this.getNonPrimitive()));
+            if (this.getAnotherOptional() != null) {
+                obj.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
+            }
+            if (this.getOptionalAny() != null) {
+                obj.set("optionalAny", om.valueToTree(this.getOptionalAny()));
+            }
+            if (this.getOptionalArray() != null) {
+                obj.set("optionalArray", om.valueToTree(this.getOptionalArray()));
+            }
+            obj.set("anumber", om.valueToTree(this.getAnumber()));
+            obj.set("astring", om.valueToTree(this.getAstring()));
+            if (this.getFirstOptional() != null) {
+                obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DerivedStruct.Jsii$Proxy that = (DerivedStruct.Jsii$Proxy) o;
+
+            if (!anotherRequired.equals(that.anotherRequired)) return false;
+            if (!bool.equals(that.bool)) return false;
+            if (!nonPrimitive.equals(that.nonPrimitive)) return false;
+            if (anotherOptional != null ? !anotherOptional.equals(that.anotherOptional) : that.anotherOptional != null) return false;
+            if (optionalAny != null ? !optionalAny.equals(that.optionalAny) : that.optionalAny != null) return false;
+            if (optionalArray != null ? !optionalArray.equals(that.optionalArray) : that.optionalArray != null) return false;
+            if (!anumber.equals(that.anumber)) return false;
+            if (!astring.equals(that.astring)) return false;
+            return firstOptional != null ? firstOptional.equals(that.firstOptional) : that.firstOptional == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = anotherRequired.hashCode();
+            result = 31 * result + (bool.hashCode());
+            result = 31 * result + (nonPrimitive.hashCode());
+            result = 31 * result + (anotherOptional != null ? anotherOptional.hashCode() : 0);
+            result = 31 * result + (optionalAny != null ? optionalAny.hashCode() : 0);
+            result = 31 * result + (optionalArray != null ? optionalArray.hashCode() : 0);
+            result = 31 * result + (anumber.hashCode());
+            result = 31 * result + (astring.hashCode());
+            result = 31 * result + (firstOptional != null ? firstOptional.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -1,0 +1,109 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.JsiiSerializable {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getBaseLevelProperty();
+
+    /**
+     * @return a {@link Builder} of {@link DiamondInheritanceBaseLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link DiamondInheritanceBaseLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Builder {
+        private java.lang.String baseLevelProperty;
+
+        /**
+         * Sets the value of BaseLevelProperty
+         * @param baseLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder baseLevelProperty(java.lang.String baseLevelProperty) {
+            this.baseLevelProperty = baseLevelProperty;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link DiamondInheritanceBaseLevelStruct}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public DiamondInheritanceBaseLevelStruct build() {
+            return new Jsii$Proxy(baseLevelProperty);
+        }
+
+    }
+
+    /**
+     * An implementation for {@link DiamondInheritanceBaseLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DiamondInheritanceBaseLevelStruct {
+        private final java.lang.String baseLevelProperty;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String baseLevelProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
+        }
+
+        @Override
+        public java.lang.String getBaseLevelProperty() {
+            return this.baseLevelProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DiamondInheritanceBaseLevelStruct.Jsii$Proxy that = (DiamondInheritanceBaseLevelStruct.Jsii$Proxy) o;
+
+            return baseLevelProperty.equals(that.baseLevelProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = baseLevelProperty.hashCode();
+            return result;
+        }
+
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -1,0 +1,132 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getFirstMidLevelProperty();
+
+    /**
+     * @return a {@link Builder} of {@link DiamondInheritanceFirstMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link DiamondInheritanceFirstMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Builder {
+        private java.lang.String firstMidLevelProperty;
+        private java.lang.String baseLevelProperty;
+
+        /**
+         * Sets the value of FirstMidLevelProperty
+         * @param firstMidLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder firstMidLevelProperty(java.lang.String firstMidLevelProperty) {
+            this.firstMidLevelProperty = firstMidLevelProperty;
+            return this;
+        }
+
+        /**
+         * Sets the value of BaseLevelProperty
+         * @param baseLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder baseLevelProperty(java.lang.String baseLevelProperty) {
+            this.baseLevelProperty = baseLevelProperty;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link DiamondInheritanceFirstMidLevelStruct}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public DiamondInheritanceFirstMidLevelStruct build() {
+            return new Jsii$Proxy(firstMidLevelProperty, baseLevelProperty);
+        }
+
+    }
+
+    /**
+     * An implementation for {@link DiamondInheritanceFirstMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DiamondInheritanceFirstMidLevelStruct {
+        private final java.lang.String firstMidLevelProperty;
+        private final java.lang.String baseLevelProperty;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.firstMidLevelProperty = this.jsiiGet("firstMidLevelProperty", java.lang.String.class);
+            this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String firstMidLevelProperty, java.lang.String baseLevelProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.firstMidLevelProperty = java.util.Objects.requireNonNull(firstMidLevelProperty, "firstMidLevelProperty is required");
+            this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
+        }
+
+        @Override
+        public java.lang.String getFirstMidLevelProperty() {
+            return this.firstMidLevelProperty;
+        }
+
+        @Override
+        public java.lang.String getBaseLevelProperty() {
+            return this.baseLevelProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
+            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DiamondInheritanceFirstMidLevelStruct.Jsii$Proxy that = (DiamondInheritanceFirstMidLevelStruct.Jsii$Proxy) o;
+
+            if (!firstMidLevelProperty.equals(that.firstMidLevelProperty)) return false;
+            return baseLevelProperty.equals(that.baseLevelProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = firstMidLevelProperty.hashCode();
+            result = 31 * result + (baseLevelProperty.hashCode());
+            return result;
+        }
+
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -1,0 +1,132 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getSecondMidLevelProperty();
+
+    /**
+     * @return a {@link Builder} of {@link DiamondInheritanceSecondMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link DiamondInheritanceSecondMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Builder {
+        private java.lang.String secondMidLevelProperty;
+        private java.lang.String baseLevelProperty;
+
+        /**
+         * Sets the value of SecondMidLevelProperty
+         * @param secondMidLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder secondMidLevelProperty(java.lang.String secondMidLevelProperty) {
+            this.secondMidLevelProperty = secondMidLevelProperty;
+            return this;
+        }
+
+        /**
+         * Sets the value of BaseLevelProperty
+         * @param baseLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder baseLevelProperty(java.lang.String baseLevelProperty) {
+            this.baseLevelProperty = baseLevelProperty;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link DiamondInheritanceSecondMidLevelStruct}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public DiamondInheritanceSecondMidLevelStruct build() {
+            return new Jsii$Proxy(secondMidLevelProperty, baseLevelProperty);
+        }
+
+    }
+
+    /**
+     * An implementation for {@link DiamondInheritanceSecondMidLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DiamondInheritanceSecondMidLevelStruct {
+        private final java.lang.String secondMidLevelProperty;
+        private final java.lang.String baseLevelProperty;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.secondMidLevelProperty = this.jsiiGet("secondMidLevelProperty", java.lang.String.class);
+            this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String secondMidLevelProperty, java.lang.String baseLevelProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.secondMidLevelProperty = java.util.Objects.requireNonNull(secondMidLevelProperty, "secondMidLevelProperty is required");
+            this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
+        }
+
+        @Override
+        public java.lang.String getSecondMidLevelProperty() {
+            return this.secondMidLevelProperty;
+        }
+
+        @Override
+        public java.lang.String getBaseLevelProperty() {
+            return this.baseLevelProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
+            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DiamondInheritanceSecondMidLevelStruct.Jsii$Proxy that = (DiamondInheritanceSecondMidLevelStruct.Jsii$Proxy) o;
+
+            if (!secondMidLevelProperty.equals(that.secondMidLevelProperty)) return false;
+            return baseLevelProperty.equals(that.baseLevelProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = secondMidLevelProperty.hashCode();
+            result = 31 * result + (baseLevelProperty.hashCode());
+            return result;
+        }
+
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -1,0 +1,178 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceFirstMidLevelStruct, software.amazon.jsii.tests.calculator.DiamondInheritanceSecondMidLevelStruct {
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getTopLevelProperty();
+
+    /**
+     * @return a {@link Builder} of {@link DiamondInheritanceTopLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for {@link DiamondInheritanceTopLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Builder {
+        private java.lang.String topLevelProperty;
+        private java.lang.String firstMidLevelProperty;
+        private java.lang.String baseLevelProperty;
+        private java.lang.String secondMidLevelProperty;
+
+        /**
+         * Sets the value of TopLevelProperty
+         * @param topLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder topLevelProperty(java.lang.String topLevelProperty) {
+            this.topLevelProperty = topLevelProperty;
+            return this;
+        }
+
+        /**
+         * Sets the value of FirstMidLevelProperty
+         * @param firstMidLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder firstMidLevelProperty(java.lang.String firstMidLevelProperty) {
+            this.firstMidLevelProperty = firstMidLevelProperty;
+            return this;
+        }
+
+        /**
+         * Sets the value of BaseLevelProperty
+         * @param baseLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder baseLevelProperty(java.lang.String baseLevelProperty) {
+            this.baseLevelProperty = baseLevelProperty;
+            return this;
+        }
+
+        /**
+         * Sets the value of SecondMidLevelProperty
+         * @param secondMidLevelProperty the value to be set
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder secondMidLevelProperty(java.lang.String secondMidLevelProperty) {
+            this.secondMidLevelProperty = secondMidLevelProperty;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link DiamondInheritanceTopLevelStruct}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public DiamondInheritanceTopLevelStruct build() {
+            return new Jsii$Proxy(topLevelProperty, firstMidLevelProperty, baseLevelProperty, secondMidLevelProperty);
+        }
+
+    }
+
+    /**
+     * An implementation for {@link DiamondInheritanceTopLevelStruct}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements DiamondInheritanceTopLevelStruct {
+        private final java.lang.String topLevelProperty;
+        private final java.lang.String firstMidLevelProperty;
+        private final java.lang.String baseLevelProperty;
+        private final java.lang.String secondMidLevelProperty;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.topLevelProperty = this.jsiiGet("topLevelProperty", java.lang.String.class);
+            this.firstMidLevelProperty = this.jsiiGet("firstMidLevelProperty", java.lang.String.class);
+            this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
+            this.secondMidLevelProperty = this.jsiiGet("secondMidLevelProperty", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String topLevelProperty, java.lang.String firstMidLevelProperty, java.lang.String baseLevelProperty, java.lang.String secondMidLevelProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.topLevelProperty = java.util.Objects.requireNonNull(topLevelProperty, "topLevelProperty is required");
+            this.firstMidLevelProperty = java.util.Objects.requireNonNull(firstMidLevelProperty, "firstMidLevelProperty is required");
+            this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
+            this.secondMidLevelProperty = java.util.Objects.requireNonNull(secondMidLevelProperty, "secondMidLevelProperty is required");
+        }
+
+        @Override
+        public java.lang.String getTopLevelProperty() {
+            return this.topLevelProperty;
+        }
+
+        @Override
+        public java.lang.String getFirstMidLevelProperty() {
+            return this.firstMidLevelProperty;
+        }
+
+        @Override
+        public java.lang.String getBaseLevelProperty() {
+            return this.baseLevelProperty;
+        }
+
+        @Override
+        public java.lang.String getSecondMidLevelProperty() {
+            return this.secondMidLevelProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("topLevelProperty", om.valueToTree(this.getTopLevelProperty()));
+            obj.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
+            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            obj.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            DiamondInheritanceTopLevelStruct.Jsii$Proxy that = (DiamondInheritanceTopLevelStruct.Jsii$Proxy) o;
+
+            if (!topLevelProperty.equals(that.topLevelProperty)) return false;
+            if (!firstMidLevelProperty.equals(that.firstMidLevelProperty)) return false;
+            if (!baseLevelProperty.equals(that.baseLevelProperty)) return false;
+            return secondMidLevelProperty.equals(that.secondMidLevelProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = topLevelProperty.hashCode();
+            result = 31 * result + (firstMidLevelProperty.hashCode());
+            result = 31 * result + (baseLevelProperty.hashCode());
+            result = 31 * result + (secondMidLevelProperty.hashCode());
+            return result;
+        }
+
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoNotOverridePrivates")
 public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
-    protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public DoNotOverridePrivates() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -9,19 +9,24 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoNotRecognizeAnyAsOptional")
 public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject {
-    protected DoNotRecognizeAnyAsOptional(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DoNotRecognizeAnyAsOptional(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DoNotRecognizeAnyAsOptional(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public DoNotRecognizeAnyAsOptional() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny, @javax.annotation.Nullable final java.lang.String _optionalString) {
+    public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny, final java.lang.String _optionalString) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny, _optionalString });
     }
 
@@ -29,7 +34,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny, @javax.annotation.Nullable final java.lang.Object _optionalAny) {
+    public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny, _optionalAny });
     }
 
@@ -37,7 +42,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(@javax.annotation.Nullable final java.lang.Object _requiredAny) {
+    public void method(final java.lang.Object _requiredAny) {
         this.jsiiCall("method", Void.class, new Object[] { _requiredAny });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
@@ -12,12 +12,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DocumentedClass")
 public class DocumentedClass extends software.amazon.jsii.JsiiObject {
-    protected DocumentedClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DocumentedClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DocumentedClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public DocumentedClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -30,7 +35,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * @param greetee The person to be greeted.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public java.lang.Number greet(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.Greetee greetee) {
+    public java.lang.Number greet(final software.amazon.jsii.tests.calculator.Greetee greetee) {
         return this.jsiiCall("greet", java.lang.Number.class, new Object[] { greetee });
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -7,19 +7,24 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DontComplainAboutVariadicAfterOptional")
 public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii.JsiiObject {
-    protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public DontComplainAboutVariadicAfterOptional() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String optionalAndVariadic(@javax.annotation.Nullable final java.lang.String optional, final java.lang.String... things) {
+    public java.lang.String optionalAndVariadic(final java.lang.String optional, final java.lang.String... things) {
         return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { optional }), java.util.Arrays.<Object>stream(things)).toArray(Object[]::new));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.DoubleTrouble")
 public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator {
-    protected DoubleTrouble(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected DoubleTrouble(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected DoubleTrouble(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public DoubleTrouble() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.EraseUndefinedHashValues")
 public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
-    protected EraseUndefinedHashValues(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected EraseUndefinedHashValues(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected EraseUndefinedHashValues(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public EraseUndefinedHashValues() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -34,7 +39,6 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public static java.lang.Object prop1IsNull() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop1IsNull", java.lang.Object.class);
     }
@@ -45,7 +49,6 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public static java.lang.Object prop2IsUndefined() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop2IsUndefined", java.lang.Object.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -11,6 +11,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOption1();
+
     /**
      * EXPERIMENTAL
      */
@@ -30,29 +31,28 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.String _option1;
-        @javax.annotation.Nullable
-        private java.lang.String _option2;
+        private java.lang.String option1;
+        private java.lang.String option2;
 
         /**
          * Sets the value of Option1
-         * @param value the value to be set
+         * @param option1 the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withOption1(@javax.annotation.Nullable final java.lang.String value) {
-            this._option1 = value;
+        public Builder option1(java.lang.String option1) {
+            this.option1 = option1;
             return this;
         }
+
         /**
          * Sets the value of Option2
-         * @param value the value to be set
+         * @param option2 the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withOption2(@javax.annotation.Nullable final java.lang.String value) {
-            this._option2 = value;
+        public Builder option2(java.lang.String option2) {
+            this.option2 = option2;
             return this;
         }
 
@@ -63,64 +63,80 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public EraseUndefinedHashValuesOptions build() {
-            return new EraseUndefinedHashValuesOptions() {
-                @javax.annotation.Nullable
-                private final java.lang.String $option1 = _option1;
-                @javax.annotation.Nullable
-                private final java.lang.String $option2 = _option2;
-
-                @Override
-                public java.lang.String getOption1() {
-                    return this.$option1;
-                }
-
-                @Override
-                public java.lang.String getOption2() {
-                    return this.$option2;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getOption1() != null) {
-                        obj.set("option1", om.valueToTree(this.getOption1()));
-                    }
-                    if (this.getOption2() != null) {
-                        obj.set("option2", om.valueToTree(this.getOption2()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(option1, option2);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link EraseUndefinedHashValuesOptions}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements EraseUndefinedHashValuesOptions {
+        private final java.lang.String option1;
+        private final java.lang.String option2;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.option1 = this.jsiiGet("option1", java.lang.String.class);
+            this.option2 = this.jsiiGet("option2", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String option1, java.lang.String option2) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.option1 = option1;
+            this.option2 = option2;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getOption1() {
-            return this.jsiiGet("option1", java.lang.String.class);
+            return this.option1;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getOption2() {
-            return this.jsiiGet("option2", java.lang.String.class);
+            return this.option2;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getOption1() != null) {
+                obj.set("option1", om.valueToTree(this.getOption1()));
+            }
+            if (this.getOption2() != null) {
+                obj.set("option2", om.valueToTree(this.getOption2()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            EraseUndefinedHashValuesOptions.Jsii$Proxy that = (EraseUndefinedHashValuesOptions.Jsii$Proxy) o;
+
+            if (option1 != null ? !option1.equals(that.option1) : that.option1 != null) return false;
+            return option2 != null ? option2.equals(that.option2) : that.option2 == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = option1 != null ? option1.hashCode() : 0;
+            result = 31 * result + (option2 != null ? option2.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
@@ -7,24 +7,29 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ExperimentalClass")
 public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
-    protected ExperimentalClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ExperimentalClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ExperimentalClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ExperimentalClass(final java.lang.String readonlyString, @javax.annotation.Nullable final java.lang.Number mutableNumber) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
+    public ExperimentalClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExperimentalClass(final java.lang.String readonlyString) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") }));
     }
 
     /**
@@ -47,7 +52,6 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
@@ -56,7 +60,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+    public void setMutableProperty(final java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -25,16 +25,16 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.String _readonlyProperty;
+        private java.lang.String readonlyProperty;
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param value the value to be set
+         * @param readonlyProperty the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withReadonlyProperty(final java.lang.String value) {
-            this._readonlyProperty = java.util.Objects.requireNonNull(value, "readonlyProperty is required");
+        public Builder readonlyProperty(java.lang.String readonlyProperty) {
+            this.readonlyProperty = readonlyProperty;
             return this;
         }
 
@@ -45,40 +45,65 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public ExperimentalStruct build() {
-            return new ExperimentalStruct() {
-                private final java.lang.String $readonlyProperty = java.util.Objects.requireNonNull(_readonlyProperty, "readonlyProperty is required");
-
-                @Override
-                public java.lang.String getReadonlyProperty() {
-                    return this.$readonlyProperty;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(readonlyProperty);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link ExperimentalStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ExperimentalStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements ExperimentalStruct {
+        private final java.lang.String readonlyProperty;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getReadonlyProperty() {
-            return this.jsiiGet("readonlyProperty", java.lang.String.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String readonlyProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
+        }
+
+        @Override
+        public java.lang.String getReadonlyProperty() {
+            return this.readonlyProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ExperimentalStruct.Jsii$Proxy that = (ExperimentalStruct.Jsii$Proxy) o;
+
+            return readonlyProperty.equals(that.readonlyProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = readonlyProperty.hashCode();
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -7,16 +7,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ExportedBaseClass")
 public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
-    protected ExportedBaseClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ExportedBaseClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ExportedBaseClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExportedBaseClass(final java.lang.Boolean success) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(success, "success is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(success, "success is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -11,6 +11,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getBoom();
+
     /**
      * EXPERIMENTAL
      */
@@ -30,27 +31,28 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.Boolean _boom;
-        private java.lang.String _prop;
+        private java.lang.Boolean boom;
+        private java.lang.String prop;
 
         /**
          * Sets the value of Boom
-         * @param value the value to be set
+         * @param boom the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withBoom(final java.lang.Boolean value) {
-            this._boom = java.util.Objects.requireNonNull(value, "boom is required");
+        public Builder boom(java.lang.Boolean boom) {
+            this.boom = boom;
             return this;
         }
+
         /**
          * Sets the value of Prop
-         * @param value the value to be set
+         * @param prop the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withProp(final java.lang.String value) {
-            this._prop = java.util.Objects.requireNonNull(value, "prop is required");
+        public Builder prop(java.lang.String prop) {
+            this.prop = prop;
             return this;
         }
 
@@ -61,56 +63,76 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public ExtendsInternalInterface build() {
-            return new ExtendsInternalInterface() {
-                private final java.lang.Boolean $boom = java.util.Objects.requireNonNull(_boom, "boom is required");
-                private final java.lang.String $prop = java.util.Objects.requireNonNull(_prop, "prop is required");
-
-                @Override
-                public java.lang.Boolean getBoom() {
-                    return this.$boom;
-                }
-
-                @Override
-                public java.lang.String getProp() {
-                    return this.$prop;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("boom", om.valueToTree(this.getBoom()));
-                    obj.set("prop", om.valueToTree(this.getProp()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(boom, prop);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link ExtendsInternalInterface}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ExtendsInternalInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements ExtendsInternalInterface {
+        private final java.lang.Boolean boom;
+        private final java.lang.String prop;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.boom = this.jsiiGet("boom", java.lang.Boolean.class);
+            this.prop = this.jsiiGet("prop", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Boolean boom, java.lang.String prop) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.boom = java.util.Objects.requireNonNull(boom, "boom is required");
+            this.prop = java.util.Objects.requireNonNull(prop, "prop is required");
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Boolean getBoom() {
-            return this.jsiiGet("boom", java.lang.Boolean.class);
+            return this.boom;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getProp() {
-            return this.jsiiGet("prop", java.lang.String.class);
+            return this.prop;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("boom", om.valueToTree(this.getBoom()));
+            obj.set("prop", om.valueToTree(this.getProp()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ExtendsInternalInterface.Jsii$Proxy that = (ExtendsInternalInterface.Jsii$Proxy) o;
+
+            if (!boom.equals(that.boom)) return false;
+            return prop.equals(that.prop);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = boom.hashCode();
+            result = 31 * result + (prop.hashCode());
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.GiveMeStructs")
 public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
-    protected GiveMeStructs(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected GiveMeStructs(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected GiveMeStructs(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public GiveMeStructs() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -31,17 +31,16 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.String _name;
+        private java.lang.String name;
 
         /**
          * Sets the value of Name
-         * @param value The name of the greetee.
+         * @param name The name of the greetee.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withName(@javax.annotation.Nullable final java.lang.String value) {
-            this._name = value;
+        public Builder name(java.lang.String name) {
+            this.name = name;
             return this;
         }
 
@@ -52,48 +51,67 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Greetee build() {
-            return new Greetee() {
-                @javax.annotation.Nullable
-                private final java.lang.String $name = _name;
-
-                @Override
-                public java.lang.String getName() {
-                    return this.$name;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getName() != null) {
-                        obj.set("name", om.valueToTree(this.getName()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(name);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link Greetee}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.Greetee {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements Greetee {
+        private final java.lang.String name;
 
         /**
-         * The name of the greetee.
-         * 
-         * Default: world
-         * 
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
-        public java.lang.String getName() {
-            return this.jsiiGet("name", java.lang.String.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.name = this.jsiiGet("name", java.lang.String.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String name) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.name = name;
+        }
+
+        @Override
+        public java.lang.String getName() {
+            return this.name;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getName() != null) {
+                obj.set("name", om.valueToTree(this.getName()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Greetee.Jsii$Proxy that = (Greetee.Jsii$Proxy) o;
+
+            return name != null ? name.equals(that.name) : that.name == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.GreetingAugmenter")
 public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
-    protected GreetingAugmenter(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected GreetingAugmenter(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected GreetingAugmenter(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public GreetingAugmenter() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -11,17 +11,20 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getA();
+
     /**
      * EXPERIMENTAL
      */
     void setA(final java.lang.String value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IAnotherPublicInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
@@ -13,10 +13,12 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getMutableProperty();
+
     /**
      * @deprecated could be better
      */
     void setMutableProperty(final java.lang.Number value);
+
     /**
      * @deprecated services no purpose
      */
@@ -24,12 +26,14 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     void method();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IDeprecatedInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**
@@ -38,7 +42,6 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
         @Override
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        @javax.annotation.Nullable
         public java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
@@ -49,7 +52,7 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
         @Override
         @Deprecated
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-        public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+        public void setMutableProperty(final java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
@@ -11,22 +11,26 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getMutableProperty();
+
     /**
      * EXPERIMENTAL
      */
     void setMutableProperty(final java.lang.Number value);
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void method();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IExperimentalInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**
@@ -34,7 +38,6 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
@@ -44,7 +47,7 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+        public void setMutableProperty(final java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
@@ -11,22 +11,26 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.List<java.lang.String> getMoreThings();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getPrivate();
+
     /**
      * EXPERIMENTAL
      */
     void setPrivate(final java.lang.String value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IExtendsPrivateInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -15,6 +15,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String farewell();
+
     /**
      * Say goodbye.
      * 
@@ -25,12 +26,14 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String goodbye();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlier {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
@@ -11,8 +11,9 @@ public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSeria
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
@@ -14,12 +14,14 @@ public interface IInterfaceImplementedByAbstractClass extends software.amazon.js
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getPropFromInterface();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -14,12 +14,14 @@ public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOtherValue();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceThatShouldNotBeADataType {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
@@ -12,12 +12,14 @@ public interface IInterfaceWithInternal extends software.amazon.jsii.JsiiSeriali
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void visible();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithInternal {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -11,18 +11,21 @@ public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializ
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getValue();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void doThings();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithMethods {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -12,19 +12,22 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    void hello(final java.lang.String arg1, @javax.annotation.Nullable final java.lang.Number arg2);
+    void hello(final java.lang.String arg1, final java.lang.Number arg2);
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithOptionalMethodArguments {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**
@@ -32,7 +35,7 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public void hello(final java.lang.String arg1, @javax.annotation.Nullable final java.lang.Number arg2) {
+        public void hello(final java.lang.String arg1, final java.lang.Number arg2) {
             this.jsiiCall("hello", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), arg2 });
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -11,22 +11,26 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getReadOnlyString();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getReadWriteString();
+
     /**
      * EXPERIMENTAL
      */
     void setReadWriteString(final java.lang.String value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -11,17 +11,20 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getFoo();
+
     /**
      * EXPERIMENTAL
      */
     void setFoo(final java.lang.Number value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
@@ -11,23 +11,27 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getProperty();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void bar();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void baz();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJSII417Derived {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
@@ -11,18 +11,21 @@ public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getHasRoot();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void foo();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External.java
@@ -11,8 +11,9 @@ public interface IJsii487External extends software.amazon.jsii.JsiiSerializable 
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii487External2.java
@@ -11,8 +11,9 @@ public interface IJsii487External2 extends software.amazon.jsii.JsiiSerializable
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External2 {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJsii496.java
@@ -11,8 +11,9 @@ public interface IJsii496 extends software.amazon.jsii.JsiiSerializable {
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii496 {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
@@ -11,17 +11,20 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getValue();
+
     /**
      * EXPERIMENTAL
      */
     void setValue(final java.lang.String value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IMutableObjectLiteral {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -11,26 +11,31 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getB();
+
     /**
      * EXPERIMENTAL
      */
     void setB(final java.lang.String value);
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getC();
+
     /**
      * EXPERIMENTAL
      */
     void setC(final java.lang.String value);
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.INonInternalInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
@@ -12,12 +12,14 @@ public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializ
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getSuccess();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IPrivatelyImplemented {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
@@ -12,12 +12,14 @@ public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable 
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String bye();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IPublicInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
@@ -12,12 +12,14 @@ public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String ciao();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IPublicInterface2 {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -18,12 +18,14 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number next();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IRandomNumberGenerator {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -11,18 +11,21 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.lib.Number getNumberProp();
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IReturnsNumber {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
@@ -9,27 +9,30 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     java.lang.Number getMutableProperty();
+
     /**
      */
     void setMutableProperty(final java.lang.Number value);
+
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     void method();
 
+
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IStableInterface {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        @javax.annotation.Nullable
         public java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
@@ -38,7 +41,7 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+        public void setMutableProperty(final java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementInternalInterface")
 public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject {
-    protected ImplementInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ImplementInternalInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ImplementInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ImplementInternalInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsInterfaceWithInternal")
 public class ImplementsInterfaceWithInternal extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IInterfaceWithInternal {
-    protected ImplementsInterfaceWithInternal(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ImplementsInterfaceWithInternal(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ImplementsInterfaceWithInternal(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ImplementsInterfaceWithInternal() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
@@ -7,11 +7,16 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsInterfaceWithInternalSubclass")
 public class ImplementsInterfaceWithInternalSubclass extends software.amazon.jsii.tests.calculator.ImplementsInterfaceWithInternal {
-    protected ImplementsInterfaceWithInternalSubclass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ImplementsInterfaceWithInternalSubclass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ImplementsInterfaceWithInternalSubclass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ImplementsInterfaceWithInternalSubclass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ImplementsPrivateInterface")
 public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject {
-    protected ImplementsPrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ImplementsPrivateInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ImplementsPrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ImplementsPrivateInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -25,36 +25,38 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.time.Instant _goo;
-        private java.lang.String _bar;
-        private software.amazon.jsii.tests.calculator.baseofbase.Very _foo;
+        private java.time.Instant goo;
+        private java.lang.String bar;
+        private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
          * Sets the value of Goo
-         * @param value the value to be set
+         * @param goo the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withGoo(final java.time.Instant value) {
-            this._goo = java.util.Objects.requireNonNull(value, "goo is required");
+        public Builder goo(java.time.Instant goo) {
+            this.goo = goo;
             return this;
         }
+
         /**
          * Sets the value of Bar
-         * @param value the value to be set
+         * @param bar the value to be set
          * @return {@code this}
          */
-        public Builder withBar(final java.lang.String value) {
-            this._bar = java.util.Objects.requireNonNull(value, "bar is required");
+        public Builder bar(java.lang.String bar) {
+            this.bar = bar;
             return this;
         }
+
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
-        public Builder withFoo(final software.amazon.jsii.tests.calculator.baseofbase.Very value) {
-            this._foo = java.util.Objects.requireNonNull(value, "foo is required");
+        public Builder foo(software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+            this.foo = foo;
             return this;
         }
 
@@ -65,64 +67,87 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public ImplictBaseOfBase build() {
-            return new ImplictBaseOfBase() {
-                private final java.time.Instant $goo = java.util.Objects.requireNonNull(_goo, "goo is required");
-                private final java.lang.String $bar = java.util.Objects.requireNonNull(_bar, "bar is required");
-                private final software.amazon.jsii.tests.calculator.baseofbase.Very $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
-
-                @Override
-                public java.time.Instant getGoo() {
-                    return this.$goo;
-                }
-
-                @Override
-                public java.lang.String getBar() {
-                    return this.$bar;
-                }
-
-                @Override
-                public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
-                    return this.$foo;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("goo", om.valueToTree(this.getGoo()));
-                    obj.set("bar", om.valueToTree(this.getBar()));
-                    obj.set("foo", om.valueToTree(this.getFoo()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(goo, bar, foo);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link ImplictBaseOfBase}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.ImplictBaseOfBase {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements ImplictBaseOfBase {
+        private final java.time.Instant goo;
+        private final java.lang.String bar;
+        private final software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.goo = this.jsiiGet("goo", java.time.Instant.class);
+            this.bar = this.jsiiGet("bar", java.lang.String.class);
+            this.foo = this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.time.Instant goo, java.lang.String bar, software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.goo = java.util.Objects.requireNonNull(goo, "goo is required");
+            this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
+            this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.time.Instant getGoo() {
-            return this.jsiiGet("goo", java.time.Instant.class);
+            return this.goo;
         }
 
         @Override
         public java.lang.String getBar() {
-            return this.jsiiGet("bar", java.lang.String.class);
+            return this.bar;
         }
 
         @Override
         public software.amazon.jsii.tests.calculator.baseofbase.Very getFoo() {
-            return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
+            return this.foo;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("goo", om.valueToTree(this.getGoo()));
+            obj.set("bar", om.valueToTree(this.getBar()));
+            obj.set("foo", om.valueToTree(this.getFoo()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ImplictBaseOfBase.Jsii$Proxy that = (ImplictBaseOfBase.Jsii$Proxy) o;
+
+            if (!goo.equals(that.goo)) return false;
+            if (!bar.equals(that.bar)) return false;
+            return foo.equals(that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = goo.hashCode();
+            result = 31 * result + (bar.hashCode());
+            result = 31 * result + (foo.hashCode());
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.InbetweenClass")
 public class InbetweenClass extends software.amazon.jsii.tests.calculator.PublicClass implements software.amazon.jsii.tests.calculator.IPublicInterface2 {
-    protected InbetweenClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected InbetweenClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected InbetweenClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public InbetweenClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
@@ -7,19 +7,23 @@ package software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasse
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo")
 public class Foo extends software.amazon.jsii.JsiiObject {
-    protected Foo(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Foo(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Foo(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Foo() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.String getBar() {
         return this.jsiiGet("bar", java.lang.String.class);
     }
@@ -28,7 +32,7 @@ public class Foo extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setBar(@javax.annotation.Nullable final java.lang.String value) {
+    public void setBar(final java.lang.String value) {
         this.jsiiSet("bar", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -25,16 +25,16 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.Number _foo;
+        private java.lang.Number foo;
 
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withFoo(final java.lang.Number value) {
-            this._foo = java.util.Objects.requireNonNull(value, "foo is required");
+        public Builder foo(java.lang.Number foo) {
+            this.foo = foo;
             return this;
         }
 
@@ -45,40 +45,65 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Hello build() {
-            return new Hello() {
-                private final java.lang.Number $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
-
-                @Override
-                public java.lang.Number getFoo() {
-                    return this.$foo;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("foo", om.valueToTree(this.getFoo()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(foo);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link Hello}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasses.Hello {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements Hello {
+        private final java.lang.Number foo;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getFoo() {
-            return this.jsiiGet("foo", java.lang.Number.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.foo = this.jsiiGet("foo", java.lang.Number.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Number foo) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
+        }
+
+        @Override
+        public java.lang.Number getFoo() {
+            return this.foo;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("foo", om.valueToTree(this.getFoo()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Hello.Jsii$Proxy that = (Hello.Jsii$Proxy) o;
+
+            return foo.equals(that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = foo.hashCode();
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -25,16 +25,16 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.Number _foo;
+        private java.lang.Number foo;
 
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withFoo(final java.lang.Number value) {
-            this._foo = java.util.Objects.requireNonNull(value, "foo is required");
+        public Builder foo(java.lang.Number foo) {
+            this.foo = foo;
             return this;
         }
 
@@ -45,40 +45,65 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Hello build() {
-            return new Hello() {
-                private final java.lang.Number $foo = java.util.Objects.requireNonNull(_foo, "foo is required");
-
-                @Override
-                public java.lang.Number getFoo() {
-                    return this.$foo;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("foo", om.valueToTree(this.getFoo()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(foo);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link Hello}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface.Hello {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements Hello {
+        private final java.lang.Number foo;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getFoo() {
-            return this.jsiiGet("foo", java.lang.Number.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.foo = this.jsiiGet("foo", java.lang.Number.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Number foo) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
+        }
+
+        @Override
+        public java.lang.Number getFoo() {
+            return this.foo;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("foo", om.valueToTree(this.getFoo()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Hello.Jsii$Proxy that = (Hello.Jsii$Proxy) o;
+
+            return foo.equals(that.foo);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = foo.hashCode();
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -7,16 +7,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSII417Derived")
 public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase {
-    protected JSII417Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JSII417Derived(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JSII417Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public JSII417Derived(final java.lang.String property) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(property, "property is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(property, "property is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSII417PublicBaseOfBase")
 public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
-    protected JSII417PublicBaseOfBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JSII417PublicBaseOfBase(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JSII417PublicBaseOfBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JSII417PublicBaseOfBase() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralForInterface")
 public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject {
-    protected JSObjectLiteralForInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JSObjectLiteralForInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JSObjectLiteralForInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JSObjectLiteralForInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralToNative")
 public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
-    protected JSObjectLiteralToNative(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JSObjectLiteralToNative(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JSObjectLiteralToNative(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JSObjectLiteralToNative() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JSObjectLiteralToNativeClass")
 public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObject {
-    protected JSObjectLiteralToNativeClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JSObjectLiteralToNativeClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JSObjectLiteralToNativeClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JSObjectLiteralToNativeClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JavaReservedWords")
 public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
-    protected JavaReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JavaReservedWords(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JavaReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JavaReservedWords() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
@@ -7,11 +7,16 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii487Derived")
 public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii487External2,software.amazon.jsii.tests.calculator.IJsii487External {
-    protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Jsii487Derived(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Jsii487Derived() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
@@ -7,11 +7,16 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Jsii496Derived")
 public class Jsii496Derived extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IJsii496 {
-    protected Jsii496Derived(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Jsii496Derived(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Jsii496Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Jsii496Derived() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
@@ -9,12 +9,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.JsiiAgent")
 public class JsiiAgent extends software.amazon.jsii.JsiiObject {
-    protected JsiiAgent(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected JsiiAgent(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected JsiiAgent(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public JsiiAgent() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -23,7 +28,6 @@ public class JsiiAgent extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public static java.lang.String getJsiiAgent() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.JsiiAgent.class, "jsiiAgent", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -19,6 +19,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number getContainerPort();
+
     /**
      * The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
      * 
@@ -30,6 +31,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getCpu();
+
     /**
      * The amount (in MiB) of memory used by the task.
      * 
@@ -54,6 +56,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getMemoryMiB();
+
     /**
      * Determines whether the Application Load Balancer will be internet-facing.
      * 
@@ -63,6 +66,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getPublicLoadBalancer();
+
     /**
      * Determines whether your Fargate Service will be assigned a public IP address.
      * 
@@ -86,65 +90,64 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.Number _containerPort;
-        @javax.annotation.Nullable
-        private java.lang.String _cpu;
-        @javax.annotation.Nullable
-        private java.lang.String _memoryMiB;
-        @javax.annotation.Nullable
-        private java.lang.Boolean _publicLoadBalancer;
-        @javax.annotation.Nullable
-        private java.lang.Boolean _publicTasks;
+        private java.lang.Number containerPort;
+        private java.lang.String cpu;
+        private java.lang.String memoryMiB;
+        private java.lang.Boolean publicLoadBalancer;
+        private java.lang.Boolean publicTasks;
 
         /**
          * Sets the value of ContainerPort
-         * @param value The container port of the application load balancer attached to your Fargate service.
+         * @param containerPort The container port of the application load balancer attached to your Fargate service.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withContainerPort(@javax.annotation.Nullable final java.lang.Number value) {
-            this._containerPort = value;
+        public Builder containerPort(java.lang.Number containerPort) {
+            this.containerPort = containerPort;
             return this;
         }
+
         /**
          * Sets the value of Cpu
-         * @param value The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
+         * @param cpu The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withCpu(@javax.annotation.Nullable final java.lang.String value) {
-            this._cpu = value;
+        public Builder cpu(java.lang.String cpu) {
+            this.cpu = cpu;
             return this;
         }
+
         /**
          * Sets the value of MemoryMiB
-         * @param value The amount (in MiB) of memory used by the task.
+         * @param memoryMiB The amount (in MiB) of memory used by the task.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withMemoryMiB(@javax.annotation.Nullable final java.lang.String value) {
-            this._memoryMiB = value;
+        public Builder memoryMiB(java.lang.String memoryMiB) {
+            this.memoryMiB = memoryMiB;
             return this;
         }
+
         /**
          * Sets the value of PublicLoadBalancer
-         * @param value Determines whether the Application Load Balancer will be internet-facing.
+         * @param publicLoadBalancer Determines whether the Application Load Balancer will be internet-facing.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withPublicLoadBalancer(@javax.annotation.Nullable final java.lang.Boolean value) {
-            this._publicLoadBalancer = value;
+        public Builder publicLoadBalancer(java.lang.Boolean publicLoadBalancer) {
+            this.publicLoadBalancer = publicLoadBalancer;
             return this;
         }
+
         /**
          * Sets the value of PublicTasks
-         * @param value Determines whether your Fargate Service will be assigned a public IP address.
+         * @param publicTasks Determines whether your Fargate Service will be assigned a public IP address.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withPublicTasks(@javax.annotation.Nullable final java.lang.Boolean value) {
-            this._publicTasks = value;
+        public Builder publicTasks(java.lang.Boolean publicTasks) {
+            this.publicTasks = publicTasks;
             return this;
         }
 
@@ -155,163 +158,119 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public LoadBalancedFargateServiceProps build() {
-            return new LoadBalancedFargateServiceProps() {
-                @javax.annotation.Nullable
-                private final java.lang.Number $containerPort = _containerPort;
-                @javax.annotation.Nullable
-                private final java.lang.String $cpu = _cpu;
-                @javax.annotation.Nullable
-                private final java.lang.String $memoryMiB = _memoryMiB;
-                @javax.annotation.Nullable
-                private final java.lang.Boolean $publicLoadBalancer = _publicLoadBalancer;
-                @javax.annotation.Nullable
-                private final java.lang.Boolean $publicTasks = _publicTasks;
-
-                @Override
-                public java.lang.Number getContainerPort() {
-                    return this.$containerPort;
-                }
-
-                @Override
-                public java.lang.String getCpu() {
-                    return this.$cpu;
-                }
-
-                @Override
-                public java.lang.String getMemoryMiB() {
-                    return this.$memoryMiB;
-                }
-
-                @Override
-                public java.lang.Boolean getPublicLoadBalancer() {
-                    return this.$publicLoadBalancer;
-                }
-
-                @Override
-                public java.lang.Boolean getPublicTasks() {
-                    return this.$publicTasks;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getContainerPort() != null) {
-                        obj.set("containerPort", om.valueToTree(this.getContainerPort()));
-                    }
-                    if (this.getCpu() != null) {
-                        obj.set("cpu", om.valueToTree(this.getCpu()));
-                    }
-                    if (this.getMemoryMiB() != null) {
-                        obj.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
-                    }
-                    if (this.getPublicLoadBalancer() != null) {
-                        obj.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
-                    }
-                    if (this.getPublicTasks() != null) {
-                        obj.set("publicTasks", om.valueToTree(this.getPublicTasks()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(containerPort, cpu, memoryMiB, publicLoadBalancer, publicTasks);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link LoadBalancedFargateServiceProps}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.LoadBalancedFargateServiceProps {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements LoadBalancedFargateServiceProps {
+        private final java.lang.Number containerPort;
+        private final java.lang.String cpu;
+        private final java.lang.String memoryMiB;
+        private final java.lang.Boolean publicLoadBalancer;
+        private final java.lang.Boolean publicTasks;
 
         /**
-         * The container port of the application load balancer attached to your Fargate service.
-         * 
-         * Corresponds to container port mapping.
-         * 
-         * Default: 80
-         * 
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.containerPort = this.jsiiGet("containerPort", java.lang.Number.class);
+            this.cpu = this.jsiiGet("cpu", java.lang.String.class);
+            this.memoryMiB = this.jsiiGet("memoryMiB", java.lang.String.class);
+            this.publicLoadBalancer = this.jsiiGet("publicLoadBalancer", java.lang.Boolean.class);
+            this.publicTasks = this.jsiiGet("publicTasks", java.lang.Boolean.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Number containerPort, java.lang.String cpu, java.lang.String memoryMiB, java.lang.Boolean publicLoadBalancer, java.lang.Boolean publicTasks) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.containerPort = containerPort;
+            this.cpu = cpu;
+            this.memoryMiB = memoryMiB;
+            this.publicLoadBalancer = publicLoadBalancer;
+            this.publicTasks = publicTasks;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Number getContainerPort() {
-            return this.jsiiGet("containerPort", java.lang.Number.class);
+            return this.containerPort;
         }
 
-        /**
-         * The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
-         * 
-         * This default is set in the underlying FargateTaskDefinition construct.
-         * 
-         * Default: 256
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getCpu() {
-            return this.jsiiGet("cpu", java.lang.String.class);
+            return this.cpu;
         }
 
-        /**
-         * The amount (in MiB) of memory used by the task.
-         * 
-         * This field is required and you must use one of the following values, which determines your range of valid values
-         * for the cpu parameter:
-         * 
-         * 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
-         * 
-         * 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
-         * 
-         * 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
-         * 
-         * Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
-         * 
-         * Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
-         * 
-         * This default is set in the underlying FargateTaskDefinition construct.
-         * 
-         * Default: 512
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getMemoryMiB() {
-            return this.jsiiGet("memoryMiB", java.lang.String.class);
+            return this.memoryMiB;
         }
 
-        /**
-         * Determines whether the Application Load Balancer will be internet-facing.
-         * 
-         * Default: true
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Boolean getPublicLoadBalancer() {
-            return this.jsiiGet("publicLoadBalancer", java.lang.Boolean.class);
+            return this.publicLoadBalancer;
         }
 
-        /**
-         * Determines whether your Fargate Service will be assigned a public IP address.
-         * 
-         * Default: false
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Boolean getPublicTasks() {
-            return this.jsiiGet("publicTasks", java.lang.Boolean.class);
+            return this.publicTasks;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getContainerPort() != null) {
+                obj.set("containerPort", om.valueToTree(this.getContainerPort()));
+            }
+            if (this.getCpu() != null) {
+                obj.set("cpu", om.valueToTree(this.getCpu()));
+            }
+            if (this.getMemoryMiB() != null) {
+                obj.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
+            }
+            if (this.getPublicLoadBalancer() != null) {
+                obj.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
+            }
+            if (this.getPublicTasks() != null) {
+                obj.set("publicTasks", om.valueToTree(this.getPublicTasks()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LoadBalancedFargateServiceProps.Jsii$Proxy that = (LoadBalancedFargateServiceProps.Jsii$Proxy) o;
+
+            if (containerPort != null ? !containerPort.equals(that.containerPort) : that.containerPort != null) return false;
+            if (cpu != null ? !cpu.equals(that.cpu) : that.cpu != null) return false;
+            if (memoryMiB != null ? !memoryMiB.equals(that.memoryMiB) : that.memoryMiB != null) return false;
+            if (publicLoadBalancer != null ? !publicLoadBalancer.equals(that.publicLoadBalancer) : that.publicLoadBalancer != null) return false;
+            return publicTasks != null ? publicTasks.equals(that.publicTasks) : that.publicTasks == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = containerPort != null ? containerPort.hashCode() : 0;
+            result = 31 * result + (cpu != null ? cpu.hashCode() : 0);
+            result = 31 * result + (memoryMiB != null ? memoryMiB.hashCode() : 0);
+            result = 31 * result + (publicLoadBalancer != null ? publicLoadBalancer.hashCode() : 0);
+            result = 31 * result + (publicTasks != null ? publicTasks.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Multiply")
 public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperation implements software.amazon.jsii.tests.calculator.IFriendlier,software.amazon.jsii.tests.calculator.IRandomNumberGenerator {
-    protected Multiply(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Multiply(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Multiply(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a BinaryOperation.
@@ -22,8 +27,8 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Multiply(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -9,16 +9,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Negate")
 public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation implements software.amazon.jsii.tests.calculator.IFriendlier {
-    protected Negate(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Negate(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Negate(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Negate(final software.amazon.jsii.tests.calculator.lib.Value operand) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
@@ -9,12 +9,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NodeStandardLibrary")
 public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
-    protected NodeStandardLibrary(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected NodeStandardLibrary(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected NodeStandardLibrary(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public NodeStandardLibrary() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -9,31 +9,36 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NullShouldBeTreatedAsUndefined")
 public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObject {
-    protected NullShouldBeTreatedAsUndefined(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected NullShouldBeTreatedAsUndefined(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected NullShouldBeTreatedAsUndefined(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, @javax.annotation.Nullable final java.lang.Object optional) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional });
+    public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, final java.lang.Object optional) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required") }));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void giveMeUndefined(@javax.annotation.Nullable final java.lang.Object value) {
+    public void giveMeUndefined(final java.lang.Object value) {
         this.jsiiCall("giveMeUndefined", Void.class, new Object[] { value });
     }
 
@@ -65,7 +70,6 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.String getChangeMeToUndefined() {
         return this.jsiiGet("changeMeToUndefined", java.lang.String.class);
     }
@@ -74,7 +78,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setChangeMeToUndefined(@javax.annotation.Nullable final java.lang.String value) {
+    public void setChangeMeToUndefined(final java.lang.String value) {
         this.jsiiSet("changeMeToUndefined", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -11,6 +11,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument();
+
     /**
      * EXPERIMENTAL
      */
@@ -30,28 +31,28 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.util.List<java.lang.Object> _arrayWithThreeElementsAndUndefinedAsSecondArgument;
-        @javax.annotation.Nullable
-        private java.lang.Object _thisShouldBeUndefined;
+        private java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument;
+        private java.lang.Object thisShouldBeUndefined;
 
         /**
          * Sets the value of ArrayWithThreeElementsAndUndefinedAsSecondArgument
-         * @param value the value to be set
+         * @param arrayWithThreeElementsAndUndefinedAsSecondArgument the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withArrayWithThreeElementsAndUndefinedAsSecondArgument(final java.util.List<java.lang.Object> value) {
-            this._arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(value, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
+        public Builder arrayWithThreeElementsAndUndefinedAsSecondArgument(java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument) {
+            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = arrayWithThreeElementsAndUndefinedAsSecondArgument;
             return this;
         }
+
         /**
          * Sets the value of ThisShouldBeUndefined
-         * @param value the value to be set
+         * @param thisShouldBeUndefined the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withThisShouldBeUndefined(@javax.annotation.Nullable final java.lang.Object value) {
-            this._thisShouldBeUndefined = value;
+        public Builder thisShouldBeUndefined(java.lang.Object thisShouldBeUndefined) {
+            this.thisShouldBeUndefined = thisShouldBeUndefined;
             return this;
         }
 
@@ -62,60 +63,78 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public NullShouldBeTreatedAsUndefinedData build() {
-            return new NullShouldBeTreatedAsUndefinedData() {
-                private final java.util.List<java.lang.Object> $arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(_arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
-                @javax.annotation.Nullable
-                private final java.lang.Object $thisShouldBeUndefined = _thisShouldBeUndefined;
-
-                @Override
-                public java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument() {
-                    return this.$arrayWithThreeElementsAndUndefinedAsSecondArgument;
-                }
-
-                @Override
-                public java.lang.Object getThisShouldBeUndefined() {
-                    return this.$thisShouldBeUndefined;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("arrayWithThreeElementsAndUndefinedAsSecondArgument", om.valueToTree(this.getArrayWithThreeElementsAndUndefinedAsSecondArgument()));
-                    if (this.getThisShouldBeUndefined() != null) {
-                        obj.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(arrayWithThreeElementsAndUndefinedAsSecondArgument, thisShouldBeUndefined);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link NullShouldBeTreatedAsUndefinedData}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements NullShouldBeTreatedAsUndefinedData {
+        private final java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument;
+        private final java.lang.Object thisShouldBeUndefined;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = this.jsiiGet("arrayWithThreeElementsAndUndefinedAsSecondArgument", java.util.List.class);
+            this.thisShouldBeUndefined = this.jsiiGet("thisShouldBeUndefined", java.lang.Object.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument, java.lang.Object thisShouldBeUndefined) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
+            this.thisShouldBeUndefined = thisShouldBeUndefined;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument() {
-            return this.jsiiGet("arrayWithThreeElementsAndUndefinedAsSecondArgument", java.util.List.class);
+            return this.arrayWithThreeElementsAndUndefinedAsSecondArgument;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Object getThisShouldBeUndefined() {
-            return this.jsiiGet("thisShouldBeUndefined", java.lang.Object.class);
+            return this.thisShouldBeUndefined;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("arrayWithThreeElementsAndUndefinedAsSecondArgument", om.valueToTree(this.getArrayWithThreeElementsAndUndefinedAsSecondArgument()));
+            if (this.getThisShouldBeUndefined() != null) {
+                obj.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NullShouldBeTreatedAsUndefinedData.Jsii$Proxy that = (NullShouldBeTreatedAsUndefinedData.Jsii$Proxy) o;
+
+            if (!arrayWithThreeElementsAndUndefinedAsSecondArgument.equals(that.arrayWithThreeElementsAndUndefinedAsSecondArgument)) return false;
+            return thisShouldBeUndefined != null ? thisShouldBeUndefined.equals(that.thisShouldBeUndefined) : that.thisShouldBeUndefined == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = arrayWithThreeElementsAndUndefinedAsSecondArgument.hashCode();
+            result = 31 * result + (thisShouldBeUndefined != null ? thisShouldBeUndefined.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -9,16 +9,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.NumberGenerator")
 public class NumberGenerator extends software.amazon.jsii.JsiiObject {
-    protected NumberGenerator(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected NumberGenerator(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected NumberGenerator(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NumberGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(generator, "generator is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(generator, "generator is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -9,12 +9,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ObjectRefsInCollections")
 public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
-    protected ObjectRefsInCollections(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ObjectRefsInCollections(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ObjectRefsInCollections(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ObjectRefsInCollections() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
@@ -10,12 +10,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Old")
 public class Old extends software.amazon.jsii.JsiiObject {
-    protected Old(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Old(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Old(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Old() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -7,24 +7,29 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalConstructorArgument")
 public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject {
-    protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
+    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") }));
     }
 
     /**
@@ -47,7 +52,6 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -25,17 +25,16 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        @javax.annotation.Nullable
-        private java.lang.String _field;
+        private java.lang.String field;
 
         /**
          * Sets the value of Field
-         * @param value the value to be set
+         * @param field the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withField(@javax.annotation.Nullable final java.lang.String value) {
-            this._field = value;
+        public Builder field(java.lang.String field) {
+            this.field = field;
             return this;
         }
 
@@ -46,44 +45,67 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public OptionalStruct build() {
-            return new OptionalStruct() {
-                @javax.annotation.Nullable
-                private final java.lang.String $field = _field;
-
-                @Override
-                public java.lang.String getField() {
-                    return this.$field;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    if (this.getField() != null) {
-                        obj.set("field", om.valueToTree(this.getField()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(field);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link OptionalStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.OptionalStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements OptionalStruct {
+        private final java.lang.String field;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
-        public java.lang.String getField() {
-            return this.jsiiGet("field", java.lang.String.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.field = this.jsiiGet("field", java.lang.String.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String field) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.field = field;
+        }
+
+        @Override
+        public java.lang.String getField() {
+            return this.field;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            if (this.getField() != null) {
+                obj.set("field", om.valueToTree(this.getField()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            OptionalStruct.Jsii$Proxy that = (OptionalStruct.Jsii$Proxy) o;
+
+            return field != null ? field.equals(that.field) : that.field == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = field != null ? field.hashCode() : 0;
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -7,24 +7,29 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OptionalStructConsumer")
 public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
-    protected OptionalStructConsumer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected OptionalStructConsumer(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected OptionalStructConsumer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalStructConsumer(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct });
+    public OptionalStructConsumer(final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalStructConsumer() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -39,7 +44,6 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.String getFieldValue() {
         return this.jsiiGet("fieldValue", java.lang.String.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.OverrideReturnsObject")
 public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
-    protected OverrideReturnsObject(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected OverrideReturnsObject(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected OverrideReturnsObject(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public OverrideReturnsObject() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PartiallyInitializedThisConsumer")
 public abstract class PartiallyInitializedThisConsumer extends software.amazon.jsii.JsiiObject {
-    protected PartiallyInitializedThisConsumer(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected PartiallyInitializedThisConsumer(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected PartiallyInitializedThisConsumer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public PartiallyInitializedThisConsumer() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -25,8 +30,9 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Polymorphism")
 public class Polymorphism extends software.amazon.jsii.JsiiObject {
-    protected Polymorphism(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Polymorphism(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Polymorphism(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Polymorphism() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -9,8 +9,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Power")
 public class Power extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
-    protected Power(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Power(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Power(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * Creates a Power operation.
@@ -22,8 +27,8 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Power(final software.amazon.jsii.tests.calculator.lib.Value base, final software.amazon.jsii.tests.calculator.lib.Value pow) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(base, "base is required"), java.util.Objects.requireNonNull(pow, "pow is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(base, "base is required"), java.util.Objects.requireNonNull(pow, "pow is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PublicClass")
 public class PublicClass extends software.amazon.jsii.JsiiObject {
-    protected PublicClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected PublicClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected PublicClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public PublicClass() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.PythonReservedWords")
 public class PythonReservedWords extends software.amazon.jsii.JsiiObject {
-    protected PythonReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected PythonReservedWords(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected PythonReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public PythonReservedWords() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -9,19 +9,23 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ReferenceEnumFromScopedPackage")
 public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObject {
-    protected ReferenceEnumFromScopedPackage(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ReferenceEnumFromScopedPackage(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ReferenceEnumFromScopedPackage(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ReferenceEnumFromScopedPackage() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule loadFoo() {
         return this.jsiiCall("loadFoo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
@@ -38,7 +42,6 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule getFoo() {
         return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
@@ -47,7 +50,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setFoo(@javax.annotation.Nullable final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
+    public void setFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiSet("foo", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
@@ -12,12 +12,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ReturnsPrivateImplementationOfInterface")
 public class ReturnsPrivateImplementationOfInterface extends software.amazon.jsii.JsiiObject {
-    protected ReturnsPrivateImplementationOfInterface(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected ReturnsPrivateImplementationOfInterface(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ReturnsPrivateImplementationOfInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public ReturnsPrivateImplementationOfInterface() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -7,19 +7,24 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.RuntimeTypeChecking")
 public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
-    protected RuntimeTypeChecking(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected RuntimeTypeChecking(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected RuntimeTypeChecking(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public RuntimeTypeChecking() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+    public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2, arg3 });
     }
 
@@ -27,7 +32,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1, @javax.annotation.Nullable final java.lang.String arg2) {
+    public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1, arg2 });
     }
 
@@ -35,7 +40,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(@javax.annotation.Nullable final java.lang.Number arg1) {
+    public void methodWithDefaultedArguments(final java.lang.Number arg1) {
         this.jsiiCall("methodWithDefaultedArguments", Void.class, new Object[] { arg1 });
     }
 
@@ -51,7 +56,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithOptionalAnyArgument(@javax.annotation.Nullable final java.lang.Object arg) {
+    public void methodWithOptionalAnyArgument(final java.lang.Object arg) {
         this.jsiiCall("methodWithOptionalAnyArgument", Void.class, new Object[] { arg });
     }
 
@@ -69,7 +74,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, @javax.annotation.Nullable final java.time.Instant arg3) {
+    public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
         this.jsiiCall("methodWithOptionalArguments", Void.class, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -13,6 +13,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getDeeperRequiredProp();
+
     /**
      * It's long, but you'll almost never pass it.
      * 
@@ -34,28 +35,28 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.String _deeperRequiredProp;
-        @javax.annotation.Nullable
-        private java.lang.String _deeperOptionalProp;
+        private java.lang.String deeperRequiredProp;
+        private java.lang.String deeperOptionalProp;
 
         /**
          * Sets the value of DeeperRequiredProp
-         * @param value It's long and required.
+         * @param deeperRequiredProp It's long and required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withDeeperRequiredProp(final java.lang.String value) {
-            this._deeperRequiredProp = java.util.Objects.requireNonNull(value, "deeperRequiredProp is required");
+        public Builder deeperRequiredProp(java.lang.String deeperRequiredProp) {
+            this.deeperRequiredProp = deeperRequiredProp;
             return this;
         }
+
         /**
          * Sets the value of DeeperOptionalProp
-         * @param value It's long, but you'll almost never pass it.
+         * @param deeperOptionalProp It's long, but you'll almost never pass it.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withDeeperOptionalProp(@javax.annotation.Nullable final java.lang.String value) {
-            this._deeperOptionalProp = value;
+        public Builder deeperOptionalProp(java.lang.String deeperOptionalProp) {
+            this.deeperOptionalProp = deeperOptionalProp;
             return this;
         }
 
@@ -66,64 +67,78 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public SecondLevelStruct build() {
-            return new SecondLevelStruct() {
-                private final java.lang.String $deeperRequiredProp = java.util.Objects.requireNonNull(_deeperRequiredProp, "deeperRequiredProp is required");
-                @javax.annotation.Nullable
-                private final java.lang.String $deeperOptionalProp = _deeperOptionalProp;
-
-                @Override
-                public java.lang.String getDeeperRequiredProp() {
-                    return this.$deeperRequiredProp;
-                }
-
-                @Override
-                public java.lang.String getDeeperOptionalProp() {
-                    return this.$deeperOptionalProp;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("deeperRequiredProp", om.valueToTree(this.getDeeperRequiredProp()));
-                    if (this.getDeeperOptionalProp() != null) {
-                        obj.set("deeperOptionalProp", om.valueToTree(this.getDeeperOptionalProp()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(deeperRequiredProp, deeperOptionalProp);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link SecondLevelStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.SecondLevelStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements SecondLevelStruct {
+        private final java.lang.String deeperRequiredProp;
+        private final java.lang.String deeperOptionalProp;
 
         /**
-         * It's long and required.
-         * 
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.deeperRequiredProp = this.jsiiGet("deeperRequiredProp", java.lang.String.class);
+            this.deeperOptionalProp = this.jsiiGet("deeperOptionalProp", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String deeperRequiredProp, java.lang.String deeperOptionalProp) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.deeperRequiredProp = java.util.Objects.requireNonNull(deeperRequiredProp, "deeperRequiredProp is required");
+            this.deeperOptionalProp = deeperOptionalProp;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getDeeperRequiredProp() {
-            return this.jsiiGet("deeperRequiredProp", java.lang.String.class);
+            return this.deeperRequiredProp;
         }
 
-        /**
-         * It's long, but you'll almost never pass it.
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getDeeperOptionalProp() {
-            return this.jsiiGet("deeperOptionalProp", java.lang.String.class);
+            return this.deeperOptionalProp;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("deeperRequiredProp", om.valueToTree(this.getDeeperRequiredProp()));
+            if (this.getDeeperOptionalProp() != null) {
+                obj.set("deeperOptionalProp", om.valueToTree(this.getDeeperOptionalProp()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SecondLevelStruct.Jsii$Proxy that = (SecondLevelStruct.Jsii$Proxy) o;
+
+            if (!deeperRequiredProp.equals(that.deeperRequiredProp)) return false;
+            return deeperOptionalProp != null ? deeperOptionalProp.equals(that.deeperOptionalProp) : that.deeperOptionalProp == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = deeperRequiredProp.hashCode();
+            result = 31 * result + (deeperOptionalProp != null ? deeperOptionalProp.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
@@ -13,12 +13,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingleInstanceTwoTypes")
 public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
-    protected SingleInstanceTwoTypes(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected SingleInstanceTwoTypes(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected SingleInstanceTwoTypes(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public SingleInstanceTwoTypes() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
@@ -11,8 +11,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonInt")
 public class SingletonInt extends software.amazon.jsii.JsiiObject {
-    protected SingletonInt(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected SingletonInt(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected SingletonInt(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
@@ -11,8 +11,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SingletonString")
 public class SingletonString extends software.amazon.jsii.JsiiObject {
-    protected SingletonString(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected SingletonString(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected SingletonString(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
@@ -6,22 +6,27 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StableClass")
 public class StableClass extends software.amazon.jsii.JsiiObject {
-    protected StableClass(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected StableClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected StableClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public StableClass(final java.lang.String readonlyString, @javax.annotation.Nullable final java.lang.Number mutableNumber) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
+    public StableClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public StableClass(final java.lang.String readonlyString) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") }));
     }
 
     /**
@@ -41,7 +46,6 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    @javax.annotation.Nullable
     public java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
@@ -49,7 +53,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public void setMutableProperty(@javax.annotation.Nullable final java.lang.Number value) {
+    public void setMutableProperty(final java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -23,16 +23,16 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     final class Builder {
-        private java.lang.String _readonlyProperty;
+        private java.lang.String readonlyProperty;
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param value the value to be set
+         * @param readonlyProperty the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        public Builder withReadonlyProperty(final java.lang.String value) {
-            this._readonlyProperty = java.util.Objects.requireNonNull(value, "readonlyProperty is required");
+        public Builder readonlyProperty(java.lang.String readonlyProperty) {
+            this.readonlyProperty = readonlyProperty;
             return this;
         }
 
@@ -43,39 +43,65 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         public StableStruct build() {
-            return new StableStruct() {
-                private final java.lang.String $readonlyProperty = java.util.Objects.requireNonNull(_readonlyProperty, "readonlyProperty is required");
-
-                @Override
-                public java.lang.String getReadonlyProperty() {
-                    return this.$readonlyProperty;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(readonlyProperty);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link StableStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.StableStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements StableStruct {
+        private final java.lang.String readonlyProperty;
 
         /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
-        @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        public java.lang.String getReadonlyProperty() {
-            return this.jsiiGet("readonlyProperty", java.lang.String.class);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String readonlyProperty) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
+        }
+
+        @Override
+        public java.lang.String getReadonlyProperty() {
+            return this.readonlyProperty;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            StableStruct.Jsii$Proxy that = (StableStruct.Jsii$Proxy) o;
+
+            return readonlyProperty.equals(that.readonlyProperty);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = readonlyProperty.hashCode();
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
@@ -11,8 +11,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StaticContext")
 public class StaticContext extends software.amazon.jsii.JsiiObject {
-    protected StaticContext(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected StaticContext(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected StaticContext(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -7,8 +7,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Statics")
 public class Statics extends software.amazon.jsii.JsiiObject {
-    protected Statics(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Statics(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Statics(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     static {
         BAR = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "BAR", java.lang.Number.class);
@@ -21,8 +26,8 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Statics(final java.lang.String value) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StripInternal")
 public class StripInternal extends software.amazon.jsii.JsiiObject {
-    protected StripInternal(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected StripInternal(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected StripInternal(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public StripInternal() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StructPassing")
 public class StructPassing extends software.amazon.jsii.JsiiObject {
-    protected StructPassing(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected StructPassing(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected StructPassing(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public StructPassing() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
@@ -9,16 +9,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Sum")
 public class Sum extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
-    protected Sum(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Sum(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Sum(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Sum() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.SyncVirtualMethods")
 public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
-    protected SyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected SyncVirtualMethods(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected SyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public SyncVirtualMethods() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Thrower")
 public class Thrower extends software.amazon.jsii.JsiiObject {
-    protected Thrower(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected Thrower(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Thrower(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public Thrower() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -13,6 +13,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getRequired();
+
     /**
      * A union to really stress test our serialization.
      * 
@@ -20,6 +21,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getSecondLevel();
+
     /**
      * You don't have to pass this.
      * 
@@ -41,49 +43,51 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.String _required;
-        private java.lang.Object _secondLevel;
-        @javax.annotation.Nullable
-        private java.lang.String _optional;
+        private java.lang.String required;
+        private java.lang.Object secondLevel;
+        private java.lang.String optional;
 
         /**
          * Sets the value of Required
-         * @param value This is a required field.
+         * @param required This is a required field.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withRequired(final java.lang.String value) {
-            this._required = java.util.Objects.requireNonNull(value, "required is required");
+        public Builder required(java.lang.String required) {
+            this.required = required;
             return this;
         }
+
         /**
          * Sets the value of SecondLevel
-         * @param value A union to really stress test our serialization.
+         * @param secondLevel A union to really stress test our serialization.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withSecondLevel(final java.lang.Number value) {
-            this._secondLevel = java.util.Objects.requireNonNull(value, "secondLevel is required");
+        public Builder secondLevel(java.lang.Number secondLevel) {
+            this.secondLevel = secondLevel;
             return this;
         }
+
         /**
          * Sets the value of SecondLevel
-         * @param value A union to really stress test our serialization.
+         * @param secondLevel A union to really stress test our serialization.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withSecondLevel(final software.amazon.jsii.tests.calculator.SecondLevelStruct value) {
-            this._secondLevel = java.util.Objects.requireNonNull(value, "secondLevel is required");
+        public Builder secondLevel(software.amazon.jsii.tests.calculator.SecondLevelStruct secondLevel) {
+            this.secondLevel = secondLevel;
             return this;
         }
+
         /**
          * Sets the value of Optional
-         * @param value You don't have to pass this.
+         * @param optional You don't have to pass this.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withOptional(@javax.annotation.Nullable final java.lang.String value) {
-            this._optional = value;
+        public Builder optional(java.lang.String optional) {
+            this.optional = optional;
             return this;
         }
 
@@ -94,82 +98,89 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public TopLevelStruct build() {
-            return new TopLevelStruct() {
-                private final java.lang.String $required = java.util.Objects.requireNonNull(_required, "required is required");
-                private final java.lang.Object $secondLevel = java.util.Objects.requireNonNull(_secondLevel, "secondLevel is required");
-                @javax.annotation.Nullable
-                private final java.lang.String $optional = _optional;
-
-                @Override
-                public java.lang.String getRequired() {
-                    return this.$required;
-                }
-
-                @Override
-                public java.lang.Object getSecondLevel() {
-                    return this.$secondLevel;
-                }
-
-                @Override
-                public java.lang.String getOptional() {
-                    return this.$optional;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("required", om.valueToTree(this.getRequired()));
-                    obj.set("secondLevel", om.valueToTree(this.getSecondLevel()));
-                    if (this.getOptional() != null) {
-                        obj.set("optional", om.valueToTree(this.getOptional()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(required, secondLevel, optional);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link TopLevelStruct}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.TopLevelStruct {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements TopLevelStruct {
+        private final java.lang.String required;
+        private final java.lang.Object secondLevel;
+        private final java.lang.String optional;
 
         /**
-         * This is a required field.
-         * 
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.required = this.jsiiGet("required", java.lang.String.class);
+            this.secondLevel = this.jsiiGet("secondLevel", java.lang.Object.class);
+            this.optional = this.jsiiGet("optional", java.lang.String.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.String required, java.lang.Object secondLevel, java.lang.String optional) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.required = java.util.Objects.requireNonNull(required, "required is required");
+            this.secondLevel = java.util.Objects.requireNonNull(secondLevel, "secondLevel is required");
+            this.optional = optional;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.String getRequired() {
-            return this.jsiiGet("required", java.lang.String.class);
+            return this.required;
         }
 
-        /**
-         * A union to really stress test our serialization.
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Object getSecondLevel() {
-            return this.jsiiGet("secondLevel", java.lang.Object.class);
+            return this.secondLevel;
         }
 
-        /**
-         * You don't have to pass this.
-         * 
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.String getOptional() {
-            return this.jsiiGet("optional", java.lang.String.class);
+            return this.optional;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("required", om.valueToTree(this.getRequired()));
+            obj.set("secondLevel", om.valueToTree(this.getSecondLevel()));
+            if (this.getOptional() != null) {
+                obj.set("optional", om.valueToTree(this.getOptional()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TopLevelStruct.Jsii$Proxy that = (TopLevelStruct.Jsii$Proxy) o;
+
+            if (!required.equals(that.required)) return false;
+            if (!secondLevel.equals(that.secondLevel)) return false;
+            return optional != null ? optional.equals(that.optional) : that.optional == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = required.hashCode();
+            result = 31 * result + (secondLevel.hashCode());
+            result = 31 * result + (optional != null ? optional.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -9,16 +9,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UnaryOperation")
 public abstract class UnaryOperation extends software.amazon.jsii.tests.calculator.lib.Operation {
-    protected UnaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected UnaryOperation(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected UnaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") }));
     }
 
     /**
@@ -33,8 +38,9 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.UnaryOperation {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -11,6 +11,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Object getBar();
+
     /**
      * EXPERIMENTAL
      */
@@ -30,58 +31,61 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     final class Builder {
-        private java.lang.Object _bar;
-        @javax.annotation.Nullable
-        private java.lang.Object _foo;
+        private java.lang.Object bar;
+        private java.lang.Object foo;
 
         /**
          * Sets the value of Bar
-         * @param value the value to be set
+         * @param bar the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withBar(final java.lang.String value) {
-            this._bar = java.util.Objects.requireNonNull(value, "bar is required");
+        public Builder bar(java.lang.String bar) {
+            this.bar = bar;
             return this;
         }
+
         /**
          * Sets the value of Bar
-         * @param value the value to be set
+         * @param bar the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withBar(final java.lang.Number value) {
-            this._bar = java.util.Objects.requireNonNull(value, "bar is required");
+        public Builder bar(java.lang.Number bar) {
+            this.bar = bar;
             return this;
         }
+
         /**
          * Sets the value of Bar
-         * @param value the value to be set
+         * @param bar the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withBar(final software.amazon.jsii.tests.calculator.AllTypes value) {
-            this._bar = java.util.Objects.requireNonNull(value, "bar is required");
+        public Builder bar(software.amazon.jsii.tests.calculator.AllTypes bar) {
+            this.bar = bar;
             return this;
         }
+
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withFoo(@javax.annotation.Nullable final java.lang.String value) {
-            this._foo = value;
+        public Builder foo(java.lang.String foo) {
+            this.foo = foo;
             return this;
         }
+
         /**
          * Sets the value of Foo
-         * @param value the value to be set
+         * @param foo the value to be set
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder withFoo(@javax.annotation.Nullable final java.lang.Number value) {
-            this._foo = value;
+        public Builder foo(java.lang.Number foo) {
+            this.foo = foo;
             return this;
         }
 
@@ -92,60 +96,78 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public UnionProperties build() {
-            return new UnionProperties() {
-                private final java.lang.Object $bar = java.util.Objects.requireNonNull(_bar, "bar is required");
-                @javax.annotation.Nullable
-                private final java.lang.Object $foo = _foo;
-
-                @Override
-                public java.lang.Object getBar() {
-                    return this.$bar;
-                }
-
-                @Override
-                public java.lang.Object getFoo() {
-                    return this.$foo;
-                }
-
-                public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-                    com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-                    com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                    obj.set("bar", om.valueToTree(this.getBar()));
-                    if (this.getFoo() != null) {
-                        obj.set("foo", om.valueToTree(this.getFoo()));
-                    }
-                    return obj;
-                }
-
-            };
+            return new Jsii$Proxy(bar, foo);
         }
+
     }
 
     /**
-     * A proxy class which represents a concrete javascript instance of this type.
+     * An implementation for {@link UnionProperties}
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.UnionProperties {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
-        }
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements UnionProperties {
+        private final java.lang.Object bar;
+        private final java.lang.Object foo;
 
         /**
-         * EXPERIMENTAL
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
          */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+            this.bar = this.jsiiGet("bar", java.lang.Object.class);
+            this.foo = this.jsiiGet("foo", java.lang.Object.class);
+        }
+
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(java.lang.Object bar, java.lang.Object foo) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
+            this.foo = foo;
+        }
+
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.lang.Object getBar() {
-            return this.jsiiGet("bar", java.lang.Object.class);
+            return this.bar;
         }
 
-        /**
-         * EXPERIMENTAL
-         */
         @Override
-        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        @javax.annotation.Nullable
         public java.lang.Object getFoo() {
-            return this.jsiiGet("foo", java.lang.Object.class);
+            return this.foo;
         }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("bar", om.valueToTree(this.getBar()));
+            if (this.getFoo() != null) {
+                obj.set("foo", om.valueToTree(this.getFoo()));
+            }
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            UnionProperties.Jsii$Proxy that = (UnionProperties.Jsii$Proxy) o;
+
+            if (!bar.equals(that.bar)) return false;
+            return foo != null ? foo.equals(that.foo) : that.foo == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = bar.hashCode();
+            result = 31 * result + (foo != null ? foo.hashCode() : 0);
+            return result;
+        }
+
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -7,19 +7,23 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UseBundledDependency")
 public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
-    protected UseBundledDependency(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected UseBundledDependency(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected UseBundledDependency(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public UseBundledDependency() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @javax.annotation.Nullable
     public java.lang.Object value() {
         return this.jsiiCall("value", java.lang.Object.class);
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
@@ -9,12 +9,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UseCalcBase")
 public class UseCalcBase extends software.amazon.jsii.JsiiObject {
-    protected UseCalcBase(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected UseCalcBase(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected UseCalcBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public UseCalcBase() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -7,16 +7,21 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UsesInterfaceWithProperties")
 public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject {
-    protected UsesInterfaceWithProperties(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected UsesInterfaceWithProperties(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected UsesInterfaceWithProperties(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public UsesInterfaceWithProperties(final software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") }));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -7,8 +7,13 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VariadicMethod")
 public class VariadicMethod extends software.amazon.jsii.JsiiObject {
-    protected VariadicMethod(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected VariadicMethod(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected VariadicMethod(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
@@ -17,8 +22,8 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public VariadicMethod(final java.lang.Number... prefix) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(prefix).toArray(Object[]::new));
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(prefix).toArray(Object[]::new)));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -7,12 +7,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VirtualMethodPlayground")
 public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
-    protected VirtualMethodPlayground(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected VirtualMethodPlayground(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected VirtualMethodPlayground(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public VirtualMethodPlayground() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
@@ -13,12 +13,17 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VoidCallback")
 public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
-    protected VoidCallback(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected VoidCallback(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected VoidCallback(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public VoidCallback() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -47,8 +52,9 @@ public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.VoidCallback {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
@@ -9,24 +9,29 @@ package software.amazon.jsii.tests.calculator;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.WithPrivatePropertyInConstructor")
 public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiObject {
-    protected WithPrivatePropertyInConstructor(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected WithPrivatePropertyInConstructor(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected WithPrivatePropertyInConstructor(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public WithPrivatePropertyInConstructor(@javax.annotation.Nullable final java.lang.String privateField) {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { privateField });
+    public WithPrivatePropertyInConstructor(final java.lang.String privateField) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { privateField }));
     }
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public WithPrivatePropertyInConstructor() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -9,12 +9,17 @@ package software.amazon.jsii.tests.calculator.composition;
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 @software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.composition.CompositeOperation")
 public abstract class CompositeOperation extends software.amazon.jsii.tests.calculator.lib.Operation {
-    protected CompositeOperation(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-        super(mode);
+
+    protected CompositeOperation(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected CompositeOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
     }
     public CompositeOperation() {
-        super(software.amazon.jsii.JsiiObject.InitializationMode.Jsii);
-        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
 
     /**
@@ -136,8 +141,9 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * A proxy class which represents a concrete javascript instance of this type.
      */
     final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.composition.CompositeOperation {
-        protected Jsii$Proxy(final software.amazon.jsii.JsiiObject.InitializationMode mode) {
-            super(mode);
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1188,6 +1188,180 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
         return 'DerivedStruct(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
 
 
+@jsii.data_type(jsii_type="jsii-calc.DiamondInheritanceBaseLevelStruct", jsii_struct_bases=[], name_mapping={'base_level_property': 'baseLevelProperty'})
+class DiamondInheritanceBaseLevelStruct():
+    def __init__(self, *, base_level_property: str):
+        """
+        :param base_level_property: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'base_level_property': base_level_property,
+        }
+
+    @property
+    def base_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('base_level_property')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'DiamondInheritanceBaseLevelStruct(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
+@jsii.data_type(jsii_type="jsii-calc.DiamondInheritanceFirstMidLevelStruct", jsii_struct_bases=[DiamondInheritanceBaseLevelStruct], name_mapping={'base_level_property': 'baseLevelProperty', 'first_mid_level_property': 'firstMidLevelProperty'})
+class DiamondInheritanceFirstMidLevelStruct(DiamondInheritanceBaseLevelStruct):
+    def __init__(self, *, base_level_property: str, first_mid_level_property: str):
+        """
+        :param base_level_property: 
+        :param first_mid_level_property: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'base_level_property': base_level_property,
+            'first_mid_level_property': first_mid_level_property,
+        }
+
+    @property
+    def base_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('base_level_property')
+
+    @property
+    def first_mid_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('first_mid_level_property')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'DiamondInheritanceFirstMidLevelStruct(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
+@jsii.data_type(jsii_type="jsii-calc.DiamondInheritanceSecondMidLevelStruct", jsii_struct_bases=[DiamondInheritanceBaseLevelStruct], name_mapping={'base_level_property': 'baseLevelProperty', 'second_mid_level_property': 'secondMidLevelProperty'})
+class DiamondInheritanceSecondMidLevelStruct(DiamondInheritanceBaseLevelStruct):
+    def __init__(self, *, base_level_property: str, second_mid_level_property: str):
+        """
+        :param base_level_property: 
+        :param second_mid_level_property: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'base_level_property': base_level_property,
+            'second_mid_level_property': second_mid_level_property,
+        }
+
+    @property
+    def base_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('base_level_property')
+
+    @property
+    def second_mid_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('second_mid_level_property')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'DiamondInheritanceSecondMidLevelStruct(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
+@jsii.data_type(jsii_type="jsii-calc.DiamondInheritanceTopLevelStruct", jsii_struct_bases=[DiamondInheritanceFirstMidLevelStruct, DiamondInheritanceSecondMidLevelStruct], name_mapping={'base_level_property': 'baseLevelProperty', 'first_mid_level_property': 'firstMidLevelProperty', 'second_mid_level_property': 'secondMidLevelProperty', 'top_level_property': 'topLevelProperty'})
+class DiamondInheritanceTopLevelStruct(DiamondInheritanceFirstMidLevelStruct, DiamondInheritanceSecondMidLevelStruct):
+    def __init__(self, *, base_level_property: str, first_mid_level_property: str, second_mid_level_property: str, top_level_property: str):
+        """
+        :param base_level_property: 
+        :param first_mid_level_property: 
+        :param second_mid_level_property: 
+        :param top_level_property: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'base_level_property': base_level_property,
+            'first_mid_level_property': first_mid_level_property,
+            'second_mid_level_property': second_mid_level_property,
+            'top_level_property': top_level_property,
+        }
+
+    @property
+    def base_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('base_level_property')
+
+    @property
+    def first_mid_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('first_mid_level_property')
+
+    @property
+    def second_mid_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('second_mid_level_property')
+
+    @property
+    def top_level_property(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('top_level_property')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'DiamondInheritanceTopLevelStruct(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
 class DoNotOverridePrivates(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoNotOverridePrivates"):
     """
     stability
@@ -6349,6 +6523,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1832,6 +1832,181 @@ DerivedStruct (interface)
       :type: string[] *(optional)* *(readonly)*
 
 
+DiamondInheritanceBaseLevelStruct (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DiamondInheritanceBaseLevelStruct
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct;
+
+      .. code-tab:: javascript
+
+         // DiamondInheritanceBaseLevelStruct is an interface
+
+      .. code-tab:: typescript
+
+         import { DiamondInheritanceBaseLevelStruct } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: baseLevelProperty
+
+      :type: string *(readonly)*
+
+
+DiamondInheritanceFirstMidLevelStruct (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DiamondInheritanceFirstMidLevelStruct
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DiamondInheritanceFirstMidLevelStruct;
+
+      .. code-tab:: javascript
+
+         // DiamondInheritanceFirstMidLevelStruct is an interface
+
+      .. code-tab:: typescript
+
+         import { DiamondInheritanceFirstMidLevelStruct } from 'jsii-calc';
+
+
+
+   :extends: :py:class:`~jsii-calc.DiamondInheritanceBaseLevelStruct`\ 
+
+
+   .. py:attribute:: firstMidLevelProperty
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: baseLevelProperty
+
+      *Inherited from* :py:attr:`jsii-calc.DiamondInheritanceBaseLevelStruct <jsii-calc.DiamondInheritanceBaseLevelStruct.baseLevelProperty>`
+
+      :type: string *(readonly)*
+
+
+DiamondInheritanceSecondMidLevelStruct (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DiamondInheritanceSecondMidLevelStruct
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DiamondInheritanceSecondMidLevelStruct;
+
+      .. code-tab:: javascript
+
+         // DiamondInheritanceSecondMidLevelStruct is an interface
+
+      .. code-tab:: typescript
+
+         import { DiamondInheritanceSecondMidLevelStruct } from 'jsii-calc';
+
+
+
+   :extends: :py:class:`~jsii-calc.DiamondInheritanceBaseLevelStruct`\ 
+
+
+   .. py:attribute:: secondMidLevelProperty
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: baseLevelProperty
+
+      *Inherited from* :py:attr:`jsii-calc.DiamondInheritanceBaseLevelStruct <jsii-calc.DiamondInheritanceBaseLevelStruct.baseLevelProperty>`
+
+      :type: string *(readonly)*
+
+
+DiamondInheritanceTopLevelStruct (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: DiamondInheritanceTopLevelStruct
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.DiamondInheritanceTopLevelStruct;
+
+      .. code-tab:: javascript
+
+         // DiamondInheritanceTopLevelStruct is an interface
+
+      .. code-tab:: typescript
+
+         import { DiamondInheritanceTopLevelStruct } from 'jsii-calc';
+
+
+
+   :extends: :py:class:`~jsii-calc.DiamondInheritanceFirstMidLevelStruct`\ 
+   :extends: :py:class:`~jsii-calc.DiamondInheritanceSecondMidLevelStruct`\ 
+
+
+   .. py:attribute:: topLevelProperty
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: baseLevelProperty
+
+      *Inherited from* :py:attr:`jsii-calc.DiamondInheritanceBaseLevelStruct <jsii-calc.DiamondInheritanceBaseLevelStruct.baseLevelProperty>`
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: firstMidLevelProperty
+
+      *Inherited from* :py:attr:`jsii-calc.DiamondInheritanceFirstMidLevelStruct <jsii-calc.DiamondInheritanceFirstMidLevelStruct.firstMidLevelProperty>`
+
+      :type: string *(readonly)*
+
+
+   .. py:attribute:: secondMidLevelProperty
+
+      *Inherited from* :py:attr:`jsii-calc.DiamondInheritanceSecondMidLevelStruct <jsii-calc.DiamondInheritanceSecondMidLevelStruct.secondMidLevelProperty>`
+
+      :type: string *(readonly)*
+
+
 DoNotOverridePrivates
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -1344,6 +1344,37 @@ assemblies
  │   │     ├── abstract
  │   │     ├── immutable
  │   │     └── type: Optional<Array<string>>
+ │   ├─┬ interface DiamondInheritanceBaseLevelStruct (experimental)
+ │   │ └─┬ members
+ │   │   └─┬ baseLevelProperty property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: string
+ │   ├─┬ interface DiamondInheritanceFirstMidLevelStruct (experimental)
+ │   │ ├─┬ interfaces
+ │   │ │ └── DiamondInheritanceBaseLevelStruct
+ │   │ └─┬ members
+ │   │   └─┬ firstMidLevelProperty property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: string
+ │   ├─┬ interface DiamondInheritanceSecondMidLevelStruct (experimental)
+ │   │ ├─┬ interfaces
+ │   │ │ └── DiamondInheritanceBaseLevelStruct
+ │   │ └─┬ members
+ │   │   └─┬ secondMidLevelProperty property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: string
+ │   ├─┬ interface DiamondInheritanceTopLevelStruct (experimental)
+ │   │ ├─┬ interfaces
+ │   │ │ ├── DiamondInheritanceFirstMidLevelStruct
+ │   │ │ └── DiamondInheritanceSecondMidLevelStruct
+ │   │ └─┬ members
+ │   │   └─┬ topLevelProperty property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: string
  │   ├─┬ interface EraseUndefinedHashValuesOptions (experimental)
  │   │ └─┬ members
  │   │   ├─┬ option1 property (experimental)

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -118,6 +118,17 @@ assemblies
  │   ├─┬ interface DerivedStruct
  │   │ └─┬ interfaces
  │   │   └── MyFirstStruct
+ │   ├── interface DiamondInheritanceBaseLevelStruct
+ │   ├─┬ interface DiamondInheritanceFirstMidLevelStruct
+ │   │ └─┬ interfaces
+ │   │   └── DiamondInheritanceBaseLevelStruct
+ │   ├─┬ interface DiamondInheritanceSecondMidLevelStruct
+ │   │ └─┬ interfaces
+ │   │   └── DiamondInheritanceBaseLevelStruct
+ │   ├─┬ interface DiamondInheritanceTopLevelStruct
+ │   │ └─┬ interfaces
+ │   │   ├── DiamondInheritanceFirstMidLevelStruct
+ │   │   └── DiamondInheritanceSecondMidLevelStruct
  │   ├── interface EraseUndefinedHashValuesOptions
  │   ├── interface ExperimentalStruct
  │   ├── interface ExtendsInternalInterface

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -587,6 +587,18 @@ assemblies
  │   │   ├── anotherOptional property
  │   │   ├── optionalAny property
  │   │   └── optionalArray property
+ │   ├─┬ interface DiamondInheritanceBaseLevelStruct
+ │   │ └─┬ members
+ │   │   └── baseLevelProperty property
+ │   ├─┬ interface DiamondInheritanceFirstMidLevelStruct
+ │   │ └─┬ members
+ │   │   └── firstMidLevelProperty property
+ │   ├─┬ interface DiamondInheritanceSecondMidLevelStruct
+ │   │ └─┬ members
+ │   │   └── secondMidLevelProperty property
+ │   ├─┬ interface DiamondInheritanceTopLevelStruct
+ │   │ └─┬ members
+ │   │   └── topLevelProperty property
  │   ├─┬ interface EraseUndefinedHashValuesOptions
  │   │ └─┬ members
  │   │   ├── option1 property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -90,6 +90,10 @@ assemblies
  │   ├── interface CalculatorProps
  │   ├── interface DeprecatedStruct
  │   ├── interface DerivedStruct
+ │   ├── interface DiamondInheritanceBaseLevelStruct
+ │   ├── interface DiamondInheritanceFirstMidLevelStruct
+ │   ├── interface DiamondInheritanceSecondMidLevelStruct
+ │   ├── interface DiamondInheritanceTopLevelStruct
  │   ├── interface EraseUndefinedHashValuesOptions
  │   ├── interface ExperimentalStruct
  │   ├── interface ExtendsInternalInterface


### PR DESCRIPTION
Overhauled structs with native implementation, builders, `equals` and `hashCode` and creation from JSII.

Fixes #525 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
