### PR TITLE
feat(java): use immutable java implementations of JSII primitive collection types array and map

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1860,3 +1860,24 @@ export class InterfacesMaker {
 
     private constructor() { }
 }
+
+export class ClassWithCollections {
+    public map: { [key: string]: string };
+    public array: string[];
+
+    public static staticMap:{ [key: string]: string } = {'key1': 'value1', 'key2': 'value2'};
+    public static staticArray: string[] = ["one", "two"];
+
+    constructor(map: { [key: string]: string }, array: string[]) {
+        this.map = map;
+        this.array = array;
+    }
+
+    static createAList(): string[] {
+        return ["one", "two"];
+    }
+
+    static createAMap(): { [key: string]: string } {
+        return {'key1': 'value1', 'key2': 'value2'};
+    }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1721,6 +1721,168 @@
         }
       ]
     },
+    "jsii-calc.ClassWithCollections": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.ClassWithCollections",
+      "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
+        "parameters": [
+          {
+            "name": "map",
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "map"
+              }
+            }
+          },
+          {
+            "name": "array",
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1864
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1876
+          },
+          "name": "createAList",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1880
+          },
+          "name": "createAMap",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "map"
+              }
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "ClassWithCollections",
+      "properties": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1869
+          },
+          "name": "staticArray",
+          "static": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1868
+          },
+          "name": "staticMap",
+          "static": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1866
+          },
+          "name": "array",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1865
+          },
+          "name": "map",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        }
+      ]
+    },
     "jsii-calc.ClassWithDocs": {
       "assembly": "jsii-calc",
       "docs": {
@@ -9453,5 +9615,5 @@
     }
   },
   "version": "0.16.0",
-  "fingerprint": "D99pLaaW2xH2uuyUa8hgakiEso/wXbcMNkP9RmOTwgo="
+  "fingerprint": "SyvtIxuwfgMPg4aYpb3VR2M4Ra4b+iLnrBwHjsLb12g="
 }

--- a/packages/jsii-java-runtime-test/pom.xml.t.js
+++ b/packages/jsii-java-runtime-test/pom.xml.t.js
@@ -32,6 +32,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -12,6 +12,7 @@ import software.amazon.jsii.tests.calculator.AllTypesEnum;
 import software.amazon.jsii.tests.calculator.AsyncVirtualMethods;
 import software.amazon.jsii.tests.calculator.Calculator;
 import software.amazon.jsii.tests.calculator.CalculatorProps;
+import software.amazon.jsii.tests.calculator.ClassWithCollections;
 import software.amazon.jsii.tests.calculator.ClassWithJavaReservedWords;
 import software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties;
 import software.amazon.jsii.tests.calculator.Constructors;
@@ -70,10 +71,15 @@ import software.amazon.jsii.tests.calculator.ConstructorPassesThisOut;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1266,6 +1272,92 @@ public class ComplianceTest {
     public void canLoadEnumValues() {
         assertNotNull(EnumDispenser.randomStringLikeEnum());
         assertNotNull(EnumDispenser.randomIntegerLikeEnum());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void listInClassCannotBeModified() {
+        List<String> modifiableList = Arrays.asList("one", "two");
+
+        ClassWithCollections classWithCollections = new ClassWithCollections(Collections.emptyMap(), modifiableList);
+
+        classWithCollections.getArray().add("three");
+    }
+
+    @Test
+    public void listInClassCanBeReadCorrectly() {
+        List<String> modifiableList = Arrays.asList("one", "two");
+
+        ClassWithCollections classWithCollections = new ClassWithCollections(Collections.emptyMap(), modifiableList);
+
+        assertThat(classWithCollections.getArray(), contains("one", "two"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void mapInClassCannotBeModified() {
+        Map<String, String> modifiableMap = new HashMap<>();
+        modifiableMap.put("key", "value");
+
+        ClassWithCollections classWithCollections = new ClassWithCollections(modifiableMap, Collections.emptyList());
+
+        classWithCollections.getMap().put("keyTwo", "valueTwo");
+    }
+
+    @Test
+    public void mapInClassCanBeReadCorrectly() {
+        Map<String, String> modifiableMap = new HashMap<>();
+        modifiableMap.put("key", "value");
+
+        ClassWithCollections classWithCollections = new ClassWithCollections(modifiableMap, Collections.emptyList());
+
+        Map<String, String> result = classWithCollections.getMap();
+        assertThat(result, hasEntry("key", "value"));
+        assertThat(result.size(), is(1));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void staticListInClassCannotBeModified() {
+        ClassWithCollections.getStaticArray().add("three");
+    }
+
+    @Test
+    public void staticListInClassCanBeReadCorrectly() {
+        assertThat(ClassWithCollections.getStaticArray(), contains("one", "two"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void staticMapInClassCannotBeModified() {
+        ClassWithCollections.getStaticMap().put("keyTwo", "valueTwo");
+    }
+
+    @Test
+    public void staticMapInClassCanBeReadCorrectly() {
+        Map<String, String> result = ClassWithCollections.getStaticMap();
+        assertThat(result, hasEntry("key1", "value1"));
+        assertThat(result, hasEntry("key2", "value2"));
+        assertThat(result.size(), is(2));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void arrayReturnedByMethodCannotBeModified() {
+        ClassWithCollections.createAList().add("three");
+    }
+
+    @Test
+    public void arrayReturnedByMethodCanBeRead() {
+        assertThat(ClassWithCollections.createAList(), contains("one", "two"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void mapReturnedByMethodCannotBeModified() {
+        ClassWithCollections.createAMap().put("keyThree", "valueThree");
+    }
+
+    @Test
+    public void mapReturnedByMethodCanBeRead() {
+        Map<String, String> result = ClassWithCollections.createAMap();
+        assertThat(result, hasEntry("key1", "value1"));
+        assertThat(result, hasEntry("key2", "value2"));
+        assertThat(result.size(), is(2));
     }
 
     static class PartiallyInitializedThisConsumerImpl extends PartiallyInitializedThisConsumer {

--- a/packages/jsii-java-runtime/pom.xml.t.js
+++ b/packages/jsii-java-runtime/pom.xml.t.js
@@ -51,6 +51,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions of the dependencies -->
         <findbugs.version>[3.0.2,3.1.0)</findbugs.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <jackson-core.version>[2.9.9,2.10.0)</jackson-core.version>
         <jackson-databind.version>[2.9.9.2,2.10.0)</jackson-databind.version>
         <javax.annotations.version>[1.3.2,1.4.0)</javax.annotations.version>
@@ -101,6 +102,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>\${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest-all -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>\${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -4,6 +4,7 @@ import fs = require('fs-extra');
 import spec = require('jsii-spec');
 import path = require('path');
 import xmlbuilder = require('xmlbuilder');
+import {CollectionTypeReference, TypeReference} from "../../../jsii-spec/lib";
 import { Generator } from '../generator';
 import logging = require('../logging');
 import { md2html } from '../markdown';
@@ -288,7 +289,7 @@ class JavaGenerator extends Generator {
 
     protected onEndClass(cls: spec.ClassType) {
         if (cls.abstract) {
-            this.emitInterfaceProxy(cls);
+            this.emitProxy(cls);
         }
 
         this.code.closeBlock();
@@ -296,9 +297,14 @@ class JavaGenerator extends Generator {
     }
 
     protected onInitializer(cls: spec.ClassType, method: spec.Method) {
+        this.code.line();
         this.addJavaDocs(method);
         this.emitStabilityAnnotations(method);
-        this.code.openBlock(`${this.renderAccessLevel(method)} ${cls.name}(${this.renderMethodParameters(method)})`);
+
+        // Abstract classes should have protected initializers
+        const initializerAccessLevel = cls.abstract ? 'protected' : this.renderAccessLevel(method);
+
+        this.code.openBlock(`${initializerAccessLevel} ${cls.name}(${this.renderMethodParameters(method)})`);
         this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
         const createObjectCall = `software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this${this.renderMethodCallArguments(method)})`;
         this.code.line(`this.setObjRef(${createObjectCall});`);
@@ -400,7 +406,7 @@ class JavaGenerator extends Generator {
         if (ifc.datatype) {
             this.emitDataType(ifc);
         } else {
-            this.emitInterfaceProxy(ifc);
+            this.emitProxy(ifc);
         }
 
         this.code.closeBlock();
@@ -408,11 +414,11 @@ class JavaGenerator extends Generator {
     }
 
     protected onInterfaceMethod(_ifc: spec.InterfaceType, method: spec.Method) {
+        this.code.line();
         const returnType = method.returns ? this.toJavaType(method.returns.type) : 'void';
         this.addJavaDocs(method);
         this.emitStabilityAnnotations(method);
         this.code.line(`${returnType} ${method.name}(${this.renderMethodParameters(method)});`);
-        this.code.line();
     }
 
     protected onInterfaceMethodOverload(ifc: spec.InterfaceType, overload: spec.Method, _originalMethod: spec.Method) {
@@ -425,16 +431,16 @@ class JavaGenerator extends Generator {
         const propName = this.code.toPascalCase(JavaGenerator.safeJavaPropertyName(prop.name));
 
         // for unions we only generate overloads for setters, not getters.
+        this.code.line();
         this.addJavaDocs(prop);
         this.emitStabilityAnnotations(prop);
         this.code.line(`${getterType} get${propName}();`);
-        this.code.line();
 
         if (!prop.immutable) {
             for (const type of setterTypes) {
+                this.code.line();
                 this.addJavaDocs(prop);
                 this.code.line(`void set${propName}(final ${type} value);`);
-                this.code.line();
             }
         }
     }
@@ -665,6 +671,7 @@ class JavaGenerator extends Generator {
 
         const javaClass = this.toJavaType(cls);
 
+        this.code.line();
         this.code.openBlock(`static`);
 
         for (const prop of consts) {
@@ -685,6 +692,7 @@ class JavaGenerator extends Generator {
         const propName = this.renderConstName(prop);
         const access = this.renderAccessLevel(prop);
 
+        this.code.line();
         this.addJavaDocs(prop);
         this.emitStabilityAnnotations(prop);
         this.code.line(`${access} final static ${propType} ${propName};`);
@@ -706,17 +714,16 @@ class JavaGenerator extends Generator {
             if (overrides) { this.code.line('@Override'); }
             this.emitStabilityAnnotations(prop);
             this.code.openBlock(`${access} ${statc}${getterType} get${propName}()`);
-
-            let statement = 'return ';
+            let statement;
             if (prop.static) {
-                statement += `software.amazon.jsii.JsiiObject.jsiiStaticGet(${javaClass}.class, `;
+                statement = `software.amazon.jsii.JsiiObject.jsiiStaticGet(${javaClass}.class, `;
             } else {
-                statement += `this.jsiiGet(`;
+                statement = `this.jsiiGet(`;
             }
 
-            statement += `"${prop.name}", ${propClass}.class);`;
+            statement += `"${prop.name}", ${propClass}.class)`;
 
-            this.code.line(statement);
+            this.code.line(`return ${this.wrapCollection(statement, prop.type)};`);
             this.code.closeBlock();
         }
 
@@ -767,8 +774,11 @@ class JavaGenerator extends Generator {
      * javascript objects that implement this interface. we want java code to be
      * able to interact with them, so we will create a proxy class which
      * implements this interface and has the same methods.
+     *
+     * These proxies are also used to extend abstract classes to allow the JSII
+     * engine to instantiate an abstract class in Java.
      */
-    private emitInterfaceProxy(ifc: spec.InterfaceType | spec.ClassType) {
+    private emitProxy(ifc: spec.InterfaceType | spec.ClassType) {
         const name = INTERFACE_PROXY_CLASS_NAME;
 
         this.code.line();
@@ -862,21 +872,93 @@ class JavaGenerator extends Generator {
         }
     }
 
-    private emitDataType(ifc: spec.InterfaceType) {
-        const interfaceName = ifc.name;
+    private toJavaProp(property: spec.Property, inherited: boolean): JavaProp {
+        const safeName = JavaGenerator.safeJavaPropertyName(property.name);
+        const propName = this.code.toPascalCase(safeName);
+
+        return {
+            docs: property.docs,
+            spec: property,
+            propName,
+            jsiiName: property.name,
+            nullable: !!property.optional,
+            fieldName: this.code.toCamelCase(safeName),
+            fieldJavaType: this.toJavaType(property.type),
+            fieldJavaClass: `${this.toJavaType(property.type, true)}.class`,
+            javaTypes: this.toJavaTypes(property.type),
+            immutable: property.immutable || false,
+            inherited,
+        };
+    }
+
+    private emitBuilderSetter(prop: JavaProp, builderName: string) {
+        for (const type of prop.javaTypes) {
+            this.code.line();
+            this.code.line('/**');
+            this.code.line(` * Sets the value of ${prop.propName}`);
+            if (prop.docs && prop.docs.summary) {
+                this.code.line(` * @param ${prop.fieldName} ${prop.docs.summary}`);
+            } else {
+                this.code.line(` * @param ${prop.fieldName} the value to be set`);
+            }
+            this.code.line(` * @return {@code this}`);
+            if (prop.docs && prop.docs.deprecated) {
+                this.code.line(` * @deprecated ${prop.docs.deprecated}`);
+            }
+            this.code.line(' */');
+            this.emitStabilityAnnotations(prop.spec);
+            this.code.openBlock(`public ${builderName} ${prop.fieldName}(${type} ${prop.fieldName})`);
+            this.code.line(`this.${prop.fieldName} = ${prop.fieldName};`);
+            this.code.line('return this;');
+            this.code.closeBlock();
+        }
+    }
+
+    private emitBuilder(classSpec: spec.InterfaceType | spec.ClassType, constructorName: string, props: JavaProp[]) {
         const builderName = 'Builder';
 
         // Start builder()
+        this.code.line();
         this.code.line('/**');
-        this.code.line(` * @return a {@link Builder} of {@link ${interfaceName}}`);
+        this.code.line(` * @return a {@link Builder} of {@link ${classSpec.name}}`);
         this.code.line(' */');
-        this.emitStabilityAnnotations(ifc);
+        this.emitStabilityAnnotations(classSpec);
         this.code.openBlock(`static ${builderName} builder()`);
         this.code.line(`return new ${builderName}();`);
         this.code.closeBlock();
-        this.code.line();
         // End builder()
 
+        // Start Builder
+        this.code.line('/**');
+        this.code.line(` * A builder for {@link ${classSpec.name}}`);
+        this.code.line(' */');
+        this.emitStabilityAnnotations(classSpec);
+        this.code.openBlock(`public static final class ${builderName}`);
+
+        props.forEach(prop => this.code.line(`private ${prop.fieldJavaType} ${prop.fieldName};`));
+        props.forEach(prop => this.emitBuilderSetter(prop, builderName));
+
+        // Start build()
+        this.code.line();
+        this.code.line('/**');
+        this.code.line(' * Builds the configured instance.');
+        this.code.line(` * @return a new instance of {@link ${classSpec.name}}`);
+        this.code.line(' * @throws NullPointerException if any required attribute was not provided');
+        this.code.line(' */');
+        this.emitStabilityAnnotations(classSpec);
+        this.code.openBlock(`public ${classSpec.name} build()`);
+
+        const propFields = props.map(prop => prop.fieldName).join(", ");
+
+        this.code.line(`return new ${constructorName}(${propFields});`);
+        this.code.closeBlock();
+        // End build()
+
+        this.code.closeBlock();
+        // End Builder
+    }
+
+    private emitDataType(ifc: spec.InterfaceType) {
         // collect all properties from all base structs and dedupe by name. It is assumed that the generation of the
         // assembly will not permit multiple overloaded inherited properties with the same name and that this will be
         // enforced by Typescript constraints.
@@ -885,24 +967,8 @@ class JavaGenerator extends Generator {
 
         function collectProps(currentIfc: spec.InterfaceType, isBaseClass = false) {
             for (const property of currentIfc.properties || []) {
-                const safeName = JavaGenerator.safeJavaPropertyName(property.name);
-                const propName = self.code.toPascalCase(safeName);
-
-                const prop: JavaProp = {
-                    docs: property.docs,
-                    spec: property,
-                    propName,
-                    jsiiName: property.name,
-                    nullable: !!property.optional,
-                    fieldName: self.code.toCamelCase(safeName),
-                    fieldJavaType: self.toJavaType(property.type),
-                    fieldJavaClass: `${self.toJavaType(property.type, true)}.class`,
-                    javaTypes: self.toJavaTypes(property.type),
-                    immutable: property.immutable || false,
-                    inherited: isBaseClass,
-                };
-
-                propsByName[prop.propName] = prop;
+                const javaProp = self.toJavaProp(property, isBaseClass);
+                propsByName[javaProp.propName] = javaProp;
             }
 
             // add props of base struct
@@ -913,65 +979,15 @@ class JavaGenerator extends Generator {
 
         collectProps(ifc);
         const props = Object.values(propsByName);
-
-        // Start Builder
-        this.code.line('/**');
-        this.code.line(` * A builder for {@link ${interfaceName}}`);
-        this.code.line(' */');
-        this.emitStabilityAnnotations(ifc);
-        this.code.openBlock(`final class ${builderName}`);
-        props.forEach(prop => this.code.line(`private ${prop.fieldJavaType} ${prop.fieldName};`));
-        this.code.line();
-
-        for (const prop of props) {
-            for (const type of prop.javaTypes) {
-                // Start property setter
-                this.code.line('/**');
-                this.code.line(` * Sets the value of ${prop.propName}`);
-                if (prop.docs && prop.docs.summary) {
-                    this.code.line(` * @param ${prop.fieldName} ${prop.docs.summary}`);
-                } else {
-                    this.code.line(` * @param ${prop.fieldName} the value to be set`);
-                }
-                this.code.line(` * @return {@code this}`);
-                if (prop.docs && prop.docs.deprecated) {
-                    this.code.line(` * @deprecated ${prop.docs.deprecated}`);
-                }
-                this.code.line(' */');
-                this.emitStabilityAnnotations(prop.spec);
-                this.code.openBlock(`public ${builderName} ${prop.fieldName}(${type} ${prop.fieldName})`);
-                this.code.line(`this.${prop.fieldName} = ${prop.fieldName};`);
-                this.code.line('return this;');
-                this.code.closeBlock();
-                this.code.line();
-                // End property setter
-            }
-        }
-
-        // Start build()
-        this.code.line('/**');
-        this.code.line(' * Builds the configured instance.');
-        this.code.line(` * @return a new instance of {@link ${interfaceName}}`);
-        this.code.line(' * @throws NullPointerException if any required attribute was not provided');
-        this.code.line(' */');
-        this.emitStabilityAnnotations(ifc);
-        this.code.openBlock(`public ${interfaceName} build()`);
-        const propFields = props.map(prop => prop.fieldName).join(", ");
-        this.code.line(`return new ${INTERFACE_PROXY_CLASS_NAME}(${propFields});`);
-        this.code.closeBlock();
-        this.code.line();
-        // End build()
-
-        this.code.closeBlock();
-        this.code.line();
-        // End Builder
+        this.emitBuilder(ifc, INTERFACE_PROXY_CLASS_NAME, props);
 
         // Start implementation class
+        this.code.line();
         this.code.line('/**');
-        this.code.line(` * An implementation for {@link ${interfaceName}}`);
+        this.code.line(` * An implementation for {@link ${ifc.name}}`);
         this.code.line(' */');
         this.emitStabilityAnnotations(ifc);
-        this.code.openBlock(`final class ${INTERFACE_PROXY_CLASS_NAME} extends software.amazon.jsii.JsiiObject implements ${interfaceName}`);
+        this.code.openBlock(`final class ${INTERFACE_PROXY_CLASS_NAME} extends software.amazon.jsii.JsiiObject implements ${ifc.name}`);
 
         // Immutable properties
         props.forEach(prop => this.code.line(`private final ${prop.fieldJavaType} ${prop.fieldName};`));
@@ -991,7 +1007,6 @@ class JavaGenerator extends Generator {
 
         // Start literal constructor
         this.code.line();
-        this.code.line();
         this.code.line('/**');
         this.code.line(' * Constructor that initializes the object based on literal property values passed by the {@link Builder}.');
         this.code.line(' */');
@@ -1002,19 +1017,19 @@ class JavaGenerator extends Generator {
             this.code.line(`this.${prop.fieldName} = ${_validateIfNonOptional(prop.fieldName, prop)};`);
         });
         this.code.closeBlock();
-        this.code.line();
         // End literal constructor
 
         // Getters
         props.forEach(prop => {
+            this.code.line();
             this.code.line('@Override');
             this.code.openBlock(`public ${prop.fieldJavaType} get${prop.propName}()`);
             this.code.line(`return this.${prop.fieldName};`);
             this.code.closeBlock();
-            this.code.line();
         });
 
         // emit $jsii$toJson which will be called to serialize this object when sent to JS
+        this.code.line();
         this.code.line('@Override');
         this.code.openBlock(`public com.fasterxml.jackson.databind.JsonNode $jsii$toJson()`);
         this.code.line(`com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;`);
@@ -1029,11 +1044,10 @@ class JavaGenerator extends Generator {
 
         this.code.line(`return obj;`);
         this.code.closeBlock();
-        this.code.line();
         // End $jsii$toJson
 
         // Generate equals() override
-        this.emitEqualsOverride(interfaceName, props);
+        this.emitEqualsOverride(ifc.name, props);
 
         // Generate hashCode() override
         this.emitHashCodeOverride(props);
@@ -1053,6 +1067,7 @@ class JavaGenerator extends Generator {
             return;
         }
 
+        this.code.line();
         this.code.line('@Override');
         this.code.openBlock('public boolean equals(Object o)');
         this.code.line('if (this == o) return true;');
@@ -1081,7 +1096,6 @@ class JavaGenerator extends Generator {
         this.code.line(`return ${finalPredicate};`);
 
         this.code.closeBlock();
-        this.code.line();
     }
 
     private emitHashCodeOverride(props: JavaProp[]) {
@@ -1090,6 +1104,7 @@ class JavaGenerator extends Generator {
             return;
         }
 
+        this.code.line();
         this.code.line('@Override');
         this.code.openBlock('public int hashCode()');
 
@@ -1100,7 +1115,6 @@ class JavaGenerator extends Generator {
         remainingProps.forEach(prop => this.code.line(`result = 31 * result + (${_hashCodeForProp(prop)});`));
         this.code.line(`return result;`);
         this.code.closeBlock();
-        this.code.line();
 
         function _hashCodeForProp(prop: JavaProp) {
             return prop.nullable ? `this.${prop.fieldName} != null ? this.${prop.fieldName}.hashCode() : 0` : `this.${prop.fieldName}.hashCode()`;
@@ -1293,10 +1307,6 @@ class JavaGenerator extends Generator {
     private renderMethodCall(cls: spec.TypeReference, method: spec.Method, async: boolean) {
         let statement = '';
 
-        if (method.returns) {
-            statement += `return `;
-        }
-
         if (method.static) {
             const javaClass = this.toJavaType(cls);
             statement += `software.amazon.jsii.JsiiObject.jsiiStaticCall(${javaClass}.class, `;
@@ -1315,8 +1325,37 @@ class JavaGenerator extends Generator {
         } else {
             statement += ', Void.class';
         }
-        statement += this.renderMethodCallArguments(method);
-        statement += ');';
+        statement += this.renderMethodCallArguments(method) + ')';
+
+        if (method.returns) {
+            statement = this.wrapCollection(statement, method.returns.type);
+        }
+
+        if (method.returns) {
+            return `return ${statement};`;
+        } else {
+            return `${statement};`;
+        }
+    }
+
+    /**
+     * Wraps a collection into an unmodifiable collection else returns the existing statement.
+     * @param statement The statement to wrap if necessary.
+     * @param type The type of the object to wrap.
+     * @returns The modified or original statement.
+     */
+    private wrapCollection(statement: string, type: TypeReference): string {
+        if (spec.isCollectionTypeReference(type)) {
+            const ref = type as CollectionTypeReference;
+            switch (ref.collection.kind) {
+                case spec.CollectionKind.Array:
+                    return `java.util.Collections.unmodifiableList(${statement})`;
+                case spec.CollectionKind.Map:
+                    return `java.util.Collections.unmodifiableMap(${statement})`;
+                default:
+                    throw new Error(`Unsupported collection kind: ${ref.collection.kind}`);
+            }
+        }
 
         return statement;
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -14,7 +14,8 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
     protected Base(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public Base() {
+
+    protected Base() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -2,6 +2,7 @@ package software.amazon.jsii.tests.calculator.base;
 
 @javax.annotation.Generated(value = "jsii-pacmak")
 public interface BaseProps extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.baseofbase.VeryBaseProps {
+
     java.lang.String getBar();
 
     /**
@@ -10,11 +11,10 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link BaseProps}
      */
-    final class Builder {
+    public static final class Builder {
         private java.lang.String bar;
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
@@ -46,7 +46,6 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         public BaseProps build() {
             return new Jsii$Proxy(bar, foo);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
             this.bar = this.jsiiGet("bar", java.lang.String.class);
             this.foo = this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -113,6 +111,5 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
             result = 31 * result + (this.foo.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/IBaseInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/IBaseInterface.java
@@ -2,8 +2,8 @@ package software.amazon.jsii.tests.calculator.base;
 
 @javax.annotation.Generated(value = "jsii-pacmak")
 public interface IBaseInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.baseofbase.IVeryBaseInterface {
-    void bar();
 
+    void bar();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -7,12 +7,12 @@ package software.amazon.jsii.tests.calculator.lib;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
+
     /**
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.Number getDoubleValue();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -10,13 +10,13 @@ package software.amazon.jsii.tests.calculator.lib;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * Say hello!
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     java.lang.String hello();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IThreeLevelsInterface.java
@@ -10,12 +10,12 @@ package software.amazon.jsii.tests.calculator.lib;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IThreeLevelsInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.base.IBaseInterface {
+
     /**
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     void baz();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -7,6 +7,7 @@ package software.amazon.jsii.tests.calculator.lib;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * An awesome number value.
      */
@@ -35,13 +36,12 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link MyFirstStruct}
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Number anumber;
         private java.lang.String astring;
         private java.util.List<java.lang.String> firstOptional;
@@ -92,7 +92,6 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         public MyFirstStruct build() {
             return new Jsii$Proxy(anumber, astring, firstOptional);
         }
-
     }
 
     /**
@@ -116,7 +115,6 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
             this.astring = this.jsiiGet("astring", java.lang.String.class);
             this.firstOptional = this.jsiiGet("firstOptional", java.util.List.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -174,6 +172,5 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
             result = 31 * result + (this.firstOptional != null ? this.firstOptional.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -16,6 +16,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
     protected Number(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a Number object.
      * 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -16,7 +16,8 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
     protected Operation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public Operation() {
+
+    protected Operation() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -7,6 +7,7 @@ package software.amazon.jsii.tests.calculator.lib;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * The first optional!
      */
@@ -34,13 +35,12 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link StructWithOnlyOptionals}
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String optional1;
         private java.lang.Number optional2;
         private java.lang.Boolean optional3;
@@ -91,7 +91,6 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         public StructWithOnlyOptionals build() {
             return new Jsii$Proxy(optional1, optional2, optional3);
         }
-
     }
 
     /**
@@ -115,7 +114,6 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
             this.optional2 = this.jsiiGet("optional2", java.lang.Number.class);
             this.optional3 = this.jsiiGet("optional3", java.lang.Boolean.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -177,6 +175,5 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
             result = 31 * result + (this.optional3 != null ? this.optional3.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -16,7 +16,8 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
     protected Value(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public Value() {
+
+    protected Value() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1721,6 +1721,168 @@
         }
       ]
     },
+    "jsii-calc.ClassWithCollections": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.ClassWithCollections",
+      "initializer": {
+        "docs": {
+          "stability": "experimental"
+        },
+        "parameters": [
+          {
+            "name": "map",
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "map"
+              }
+            }
+          },
+          {
+            "name": "array",
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1864
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1876
+          },
+          "name": "createAList",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1880
+          },
+          "name": "createAMap",
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "map"
+              }
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "ClassWithCollections",
+      "properties": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1869
+          },
+          "name": "staticArray",
+          "static": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1868
+          },
+          "name": "staticMap",
+          "static": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1866
+          },
+          "name": "array",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1865
+          },
+          "name": "map",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        }
+      ]
+    },
     "jsii-calc.ClassWithDocs": {
       "assembly": "jsii-calc",
       "docs": {
@@ -9453,5 +9615,5 @@
     }
   },
   "version": "0.16.0",
-  "fingerprint": "D99pLaaW2xH2uuyUa8hgakiEso/wXbcMNkP9RmOTwgo="
+  "fingerprint": "SyvtIxuwfgMPg4aYpb3VR2M4Ra4b+iLnrBwHjsLb12g="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithCollections.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ClassWithCollections.cs
@@ -1,0 +1,84 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), fullyQualifiedName: "jsii-calc.ClassWithCollections", parametersJson: "[{\"name\":\"map\",\"type\":{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"map\"}}},{\"name\":\"array\",\"type\":{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"array\"}}}]")]
+    public class ClassWithCollections : DeputyBase
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        public ClassWithCollections(System.Collections.Generic.IDictionary<string, string> map, string[] array): base(new DeputyProps(new object[]{map, array}))
+        {
+        }
+
+        protected ClassWithCollections(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected ClassWithCollections(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "createAList", returnsJson: "{\"type\":{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"array\"}}}")]
+        public static string[] CreateAList()
+        {
+            return InvokeStaticMethod<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new object[]{});
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "createAMap", returnsJson: "{\"type\":{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"map\"}}}")]
+        public static System.Collections.Generic.IDictionary<string, string> CreateAMap()
+        {
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new object[]{});
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "staticArray", typeJson: "{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"array\"}}")]
+        public static string[] StaticArray
+        {
+            get => GetStaticProperty<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections));
+            set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), value);
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "staticMap", typeJson: "{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"map\"}}")]
+        public static System.Collections.Generic.IDictionary<string, string> StaticMap
+        {
+            get => GetStaticProperty<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections));
+            set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), value);
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "array", typeJson: "{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"array\"}}")]
+        public virtual string[] Array
+        {
+            get => GetInstanceProperty<string[]>();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "map", typeJson: "{\"collection\":{\"elementtype\":{\"primitive\":\"string\"},\"kind\":\"map\"}}")]
+        public virtual System.Collections.Generic.IDictionary<string, string> Map
+        {
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, string>>();
+            set => SetInstanceProperty(value);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -32,6 +32,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.CalculatorProps": return software.amazon.jsii.tests.calculator.CalculatorProps.class;
             case "jsii-calc.ClassThatImplementsTheInternalInterface": return software.amazon.jsii.tests.calculator.ClassThatImplementsTheInternalInterface.class;
             case "jsii-calc.ClassThatImplementsThePrivateInterface": return software.amazon.jsii.tests.calculator.ClassThatImplementsThePrivateInterface.class;
+            case "jsii-calc.ClassWithCollections": return software.amazon.jsii.tests.calculator.ClassWithCollections.class;
             case "jsii-calc.ClassWithDocs": return software.amazon.jsii.tests.calculator.ClassWithDocs.class;
             case "jsii-calc.ClassWithJavaReservedWords": return software.amazon.jsii.tests.calculator.ClassWithJavaReservedWords.class;
             case "jsii-calc.ClassWithMutableObjectLiteralProperty": return software.amazon.jsii.tests.calculator.ClassWithMutableObjectLiteralProperty.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -15,7 +15,8 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
     protected AbstractClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public AbstractClass() {
+
+    protected AbstractClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
@@ -15,7 +15,8 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
     protected AbstractClassBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public AbstractClassBase() {
+
+    protected AbstractClassBase() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
@@ -15,6 +15,7 @@ public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
     protected AbstractClassReturner(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public AbstractClassReturner() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -17,6 +17,7 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
     protected Add(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a BinaryOperation.
      * 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -20,6 +20,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
     protected AllTypes(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public AllTypes() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
@@ -62,7 +63,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getAnyArrayProperty() {
-        return this.jsiiGet("anyArrayProperty", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("anyArrayProperty", java.util.List.class));
     }
 
     /**
@@ -78,7 +79,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getAnyMapProperty() {
-        return this.jsiiGet("anyMapProperty", java.util.Map.class);
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("anyMapProperty", java.util.Map.class));
     }
 
     /**
@@ -110,7 +111,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getArrayProperty() {
-        return this.jsiiGet("arrayProperty", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("arrayProperty", java.util.List.class));
     }
 
     /**
@@ -190,7 +191,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> getMapProperty() {
-        return this.jsiiGet("mapProperty", java.util.Map.class);
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("mapProperty", java.util.Map.class));
     }
 
     /**
@@ -238,7 +239,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getUnionArrayProperty() {
-        return this.jsiiGet("unionArrayProperty", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("unionArrayProperty", java.util.List.class));
     }
 
     /**
@@ -254,7 +255,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getUnionMapProperty() {
-        return this.jsiiGet("unionMapProperty", java.util.Map.class);
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("unionMapProperty", java.util.Map.class));
     }
 
     /**
@@ -310,7 +311,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Object> getUnknownArrayProperty() {
-        return this.jsiiGet("unknownArrayProperty", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("unknownArrayProperty", java.util.List.class));
     }
 
     /**
@@ -326,7 +327,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.lang.Object> getUnknownMapProperty() {
-        return this.jsiiGet("unknownMapProperty", java.util.Map.class);
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("unknownMapProperty", java.util.Map.class));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -15,6 +15,7 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
     protected AllowedMethodNames(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public AllowedMethodNames() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -15,6 +15,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     protected AsyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public AsyncVirtualMethods() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AugmentableClass.java
@@ -15,6 +15,7 @@ public class AugmentableClass extends software.amazon.jsii.JsiiObject {
     protected AugmentableClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public AugmentableClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -17,6 +17,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
     protected BinaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a BinaryOperation.
      * 
@@ -26,7 +27,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * @param rhs Right-hand side operand.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
+    protected BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") }));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -17,6 +17,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
     protected Calculator(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a Calculator object.
      * 
@@ -29,6 +30,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props }));
     }
+
     /**
      * Creates a Calculator object.
      * 
@@ -108,7 +110,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getOperationsLog() {
-        return this.jsiiGet("operationsLog", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("operationsLog", java.util.List.class));
     }
 
     /**
@@ -118,7 +120,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.Map<java.lang.String, java.util.List<software.amazon.jsii.tests.calculator.lib.Value>> getOperationsMap() {
-        return this.jsiiGet("operationsMap", java.util.Map.class);
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("operationsMap", java.util.Map.class));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -27,12 +28,11 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link CalculatorProps}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Number initialValue;
         private java.lang.Number maximumValue;
 
@@ -67,7 +67,6 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         public CalculatorProps build() {
             return new Jsii$Proxy(initialValue, maximumValue);
         }
-
     }
 
     /**
@@ -88,7 +87,6 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
             this.initialValue = this.jsiiGet("initialValue", java.lang.Number.class);
             this.maximumValue = this.jsiiGet("maximumValue", java.lang.Number.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -139,6 +137,5 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
             result = 31 * result + (this.maximumValue != null ? this.maximumValue.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
@@ -15,6 +15,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
     protected ClassThatImplementsTheInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ClassThatImplementsTheInternalInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
@@ -15,6 +15,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
     protected ClassThatImplementsThePrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ClassThatImplementsThePrivateInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
@@ -1,0 +1,107 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ClassWithCollections")
+public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
+
+    protected ClassWithCollections(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ClassWithCollections(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public ClassWithCollections(final java.util.Map<java.lang.String, java.lang.String> map, final java.util.List<java.lang.String> array) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(map, "map is required"), java.util.Objects.requireNonNull(array, "array is required") }));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.util.List<java.lang.String> createAList() {
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "createAList", java.util.List.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.util.Map<java.lang.String, java.lang.String> createAMap() {
+        return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "createAMap", java.util.Map.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.util.List<java.lang.String> getStaticArray() {
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticArray", java.util.List.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static void setStaticArray(final java.util.List<java.lang.String> value) {
+        software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticArray", java.util.Objects.requireNonNull(value, "staticArray is required"));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.util.Map<java.lang.String, java.lang.String> getStaticMap() {
+        return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticMap", java.util.Map.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static void setStaticMap(final java.util.Map<java.lang.String, java.lang.String> value) {
+        software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticMap", java.util.Objects.requireNonNull(value, "staticMap is required"));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public java.util.List<java.lang.String> getArray() {
+        return java.util.Collections.unmodifiableList(this.jsiiGet("array", java.util.List.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public void setArray(final java.util.List<java.lang.String> value) {
+        this.jsiiSet("array", java.util.Objects.requireNonNull(value, "array is required"));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public java.util.Map<java.lang.String, java.lang.String> getMap() {
+        return java.util.Collections.unmodifiableMap(this.jsiiGet("map", java.util.Map.class));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public void setMap(final java.util.Map<java.lang.String, java.lang.String> value) {
+        this.jsiiSet("map", java.util.Objects.requireNonNull(value, "map is required"));
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithDocs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithDocs.java
@@ -24,6 +24,7 @@ public class ClassWithDocs extends software.amazon.jsii.JsiiObject {
     protected ClassWithDocs(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ClassWithDocs() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
@@ -15,6 +15,7 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
     protected ClassWithJavaReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
@@ -15,6 +15,7 @@ public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.
     protected ClassWithMutableObjectLiteralProperty(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ClassWithMutableObjectLiteralProperty() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -15,6 +15,7 @@ public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
     protected ConstructorPassesThisOut(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
@@ -15,6 +15,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
     protected Constructors(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Constructors() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
@@ -33,7 +34,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenInterfaces() {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterfaces", java.util.List.class);
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterfaces", java.util.List.class));
     }
 
     /**
@@ -41,7 +42,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenSubInterfaces() {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenSubInterfaces", java.util.List.class);
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenSubInterfaces", java.util.List.class));
     }
 
     /**
@@ -73,6 +74,6 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> makeInterfaces() {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterfaces", java.util.List.class);
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterfaces", java.util.List.class));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -15,6 +15,7 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
     protected ConsumersOfThisCrazyTypeSystem(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ConsumersOfThisCrazyTypeSystem() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
@@ -17,6 +17,7 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
     protected DataRenderer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -15,6 +15,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
     protected DefaultedConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -23,6 +24,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 }));
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -31,6 +33,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 }));
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -39,6 +42,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
@@ -16,6 +16,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
     protected DeprecatedClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * @deprecated this constructor is "just" okay
      */
@@ -25,6 +26,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
+
     /**
      * @deprecated this constructor is "just" okay
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -7,6 +7,7 @@ package software.amazon.jsii.tests.calculator;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * @deprecated well, yeah
      */
@@ -22,13 +23,12 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DeprecatedStruct}
      */
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String readonlyProperty;
 
         /**
@@ -54,7 +54,6 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
         public DeprecatedStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }
-
     }
 
     /**
@@ -74,7 +73,6 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
             this.setObjRef(objRef);
             this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -112,6 +110,5 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
             int result = this.readonlyProperty.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
@@ -15,6 +15,7 @@ public class Base extends software.amazon.jsii.JsiiObject {
     protected Base(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Base() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Derived.java
@@ -15,6 +15,7 @@ public class Derived extends software.amazon.jsii.tests.calculator.DerivedClassH
     protected Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Derived() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.lib.MyFirstStruct {
+
     /**
      * EXPERIMENTAL
      */
@@ -55,12 +56,11 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DerivedStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.time.Instant anotherRequired;
         private java.lang.Boolean bool;
         private software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive;
@@ -182,7 +182,6 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         public DerivedStruct build() {
             return new Jsii$Proxy(anotherRequired, bool, nonPrimitive, anotherOptional, optionalAny, optionalArray, anumber, astring, firstOptional);
         }
-
     }
 
     /**
@@ -217,7 +216,6 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
             this.astring = this.jsiiGet("astring", java.lang.String.class);
             this.firstOptional = this.jsiiGet("firstOptional", java.util.List.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -335,6 +333,5 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
             result = 31 * result + (this.firstOptional != null ? this.firstOptional.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DiamondInheritanceBaseLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String baseLevelProperty;
 
         /**
@@ -47,7 +47,6 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
         public DiamondInheritanceBaseLevelStruct build() {
             return new Jsii$Proxy(baseLevelProperty);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
             this.setObjRef(objRef);
             this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -104,6 +102,5 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
             int result = this.baseLevelProperty.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DiamondInheritanceFirstMidLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String firstMidLevelProperty;
         private java.lang.String baseLevelProperty;
 
@@ -59,7 +59,6 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
         public DiamondInheritanceFirstMidLevelStruct build() {
             return new Jsii$Proxy(firstMidLevelProperty, baseLevelProperty);
         }
-
     }
 
     /**
@@ -80,7 +79,6 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
             this.firstMidLevelProperty = this.jsiiGet("firstMidLevelProperty", java.lang.String.class);
             this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -127,6 +125,5 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
             result = 31 * result + (this.baseLevelProperty.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceBaseLevelStruct {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DiamondInheritanceSecondMidLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String secondMidLevelProperty;
         private java.lang.String baseLevelProperty;
 
@@ -59,7 +59,6 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
         public DiamondInheritanceSecondMidLevelStruct build() {
             return new Jsii$Proxy(secondMidLevelProperty, baseLevelProperty);
         }
-
     }
 
     /**
@@ -80,7 +79,6 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
             this.secondMidLevelProperty = this.jsiiGet("secondMidLevelProperty", java.lang.String.class);
             this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -127,6 +125,5 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
             result = 31 * result + (this.baseLevelProperty.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.DiamondInheritanceFirstMidLevelStruct, software.amazon.jsii.tests.calculator.DiamondInheritanceSecondMidLevelStruct {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link DiamondInheritanceTopLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String topLevelProperty;
         private java.lang.String firstMidLevelProperty;
         private java.lang.String baseLevelProperty;
@@ -83,7 +83,6 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         public DiamondInheritanceTopLevelStruct build() {
             return new Jsii$Proxy(topLevelProperty, firstMidLevelProperty, baseLevelProperty, secondMidLevelProperty);
         }
-
     }
 
     /**
@@ -108,7 +107,6 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
             this.baseLevelProperty = this.jsiiGet("baseLevelProperty", java.lang.String.class);
             this.secondMidLevelProperty = this.jsiiGet("secondMidLevelProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -173,6 +171,5 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
             result = 31 * result + (this.secondMidLevelProperty.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -15,6 +15,7 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
     protected DoNotOverridePrivates(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public DoNotOverridePrivates() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -17,6 +17,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
     protected DoNotRecognizeAnyAsOptional(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public DoNotRecognizeAnyAsOptional() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
@@ -20,6 +20,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
     protected DocumentedClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public DocumentedClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -15,6 +15,7 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
     protected DontComplainAboutVariadicAfterOptional(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public DontComplainAboutVariadicAfterOptional() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
@@ -15,6 +15,7 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
     protected DoubleTrouble(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public DoubleTrouble() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -15,6 +15,7 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
     protected EraseUndefinedHashValues(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public EraseUndefinedHashValues() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -25,12 +26,11 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link EraseUndefinedHashValuesOptions}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String option1;
         private java.lang.String option2;
 
@@ -65,7 +65,6 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
         public EraseUndefinedHashValuesOptions build() {
             return new Jsii$Proxy(option1, option2);
         }
-
     }
 
     /**
@@ -86,7 +85,6 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
             this.option1 = this.jsiiGet("option1", java.lang.String.class);
             this.option2 = this.jsiiGet("option2", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -137,6 +135,5 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
             result = 31 * result + (this.option2 != null ? this.option2.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
@@ -15,6 +15,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
     protected ExperimentalClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -23,6 +24,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link ExperimentalStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String readonlyProperty;
 
         /**
@@ -47,7 +47,6 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
         public ExperimentalStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
             this.setObjRef(objRef);
             this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -104,6 +102,5 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
             int result = this.readonlyProperty.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -15,6 +15,7 @@ public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
     protected ExportedBaseClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -25,12 +26,11 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link ExtendsInternalInterface}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Boolean boom;
         private java.lang.String prop;
 
@@ -65,7 +65,6 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
         public ExtendsInternalInterface build() {
             return new Jsii$Proxy(boom, prop);
         }
-
     }
 
     /**
@@ -86,7 +85,6 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
             this.boom = this.jsiiGet("boom", java.lang.Boolean.class);
             this.prop = this.jsiiGet("prop", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -133,6 +131,5 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
             result = 31 * result + (this.prop.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -15,6 +15,7 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
     protected GiveMeStructs(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public GiveMeStructs() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Greetee extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * The name of the greetee.
      * 
@@ -25,12 +26,11 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link Greetee}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String name;
 
         /**
@@ -53,7 +53,6 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
         public Greetee build() {
             return new Jsii$Proxy(name);
         }
-
     }
 
     /**
@@ -72,7 +71,6 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
             this.setObjRef(objRef);
             this.name = this.jsiiGet("name", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -112,6 +110,5 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
             int result = this.name != null ? this.name.hashCode() : 0;
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -15,6 +15,7 @@ public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
     protected GreetingAugmenter(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public GreetingAugmenter() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -16,7 +17,6 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
      * EXPERIMENTAL
      */
     void setA(final java.lang.String value);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
@@ -7,6 +7,7 @@ package software.amazon.jsii.tests.calculator;
 @Deprecated
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
 public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * @deprecated could be better
      */
@@ -25,7 +26,6 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
     @Deprecated
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     void method();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IExperimentalInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -22,7 +23,6 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void method();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -23,7 +24,6 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
      */
     void setPrivateValue(final java.lang.String value);
 
-
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
@@ -39,7 +39,7 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public java.util.List<java.lang.String> getMoreThings() {
-            return this.jsiiGet("moreThings", java.util.List.class);
+            return java.util.Collections.unmodifiableList(this.jsiiGet("moreThings", java.util.List.class));
         }
 
         /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.lib.IFriendly {
+
     /**
      * Say farewell.
      * 
@@ -25,7 +26,6 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String goodbye();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
@@ -8,12 +8,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceImplementedByAbstractClass extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getPropFromInterface();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -8,12 +8,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IInterfaceWithMethods {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String getOtherValue();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithInternal.java
@@ -6,12 +6,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithInternal extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void visible();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -17,7 +18,6 @@ public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializ
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void doThings();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithOptionalMethodArguments extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,7 +20,6 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void hello(final java.lang.String arg1);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -22,7 +23,6 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     void setReadWriteString(final java.lang.String value);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IInterfaceWithProperties {
+
     /**
      * EXPERIMENTAL
      */
@@ -16,7 +17,6 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
      * EXPERIMENTAL
      */
     void setFoo(final java.lang.Number value);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IJSII417PublicBaseOfBase {
+
     /**
      * EXPERIMENTAL
      */
@@ -23,7 +24,6 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void baz();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -17,7 +18,6 @@ public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSeria
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     void foo();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -16,7 +17,6 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     void setValue(final java.lang.String value);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.IAnotherPublicInterface {
+
     /**
      * EXPERIMENTAL
      */
@@ -27,7 +28,6 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     void setC(final java.lang.String value);
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
@@ -6,12 +6,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Boolean getSuccess();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
@@ -6,12 +6,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String bye();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
@@ -6,12 +6,12 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.String ciao();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * Returns another random number.
      * 
@@ -17,7 +18,6 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     java.lang.Number next();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -17,7 +18,6 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
@@ -5,6 +5,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
 public interface IStableInterface extends software.amazon.jsii.JsiiSerializable {
+
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -18,7 +19,6 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     void method();
-
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
@@ -15,6 +15,7 @@ public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject 
     protected ImplementInternalInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ImplementInternalInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternal.java
@@ -15,6 +15,7 @@ public class ImplementsInterfaceWithInternal extends software.amazon.jsii.JsiiOb
     protected ImplementsInterfaceWithInternal(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ImplementsInterfaceWithInternal() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsInterfaceWithInternalSubclass.java
@@ -15,6 +15,7 @@ public class ImplementsInterfaceWithInternalSubclass extends software.amazon.jsi
     protected ImplementsInterfaceWithInternalSubclass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ImplementsInterfaceWithInternalSubclass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
@@ -15,6 +15,7 @@ public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject 
     protected ImplementsPrivateInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ImplementsPrivateInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.base.BaseProps {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link ImplictBaseOfBase}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.time.Instant goo;
         private java.lang.String bar;
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
@@ -69,7 +69,6 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         public ImplictBaseOfBase build() {
             return new Jsii$Proxy(goo, bar, foo);
         }
-
     }
 
     /**
@@ -92,7 +91,6 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
             this.bar = this.jsiiGet("bar", java.lang.String.class);
             this.foo = this.jsiiGet("foo", software.amazon.jsii.tests.calculator.baseofbase.Very.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -148,6 +146,5 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
             result = 31 * result + (this.foo.hashCode());
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
@@ -15,6 +15,7 @@ public class InbetweenClass extends software.amazon.jsii.tests.calculator.Public
     protected InbetweenClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public InbetweenClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
@@ -15,6 +15,7 @@ public class Foo extends software.amazon.jsii.JsiiObject {
     protected Foo(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Foo() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator.InterfaceInNamespaceIncludesClasse
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Hello extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link Hello}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Number foo;
 
         /**
@@ -47,7 +47,6 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         public Hello build() {
             return new Jsii$Proxy(foo);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             this.setObjRef(objRef);
             this.foo = this.jsiiGet("foo", java.lang.Number.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -104,6 +102,5 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             int result = this.foo.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator.InterfaceInNamespaceOnlyInterface;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface Hello extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link Hello}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Number foo;
 
         /**
@@ -47,7 +47,6 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         public Hello build() {
             return new Jsii$Proxy(foo);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             this.setObjRef(objRef);
             this.foo = this.jsiiGet("foo", java.lang.Number.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -104,6 +102,5 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
             int result = this.foo.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
@@ -23,6 +23,6 @@ public class InterfacesMaker extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public static java.util.List<software.amazon.jsii.tests.calculator.lib.IDoublable> makeInterfaces(final java.lang.Number count) {
-        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfacesMaker.class, "makeInterfaces", java.util.List.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfacesMaker.class, "makeInterfaces", java.util.List.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") }));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -15,6 +15,7 @@ public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII41
     protected JSII417Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
@@ -15,6 +15,7 @@ public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
     protected JSII417PublicBaseOfBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JSII417PublicBaseOfBase() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
@@ -15,6 +15,7 @@ public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject
     protected JSObjectLiteralForInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JSObjectLiteralForInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
@@ -15,6 +15,7 @@ public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
     protected JSObjectLiteralToNative(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JSObjectLiteralToNative() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
@@ -15,6 +15,7 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
     protected JSObjectLiteralToNativeClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JSObjectLiteralToNativeClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
@@ -15,6 +15,7 @@ public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
     protected JavaReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JavaReservedWords() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii487Derived.java
@@ -15,6 +15,7 @@ public class Jsii487Derived extends software.amazon.jsii.JsiiObject implements s
     protected Jsii487Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Jsii487Derived() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Jsii496Derived.java
@@ -15,6 +15,7 @@ public class Jsii496Derived extends software.amazon.jsii.JsiiObject implements s
     protected Jsii496Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Jsii496Derived() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
@@ -17,6 +17,7 @@ public class JsiiAgent extends software.amazon.jsii.JsiiObject {
     protected JsiiAgent(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public JsiiAgent() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -8,6 +8,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * The container port of the application load balancer attached to your Fargate service.
      * 
@@ -84,12 +85,11 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link LoadBalancedFargateServiceProps}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Number containerPort;
         private java.lang.String cpu;
         private java.lang.String memoryMiB;
@@ -160,7 +160,6 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         public LoadBalancedFargateServiceProps build() {
             return new Jsii$Proxy(containerPort, cpu, memoryMiB, publicLoadBalancer, publicTasks);
         }
-
     }
 
     /**
@@ -187,7 +186,6 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
             this.publicLoadBalancer = this.jsiiGet("publicLoadBalancer", java.lang.Boolean.class);
             this.publicTasks = this.jsiiGet("publicTasks", java.lang.Boolean.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -271,6 +269,5 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
             result = 31 * result + (this.publicTasks != null ? this.publicTasks.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -17,6 +17,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
     protected Multiply(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a BinaryOperation.
      * 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -17,6 +17,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
     protected Negate(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
@@ -17,6 +17,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
     protected NodeStandardLibrary(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public NodeStandardLibrary() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -17,6 +17,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
     protected NullShouldBeTreatedAsUndefined(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -25,6 +26,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -25,12 +26,11 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link NullShouldBeTreatedAsUndefinedData}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument;
         private java.lang.Object thisShouldBeUndefined;
 
@@ -65,7 +65,6 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
         public NullShouldBeTreatedAsUndefinedData build() {
             return new Jsii$Proxy(arrayWithThreeElementsAndUndefinedAsSecondArgument, thisShouldBeUndefined);
         }
-
     }
 
     /**
@@ -86,7 +85,6 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
             this.arrayWithThreeElementsAndUndefinedAsSecondArgument = this.jsiiGet("arrayWithThreeElementsAndUndefinedAsSecondArgument", java.util.List.class);
             this.thisShouldBeUndefined = this.jsiiGet("thisShouldBeUndefined", java.lang.Object.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -135,6 +133,5 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
             result = 31 * result + (this.thisShouldBeUndefined != null ? this.thisShouldBeUndefined.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -17,6 +17,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
     protected NumberGenerator(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -17,6 +17,7 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
     protected ObjectRefsInCollections(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ObjectRefsInCollections() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Old.java
@@ -18,6 +18,7 @@ public class Old extends software.amazon.jsii.JsiiObject {
     protected Old(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Old() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -15,6 +15,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
     protected OptionalConstructorArgument(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -23,6 +24,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -19,12 +20,11 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link OptionalStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String field;
 
         /**
@@ -47,7 +47,6 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
         public OptionalStruct build() {
             return new Jsii$Proxy(field);
         }
-
     }
 
     /**
@@ -66,7 +65,6 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
             this.setObjRef(objRef);
             this.field = this.jsiiGet("field", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -106,6 +104,5 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
             int result = this.field != null ? this.field.hashCode() : 0;
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -15,6 +15,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
     protected OptionalStructConsumer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -23,6 +24,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -15,6 +15,7 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
     protected OverrideReturnsObject(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public OverrideReturnsObject() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -15,7 +15,8 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
     protected PartiallyInitializedThisConsumer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public PartiallyInitializedThisConsumer() {
+
+    protected PartiallyInitializedThisConsumer() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -15,6 +15,7 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
     protected Polymorphism(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Polymorphism() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -17,6 +17,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
     protected Power(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * Creates a Power operation.
      * 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PublicClass.java
@@ -15,6 +15,7 @@ public class PublicClass extends software.amazon.jsii.JsiiObject {
     protected PublicClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public PublicClass() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PythonReservedWords.java
@@ -15,6 +15,7 @@ public class PythonReservedWords extends software.amazon.jsii.JsiiObject {
     protected PythonReservedWords(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public PythonReservedWords() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -17,6 +17,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
     protected ReferenceEnumFromScopedPackage(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ReferenceEnumFromScopedPackage() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
@@ -20,6 +20,7 @@ public class ReturnsPrivateImplementationOfInterface extends software.amazon.jsi
     protected ReturnsPrivateImplementationOfInterface(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public ReturnsPrivateImplementationOfInterface() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -15,6 +15,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
     protected RuntimeTypeChecking(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public RuntimeTypeChecking() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * It's long and required.
      * 
@@ -29,12 +30,11 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link SecondLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String deeperRequiredProp;
         private java.lang.String deeperOptionalProp;
 
@@ -69,7 +69,6 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
         public SecondLevelStruct build() {
             return new Jsii$Proxy(deeperRequiredProp, deeperOptionalProp);
         }
-
     }
 
     /**
@@ -90,7 +89,6 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
             this.deeperRequiredProp = this.jsiiGet("deeperRequiredProp", java.lang.String.class);
             this.deeperOptionalProp = this.jsiiGet("deeperOptionalProp", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -139,6 +137,5 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
             result = 31 * result + (this.deeperOptionalProp != null ? this.deeperOptionalProp.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
@@ -21,6 +21,7 @@ public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
     protected SingleInstanceTwoTypes(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public SingleInstanceTwoTypes() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
@@ -14,6 +14,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     protected StableClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -21,6 +22,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber }));
     }
+
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -5,6 +5,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
 public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -17,12 +18,11 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link StableStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String readonlyProperty;
 
         /**
@@ -45,7 +45,6 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
         public StableStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }
-
     }
 
     /**
@@ -64,7 +63,6 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
             this.setObjRef(objRef);
             this.readonlyProperty = this.jsiiGet("readonlyProperty", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -102,6 +100,5 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
             int result = this.readonlyProperty.hashCode();
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -15,12 +15,14 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     protected Statics(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     static {
         BAR = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "BAR", java.lang.Number.class);
         CONST_OBJ = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "ConstObj", software.amazon.jsii.tests.calculator.DoubleTrouble.class);
         FOO = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "Foo", java.lang.String.class);
         ZOO_BAR = software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "zooBar", java.util.Map.class);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -49,6 +51,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
     public java.lang.String justMethod() {
         return this.jsiiCall("justMethod", java.lang.String.class);
     }
+
     /**
      * Constants may also use all-caps.
      * 
@@ -56,11 +59,13 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static java.lang.Number BAR;
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static software.amazon.jsii.tests.calculator.DoubleTrouble CONST_OBJ;
+
     /**
      * Jsdocs for static property.
      * 
@@ -68,6 +73,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public final static java.lang.String FOO;
+
     /**
      * Constants can also use camelCase.
      * 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
@@ -15,6 +15,7 @@ public class StripInternal extends software.amazon.jsii.JsiiObject {
     protected StripInternal(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public StripInternal() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -15,6 +15,7 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
     protected StructPassing(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public StructPassing() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -37,12 +38,11 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link StructWithJavaReservedWords}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String defaultValue;
         private java.lang.String assertValue;
         private java.lang.String result;
@@ -101,7 +101,6 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         public StructWithJavaReservedWords build() {
             return new Jsii$Proxy(defaultValue, assertValue, result, that);
         }
-
     }
 
     /**
@@ -126,7 +125,6 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
             this.result = this.jsiiGet("result", java.lang.String.class);
             this.that = this.jsiiGet("that", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -197,6 +195,5 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
             result = 31 * result + (this.that != null ? this.that.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
@@ -17,6 +17,7 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
     protected Sum(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -44,7 +45,7 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getParts() {
-        return this.jsiiGet("parts", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("parts", java.util.List.class));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -15,6 +15,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
     protected SyncVirtualMethods(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public SyncVirtualMethods() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Thrower.java
@@ -15,6 +15,7 @@ public class Thrower extends software.amazon.jsii.JsiiObject {
     protected Thrower(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public Thrower() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * This is a required field.
      * 
@@ -37,12 +38,11 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link TopLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.String required;
         private java.lang.Object secondLevel;
         private java.lang.String optional;
@@ -100,7 +100,6 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         public TopLevelStruct build() {
             return new Jsii$Proxy(required, secondLevel, optional);
         }
-
     }
 
     /**
@@ -123,7 +122,6 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
             this.secondLevel = this.jsiiGet("secondLevel", java.lang.Object.class);
             this.optional = this.jsiiGet("optional", java.lang.String.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -181,6 +179,5 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
             result = 31 * result + (this.optional != null ? this.optional.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -17,11 +17,12 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
     protected UnaryOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
+    protected UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") }));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -6,6 +6,7 @@ package software.amazon.jsii.tests.calculator;
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
 public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
+
     /**
      * EXPERIMENTAL
      */
@@ -25,12 +26,11 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
     static Builder builder() {
         return new Builder();
     }
-
     /**
      * A builder for {@link UnionProperties}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    final class Builder {
+    public static final class Builder {
         private java.lang.Object bar;
         private java.lang.Object foo;
 
@@ -98,7 +98,6 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         public UnionProperties build() {
             return new Jsii$Proxy(bar, foo);
         }
-
     }
 
     /**
@@ -119,7 +118,6 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
             this.bar = this.jsiiGet("bar", java.lang.Object.class);
             this.foo = this.jsiiGet("foo", java.lang.Object.class);
         }
-
 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
@@ -168,6 +166,5 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
             result = 31 * result + (this.foo != null ? this.foo.hashCode() : 0);
             return result;
         }
-
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -15,6 +15,7 @@ public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
     protected UseBundledDependency(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public UseBundledDependency() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
@@ -17,6 +17,7 @@ public class UseCalcBase extends software.amazon.jsii.JsiiObject {
     protected UseCalcBase(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public UseCalcBase() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -15,6 +15,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
     protected UsesInterfaceWithProperties(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -15,6 +15,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
     protected VariadicMethod(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      * 
@@ -34,6 +35,6 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {
-        return this.jsiiCall("asArray", java.util.List.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(first, "first is required") }), java.util.Arrays.<Object>stream(others)).toArray(Object[]::new));
+        return java.util.Collections.unmodifiableList(this.jsiiCall("asArray", java.util.List.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(first, "first is required") }), java.util.Arrays.<Object>stream(others)).toArray(Object[]::new)));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -15,6 +15,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
     protected VirtualMethodPlayground(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     public VirtualMethodPlayground() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
@@ -21,7 +21,8 @@ public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
     protected VoidCallback(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public VoidCallback() {
+
+    protected VoidCallback() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
@@ -17,6 +17,7 @@ public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiO
     protected WithPrivatePropertyInConstructor(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
+
     /**
      * EXPERIMENTAL
      */
@@ -25,6 +26,7 @@ public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiO
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { privateField }));
     }
+
     /**
      * EXPERIMENTAL
      */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -17,7 +17,8 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
     protected CompositeOperation(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
         super(initializationMode);
     }
-    public CompositeOperation() {
+
+    protected CompositeOperation() {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
     }
@@ -61,7 +62,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getDecorationPostfixes() {
-        return this.jsiiGet("decorationPostfixes", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("decorationPostfixes", java.util.List.class));
     }
 
     /**
@@ -81,7 +82,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     public java.util.List<java.lang.String> getDecorationPrefixes() {
-        return this.jsiiGet("decorationPrefixes", java.util.List.class);
+        return java.util.Collections.unmodifiableList(this.jsiiGet("decorationPrefixes", java.util.List.class));
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -666,6 +666,92 @@ class CalculatorProps():
         return 'CalculatorProps(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
 
 
+class ClassWithCollections(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithCollections"):
+    """
+    stability
+    :stability: experimental
+    """
+    def __init__(self, map: typing.Mapping[str,str], array: typing.List[str]) -> None:
+        """
+        :param map: -
+        :param array: -
+
+        stability
+        :stability: experimental
+        """
+        jsii.create(ClassWithCollections, self, [map, array])
+
+    @jsii.member(jsii_name="createAList")
+    @classmethod
+    def create_a_list(cls) -> typing.List[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.sinvoke(cls, "createAList", [])
+
+    @jsii.member(jsii_name="createAMap")
+    @classmethod
+    def create_a_map(cls) -> typing.Mapping[str,str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.sinvoke(cls, "createAMap", [])
+
+    @classproperty
+    @jsii.member(jsii_name="staticArray")
+    def static_array(cls) -> typing.List[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.sget(cls, "staticArray")
+
+    @static_array.setter
+    def static_array(cls, value: typing.List[str]):
+        return jsii.sset(cls, "staticArray", value)
+
+    @classproperty
+    @jsii.member(jsii_name="staticMap")
+    def static_map(cls) -> typing.Mapping[str,str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.sget(cls, "staticMap")
+
+    @static_map.setter
+    def static_map(cls, value: typing.Mapping[str,str]):
+        return jsii.sset(cls, "staticMap", value)
+
+    @property
+    @jsii.member(jsii_name="array")
+    def array(self) -> typing.List[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.get(self, "array")
+
+    @array.setter
+    def array(self, value: typing.List[str]):
+        return jsii.set(self, "array", value)
+
+    @property
+    @jsii.member(jsii_name="map")
+    def map(self) -> typing.Mapping[str,str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.get(self, "map")
+
+    @map.setter
+    def map(self, value: typing.Mapping[str,str]):
+        return jsii.set(self, "map", value)
+
+
 class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"):
     """This class has docs.
 
@@ -6660,6 +6746,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "StructWithJavaReservedWords", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "StructWithJavaReservedWords", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -1179,6 +1179,68 @@ ClassThatImplementsThePrivateInterface
       :type: string
 
 
+ClassWithCollections
+^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: ClassWithCollections(map, array)
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.ClassWithCollections;
+
+      .. code-tab:: javascript
+
+         const { ClassWithCollections } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { ClassWithCollections } from 'jsii-calc';
+
+
+
+   :param map: 
+   :type map: string => string
+   :param array: 
+   :type array: string[]
+
+   .. py:staticmethod:: createAList() -> string[]
+
+      :rtype: string[]
+
+
+   .. py:staticmethod:: createAMap() -> string => string
+
+      :rtype: string => string
+
+
+   .. py:attribute:: staticArray
+
+      :type: string[] *(static)*
+
+
+   .. py:attribute:: staticMap
+
+      :type: string => string *(static)*
+
+
+   .. py:attribute:: array
+
+      :type: string[]
+
+
+   .. py:attribute:: map
+
+      :type: string => string
+
+
 ClassWithDocs
 ^^^^^^^^^^^^^
 

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -12,6 +12,7 @@ BinaryOperation
 Calculator
 ClassThatImplementsTheInternalInterface
 ClassThatImplementsThePrivateInterface
+ClassWithCollections
 ClassWithDocs
 ClassWithJavaReservedWords
 ClassWithMutableObjectLiteralProperty

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -245,6 +245,30 @@ assemblies
  │   │   │ └── type: string
  │   │   └─┬ e property (experimental)
  │   │     └── type: string
+ │   ├─┬ class ClassWithCollections (experimental)
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>(map,array) initializer (experimental)
+ │   │   │ └─┬ parameters
+ │   │   │   ├─┬ map
+ │   │   │   │ └── type: Map<string => string>
+ │   │   │   └─┬ array
+ │   │   │     └── type: Array<string>
+ │   │   ├─┬ static createAList() method (experimental)
+ │   │   │ ├── static
+ │   │   │ └── returns: Array<string>
+ │   │   ├─┬ static createAMap() method (experimental)
+ │   │   │ ├── static
+ │   │   │ └── returns: Map<string => string>
+ │   │   ├─┬ static staticArray property (experimental)
+ │   │   │ ├── static
+ │   │   │ └── type: Array<string>
+ │   │   ├─┬ static staticMap property (experimental)
+ │   │   │ ├── static
+ │   │   │ └── type: Map<string => string>
+ │   │   ├─┬ array property (experimental)
+ │   │   │ └── type: Array<string>
+ │   │   └─┬ map property (experimental)
+ │   │     └── type: Map<string => string>
  │   ├─┬ class ClassWithDocs (stable)
  │   │ └─┬ members
  │   │   └── <initializer>() initializer (stable)

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -21,6 +21,7 @@ assemblies
  │   │ └── interfaces: INonInternalInterface
  │   ├─┬ class ClassThatImplementsThePrivateInterface
  │   │ └── interfaces: INonInternalInterface
+ │   ├── class ClassWithCollections
  │   ├── class ClassWithDocs
  │   ├── class ClassWithJavaReservedWords
  │   ├── class ClassWithMutableObjectLiteralProperty

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -102,6 +102,15 @@ assemblies
  │   │   ├── b property
  │   │   ├── c property
  │   │   └── e property
+ │   ├─┬ class ClassWithCollections
+ │   │ └─┬ members
+ │   │   ├── <initializer>(map,array) initializer
+ │   │   ├── static createAList() method
+ │   │   ├── static createAMap() method
+ │   │   ├── static staticArray property
+ │   │   ├── static staticMap property
+ │   │   ├── array property
+ │   │   └── map property
  │   ├─┬ class ClassWithDocs
  │   │ └─┬ members
  │   │   └── <initializer>() initializer

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -13,6 +13,7 @@ assemblies
  │   ├── class Calculator
  │   ├── class ClassThatImplementsTheInternalInterface
  │   ├── class ClassThatImplementsThePrivateInterface
+ │   ├── class ClassWithCollections
  │   ├── class ClassWithDocs
  │   ├── class ClassWithJavaReservedWords
  │   ├── class ClassWithMutableObjectLiteralProperty

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -23,7 +23,7 @@ for (const source of fs.readdirSync(SOURCE_DIR)) {
             expect(
                 errors.find(e => _messageText(e).indexOf(expectation) !== -1),
                 `No error contained: ${expectation}. Errors: \n${errors.map((e, i) => `[${i}] ${e.messageText}`).join('\n')}`
-            ).not.toBe(null);
+            ).toBeDefined();
         }
 
         // Cleaning up...
@@ -34,7 +34,7 @@ for (const source of fs.readdirSync(SOURCE_DIR)) {
             await fs.remove(path.join(SOURCE_DIR, '.jsii'));
             await fs.remove(path.join(SOURCE_DIR, 'tsconfig.json'));
         }
-    });
+    }, 10000);
 }
 
 const MATCH_ERROR_MARKER = '///!MATCH_ERROR:';


### PR DESCRIPTION
This commit wraps JSII primitive collections with immutable Java implementations. This includes wrapping arrays with Collections.unmodifiableList() and maps with Collections.unmodifiableMap(). This helps keep Java collections in sync with Node.

It also includes a refactor to the Java code generator around the generation of builders for objects.

Finally, it fixes a bug in the testing framework (negatives.test.ts) that was checking a value was not null rather than defined. This missed the case of the tests returning undefined.

Fixes #722 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
