### PR TITLE
fix(jsii): Correct the 'types' attribute in package.json

### DIFF
--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -20,7 +20,7 @@
     "node": ">= 10.3.0"
   },
   "main": "lib/index.js",
-  "types": "lib/index.ts",
+  "types": "lib/index.d.ts",
   "bin": {
     "jsii": "bin/jsii"
   },


### PR DESCRIPTION
index.ts is not part of the tarball. Switch to the declaration file
instead.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
