### PR TITLE
feat(java): offer short-hand list setter in builders

### DIFF
--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -83,6 +83,18 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
+         * Sets the value of FirstOptional
+         * @param firstOptional the value to be set.
+         * @return {@code this}
+         */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
+        public Builder firstOptional(java.lang.String... firstOptional) {
+            this.firstOptional = java.util.Collections.unmodifiableList(java.util.Arrays.<java.lang.String>asList(firstOptional));
+            return this;
+        }
+
+        /**
          * Builds the configured instance.
          * @return a new instance of {@link MyFirstStruct}
          * @throws NullPointerException if any required attribute was not provided

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -138,6 +138,17 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
+         * Sets the value of OptionalArray
+         * @param optionalArray the value to be set.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder optionalArray(java.lang.String... optionalArray) {
+            this.optionalArray = java.util.Collections.unmodifiableList(java.util.Arrays.<java.lang.String>asList(optionalArray));
+            return this;
+        }
+
+        /**
          * Sets the value of Anumber
          * @param anumber An awesome number value. This parameter is required.
          * @return {@code this}
@@ -170,6 +181,18 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         public Builder firstOptional(java.util.List<java.lang.String> firstOptional) {
             this.firstOptional = firstOptional;
+            return this;
+        }
+
+        /**
+         * Sets the value of FirstOptional
+         * @param firstOptional the value to be set.
+         * @return {@code this}
+         */
+        @Deprecated
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
+        public Builder firstOptional(java.lang.String... firstOptional) {
+            this.firstOptional = java.util.Collections.unmodifiableList(java.util.Arrays.<java.lang.String>asList(firstOptional));
             return this;
         }
 


### PR DESCRIPTION
Leverage Java variadic methods to provide a list setter for builders
that converts the variadic parameter to a list (using `Arrays.asList`)
except if that is ambiguous (`List<Object>`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
