### PR TITLE
fix(superchain): fix python distribution due to old setuptools

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -43,7 +43,7 @@ RUN yum install -y powershell                                                   
 
 # Install Python 3
 RUN yum -y install python3 python3-pip python3-wheel                                                                    \
-  && python3 -m pip install --upgrade pip wheel                                                                         \
+  && python3 -m pip install --upgrade pip wheel setuptools                                                              \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install Ruby 2.4+


### PR DESCRIPTION
Upgrade the python `setuptools` modules to latest in order to enable support
for the `long_description_content_type` distribution option.

Tested in CDK's master build and publishing pipeline.

Fixes #708

