### PR TITLE
chore: tweak mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,46 +4,46 @@ pull_request_rules:
   - name: automatic merge
     actions:
       comment:
-        message: Thank you for contributing! Your pull request is now being automatically merged.
+        message: |
+          Thank you for contributing! :heart:
+
+          Your pull request is ready to be automatically merged.
       merge:
         strict: smart
         method: squash
         strict_method: merge
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
       delete_head_branch: {}
-      dismiss_reviews: {}
     conditions:
       - -title~=(WIP|wip)
-      - -label~=^(blocked|do-not-merge)
+      - label!=blocked
+      - label!=do-not-merge
       - -merged
       - -closed
-      - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
+      - "#approved-reviews-by>=1"
+      - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"
       - status-success=AWS CodeBuild us-east-1 (jsii-build)
+      - status-success=continuous-integration/travis-ci/pr
       - status-success=Semantic Pull Request
-  - name: comment checklist
-    actions:
-      comment:
-        message: |
-          ### Pull Request Checklist
-          * [ ] Testing
-            - Unit test added (prefer not to modify an existing test, otherwise, it's probably a breaking change)
-          * [ ] Title and Description
-            - __Change type__: title prefixed with **fix**, **feat** and module name in parens, which will appear in changelog
-            - __Title__: use lower-case and doesn't end with a period
-            - __Breaking?__: last paragraph: 'BREAKING CHANGE: <describe what changed + link for details>'
-            - __Issues__: Indicate issues fixed via: '**Fixes #xxx**' or '**Closes #xxx**'
-    conditions:
-      - base=master
   - name: remove stale reviews
     actions:
-      dismiss_reviews: {}
+      dismiss_reviews:
+        approved: true
+        changes_requested: false
     conditions:
       - base=master
   - name: if fails conventional commits
     actions:
       comment:
-        message: Title does not follow the guidelines of [Conventional Commits](https://www.conventionalcommits.org). Please adjust title before merge.
+        message: |
+          The title of this Pull Request does not conform with [Conventional Commits] guidelines. It
+          will need to be adjusted before the PR can be merged.
+
+          [Conventional Commits]: https://www.conventionalcommits.org
     conditions:
       - -status-success=Semantic Pull Request

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,6 +31,8 @@ pull_request_rules:
   - name: delete branch after merge
     actions:
       delete_head_branch: {}
+    conditions:
+      - merged
   - name: if fails conventional commits
     actions:
       comment:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,9 +5,8 @@ pull_request_rules:
     actions:
       comment:
         message: |
-          Thank you for contributing! :heart:
-
-          Your pull request is ready to be automatically merged.
+          Thank you for contributing! :heart: I will now look into making sure
+          the PR is up-to-date, then proceed to try and merge it!
       merge:
         strict: smart
         method: squash
@@ -15,7 +14,6 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
-      delete_head_branch: {}
     conditions:
       - -title~=(WIP|wip)
       - label!=blocked
@@ -30,13 +28,9 @@ pull_request_rules:
       - status-success=AWS CodeBuild us-east-1 (jsii-build)
       - status-success=continuous-integration/travis-ci/pr
       - status-success=Semantic Pull Request
-  - name: remove stale reviews
+  - name: delete branch after merge
     actions:
-      dismiss_reviews:
-        approved: true
-        changes_requested: false
-    conditions:
-      - base=master
+      delete_head_branch: {}
   - name: if fails conventional commits
     actions:
       comment:


### PR DESCRIPTION
- Require the TravisCI has passed before auto-merging a PR. This is
  required to ensure the `jsii/superchain` Docker image was correctly
  built and tested before going forward.
- Drop stale "approved" reviews, but keep stale "changes requested"
  reviews, so that people who requested changes can come and verify that
  the changes were indeed applied.
- Remove the "Pull Request Checklist" message as it was emitted multiple
  times and that god somewhat irritating. Didn't seem to find a clean
  way to prevent multiple emission here.
- Tweaked message for when a PR is ready for automatic merging.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
