### PR TITLE
feat(superchain): ship with openssl CLI tools

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -35,7 +35,7 @@ RUN amazon-linux-extras install docker                                          
 VOLUME /var/lib/docker
 
 # Install shared dependencies
-RUN yum -y install awscli git gzip rsync tar unzip zip                                                                  \
+RUN yum -y install awscli git gzip openssl rsync tar unzip zip                                                          \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install NVM and Node 8+

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -25,6 +25,7 @@ Tool / Utility | Version
 `docker`       | `>= 18.06.1-ce`
 `git`          | `>= 2.17.2`
 `make`         | `>= 3.82`
+`openssl`      | `>= 1.0.2k`
 `rsync`        | `>= 3.1.2-4`
 `zip` & `unzip`| `>= 6.0-19`
 


### PR DESCRIPTION
Adds the OpenSSL CLI tools that can be used for a large number of
applications.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
