### PR TITLE
feat(java): Indicate if method param is required

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -896,11 +896,8 @@ class JavaGenerator extends Generator {
             this.code.line();
             this.code.line('/**');
             this.code.line(` * Sets the value of ${prop.propName}`);
-            if (prop.docs && prop.docs.summary) {
-                this.code.line(` * @param ${prop.fieldName} ${prop.docs.summary}`);
-            } else {
-                this.code.line(` * @param ${prop.fieldName} the value to be set`);
-            }
+            const summary = (prop.docs && prop.docs.summary) || "the value to be set";
+            this.code.line(` * ${paramJavadoc(prop.fieldName, prop.nullable, summary)}`);
             this.code.line(` * @return {@code this}`);
             if (prop.docs && prop.docs.deprecated) {
                 this.code.line(` * @deprecated ${prop.docs.deprecated}`);
@@ -1194,9 +1191,8 @@ class JavaGenerator extends Generator {
             const method = doc as spec.Method;
             if (method.parameters) {
                 for (const param of method.parameters) {
-                    if (param.docs && param.docs.summary) {
-                        tagLines.push(`@param ${param.name} ${param.docs.summary}`);
-                    }
+                    const summary = (param.docs && param.docs.summary) || undefined;
+                    tagLines.push(paramJavadoc(param.name, param.optional, summary));
                 }
             }
         }
@@ -1542,4 +1538,19 @@ function isNullable(optionalValue: spec.OptionalValue | undefined): boolean {
     return optionalValue.optional
         || (spec.isPrimitiveTypeReference(optionalValue.type)
             && optionalValue.type.primitive === spec.PrimitiveType.Any);
+}
+
+function paramJavadoc(name: string, optional?: boolean, summary?: string): string {
+    const parts = ['@param', name];
+    if (summary) { parts.push(endWithPeriod(summary)); }
+    if (!optional) { parts.push('This parameter is required.'); }
+
+    return parts.join(' ');
+}
+
+function endWithPeriod(s: string): string {
+    if (!s.endsWith('.')) {
+        return s + '.';
+    }
+    return s;
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -20,7 +20,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
 
         /**
          * Sets the value of Bar
-         * @param bar the value to be set
+         * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
         public Builder bar(java.lang.String bar) {
@@ -30,7 +30,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */
         public Builder foo(software.amazon.jsii.tests.calculator.baseofbase.Very foo) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -48,7 +48,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Anumber
-         * @param anumber An awesome number value.
+         * @param anumber An awesome number value. This parameter is required.
          * @return {@code this}
          */
         @Deprecated
@@ -60,7 +60,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Astring
-         * @param astring A string value.
+         * @param astring A string value. This parameter is required.
          * @return {@code this}
          */
         @Deprecated
@@ -72,7 +72,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of FirstOptional
-         * @param firstOptional the value to be set
+         * @param firstOptional the value to be set.
          * @return {@code this}
          */
         @Deprecated

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -20,7 +20,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
     /**
      * Creates a Number object.
      * 
-     * @param value The number.
+     * @param value The number. This parameter is required.
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -47,7 +47,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
 
         /**
          * Sets the value of Optional1
-         * @param optional1 The first optional!
+         * @param optional1 The first optional!.
          * @return {@code this}
          */
         @Deprecated
@@ -59,7 +59,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
 
         /**
          * Sets the value of Optional2
-         * @param optional2 the value to be set
+         * @param optional2 the value to be set.
          * @return {@code this}
          */
         @Deprecated
@@ -71,7 +71,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
 
         /**
          * Sets the value of Optional3
-         * @param optional3 the value to be set
+         * @param optional3 the value to be set.
          * @return {@code this}
          */
         @Deprecated

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -23,6 +23,8 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param name This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public abstract java.lang.String abstractMethod(final java.lang.String name);
@@ -73,6 +75,8 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
 
         /**
          * EXPERIMENTAL
+         * 
+         * @param name This parameter is required.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -23,8 +23,8 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      * 
      * EXPERIMENTAL
      * 
-     * @param lhs Left-hand side operand.
-     * @param rhs Right-hand side operand.
+     * @param lhs Left-hand side operand. This parameter is required.
+     * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Add(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -28,6 +28,8 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param inp This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void anyIn(final java.lang.Object inp) {
@@ -44,6 +46,8 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.StringEnum enumMethod(final software.amazon.jsii.tests.calculator.StringEnum value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -23,6 +23,9 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _p1 This parameter is required.
+     * @param _p2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void getBar(final java.lang.String _p1, final java.lang.Number _p2) {
@@ -33,6 +36,8 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
      * 
      * EXPERIMENTAL
+     * 
+     * @param withParam This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String getFoo(final java.lang.String withParam) {
@@ -41,6 +46,10 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _x This parameter is required.
+     * @param _y This parameter is required.
+     * @param _z This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setBar(final java.lang.String _x, final java.lang.Number _y, final java.lang.Boolean _z) {
@@ -51,6 +60,9 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
      * 
      * EXPERIMENTAL
+     * 
+     * @param _x This parameter is required.
+     * @param _y This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void setFoo(final java.lang.String _x, final java.lang.Number _y) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -63,6 +63,8 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param mult This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMe(final java.lang.Number mult) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -23,8 +23,8 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * 
      * EXPERIMENTAL
      * 
-     * @param lhs Left-hand side operand.
-     * @param rhs Right-hand side operand.
+     * @param lhs Left-hand side operand. This parameter is required.
+     * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     protected BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -46,6 +46,8 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * Adds a number to the current value.
      * 
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void add(final java.lang.Number value) {
@@ -56,6 +58,8 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * Multiplies the current value by a number.
      * 
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void mul(final java.lang.Number value) {
@@ -76,6 +80,8 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * Raises the current value by a power.
      * 
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void pow(final java.lang.Number value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -38,7 +38,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of InitialValue
-         * @param initialValue the value to be set
+         * @param initialValue the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -49,7 +49,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of MaximumValue
-         * @param maximumValue the value to be set
+         * @param maximumValue the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
@@ -18,6 +18,9 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param map This parameter is required.
+     * @param array This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ClassWithCollections(final java.util.Map<java.lang.String, java.lang.String> map, final java.util.List<java.lang.String> array) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
@@ -18,6 +18,8 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param int This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ClassWithJavaReservedWords(final java.lang.String intValue) {
@@ -27,6 +29,8 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param assert This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String doImport(final java.lang.String assertValue) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
@@ -20,6 +20,9 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param readOnlyString This parameter is required.
+     * @param readWriteString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties create(final java.lang.String readOnlyString, final java.lang.String readWriteString) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -18,6 +18,8 @@ public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param consumer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ConstructorPassesThisOut(final software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -23,6 +23,8 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String consumeAnotherPublicInterface(final software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
@@ -31,6 +33,8 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
@@ -29,6 +29,8 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param data
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String render(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct data) {
@@ -45,6 +47,8 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param data This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String renderArbitrary(final java.util.Map<java.lang.String, java.lang.Object> data) {
@@ -53,6 +57,8 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param map This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String renderMap(final java.util.Map<java.lang.String, java.lang.Object> map) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -18,6 +18,10 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
+     * @param arg2
+     * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
@@ -27,6 +31,9 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
+     * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
@@ -36,6 +43,8 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public DefaultedConstructorArgument(final java.lang.Number arg1) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
@@ -19,6 +19,8 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
 
     /**
      * @deprecated this constructor is "just" okay
+     * @param readonlyString This parameter is required.
+     * @param mutableNumber
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
@@ -29,6 +31,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
 
     /**
      * @deprecated this constructor is "just" okay
+     * @param readonlyString This parameter is required.
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -33,7 +33,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param readonlyProperty the value to be set
+         * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          * @deprecated well, yeah
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -73,7 +73,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of AnotherRequired
-         * @param anotherRequired the value to be set
+         * @param anotherRequired the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -84,7 +84,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of Bool
-         * @param bool the value to be set
+         * @param bool the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -95,7 +95,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of NonPrimitive
-         * @param nonPrimitive An example of a non primitive property.
+         * @param nonPrimitive An example of a non primitive property. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -117,7 +117,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of OptionalAny
-         * @param optionalAny the value to be set
+         * @param optionalAny the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -128,7 +128,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of OptionalArray
-         * @param optionalArray the value to be set
+         * @param optionalArray the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -139,7 +139,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of Anumber
-         * @param anumber An awesome number value.
+         * @param anumber An awesome number value. This parameter is required.
          * @return {@code this}
          */
         @Deprecated
@@ -151,7 +151,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of Astring
-         * @param astring A string value.
+         * @param astring A string value. This parameter is required.
          * @return {@code this}
          */
         @Deprecated
@@ -163,7 +163,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         /**
          * Sets the value of FirstOptional
-         * @param firstOptional the value to be set
+         * @param firstOptional the value to be set.
          * @return {@code this}
          */
         @Deprecated

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -29,7 +29,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
 
         /**
          * Sets the value of BaseLevelProperty
-         * @param baseLevelProperty the value to be set
+         * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -30,7 +30,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
 
         /**
          * Sets the value of FirstMidLevelProperty
-         * @param firstMidLevelProperty the value to be set
+         * @param firstMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -41,7 +41,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
 
         /**
          * Sets the value of BaseLevelProperty
-         * @param baseLevelProperty the value to be set
+         * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -30,7 +30,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
 
         /**
          * Sets the value of SecondMidLevelProperty
-         * @param secondMidLevelProperty the value to be set
+         * @param secondMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -41,7 +41,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
 
         /**
          * Sets the value of BaseLevelProperty
-         * @param baseLevelProperty the value to be set
+         * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -32,7 +32,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
 
         /**
          * Sets the value of TopLevelProperty
-         * @param topLevelProperty the value to be set
+         * @param topLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -43,7 +43,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
 
         /**
          * Sets the value of FirstMidLevelProperty
-         * @param firstMidLevelProperty the value to be set
+         * @param firstMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -54,7 +54,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
 
         /**
          * Sets the value of BaseLevelProperty
-         * @param baseLevelProperty the value to be set
+         * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -65,7 +65,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
 
         /**
          * Sets the value of SecondMidLevelProperty
-         * @param secondMidLevelProperty the value to be set
+         * @param secondMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -23,6 +23,8 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param newValue This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void changePrivatePropertyValue(final java.lang.String newValue) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -25,6 +25,10 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _requiredAny This parameter is required.
+     * @param _optionalAny
+     * @param _optionalString
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny, final java.lang.String _optionalString) {
@@ -33,6 +37,9 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _requiredAny This parameter is required.
+     * @param _optionalAny
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny) {
@@ -41,6 +48,8 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _requiredAny This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void method(final java.lang.Object _requiredAny) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -23,6 +23,9 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param optional
+     * @param things This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String optionalAndVariadic(final java.lang.String optional, final java.lang.String... things) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -28,6 +28,9 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * are being erased when sending values from native code to JS.
      * 
      * EXPERIMENTAL
+     * 
+     * @param opts This parameter is required.
+     * @param key This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.Boolean doesKeyExist(final software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions opts, final java.lang.String key) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -36,7 +36,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
 
         /**
          * Sets the value of Option1
-         * @param option1 the value to be set
+         * @param option1 the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -47,7 +47,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
 
         /**
          * Sets the value of Option2
-         * @param option2 the value to be set
+         * @param option2 the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
@@ -18,6 +18,9 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param readonlyString This parameter is required.
+     * @param mutableNumber
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExperimentalClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
@@ -27,6 +30,8 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param readonlyString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExperimentalClass(final java.lang.String readonlyString) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -29,7 +29,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param readonlyProperty the value to be set
+         * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -18,6 +18,8 @@ public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param success This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public ExportedBaseClass(final java.lang.Boolean success) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -36,7 +36,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
 
         /**
          * Sets the value of Boom
-         * @param boom the value to be set
+         * @param boom the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -47,7 +47,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
 
         /**
          * Sets the value of Prop
-         * @param prop the value to be set
+         * @param prop the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -25,6 +25,8 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
      * 
      * EXPERIMENTAL
+     * 
+     * @param derived This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
@@ -35,6 +37,8 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * Returns the boolean from a DerivedStruct struct.
      * 
      * EXPERIMENTAL
+     * 
+     * @param derived This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
@@ -45,6 +49,8 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * Returns the "anumber" from a MyFirstStruct struct;
      * 
      * EXPERIMENTAL
+     * 
+     * @param first This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number readFirstNumber(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -23,6 +23,8 @@ public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param friendly This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String betterGreeting(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -11,12 +11,17 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
+     * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1, final java.lang.Number arg2);
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1);
@@ -32,6 +37,9 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
 
         /**
          * EXPERIMENTAL
+         * 
+         * @param arg1 This parameter is required.
+         * @param arg2
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
@@ -41,6 +49,8 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
 
         /**
          * EXPERIMENTAL
+         * 
+         * @param arg1 This parameter is required.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -31,7 +31,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
 
         /**
          * Sets the value of Goo
-         * @param goo the value to be set
+         * @param goo the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -42,7 +42,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
 
         /**
          * Sets the value of Bar
-         * @param bar the value to be set
+         * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
         public Builder bar(java.lang.String bar) {
@@ -52,7 +52,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */
         public Builder foo(software.amazon.jsii.tests.calculator.baseofbase.Very foo) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -29,7 +29,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -29,7 +29,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
@@ -20,6 +20,8 @@ public class InterfacesMaker extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.lib.IDoublable> makeInterfaces(final java.lang.Number count) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -18,6 +18,8 @@ public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII41
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param property This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public JSII417Derived(final java.lang.String property) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -23,8 +23,8 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      * 
      * EXPERIMENTAL
      * 
-     * @param lhs Left-hand side operand.
-     * @param rhs Right-hand side operand.
+     * @param lhs Left-hand side operand. This parameter is required.
+     * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Multiply(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -20,6 +20,8 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param operand This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Negate(final software.amazon.jsii.tests.calculator.lib.Value operand) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -20,6 +20,9 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _param1 This parameter is required.
+     * @param optional
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, final java.lang.Object optional) {
@@ -29,6 +32,8 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param _param1 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NullShouldBeTreatedAsUndefined(final java.lang.String _param1) {
@@ -38,6 +43,8 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void giveMeUndefined(final java.lang.Object value) {
@@ -54,6 +61,8 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param input This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void giveMeUndefinedInsideAnObject(final software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData input) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -36,7 +36,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
 
         /**
          * Sets the value of ArrayWithThreeElementsAndUndefinedAsSecondArgument
-         * @param arrayWithThreeElementsAndUndefinedAsSecondArgument the value to be set
+         * @param arrayWithThreeElementsAndUndefinedAsSecondArgument the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -47,7 +47,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
 
         /**
          * Sets the value of ThisShouldBeUndefined
-         * @param thisShouldBeUndefined the value to be set
+         * @param thisShouldBeUndefined the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -20,6 +20,8 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param generator This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public NumberGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
@@ -29,6 +31,8 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param gen This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean isSameGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -27,6 +27,8 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
      * Returns the sum of all values.
      * 
      * EXPERIMENTAL
+     * 
+     * @param values This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumFromArray(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
@@ -37,6 +39,8 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
      * Returns the sum of all values in a map.
      * 
      * EXPERIMENTAL
+     * 
+     * @param values This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumFromMap(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> values) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -18,6 +18,10 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
+     * @param arg2 This parameter is required.
+     * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
@@ -27,6 +31,9 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
+     * @param arg2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -29,7 +29,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Field
-         * @param field the value to be set
+         * @param field the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -18,6 +18,8 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param optionalStruct
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public OptionalStructConsumer(final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -23,6 +23,8 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number test(final software.amazon.jsii.tests.calculator.IReturnsNumber obj) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -23,6 +23,10 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param obj This parameter is required.
+     * @param dt This parameter is required.
+     * @param ev This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public abstract java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev);
@@ -38,6 +42,10 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
 
         /**
          * EXPERIMENTAL
+         * 
+         * @param obj This parameter is required.
+         * @param dt This parameter is required.
+         * @param ev This parameter is required.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -23,6 +23,8 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param friendly This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String sayHello(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -23,8 +23,8 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      * 
      * EXPERIMENTAL
      * 
-     * @param base The base of the power.
-     * @param pow The number of times to multiply.
+     * @param base The base of the power. This parameter is required.
+     * @param pow The number of times to multiply. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Power(final software.amazon.jsii.tests.calculator.lib.Value base, final software.amazon.jsii.tests.calculator.lib.Value pow) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -33,6 +33,8 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void saveFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -23,6 +23,10 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
+     * @param arg2
+     * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
@@ -31,6 +35,9 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
+     * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2) {
@@ -39,6 +46,8 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg1
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithDefaultedArguments(final java.lang.Number arg1) {
@@ -55,6 +64,8 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param arg
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalAnyArgument(final java.lang.Object arg) {
@@ -73,6 +84,10 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * Used to verify verification of number of method arguments.
      * 
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
+     * @param arg2 This parameter is required.
+     * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
@@ -83,6 +98,9 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * Used to verify verification of number of method arguments.
      * 
      * EXPERIMENTAL
+     * 
+     * @param arg1 This parameter is required.
+     * @param arg2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -40,7 +40,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
 
         /**
          * Sets the value of DeeperRequiredProp
-         * @param deeperRequiredProp It's long and required.
+         * @param deeperRequiredProp It's long and required. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
@@ -22,6 +22,8 @@ public class SingletonInt extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean isSingletonInt(final java.lang.Number value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
@@ -22,6 +22,8 @@ public class SingletonString extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Boolean isSingletonString(final java.lang.String value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
@@ -16,6 +16,8 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     }
 
     /**
+     * @param readonlyString This parameter is required.
+     * @param mutableNumber
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public StableClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
@@ -24,6 +26,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     }
 
     /**
+     * @param readonlyString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public StableClass(final java.lang.String readonlyString) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -27,7 +27,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of ReadonlyProperty
-         * @param readonlyProperty the value to be set
+         * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -25,6 +25,8 @@ public class Statics extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public Statics(final java.lang.String value) {
@@ -37,7 +39,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * 
      * EXPERIMENTAL
      * 
-     * @param name The name of the person to say hello to.
+     * @param name The name of the person to say hello to. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.lang.String staticMethod(final java.lang.String name) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -22,6 +22,8 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
     }
 
     /**
+     * @param _positional This parameter is required.
+     * @param inputs This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
     public static java.lang.Number howManyVarArgsDidIPass(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct... inputs) {
@@ -29,6 +31,8 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
     }
 
     /**
+     * @param _positional This parameter is required.
+     * @param input This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
     public static software.amazon.jsii.tests.calculator.TopLevelStruct roundTrip(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct input) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -50,7 +50,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
 
         /**
          * Sets the value of DefaultValue
-         * @param defaultValue the value to be set
+         * @param defaultValue the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -61,7 +61,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
 
         /**
          * Sets the value of AssertValue
-         * @param assertValue the value to be set
+         * @param assertValue the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -72,7 +72,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
 
         /**
          * Sets the value of Result
-         * @param result the value to be set
+         * @param result the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -83,7 +83,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
 
         /**
          * Sets the value of That
-         * @param that the value to be set
+         * @param that the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -39,6 +39,8 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void modifyOtherProperty(final java.lang.String value) {
@@ -47,6 +49,8 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void modifyValueOfTheProperty(final java.lang.String value) {
@@ -87,6 +91,8 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param n This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number virtualMethod(final java.lang.Number n) {
@@ -95,6 +101,8 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public void writeA(final java.lang.Number value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -49,7 +49,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Required
-         * @param required This is a required field.
+         * @param required This is a required field. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -60,7 +60,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of SecondLevel
-         * @param secondLevel A union to really stress test our serialization.
+         * @param secondLevel A union to really stress test our serialization. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -71,7 +71,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of SecondLevel
-         * @param secondLevel A union to really stress test our serialization.
+         * @param secondLevel A union to really stress test our serialization. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -20,6 +20,8 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param operand This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     protected UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -36,7 +36,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Bar
-         * @param bar the value to be set
+         * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -47,7 +47,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Bar
-         * @param bar the value to be set
+         * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -58,7 +58,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Bar
-         * @param bar the value to be set
+         * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -69,7 +69,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -80,7 +80,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         /**
          * Sets the value of Foo
-         * @param foo the value to be set
+         * @param foo the value to be set.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -18,6 +18,8 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public UsesInterfaceWithProperties(final software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
@@ -35,6 +37,8 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param ext This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String readStringAndNumber(final software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
@@ -43,6 +47,8 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.String writeAndRead(final java.lang.String value) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -19,7 +19,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
     /**
      * EXPERIMENTAL
      * 
-     * @param prefix a prefix that will be use for all values returned by `#asArray`.
+     * @param prefix a prefix that will be use for all values returned by `#asArray`. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public VariadicMethod(final java.lang.Number... prefix) {
@@ -30,8 +30,8 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
     /**
      * EXPERIMENTAL
      * 
-     * @param first the first element of the array to be returned (after the `prefix` provided at construction time).
-     * @param others other elements to be included in the array.
+     * @param first the first element of the array to be returned (after the `prefix` provided at construction time). This parameter is required.
+     * @param others other elements to be included in the array. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -23,6 +23,8 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param index This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMeAsync(final java.lang.Number index) {
@@ -31,6 +33,8 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param index This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number overrideMeSync(final java.lang.Number index) {
@@ -39,6 +43,8 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number parallelSumAsync(final java.lang.Number count) {
@@ -47,6 +53,8 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number serialSumAsync(final java.lang.Number count) {
@@ -55,6 +63,8 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.lang.Number sumSync(final java.lang.Number count) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
@@ -20,6 +20,8 @@ public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiO
 
     /**
      * EXPERIMENTAL
+     * 
+     * @param privateField
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public WithPrivatePropertyInConstructor(final java.lang.String privateField) {


### PR DESCRIPTION
This commit enhances javadoc generation for Java classes so that required
method/constructor parameters are indicated in their description in the javadoc.

This makes it easy for customers to see which paramaters must be provided when
interacting with libraries from Java.

Fixes #365

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
