### PR TITLE
feat(jsii): improve locality of warnings emitted for reserved words

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1018,7 +1018,7 @@ export class Assembler implements Emitter {
   private _warnAboutReservedWords(symbol: ts.Symbol) {
     const reservingLanguages = isReservedName(symbol.name);
     if (reservingLanguages) {
-      this._diagnostic(symbol.valueDeclaration,
+      this._diagnostic(ts.getNameOfDeclaration(symbol.valueDeclaration) || symbol.valueDeclaration,
         ts.DiagnosticCategory.Warning,
         `'${symbol.name}' is a reserved word in ${reservingLanguages.join(', ')}. Using this name may cause problems `
         + 'when generating language bindings. Consider using a different name.');


### PR DESCRIPTION
Instead of tagging the entire declaration, only tag the name part of it
when emitting warnings about usage of reserved words from one of the
supported languages. This improves the actionability of the messages,
and makes for shorter log entries, too.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
