### PR TITLE
feat(jsii): enable strictPropertyInitialization checks

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -28,7 +28,7 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
   resolveJsonModule: true,
   strict: true,
   strictNullChecks: true,
-  strictPropertyInitialization: false,
+  strictPropertyInitialization: true,
   stripInternal: true,
   target: ts.ScriptTarget.ES2017
 };


### PR DESCRIPTION
This will prevent forgotten initialization errors such as the root cause
of aws/aws-cdk#4286.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
