### PR TITLE
chore: update gitattributes to recognize common binary types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,11 @@
 # Currently, this repository has LF dependecnies in building and testing, with json, sh, and no extensions.
 # Until this is fixed, it is best to just set the whole repository to be LF.
 * eol=lf
+
+*.gif binary
+*.zip binary
+*.png binary
+*.jpg binary
+*.tgz binary
+*.tar.gz binary
+


### PR DESCRIPTION
PNG files may cause working tree confusion without this change.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
