### PR TITLE
fix: stack overflow in KernelHost.run()

### DIFF
--- a/packages/jsii-runtime/lib/host.ts
+++ b/packages/jsii-runtime/lib/host.ts
@@ -14,7 +14,11 @@ export class KernelHost {
             return; // done
         }
 
-        this.processRequest(req, () => this.run());
+        this.processRequest(req, () => {
+            // Schedule the call to run on the next event loop iteration to
+            // avoid recursion.
+            setImmediate(() => this.run())
+        });
     }
 
     private callbackHandler(callback: api.Callback) {

--- a/packages/jsii-runtime/package.json
+++ b/packages/jsii-runtime/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc --build && chmod +x bin/jsii-runtime && /bin/bash ./bundle.sh",
     "watch": "tsc --build -w",
-    "test": "/bin/bash test/playback-test.sh",
+    "test": "/bin/bash test/playback-test.sh && node test/stress-test.js",
     "package": "package-js"
   },
   "devDependencies": {

--- a/packages/jsii-runtime/test/stress-test.ts
+++ b/packages/jsii-runtime/test/stress-test.ts
@@ -1,0 +1,26 @@
+import { InputOutput, Input, Output } from "../lib/in-out";
+import { KernelHost } from "../lib/host";
+
+const requestCount = 250000;
+
+class FakeInputOutput extends InputOutput {
+    debug = false;
+    private count: number = 0;
+
+    write(_: Output) { }
+
+    read(): Input | undefined {
+        if(this.count == requestCount) {
+            return undefined;
+        }
+
+        ++this.count;
+        return { api: 'stats' };
+    }
+}
+
+const inout = new FakeInputOutput();
+const host = new KernelHost(inout, { debug: false, noStack: false });
+host.run();
+
+console.info("jsii-runtime stress test succeeded");


### PR DESCRIPTION
Fixes #778. This PR eliminates the mutual recursion between `KernelHost.run()` and `KernelHost.processRequest()` by scheduling the recursive `KernelHost.run()` call to run on the next iteration of the event loop.

The code change has been tested as follows:

- by running the stress-test script with and without the change to confirm that the crash occurs without the change and does not occur with the change;
- by running the unit tests to confirm that behavior is consistent;
- by synthesizing our internal CDK stack and confirming that the crash does not occur and that resources are generated correctly.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
