### PR TITLE
fix(jsii): allow more flexible package versioning

### DIFF
--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -77,7 +77,8 @@ export async function loadProjectInfo(projectRoot: string, { fixPeerDependencies
         version = _resolveVersion(version as any, projectRoot).version;
         pkg.peerDependencies = pkg.peerDependencies || {};
         const peerVersion = _resolveVersion(pkg.peerDependencies[name], projectRoot).version;
-        if (peerVersion === version) {
+        if ((!peerVersion && !version) || (peerVersion && version &&
+                new semver.Range(peerVersion).intersects(new semver.Range(version as string)))) {
             return;
         }
         if (!fixPeerDependencies) {

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -6,6 +6,9 @@ import { ProjectInfo } from '../lib/project-info';
 
 const SOURCE_DIR = path.join(__dirname, 'negatives');
 
+// invoking the compiler often doesn't complete in Jest's default 5 second timeout
+jest.setTimeout(60_000);
+
 for (const source of fs.readdirSync(SOURCE_DIR)) {
     if (!source.startsWith('neg.') || !source.endsWith('.ts') || source.endsWith('.d.ts')) { continue; }
     const filePath = path.join(SOURCE_DIR, source);

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -134,6 +134,30 @@ describe('loadProjectInfo', () => {
             info.peerDependencies[TEST_DEP_ASSEMBLY.name] = '^42.1337.0';
         })
     );
+
+    test('loads with a different, but intersecting, peerDependency version (when not auto-fixing)', () => _withTestProject(async projectRoot => {
+            await loadProjectInfo(projectRoot, { fixPeerDependencies: false });
+
+            const info = require(path.join(projectRoot, 'package.json'));
+            expect(info.dependencies[TEST_DEP_ASSEMBLY.name]).toBe("1.2.4");
+            expect(info.peerDependencies[TEST_DEP_ASSEMBLY.name]).toBe("^1.2.4");
+        }, info => {
+            info.dependencies[TEST_DEP_ASSEMBLY.name] = '1.2.4';
+            info.peerDependencies[TEST_DEP_ASSEMBLY.name] = '^1.2.4';
+        })
+    );
+
+    test('loads with a different, but intersecting, dependency version (when not auto-fixing)', () => _withTestProject(async projectRoot => {
+            await loadProjectInfo(projectRoot, { fixPeerDependencies: false });
+
+            const info = require(path.join(projectRoot, 'package.json'));
+            expect(info.dependencies[TEST_DEP_ASSEMBLY.name]).toBe("^1.2.4");
+            expect(info.peerDependencies[TEST_DEP_ASSEMBLY.name]).toBe("1.2.4");
+        }, info => {
+            info.dependencies[TEST_DEP_ASSEMBLY.name] = '^1.2.4';
+            info.peerDependencies[TEST_DEP_ASSEMBLY.name] = '1.2.4';
+        })
+    );
 });
 
 const TEST_DEP_ASSEMBLY: spec.Assembly = {


### PR DESCRIPTION
Before this change, the versions of a single dependency between `dependency`
and `peerDependency` sections of a JSII package had to be identical.
This loosens this requirement: they now have to be only intersecting
(in the Semantic Versioning sense of the word).

Needed for https://github.com/aws/aws-cdk/issues/3711

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
