### PR TITLE
feat: configure AWS logo for NuGet packages

### DIFF
--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -18,7 +18,8 @@
       },
       "dotnet": {
         "namespace": "Amazon.JSII.Tests.CalculatorNamespace",
-        "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
+        "packageId": "Amazon.JSII.Tests.CalculatorPackageId",
+        "iconUrl": "https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png"
       },
       "python": {
         "distName": "jsii-calc",

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -210,6 +210,7 @@
   "schema": "jsii/0.10.0",
   "targets": {
     "dotnet": {
+      "iconUrl": "https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png",
       "namespace": "Amazon.JSII.Tests.CalculatorNamespace",
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
     },
@@ -9615,5 +9616,5 @@
     }
   },
   "version": "0.17.0",
-  "fingerprint": "izzAyIl+j9C+Td89XVvxC7M9UPkjYsYVLhlLCDPsVDY="
+  "fingerprint": "3AZBzWGigiml1w1CpsQCzfmubSSS3F8vFHqddOFLO1Y="
 }

--- a/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
+++ b/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Amazon.JSII.Analyzers.UnitTests</AssemblyName>
   </PropertyGroup>
@@ -20,6 +20,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Amazon.JSII.Analyzers\Amazon.JSII.Analyzers.csproj" />
   </ItemGroup>
-  
-  
+
+
 </Project>

--- a/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
+++ b/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
@@ -4,8 +4,9 @@
     <PropertyGroup>
         <PackageId>Amazon.JSII.Analyzers</PackageId>
         <Title>.NET Roslyn Analyzers for JSII</Title>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
     </PropertyGroup>
 
     <ItemGroup>

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Amazon.JSII.JsonModel.csproj
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Amazon.JSII.JsonModel.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <PackageId>Amazon.JSII.JsonModel</PackageId>
     <Title>.NET JsonModel for JSII</Title>
+    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <PackageId>Amazon.JSII.Runtime</PackageId>
     <Title>.NET Runtime for JSII</Title>
+    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/jsii-kernel/test/kernel.test.ts
+++ b/packages/jsii-kernel/test/kernel.test.ts
@@ -203,6 +203,7 @@ defineTest('objects created inside the sandbox are returned with type info and n
 defineTest('naming allows returns the module name for different languages', (sandbox) => {
   expect(sandbox.naming({ assembly: 'jsii-calc' }).naming).toEqual({
     dotnet: {
+      iconUrl: 'https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png',
       namespace: 'Amazon.JSII.Tests.CalculatorNamespace',
       packageId: 'Amazon.JSII.Tests.CalculatorPackageId',
     },
@@ -562,9 +563,9 @@ defineTest('sync overrides: properties - readwrite', (sandbox) => {
       expect(callback.set.property).toBe('theProperty');
       setValue = callback.set.value;
       return undefined;
-    } 
+    }
     throw new Error('Invalid callback. Expected get/set');
-    
+
   });
 
   const value = sandbox.invoke({ objref: obj, method: 'retrieveValueOfTheProperty' });
@@ -591,9 +592,9 @@ defineTest('sync overrides: properties - readwrite (backed by functions)', (sand
       expect(callback.set.property).toBe('otherProperty');
       setValue = callback.set.value;
       return undefined;
-    } 
+    }
     throw new Error('Invalid callback. Expected get/set');
-    
+
   });
 
   const value = sandbox.invoke({ objref: obj, method: 'retrieveOtherProperty' });

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -55,7 +55,7 @@ export default class Dotnet extends Target {
     await this.copyFiles(
       path.join(sourceDir, packageId, 'bin', 'Release'),
       outDir);
-    await fs.remove(path.join(outDir, 'netstandard2.0'));
+    await fs.remove(path.join(outDir, 'netcoreapp2.1'));
   }
 
   private async generateNuGetConfigForLocalDeps(sourceDirectory: string, currentOutputDirectory: string): Promise<void> {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -210,6 +210,7 @@
   "schema": "jsii/0.10.0",
   "targets": {
     "dotnet": {
+      "iconUrl": "https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png",
       "namespace": "Amazon.JSII.Tests.CalculatorNamespace",
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
     },
@@ -9615,5 +9616,5 @@
     }
   },
   "version": "0.17.0",
-  "fingerprint": "izzAyIl+j9C+Td89XVvxC7M9UPkjYsYVLhlLCDPsVDY="
+  "fingerprint": "3AZBzWGigiml1w1CpsQCzfmubSSS3F8vFHqddOFLO1Y="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
@@ -12,6 +12,7 @@
     <LicenseUrl>https://spdx.org/licenses/Apache-2.0.html</LicenseUrl>
     <Authors>Amazon Web Services</Authors>
     <Language>en-US</Language>
+    <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="jsii-calc-0.17.0.tgz"/>

--- a/packages/jsii-ruby-runtime/project/Gemfile.lock
+++ b/packages/jsii-ruby-runtime/project/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jsii_runtime (0.16.0)
+    jsii_runtime (0.17.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/jsii/test/negatives/.gitignore
+++ b/packages/jsii/test/negatives/.gitignore
@@ -1,1 +1,2 @@
 !mylib.d.ts
+tsconfig.json


### PR DESCRIPTION
Configure a `PackageIconUrl` on all the NuGet packages, so as to have a
somewhat consistent branding experience. Currently, the AWS logo is
being used; this may later be replaced by a `jsii` logo if/when we get
one.

Fixes #773 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
