### PR TITLE
chore(superchain): stop pre-populating package cache

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -1,8 +1,8 @@
 FROM amazonlinux:2
 
 # Install .NET Core, mono & PowerShell
-ENV DOTNET_CLI_TELEMETRY_OPTOUT=1                                                                                       \
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true                                                                                    \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 COPY gpg/mono.asc /tmp/mono.asc
 RUN rpm --import "https://packages.microsoft.com/keys/microsoft.asc"                                                    \
   && rpm -Uvh "https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm"                                \


### PR DESCRIPTION
The install of dotnet in the Docker build caused the first-time
experience to trigger as the environment variable apparently must be set
to `true` and not `1`. This causes a package cache to be pre-populated
(to spee dup future builds), however as this is baked into a Docker
image, this will cause bloat & will probably result in stale cached
artifacts.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
