### PR TITLE
fix(jsii-diff): add 'main' property to package.json

### DIFF
--- a/packages/jsii-diff/package.json
+++ b/packages/jsii-diff/package.json
@@ -19,6 +19,7 @@
   "engines": {
     "node": ">= 10.3.0"
   },
+  "main": "lib/index.js",
   "bin": {
     "jsii-diff": "bin/jsii-diff"
   },


### PR DESCRIPTION
Without the main property, a consuming module cannot `require` it.
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
