### PR TITLE
fix(dotnet): Fix property set for nested Dictionaries

### DIFF
--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -91,6 +91,19 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             types.MapProperty = map;
             Assert.Equal((double) 123, types.MapProperty["Foo"].Value);
         }
+        
+        [Fact(DisplayName = Prefix + nameof(ComplexCollectionTypes))]
+        public void ComplexCollectionTypes()
+        {
+            // See https://github.com/aws/aws-cdk/issues/2496
+            AllTypes types = new AllTypes();
+            // complex map
+            IDictionary<string, object> map = new Dictionary<string, object>();
+            map.Add("Foo", new Dictionary<string, object>() { {"Key", 123}});
+            types.AnyMapProperty = map;
+            var dict = (Dictionary<string, object>)types.AnyMapProperty["Foo"];
+            Assert.Equal(123, dict["Key"]);
+        }
 
         [Fact(DisplayName = Prefix + nameof(DynamicTypes))]
         public void DynamicTypes()

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -99,10 +99,10 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             AllTypes types = new AllTypes();
             // complex map
             IDictionary<string, object> map = new Dictionary<string, object>();
-            map.Add("Foo", new Dictionary<string, object>() { {"Key", 123}});
+            map.Add("Foo", new Dictionary<string, object>() { {"Key", 123d}});
             types.AnyMapProperty = map;
             var dict = (Dictionary<string, object>)types.AnyMapProperty["Foo"];
-            Assert.Equal(123, dict["Key"]);
+            Assert.Equal(123d, dict["Key"]);
         }
 
         [Fact(DisplayName = Prefix + nameof(DynamicTypes))]

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -263,7 +263,16 @@ namespace Amazon.JSII.Runtime.Services.Converters
             foreach (string key in keys)
             {
                 object element = indexer.GetValue(value, new object[] {key});
-                if (!TryConvert(elementType, referenceMap, element, out object convertedElement))
+
+                TypeReference childElementType = InferType(referenceMap, element);
+
+                // We should not pass the parent element type as we are in a map
+                // A map<string, object> could be a map<string, map<string, object> etc
+                // If we pass the parent referenceMap then it will try to convert it as Any
+                // So by inferring the child element type we are always converting the correct type.
+                // See https://github.com/aws/aws-cdk/issues/2496
+                
+                if (!TryConvert(childElementType, referenceMap, element, out object convertedElement))
                 {
                     result = null;
                     return false;


### PR DESCRIPTION
The runtime fails to cast properties when a Dictionary<string, object> _is actually_ a Dictionary<string, Dictionary<string, object>>

Example:

```
            var launchTemplateData = new CfnLaunchTemplate.LaunchTemplateDataProperty
            {
                InstanceType = "t3.medium",
                Monitoring = new CfnLaunchTemplate.MonitoringProperty { Enabled = true }
            };

            var cfnLaunchTemplate = new CfnLaunchTemplate(stack, "template", new CfnLaunchTemplateProps
            {
                LaunchTemplateData = launchTemplateData,
                LaunchTemplateName = "template"
            });
```

In this example, the LaunchTemplateData property is a Dictionary<string, object>. However, the 'Monitoring' key is also a Dictionary<string, object>. This was not supported by the runtime and would fail.

Fixes https://github.com/aws/aws-cdk/issues/2496

Cdk synth output after the fix:

```
Resources:
  template:
    Type: AWS::EC2::LaunchTemplate
    Properties:
      LaunchTemplateData:
        InstanceType: t3.medium
        Monitoring:
          Enabled: true
      LaunchTemplateName: template
    Metadata:
      aws:cdk:path: HamzaStack/template
```

Also added a unit test to cover complex properties.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
