### PR TITLE
feat(kernel): annotate implemented interfaces on "ObjRef"s

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "bump": "bash scripts/bump.sh",
     "fetch-dotnet-snk": "bash scripts/fetch-dotnet-snk.sh",
     "install-local-packages": "node scripts/install-local-packages.js",
-    "package": "bash scripts/package.sh"
+    "package": "bash scripts/package.sh",
+    "test": "lerna run test --stream"
   },
   "devDependencies": {
     "@types/node": "^8.10.54",

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1880,3 +1880,23 @@ export class ClassWithCollections {
         return {'key1': 'value1', 'key2': 'value2'};
     }
 }
+
+/**
+ * We can return an anonymous interface implementation from an override without losing the interface
+ * declarations.
+ */
+export interface IAnonymousImplementationProvider {
+    provide(): IAnonymouslyImplementMe;
+}
+export class AnonymousImplementationProvider implements IAnonymousImplementationProvider {
+    public provide(): IAnonymouslyImplementMe {
+        return {
+            value: 1337,
+            verb() { return 'to implement'; },
+        };
+    }
+}
+export interface IAnonymouslyImplementMe {
+    value: number;
+    verb(): string;
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1034,6 +1034,41 @@
       ],
       "name": "AllowedMethodNames"
     },
+    "jsii-calc.AnonymousImplementationProvider": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.AnonymousImplementationProvider",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IAnonymousImplementationProvider"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1891
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1892
+          },
+          "name": "provide",
+          "overrides": "jsii-calc.IAnonymousImplementationProvider",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.IAnonymouslyImplementMe"
+            }
+          }
+        }
+      ],
+      "name": "AnonymousImplementationProvider"
+    },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
       "docs": {
@@ -3796,6 +3831,85 @@
         }
       ],
       "name": "GreetingAugmenter"
+    },
+    "jsii-calc.IAnonymousImplementationProvider": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "We can return an anonymous interface implementation from an override without losing the interface declarations."
+      },
+      "fqn": "jsii-calc.IAnonymousImplementationProvider",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1888
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1889
+          },
+          "name": "provide",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.IAnonymouslyImplementMe"
+            }
+          }
+        }
+      ],
+      "name": "IAnonymousImplementationProvider"
+    },
+    "jsii-calc.IAnonymouslyImplementMe": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.IAnonymouslyImplementMe",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1899
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1901
+          },
+          "name": "verb",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IAnonymouslyImplementMe",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1900
+          },
+          "name": "value",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
     },
     "jsii-calc.IAnotherPublicInterface": {
       "assembly": "jsii-calc",
@@ -9617,5 +9731,5 @@
     }
   },
   "version": "0.17.0",
-  "fingerprint": "0rRLU+O4hydb2vIjisfE/CmN7SzcwuHuf1lZMR5qwJg="
+  "fingerprint": "Qt/kBLkuUPM6aMutORjHa2+23lDPZD7iVm58r8frz70="
 }

--- a/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/jsii-java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -198,6 +198,9 @@ public final class JsiiEngine implements JsiiCallbackHandler {
      * @return The Java class name.
      */
     private Class<?> resolveJavaClass(final String fqn) throws ClassNotFoundException {
+        if ("Object".equals(fqn)) {
+            return JsiiObject.class;
+        }
         String[] parts = fqn.split("\\.");
         if (parts.length < 2) {
             throw new JsiiException("Malformed FQN: " + fqn);

--- a/packages/jsii-kernel/lib/api.ts
+++ b/packages/jsii-kernel/lib/api.ts
@@ -1,9 +1,14 @@
 export const TOKEN_REF = '$jsii.byref';
+export const TOKEN_INTERFACES = '$jsii.interfaces';
 export const TOKEN_DATE = '$jsii.date';
 export const TOKEN_ENUM = '$jsii.enum';
 
 export interface ObjRef {
   [TOKEN_REF]: string;
+}
+
+export interface AnnotatedObjRef extends ObjRef {
+  [TOKEN_INTERFACES]?: string[];
 }
 
 export function isObjRef(value: any): value is ObjRef {
@@ -75,13 +80,29 @@ export interface LoadResponse {
 }
 
 export interface CreateRequest {
+  /**
+   * The FQN of the class of which an instance is requested (or "Object")
+   */
   fqn: string;
+  /**
+   * The FQNs of interfaces the instance implements, if any. Declaring
+   * interfaces that the class denoted by `fqn` implements is not necessary.
+   * This means that memebers of interfaces found in this property should
+   * declare members that are found in the `overrides` property.
+   */
+  interfaces?: string[];
+  /**
+   * Arguments to pass to the constructor of `fqn`. ("Object" accepts none)
+   */
   args?: any[];
+  /**
+   * Declarations of method overrides that should trigger callbacks
+   */
   overrides?: Override[];
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
-export interface CreateResponse extends ObjRef {}
+export interface CreateResponse extends AnnotatedObjRef {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface DelRequest {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1034,6 +1034,41 @@
       ],
       "name": "AllowedMethodNames"
     },
+    "jsii-calc.AnonymousImplementationProvider": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.AnonymousImplementationProvider",
+      "initializer": {},
+      "interfaces": [
+        "jsii-calc.IAnonymousImplementationProvider"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1891
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1892
+          },
+          "name": "provide",
+          "overrides": "jsii-calc.IAnonymousImplementationProvider",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.IAnonymouslyImplementMe"
+            }
+          }
+        }
+      ],
+      "name": "AnonymousImplementationProvider"
+    },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
       "docs": {
@@ -3796,6 +3831,85 @@
         }
       ],
       "name": "GreetingAugmenter"
+    },
+    "jsii-calc.IAnonymousImplementationProvider": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "We can return an anonymous interface implementation from an override without losing the interface declarations."
+      },
+      "fqn": "jsii-calc.IAnonymousImplementationProvider",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1888
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1889
+          },
+          "name": "provide",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.IAnonymouslyImplementMe"
+            }
+          }
+        }
+      ],
+      "name": "IAnonymousImplementationProvider"
+    },
+    "jsii-calc.IAnonymouslyImplementMe": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.IAnonymouslyImplementMe",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1899
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1901
+          },
+          "name": "verb",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IAnonymouslyImplementMe",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1900
+          },
+          "name": "value",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
     },
     "jsii-calc.IAnotherPublicInterface": {
       "assembly": "jsii-calc",
@@ -9617,5 +9731,5 @@
     }
   },
   "version": "0.17.0",
-  "fingerprint": "0rRLU+O4hydb2vIjisfE/CmN7SzcwuHuf1lZMR5qwJg="
+  "fingerprint": "Qt/kBLkuUPM6aMutORjHa2+23lDPZD7iVm58r8frz70="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AnonymousImplementationProvider.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AnonymousImplementationProvider.cs
@@ -1,0 +1,32 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AnonymousImplementationProvider), fullyQualifiedName: "jsii-calc.AnonymousImplementationProvider")]
+    public class AnonymousImplementationProvider : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IAnonymousImplementationProvider
+    {
+        public AnonymousImplementationProvider(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        protected AnonymousImplementationProvider(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected AnonymousImplementationProvider(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "provide", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IAnonymouslyImplementMe\"}}", isOverride: true)]
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe Provide()
+        {
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymousImplementationProvider.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymousImplementationProvider.cs
@@ -1,0 +1,18 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>We can return an anonymous interface implementation from an override without losing the interface declarations.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IAnonymousImplementationProvider), fullyQualifiedName: "jsii-calc.IAnonymousImplementationProvider")]
+    public interface IAnonymousImplementationProvider
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "provide", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IAnonymouslyImplementMe\"}}")]
+        Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe Provide();
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymousImplementationProviderProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymousImplementationProviderProxy.cs
@@ -1,0 +1,25 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>We can return an anonymous interface implementation from an override without losing the interface declarations.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IAnonymousImplementationProvider), fullyQualifiedName: "jsii-calc.IAnonymousImplementationProvider")]
+    internal sealed class IAnonymousImplementationProviderProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IAnonymousImplementationProvider
+    {
+        private IAnonymousImplementationProviderProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "provide", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.IAnonymouslyImplementMe\"}}")]
+        public Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe Provide()
+        {
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymouslyImplementMe.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymouslyImplementMe.cs
@@ -1,0 +1,26 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IAnonymouslyImplementMe), fullyQualifiedName: "jsii-calc.IAnonymouslyImplementMe")]
+    public interface IAnonymouslyImplementMe
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        double Value
+        {
+            get;
+            set;
+        }
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "verb", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        string Verb();
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymouslyImplementMeProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IAnonymouslyImplementMeProxy.cs
@@ -1,0 +1,34 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IAnonymouslyImplementMe), fullyQualifiedName: "jsii-calc.IAnonymouslyImplementMe")]
+    internal sealed class IAnonymouslyImplementMeProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe
+    {
+        private IAnonymouslyImplementMeProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "value", typeJson: "{\"primitive\":\"number\"}")]
+        public double Value
+        {
+            get => GetInstanceProperty<double>();
+            set => SetInstanceProperty(value);
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "verb", returnsJson: "{\"type\":{\"primitive\":\"string\"}}")]
+        public string Verb()
+        {
+            return InvokeInstanceMethod<string>(new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -25,6 +25,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.AllTypes": return software.amazon.jsii.tests.calculator.AllTypes.class;
             case "jsii-calc.AllTypesEnum": return software.amazon.jsii.tests.calculator.AllTypesEnum.class;
             case "jsii-calc.AllowedMethodNames": return software.amazon.jsii.tests.calculator.AllowedMethodNames.class;
+            case "jsii-calc.AnonymousImplementationProvider": return software.amazon.jsii.tests.calculator.AnonymousImplementationProvider.class;
             case "jsii-calc.AsyncVirtualMethods": return software.amazon.jsii.tests.calculator.AsyncVirtualMethods.class;
             case "jsii-calc.AugmentableClass": return software.amazon.jsii.tests.calculator.AugmentableClass.class;
             case "jsii-calc.BinaryOperation": return software.amazon.jsii.tests.calculator.BinaryOperation.class;
@@ -68,6 +69,8 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.GiveMeStructs": return software.amazon.jsii.tests.calculator.GiveMeStructs.class;
             case "jsii-calc.Greetee": return software.amazon.jsii.tests.calculator.Greetee.class;
             case "jsii-calc.GreetingAugmenter": return software.amazon.jsii.tests.calculator.GreetingAugmenter.class;
+            case "jsii-calc.IAnonymousImplementationProvider": return software.amazon.jsii.tests.calculator.IAnonymousImplementationProvider.class;
+            case "jsii-calc.IAnonymouslyImplementMe": return software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class;
             case "jsii-calc.IAnotherPublicInterface": return software.amazon.jsii.tests.calculator.IAnotherPublicInterface.class;
             case "jsii-calc.IDeprecatedInterface": return software.amazon.jsii.tests.calculator.IDeprecatedInterface.class;
             case "jsii-calc.IExperimentalInterface": return software.amazon.jsii.tests.calculator.IExperimentalInterface.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AnonymousImplementationProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AnonymousImplementationProvider.java
@@ -1,0 +1,32 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AnonymousImplementationProvider")
+public class AnonymousImplementationProvider extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IAnonymousImplementationProvider {
+
+    protected AnonymousImplementationProvider(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AnonymousImplementationProvider(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    public AnonymousImplementationProvider() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        this.setObjRef(software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this));
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    @Override
+    public software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provide() {
+        return this.jsiiCall("provide", software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
@@ -1,0 +1,36 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * We can return an anonymous interface implementation from an override without losing the interface declarations.
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface IAnonymousImplementationProvider extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provide();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IAnonymousImplementationProvider {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+        }
+
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
+        public software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provide() {
+            return this.jsiiCall("provide", software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
@@ -1,0 +1,63 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface IAnonymouslyImplementMe extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.Number getValue();
+
+    /**
+     * EXPERIMENTAL
+     */
+    void setValue(final java.lang.Number value);
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String verb();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.setObjRef(objRef);
+        }
+
+        /**
+         * EXPERIMENTAL
+         */
+        @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public java.lang.Number getValue() {
+            return this.jsiiGet("value", java.lang.Number.class);
+        }
+
+        /**
+         * EXPERIMENTAL
+         */
+        @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public void setValue(final java.lang.Number value) {
+            this.jsiiSet("value", java.util.Objects.requireNonNull(value, "value is required"));
+        }
+
+        /**
+         * EXPERIMENTAL
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
+        public java.lang.String verb() {
+            return this.jsiiCall("verb", java.lang.String.class);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -1999,6 +1999,120 @@ class GreetingAugmenter(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GreetingAu
         return jsii.invoke(self, "betterGreeting", [friendly])
 
 
+@jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
+class IAnonymousImplementationProvider(jsii.compat.Protocol):
+    """We can return an anonymous interface implementation from an override without losing the interface declarations.
+
+    stability
+    :stability: experimental
+    """
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _IAnonymousImplementationProviderProxy
+
+    @jsii.member(jsii_name="provide")
+    def provide(self) -> "IAnonymouslyImplementMe":
+        """
+        stability
+        :stability: experimental
+        """
+        ...
+
+
+class _IAnonymousImplementationProviderProxy():
+    """We can return an anonymous interface implementation from an override without losing the interface declarations.
+
+    stability
+    :stability: experimental
+    """
+    __jsii_type__ = "jsii-calc.IAnonymousImplementationProvider"
+    @jsii.member(jsii_name="provide")
+    def provide(self) -> "IAnonymouslyImplementMe":
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.invoke(self, "provide", [])
+
+
+@jsii.implements(IAnonymousImplementationProvider)
+class AnonymousImplementationProvider(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AnonymousImplementationProvider"):
+    """
+    stability
+    :stability: experimental
+    """
+    def __init__(self) -> None:
+        jsii.create(AnonymousImplementationProvider, self, [])
+
+    @jsii.member(jsii_name="provide")
+    def provide(self) -> "IAnonymouslyImplementMe":
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.invoke(self, "provide", [])
+
+
+@jsii.interface(jsii_type="jsii-calc.IAnonymouslyImplementMe")
+class IAnonymouslyImplementMe(jsii.compat.Protocol):
+    """
+    stability
+    :stability: experimental
+    """
+    @staticmethod
+    def __jsii_proxy_class__():
+        return _IAnonymouslyImplementMeProxy
+
+    @property
+    @jsii.member(jsii_name="value")
+    def value(self) -> jsii.Number:
+        """
+        stability
+        :stability: experimental
+        """
+        ...
+
+    @value.setter
+    def value(self, value: jsii.Number):
+        ...
+
+    @jsii.member(jsii_name="verb")
+    def verb(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        ...
+
+
+class _IAnonymouslyImplementMeProxy():
+    """
+    stability
+    :stability: experimental
+    """
+    __jsii_type__ = "jsii-calc.IAnonymouslyImplementMe"
+    @property
+    @jsii.member(jsii_name="value")
+    def value(self) -> jsii.Number:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.get(self, "value")
+
+    @value.setter
+    def value(self, value: jsii.Number):
+        return jsii.set(self, "value", value)
+
+    @jsii.member(jsii_name="verb")
+    def verb(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.invoke(self, "verb", [])
+
+
 @jsii.interface(jsii_type="jsii-calc.IAnotherPublicInterface")
 class IAnotherPublicInterface(jsii.compat.Protocol):
     """
@@ -6746,6 +6860,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "StructWithJavaReservedWords", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AnonymousImplementationProvider", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnonymousImplementationProvider", "IAnonymouslyImplementMe", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "StructWithJavaReservedWords", "Sum", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/sphinx/jsii-calc.rst
@@ -614,6 +614,42 @@ AllowedMethodNames
       :type _y: number
 
 
+AnonymousImplementationProvider
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: AnonymousImplementationProvider()
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.AnonymousImplementationProvider;
+
+      .. code-tab:: javascript
+
+         const { AnonymousImplementationProvider } = require('jsii-calc');
+
+      .. code-tab:: typescript
+
+         import { AnonymousImplementationProvider } from 'jsii-calc';
+
+
+
+   :implements: :py:class:`~jsii-calc.IAnonymousImplementationProvider`\ 
+
+   .. py:method:: provide() -> jsii-calc.IAnonymouslyImplementMe
+
+      *Implements* :py:meth:`jsii-calc.IAnonymousImplementationProvider.provide`
+
+      :rtype: :py:class:`~jsii-calc.IAnonymouslyImplementMe`\ 
+
+
 AsyncVirtualMethods
 ^^^^^^^^^^^^^^^^^^^
 
@@ -2823,6 +2859,85 @@ GreetingAugmenter
       :param friendly: 
       :type friendly: :py:class:`@scope/jsii-calc-lib.IFriendly`\ 
       :rtype: string
+
+
+IAnonymousImplementationProvider (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IAnonymousImplementationProvider
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IAnonymousImplementationProvider;
+
+      .. code-tab:: javascript
+
+         // IAnonymousImplementationProvider is an interface
+
+      .. code-tab:: typescript
+
+         import { IAnonymousImplementationProvider } from 'jsii-calc';
+
+
+
+   We can return an anonymous interface implementation from an override without losing the interface declarations.
+
+
+
+
+
+   .. py:method:: provide() -> jsii-calc.IAnonymouslyImplementMe
+
+      :rtype: :py:class:`~jsii-calc.IAnonymouslyImplementMe`\ 
+      :abstract: Yes
+
+
+IAnonymouslyImplementMe (interface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. py:class:: IAnonymouslyImplementMe
+
+   **Language-specific names:**
+
+   .. tabs::
+
+      .. code-tab:: c#
+
+         using Amazon.JSII.Tests.CalculatorNamespace;
+
+      .. code-tab:: java
+
+         import software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe;
+
+      .. code-tab:: javascript
+
+         // IAnonymouslyImplementMe is an interface
+
+      .. code-tab:: typescript
+
+         import { IAnonymouslyImplementMe } from 'jsii-calc';
+
+
+
+
+
+   .. py:attribute:: value
+
+      :type: number
+
+
+   .. py:method:: verb() -> string
+
+      :rtype: string
+      :abstract: Yes
 
 
 IAnotherPublicInterface (interface)

--- a/packages/jsii-reflect/test/classes.expected.txt
+++ b/packages/jsii-reflect/test/classes.expected.txt
@@ -4,6 +4,7 @@ AbstractClassReturner
 Add
 AllTypes
 AllowedMethodNames
+AnonymousImplementationProvider
 AsyncVirtualMethods
 AugmentableClass
 Base

--- a/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.all.expected.txt
@@ -137,6 +137,12 @@ assemblies
  │   │     │ └─┬ _y
  │   │     │   └── type: number
  │   │     └── returns: void
+ │   ├─┬ class AnonymousImplementationProvider (experimental)
+ │   │ ├── interfaces: IAnonymousImplementationProvider
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer (experimental)
+ │   │   └─┬ provide() method (experimental)
+ │   │     └── returns: jsii-calc.IAnonymouslyImplementMe
  │   ├─┬ class AsyncVirtualMethods (experimental)
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer (experimental)
@@ -1461,6 +1467,19 @@ assemblies
  │   │     ├── abstract
  │   │     ├── immutable
  │   │     └── type: Optional<string>
+ │   ├─┬ interface IAnonymousImplementationProvider (experimental)
+ │   │ └─┬ members
+ │   │   └─┬ provide() method (experimental)
+ │   │     ├── abstract
+ │   │     └── returns: jsii-calc.IAnonymouslyImplementMe
+ │   ├─┬ interface IAnonymouslyImplementMe (experimental)
+ │   │ └─┬ members
+ │   │   ├─┬ verb() method (experimental)
+ │   │   │ ├── abstract
+ │   │   │ └── returns: string
+ │   │   └─┬ value property (experimental)
+ │   │     ├── abstract
+ │   │     └── type: number
  │   ├─┬ interface IAnotherPublicInterface (experimental)
  │   │ └─┬ members
  │   │   └─┬ a property (experimental)

--- a/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.inheritance.expected.txt
@@ -10,6 +10,8 @@ assemblies
  │   │ └── base: BinaryOperation
  │   ├── class AllTypes
  │   ├── class AllowedMethodNames
+ │   ├─┬ class AnonymousImplementationProvider
+ │   │ └── interfaces: IAnonymousImplementationProvider
  │   ├── class AsyncVirtualMethods
  │   ├── class AugmentableClass
  │   ├─┬ class BinaryOperation
@@ -137,6 +139,8 @@ assemblies
  │   ├── interface ExperimentalStruct
  │   ├── interface ExtendsInternalInterface
  │   ├── interface Greetee
+ │   ├── interface IAnonymousImplementationProvider
+ │   ├── interface IAnonymouslyImplementMe
  │   ├── interface IAnotherPublicInterface
  │   ├── interface IDeprecatedInterface
  │   ├── interface IExperimentalInterface

--- a/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.members.expected.txt
@@ -54,6 +54,10 @@ assemblies
  │   │   ├── getFoo(withParam) method
  │   │   ├── setBar(_x,_y,_z) method
  │   │   └── setFoo(_x,_y) method
+ │   ├─┬ class AnonymousImplementationProvider
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   └── provide() method
  │   ├─┬ class AsyncVirtualMethods
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -634,6 +638,13 @@ assemblies
  │   ├─┬ interface Greetee
  │   │ └─┬ members
  │   │   └── name property
+ │   ├─┬ interface IAnonymousImplementationProvider
+ │   │ └─┬ members
+ │   │   └── provide() method
+ │   ├─┬ interface IAnonymouslyImplementMe
+ │   │ └─┬ members
+ │   │   ├── verb() method
+ │   │   └── value property
  │   ├─┬ interface IAnotherPublicInterface
  │   │ └─┬ members
  │   │   └── a property

--- a/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
+++ b/packages/jsii-reflect/test/jsii-tree.test.types.expected.txt
@@ -7,6 +7,7 @@ assemblies
  │   ├── class Add
  │   ├── class AllTypes
  │   ├── class AllowedMethodNames
+ │   ├── class AnonymousImplementationProvider
  │   ├── class AsyncVirtualMethods
  │   ├── class AugmentableClass
  │   ├── class BinaryOperation
@@ -102,6 +103,8 @@ assemblies
  │   ├── interface ExperimentalStruct
  │   ├── interface ExtendsInternalInterface
  │   ├── interface Greetee
+ │   ├── interface IAnonymousImplementationProvider
+ │   ├── interface IAnonymouslyImplementMe
  │   ├── interface IAnotherPublicInterface
  │   ├── interface IDeprecatedInterface
  │   ├── interface IExperimentalInterface


### PR DESCRIPTION
Annotating the interfaces implemented by an object instance with the
outbound Object Reference, and allowing the kernel's "create" call to
receive a list of interfaces allows the kernel to use more run-time type
information and operate safer.

Fixes #818

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
