### PR TITLE
fix(dotnet): use snupkg format for dotnet symbol packages

### DIFF
--- a/packages/jsii-build-tools/bin/package-dotnet
+++ b/packages/jsii-build-tools/bin/package-dotnet
@@ -2,6 +2,4 @@
 set -euo pipefail
 rm -fr dist/dotnet
 mkdir -p dist/dotnet
-cp *.nupkg dist/dotnet
-
-
+cp *.nupkg *.snupkg dist/dotnet

--- a/packages/jsii-dotnet-analyzers/.gitignore
+++ b/packages/jsii-dotnet-analyzers/.gitignore
@@ -11,6 +11,7 @@ coverage/
 
 
 *.nupkg
+*.snupkg
 bin/
 cli/
 obj/

--- a/packages/jsii-dotnet-analyzers/NuGet.Metadata.props.t.js
+++ b/packages/jsii-dotnet-analyzers/NuGet.Metadata.props.t.js
@@ -4,6 +4,7 @@ process.stdout.write(`<Project>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>True</IncludeSource>
     <PackageOutputPath>..\\..\\bin\\$(Configuration)\\NuGet\\</PackageOutputPath>
     <PackageVersion>$(JsiiVersion)</PackageVersion>

--- a/packages/jsii-dotnet-analyzers/build.sh
+++ b/packages/jsii-dotnet-analyzers/build.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 dotnet build --force -c Release ./src/Amazon.JSII.Analyzers
 
-cp -f ./bin/Release/NuGet/*.nupkg .
+cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/jsii-dotnet-jsonmodel/.gitignore
+++ b/packages/jsii-dotnet-jsonmodel/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 coverage/
 
 *.nupkg
+*.snupkg
 bin/
 cli/
 obj/

--- a/packages/jsii-dotnet-jsonmodel/NuGet.Metadata.props.t.js
+++ b/packages/jsii-dotnet-jsonmodel/NuGet.Metadata.props.t.js
@@ -4,6 +4,7 @@ process.stdout.write(`<Project>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>True</IncludeSource>
     <PackageOutputPath>..\\..\\bin\\$(Configuration)\\NuGet\\</PackageOutputPath>
     <PackageVersion>$(JsiiVersion)</PackageVersion>

--- a/packages/jsii-dotnet-jsonmodel/build.sh
+++ b/packages/jsii-dotnet-jsonmodel/build.sh
@@ -5,4 +5,4 @@ npm run gen
 
 dotnet build --force -c Release ./src/Amazon.JSII.JsonModel.sln
 
-cp -f ./bin/Release/NuGet/*.nupkg .
+cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/jsii-dotnet-runtime/.gitignore
+++ b/packages/jsii-dotnet-runtime/.gitignore
@@ -20,6 +20,7 @@ coverage/
 
 
 *.nupkg
+*.snupkg
 bin/
 cli/
 obj/

--- a/packages/jsii-dotnet-runtime/NuGet.Metadata.props.t.js
+++ b/packages/jsii-dotnet-runtime/NuGet.Metadata.props.t.js
@@ -4,6 +4,7 @@ process.stdout.write(`<Project>
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>True</IncludeSource>
     <PackageOutputPath>..\\..\\bin\\$(Configuration)\\NuGet\\</PackageOutputPath>
     <PackageVersion>$(JsiiVersion)</PackageVersion>

--- a/packages/jsii-dotnet-runtime/build.sh
+++ b/packages/jsii-dotnet-runtime/build.sh
@@ -11,4 +11,4 @@ rsync -av node_modules/jsii-runtime/webpack/ ${bundle_dir}
 # built before the calc packages are generated.
 dotnet build --force -c Release ./src/Amazon.JSII.Runtime
 
-cp -f ./bin/Release/NuGet/*.nupkg .
+cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -54,6 +54,7 @@ export class FileGenerator {
     propertyGroup.ele('GeneratePackageOnBuild', 'true');
     propertyGroup.ele('GenerateDocumentationFile', 'true');
     propertyGroup.ele('IncludeSymbols', 'true');
+    propertyGroup.ele('SymbolPackageFormat', 'snupkg');
     propertyGroup.ele('IncludeSource', 'true');
     propertyGroup.ele('PackageVersion', this.getDecoratedVersion(assembly));
     propertyGroup.ele('PackageId', packageId);

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
@@ -4,6 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PackageVersion>0.17.0</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId.BasePackageId</PackageId>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
@@ -4,6 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PackageVersion>0.17.0-devpreview</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId.LibPackageId</PackageId>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
@@ -4,6 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSource>true</IncludeSource>
     <PackageVersion>0.17.0</PackageVersion>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId</PackageId>


### PR DESCRIPTION
The legacy format is not supported by NuGet's own symbols server, and the
SymbolSource server is currently experiencing a certificate expiration event,
which seems to be a somewhat recurring issue (NuGet/Home#6082).

More info: https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
