### PR TITLE
fix(kernel): correct deserialization of structs in union contexts

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -1976,3 +1976,44 @@ class PrivateType extends Implementation implements IAnonymouslyImplementMe {
         return 'to implement';
     }
 }
+
+/**
+ * We can serialize and deserialize structs without silently ignoring optional fields.
+ */
+export interface StructA {
+    readonly requiredString: string;
+    readonly optionalString?: string;
+    readonly optionalNumber?: number;
+}
+/**
+ * This intentionally overlaps with StructA (where only requiredString is provided) to test htat
+ * the kernel properly disambiguates those.
+ */
+export interface StructB {
+    readonly requiredString: string;
+    readonly optionalBoolean?: boolean;
+    readonly optionalStructA?: StructA;
+}
+export class StructUnionConsumer {
+    public static isStructA(struct: StructA | StructB): struct is StructA {
+        const keys = new Set(Object.keys(struct));
+        switch (keys.size) {
+            case 1: return keys.has('requiredString');
+            case 2: return keys.has('requiredString') && (keys.has('optionalNumber') || keys.has('optionalString'));
+            case 3: return keys.has('requiredString') && keys.has('optionalNumber') && keys.has('optionalString');
+            default: return false;
+        }
+    }
+
+    public static isStructB(struct: StructA | StructB): struct is StructB {
+        const keys = new Set(Object.keys(struct));
+        switch (keys.size) {
+            case 1: return keys.has('requiredString');
+            case 2: return keys.has('requiredString') && (keys.has('optionalBoolean') || keys.has('optionalStructA'));
+            case 3: return keys.has('requiredString') && keys.has('optionalBoolean') && keys.has('optionalStructA');
+            default: return false;
+        }
+    }
+
+    private constructor() { }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -8559,6 +8559,134 @@
         }
       ]
     },
+    "jsii-calc.StructA": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental",
+        "summary": "We can serialize and deserialize structs without silently ignoring optional fields."
+      },
+      "fqn": "jsii-calc.StructA",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1983
+      },
+      "name": "StructA",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1984
+          },
+          "name": "requiredString",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1986
+          },
+          "name": "optionalNumber",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1985
+          },
+          "name": "optionalString",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.StructB": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental",
+        "summary": "This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those."
+      },
+      "fqn": "jsii-calc.StructB",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1992
+      },
+      "name": "StructB",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1993
+          },
+          "name": "requiredString",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1994
+          },
+          "name": "optionalBoolean",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1995
+          },
+          "name": "optionalStructA",
+          "optional": true,
+          "type": {
+            "fqn": "jsii-calc.StructA"
+          }
+        }
+      ]
+    },
     "jsii-calc.StructPassing": {
       "assembly": "jsii-calc",
       "docs": {
@@ -8637,6 +8765,87 @@
         }
       ],
       "name": "StructPassing"
+    },
+    "jsii-calc.StructUnionConsumer": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.StructUnionConsumer",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1997
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1998
+          },
+          "name": "isStructA",
+          "parameters": [
+            {
+              "name": "struct",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "jsii-calc.StructA"
+                    },
+                    {
+                      "fqn": "jsii-calc.StructB"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2008
+          },
+          "name": "isStructB",
+          "parameters": [
+            {
+              "name": "struct",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "jsii-calc.StructA"
+                    },
+                    {
+                      "fqn": "jsii-calc.StructB"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "StructUnionConsumer"
     },
     "jsii-calc.StructWithJavaReservedWords": {
       "assembly": "jsii-calc",
@@ -10119,5 +10328,5 @@
     }
   },
   "version": "0.19.0",
-  "fingerprint": "MZT68aeJ7MEeDJORDPKkIyqOqOLC+Yb3LcDU7XrxgCQ="
+  "fingerprint": "x2+sbdlYAHP8MHude74WmIipYqqFoEMnnpxBnz5DvZ0="
 }

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -1015,6 +1015,25 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             Assert.Equal(1337d, provider.ProvideAsInterface().Value);
             Assert.Equal("to implement", provider.ProvideAsInterface().Verb());
         }
+
+        [Fact(DisplayName = Prefix + nameof(CorrectlyDeserializesStructUnions))]
+        public void CorrectlyDeserializesStructUnions()
+        {
+            var a0 = new StructA { RequiredString = "Present!", OptionalString = "Bazinga!" };
+            var a1 = new StructA { RequiredString = "Present!", OptionalNumber = 1337 };
+            var b0 = new StructB { RequiredString = "Present!", OptionalBoolean = true };
+            var b1 = new StructB { RequiredString = "Present!", OptionalStructA = a1 };
+            
+            Assert.True(StructUnionConsumer.IsStructA(a0));
+            Assert.True(StructUnionConsumer.IsStructA(a1));
+            Assert.False(StructUnionConsumer.IsStructA(b0));
+            Assert.False(StructUnionConsumer.IsStructA(b1));
+            
+            Assert.False(StructUnionConsumer.IsStructB(a0));
+            Assert.False(StructUnionConsumer.IsStructB(a1));
+            Assert.True(StructUnionConsumer.IsStructB(b0));
+            Assert.True(StructUnionConsumer.IsStructB(b1));
+        }
         
         class DataRendererSubclass : DataRenderer
         {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/JsiiByValueAttribute.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/JsiiByValueAttribute.cs
@@ -5,5 +5,11 @@ namespace Amazon.JSII.Runtime.Deputy
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class JsiiByValueAttribute : Attribute
     {
+        public JsiiByValueAttribute(string fqn)
+        {
+            Fqn = fqn ?? throw new ArgumentNullException(nameof(fqn));
+        }
+        
+        public string Fqn { get; } 
     }
 }

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -46,9 +46,10 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return true;
             }
 
-            if (Attribute.GetCustomAttribute(value.GetType(), typeof(JsiiByValueAttribute)) != null)
+            var byValueAttribute = value.GetType().GetCustomAttribute<JsiiByValueAttribute>();
+            if (byValueAttribute != null)
             {
-                var resultObject = new JObject();
+                var data = new JObject();
                 foreach (var prop in value.GetType().GetProperties())
                 {
                     var jsiiProperty = (JsiiPropertyAttribute) prop.GetCustomAttribute(typeof(JsiiPropertyAttribute), true);
@@ -68,9 +69,16 @@ namespace Amazon.JSII.Runtime.Services.Converters
                         continue;
                     }
 
-                    resultObject.Add(new JProperty(jsiiProperty.Name, convertedPropValue));
+                    data.Add(new JProperty(jsiiProperty.Name, convertedPropValue));
                 }
 
+                var structInfo = new JObject();
+                structInfo.Add(new JProperty("fqn", byValueAttribute.Fqn));
+                structInfo.Add(new JProperty("data", data));
+                
+                var resultObject = new JObject();
+                resultObject.Add(new JProperty("$jsii.struct", structInfo));
+                
                 result = resultObject;
                 return true;
             }

--- a/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/jsii-java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -1361,6 +1361,36 @@ public class ComplianceTest {
         assertEquals("to implement", provider.provideAsInterface().verb());
     }
 
+    @Test
+    public void correctlyDeserializesStructUnions() {
+        final StructA a0 = StructA.builder()
+                .requiredString("Present!")
+                .optionalString("Bazinga!")
+                .build();
+        final StructA a1 = StructA.builder()
+                .requiredString("Present!")
+                .optionalNumber(1337)
+                .build();
+        final StructB b0 = StructB.builder()
+                .requiredString("Present!")
+                .optionalBoolean(true)
+                .build();
+        final StructB b1 = StructB.builder()
+                .requiredString("Present!")
+                .optionalStructA(a1)
+                .build();
+
+        assertTrue(StructUnionConsumer.isStructA(a0));
+        assertTrue(StructUnionConsumer.isStructA(a1));
+        assertFalse(StructUnionConsumer.isStructA(b0));
+        assertFalse(StructUnionConsumer.isStructA(b1));
+
+        assertFalse(StructUnionConsumer.isStructB(a0));
+        assertFalse(StructUnionConsumer.isStructB(a1));
+        assertTrue(StructUnionConsumer.isStructB(b0));
+        assertTrue(StructUnionConsumer.isStructB(b1));
+    }
+
     static class PartiallyInitializedThisConsumerImpl extends PartiallyInitializedThisConsumer {
         @Override
         public String consumePartiallyInitializedThis(final ConstructorPassesThisOut obj,

--- a/packages/jsii-kernel/lib/api.ts
+++ b/packages/jsii-kernel/lib/api.ts
@@ -3,13 +3,14 @@ export const TOKEN_INTERFACES = '$jsii.interfaces';
 export const TOKEN_DATE = '$jsii.date';
 export const TOKEN_ENUM = '$jsii.enum';
 export const TOKEN_MAP = '$jsii.map';
+export const TOKEN_STRUCT = '$jsii.struct';
 
 export interface ObjRef {
-  [TOKEN_REF]: string;
+  readonly [TOKEN_REF]: string;
 }
 
 export interface AnnotatedObjRef extends ObjRef {
-  [TOKEN_INTERFACES]?: string[];
+  [TOKEN_INTERFACES]?: readonly string[];
 }
 
 export function isObjRef(value: any): value is ObjRef {
@@ -17,7 +18,7 @@ export function isObjRef(value: any): value is ObjRef {
 }
 
 export interface WireDate {
-  [TOKEN_DATE]: string;
+  readonly [TOKEN_DATE]: string;
 }
 
 export function isWireDate(value: any): value is WireDate {
@@ -25,7 +26,7 @@ export function isWireDate(value: any): value is WireDate {
 }
 
 export interface WireEnum {
-  [TOKEN_ENUM]: string;
+  readonly [TOKEN_ENUM]: string;
 }
 
 export function isWireEnum(value: any): value is WireEnum {
@@ -33,18 +34,29 @@ export function isWireEnum(value: any): value is WireEnum {
 }
 
 export interface WireMap {
-  [TOKEN_MAP]: { [key: string]: any };
+  readonly [TOKEN_MAP]: { readonly [key: string]: any };
 }
 
 export function isWireMap(value: any): value is WireMap {
   return typeof value === 'object' && value !== null && TOKEN_MAP in value;
 }
 
+export interface WireStruct {
+  readonly [TOKEN_STRUCT]: {
+    readonly fqn: string;
+    readonly data: { [key: string]: any };
+  };
+}
+
+export function isWireStruct(value: any): value is WireStruct {
+  return typeof value === 'object' && value !== null && TOKEN_STRUCT in value;
+}
+
 export type Override = MethodOverride | PropertyOverride;
 
 export interface MethodOverride {
-  method: string;
-  cookie?: string;
+  readonly method: string;
+  readonly cookie?: string;
 }
 
 export function isMethodOverride(value: Override): value is MethodOverride {
@@ -52,8 +64,8 @@ export function isMethodOverride(value: Override): value is MethodOverride {
 }
 
 export interface PropertyOverride {
-  property: string;
-  cookie?: string;
+  readonly property: string;
+  readonly cookie?: string;
 }
 
 export function isPropertyOverride(value: Override): value is PropertyOverride {
@@ -61,38 +73,38 @@ export function isPropertyOverride(value: Override): value is PropertyOverride {
 }
 
 export interface Callback {
-  cbid: string;
-  cookie: string | undefined;
-  invoke?: InvokeRequest;
-  get?: GetRequest;
-  set?: SetRequest;
+  readonly cbid: string;
+  readonly cookie: string | undefined;
+  readonly invoke?: InvokeRequest;
+  readonly get?: GetRequest;
+  readonly set?: SetRequest;
 }
 
 export interface HelloResponse {
-  hello: string;
+  readonly hello: string;
 }
 
 export interface LoadRequest {
   /** The name of the assembly */
-  name: string;
+  readonly name: string;
 
   /** Assembly version */
-  version: string;
+  readonly version: string;
 
   /** The tarball of the package */
-  tarball: string;
+  readonly tarball: string;
 }
 
 export interface LoadResponse {
-  assembly: string;
-  types: number;
+  readonly assembly: string;
+  readonly types: number;
 }
 
 export interface CreateRequest {
   /**
    * The FQN of the class of which an instance is requested (or "Object")
    */
-  fqn: string;
+  readonly fqn: string;
 
   /**
    * The FQNs of interfaces the instance implements, if any. Declaring
@@ -100,17 +112,17 @@ export interface CreateRequest {
    * This means that memebers of interfaces found in this property should
    * declare members that are found in the `overrides` property.
    */
-  interfaces?: string[];
+  readonly interfaces?: string[];
 
   /**
    * Arguments to pass to the constructor of `fqn`. ("Object" accepts none)
    */
-  args?: any[];
+  readonly args?: any[];
 
   /**
    * Declarations of method overrides that should trigger callbacks
    */
-  overrides?: Override[];
+  readonly overrides?: Override[];
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -118,7 +130,7 @@ export interface CreateResponse extends AnnotatedObjRef {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface DelRequest {
-  objref: ObjRef;
+  readonly objref: ObjRef;
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -126,29 +138,29 @@ export interface DelResponse {}
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface GetRequest {
-  objref: ObjRef;
-  property: string;
+  readonly objref: ObjRef;
+  readonly property: string;
 }
 
 export interface StaticGetRequest {
-  fqn: string;
-  property: string;
+  readonly fqn: string;
+  readonly property: string;
 }
 
 export interface GetResponse {
-  value: any;
+  readonly value: any;
 }
 
 export interface StaticSetRequest {
-  fqn: string;
-  property: string;
-  value: any;
+  readonly fqn: string;
+  readonly property: string;
+  readonly value: any;
 }
 
 export interface SetRequest {
-  objref: ObjRef;
-  property: string;
-  value: any;
+  readonly objref: ObjRef;
+  readonly property: string;
+  readonly value: any;
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -156,37 +168,37 @@ export interface SetResponse { }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface StaticInvokeRequest {
-  fqn: string;
-  method: string;
-  args?: any[];
+  readonly fqn: string;
+  readonly method: string;
+  readonly args?: any[];
 }
 
 export interface InvokeRequest {
-  objref: ObjRef;
-  method: string;
-  args?: any[];
+  readonly objref: ObjRef;
+  readonly method: string;
+  readonly args?: any[];
 }
 
 export interface InvokeResponse {
-  result: any;
+  readonly result: any;
 }
 
 export interface BeginRequest {
-  objref: ObjRef;
-  method: string;
-  args?: any[];
+  readonly objref: ObjRef;
+  readonly method: string;
+  readonly args?: any[];
 }
 
 export interface BeginResponse {
-  promiseid: string;
+  readonly promiseid: string;
 }
 
 export interface EndRequest {
-  promiseid: string;
+  readonly promiseid: string;
 }
 
 export interface EndResponse {
-  result: any;
+  readonly result: any;
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -194,25 +206,25 @@ export interface CallbacksRequest { }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface CallbacksResponse {
-  callbacks: Callback[];
+  readonly callbacks: Callback[];
 }
 
 export interface CompleteRequest {
-  cbid: string;
-  err?: string;
-  result?: any;
+  readonly cbid: string;
+  readonly err?: string;
+  readonly result?: any;
 }
 
 export interface CompleteResponse {
-  cbid: string;
+  readonly cbid: string;
 }
 
 export interface NamingRequest {
-  assembly: string;
+  readonly assembly: string;
 }
 
 export interface NamingResponse {
-  naming: { [language: string]: { [key: string]: any } | undefined };
+  readonly naming: { readonly [language: string]: { readonly [key: string]: any } | undefined };
 }
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -220,7 +232,7 @@ export interface StatsRequest { }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface StatsResponse {
-  objectCount: number;
+  readonly objectCount: number;
 }
 
 export type KernelRequest =
@@ -253,10 +265,10 @@ export type KernelResponse =
     StatsResponse;
 
 export interface OkayResponse {
-  ok: any;
+  readonly ok: any;
 }
 
 export interface ErrorResponse {
-  error: string;
-  stack?: string;
+  readonly error: string;
+  readonly stack?: string;
 }

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -544,15 +544,15 @@ export class DotNetGenerator extends Generator {
      * This is used to emit a class implementing an interface when the datatype property is true in the jsii model
      * The generation of the interface proxy may not be needed if the interface is also set as a datatype
      */
-  private emitInterfaceDataType(ifc: spec.InterfaceType | spec.ClassType): void {
+  private emitInterfaceDataType(ifc: spec.InterfaceType): void {
     // Interface datatypes do not need to be prefixed by I, we can call convertClassName
-    const name = this.nameutils.convertClassName(ifc as spec.ClassType);
+    const name = this.nameutils.convertClassName(ifc);
     const namespace = ifc.namespace ? `${this.assembly.targets!.dotnet!.namespace}.${ifc.namespace}` : this.assembly.targets!.dotnet!.namespace;
     const isNested = this.isNested(ifc);
     this.openFileIfNeeded(name, namespace, isNested);
     this.dotnetDocGenerator.emitDocs(ifc);
     const suffix = `: ${this.typeresolver.toNativeFqn(ifc.fqn)}`;
-    this.dotnetRuntimeGenerator.emitAttributesForInterfaceDatatype();
+    this.dotnetRuntimeGenerator.emitAttributesForInterfaceDatatype(ifc);
     this.code.openBlock(`public class ${name} ${suffix}`);
     this.flagFirstMemberWritten(false);
     const datatype = true;

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
@@ -33,10 +33,12 @@ export class DotNetRuntimeGenerator {
   /**
      * Emits the jsii attribute for an interface datatype
      *
-     * Ex: [JsiiByValue]
+     * @param ifc the annotated interface type.
+     *
+     * Ex: [JsiiByValue(fqn: "assembly.TypeName")]
      */
-  public emitAttributesForInterfaceDatatype() {
-    const jsiiAttribute = '[JsiiByValue]';
+  public emitAttributesForInterfaceDatatype(ifc: spec.InterfaceType) {
+    const jsiiAttribute = `[JsiiByValue(fqn: "${ifc.fqn}")]`;
     this.code.line(jsiiAttribute);
   }
 

--- a/packages/jsii-pacmak/lib/targets/dotnet/nameutils.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/nameutils.ts
@@ -38,13 +38,13 @@ export class DotNetNameUtils {
     if (original.datatype) {
       // Datatype interfaces need to be prefixed by I so that they don't clash with the prop object implementation
       return `I${this.capitalizeWord(original.name)}`;
-    } 
+    }
     // Non datatype interfaces are guaranteed by JSII to be prefixed by I already
     return this.capitalizeWord(original.name);
-    
+
   }
 
-  public convertClassName(original: spec.ClassType) {
+  public convertClassName(original: spec.ClassType | spec.InterfaceType) {
     if (this.isInvalidName(original.name)) {
       throw new Error(`Invalid class name: ${original}`);
     }
@@ -102,9 +102,9 @@ export class DotNetNameUtils {
     }
     if (RESERVED_KEYWORDS.includes(name)) {
       return `@${name}`;
-    } 
+    }
     return name;
-    
+
   }
 
   private slugify(name: string): string {

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1256,7 +1256,7 @@ class JavaGenerator extends Generator {
     this.code.line('/**');
     this.code.line(' * Constructor that initializes the object based on literal property values passed by the {@link Builder}.');
     this.code.line(' */');
-    const constructorArgs = props.map(prop => `${prop.fieldJavaType} ${prop.fieldName}`).join(', ');
+    const constructorArgs = props.map(prop => `final ${prop.fieldJavaType} ${prop.fieldName}`).join(', ');
     this.code.openBlock(`private ${INTERFACE_PROXY_CLASS_NAME}(${constructorArgs})`);
     this.code.line('super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);');
     props.forEach(prop => {
@@ -1278,15 +1278,26 @@ class JavaGenerator extends Generator {
     this.code.line();
     this.code.line('@Override');
     this.code.openBlock('public com.fasterxml.jackson.databind.JsonNode $jsii$toJson()');
-    this.code.line('com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;');
-    this.code.line('com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();');
+    this.code.line('final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;');
+    this.code.line('final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();');
 
+    this.code.line();
     for (const prop of props) {
       if (prop.nullable) { this.code.openBlock(`if (this.get${prop.propName}() != null)`); }
-      this.code.line(`obj.set("${prop.spec.name}", om.valueToTree(this.get${prop.propName}()));`);
+      this.code.line(`data.set("${prop.spec.name}", om.valueToTree(this.get${prop.propName}()));`);
       if (prop.nullable) { this.code.closeBlock(); }
     }
 
+    this.code.line();
+    this.code.line('final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();');
+    this.code.line(`struct.set("fqn", om.valueToTree("${ifc.fqn}"));`);
+    this.code.line('struct.set("data", data);');
+
+    this.code.line();
+    this.code.line('final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();');
+    this.code.line('obj.set("$jsii.struct", struct);');
+
+    this.code.line();
     this.code.line('return obj;');
     this.code.closeBlock();
     // End $jsii$toJson

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon/JSII/Tests/CalculatorNamespace/BaseNamespace/BaseProps.cs
@@ -2,7 +2,7 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
 {
-    [JsiiByValue]
+    [JsiiByValue(fqn: "@scope/jsii-calc-base.BaseProps")]
     public class BaseProps : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.IBaseProps
     {
         [JsiiProperty(name: "bar", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -70,7 +70,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String bar, software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+        private Jsii$Proxy(final java.lang.String bar, final software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
             this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
@@ -88,10 +88,19 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("bar", om.valueToTree(this.getBar()));
-            obj.set("foo", om.valueToTree(this.getFoo()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("bar", om.valueToTree(this.getBar()));
+            data.set("foo", om.valueToTree(this.getFoo()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("@scope/jsii-calc-base.BaseProps"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/MyFirstStruct.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// stability: Deprecated
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "@scope/jsii-calc-lib.MyFirstStruct")]
     public class MyFirstStruct : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct
     {
         /// <summary>An awesome number value.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/StructWithOnlyOptionals.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     /// <remarks>
     /// stability: Deprecated
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "@scope/jsii-calc-lib.StructWithOnlyOptionals")]
     public class StructWithOnlyOptionals : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals
     {
         /// <summary>The first optional!</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -122,7 +122,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number anumber, java.lang.String astring, java.util.List<java.lang.String> firstOptional) {
+        private Jsii$Proxy(final java.lang.Number anumber, final java.lang.String astring, final java.util.List<java.lang.String> firstOptional) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.anumber = java.util.Objects.requireNonNull(anumber, "anumber is required");
             this.astring = java.util.Objects.requireNonNull(astring, "astring is required");
@@ -146,13 +146,22 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("anumber", om.valueToTree(this.getAnumber()));
-            obj.set("astring", om.valueToTree(this.getAstring()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("anumber", om.valueToTree(this.getAnumber()));
+            data.set("astring", om.valueToTree(this.getAstring()));
             if (this.getFirstOptional() != null) {
-                obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                data.set("firstOptional", om.valueToTree(this.getFirstOptional()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("@scope/jsii-calc-lib.MyFirstStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -125,7 +125,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String optional1, java.lang.Number optional2, java.lang.Boolean optional3) {
+        private Jsii$Proxy(final java.lang.String optional1, final java.lang.Number optional2, final java.lang.Boolean optional3) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.optional1 = optional1;
             this.optional2 = optional2;
@@ -149,17 +149,26 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getOptional1() != null) {
-                obj.set("optional1", om.valueToTree(this.getOptional1()));
+                data.set("optional1", om.valueToTree(this.getOptional1()));
             }
             if (this.getOptional2() != null) {
-                obj.set("optional2", om.valueToTree(this.getOptional2()));
+                data.set("optional2", om.valueToTree(this.getOptional2()));
             }
             if (this.getOptional3() != null) {
-                obj.set("optional3", om.valueToTree(this.getOptional3()));
+                data.set("optional3", om.valueToTree(this.getOptional3()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("@scope/jsii-calc-lib.StructWithOnlyOptionals"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -8559,6 +8559,134 @@
         }
       ]
     },
+    "jsii-calc.StructA": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental",
+        "summary": "We can serialize and deserialize structs without silently ignoring optional fields."
+      },
+      "fqn": "jsii-calc.StructA",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1983
+      },
+      "name": "StructA",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1984
+          },
+          "name": "requiredString",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1986
+          },
+          "name": "optionalNumber",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1985
+          },
+          "name": "optionalString",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "jsii-calc.StructB": {
+      "assembly": "jsii-calc",
+      "datatype": true,
+      "docs": {
+        "stability": "experimental",
+        "summary": "This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those."
+      },
+      "fqn": "jsii-calc.StructB",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1992
+      },
+      "name": "StructB",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1993
+          },
+          "name": "requiredString",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1994
+          },
+          "name": "optionalBoolean",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1995
+          },
+          "name": "optionalStructA",
+          "optional": true,
+          "type": {
+            "fqn": "jsii-calc.StructA"
+          }
+        }
+      ]
+    },
     "jsii-calc.StructPassing": {
       "assembly": "jsii-calc",
       "docs": {
@@ -8637,6 +8765,87 @@
         }
       ],
       "name": "StructPassing"
+    },
+    "jsii-calc.StructUnionConsumer": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental"
+      },
+      "fqn": "jsii-calc.StructUnionConsumer",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 1997
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 1998
+          },
+          "name": "isStructA",
+          "parameters": [
+            {
+              "name": "struct",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "jsii-calc.StructA"
+                    },
+                    {
+                      "fqn": "jsii-calc.StructB"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2008
+          },
+          "name": "isStructB",
+          "parameters": [
+            {
+              "name": "struct",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "jsii-calc.StructA"
+                    },
+                    {
+                      "fqn": "jsii-calc.StructB"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "boolean"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "StructUnionConsumer"
     },
     "jsii-calc.StructWithJavaReservedWords": {
       "assembly": "jsii-calc",
@@ -10119,5 +10328,5 @@
     }
   },
   "version": "0.19.0",
-  "fingerprint": "MZT68aeJ7MEeDJORDPKkIyqOqOLC+Yb3LcDU7XrxgCQ="
+  "fingerprint": "x2+sbdlYAHP8MHude74WmIipYqqFoEMnnpxBnz5DvZ0="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.CalculatorProps")]
     public class CalculatorProps : Amazon.JSII.Tests.CalculatorNamespace.ICalculatorProps
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DeprecatedStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Deprecated
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DeprecatedStruct")]
     public class DeprecatedStruct : Amazon.JSII.Tests.CalculatorNamespace.IDeprecatedStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DerivedStruct.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DerivedStruct")]
     public class DerivedStruct : Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceBaseLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DiamondInheritanceBaseLevelStruct")]
     public class DiamondInheritanceBaseLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceBaseLevelStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceFirstMidLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DiamondInheritanceFirstMidLevelStruct")]
     public class DiamondInheritanceFirstMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceFirstMidLevelStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceSecondMidLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DiamondInheritanceSecondMidLevelStruct")]
     public class DiamondInheritanceSecondMidLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceSecondMidLevelStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/DiamondInheritanceTopLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.DiamondInheritanceTopLevelStruct")]
     public class DiamondInheritanceTopLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.IDiamondInheritanceTopLevelStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EraseUndefinedHashValuesOptions.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.EraseUndefinedHashValuesOptions")]
     public class EraseUndefinedHashValuesOptions : Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExperimentalStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.ExperimentalStruct")]
     public class ExperimentalStruct : Amazon.JSII.Tests.CalculatorNamespace.IExperimentalStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ExtendsInternalInterface.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.ExtendsInternalInterface")]
     public class ExtendsInternalInterface : Amazon.JSII.Tests.CalculatorNamespace.IExtendsInternalInterface
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Greetee.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.Greetee")]
     public class Greetee : Amazon.JSII.Tests.CalculatorNamespace.IGreetee
     {
         /// <summary>The name of the greetee.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStructA.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStructA.cs
@@ -1,0 +1,47 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>We can serialize and deserialize structs without silently ignoring optional fields.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IStructA), fullyQualifiedName: "jsii-calc.StructA")]
+    public interface IStructA
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}")]
+        string RequiredString
+        {
+            get;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "optionalNumber", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
+        [Amazon.JSII.Runtime.Deputy.JsiiOptional]
+        double? OptionalNumber
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "optionalString", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
+        [Amazon.JSII.Runtime.Deputy.JsiiOptional]
+        string OptionalString
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStructB.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IStructB.cs
@@ -1,0 +1,47 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IStructB), fullyQualifiedName: "jsii-calc.StructB")]
+    public interface IStructB
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}")]
+        string RequiredString
+        {
+            get;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "optionalBoolean", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
+        [Amazon.JSII.Runtime.Deputy.JsiiOptional]
+        bool? OptionalBoolean
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "optionalStructA", typeJson: "{\"fqn\":\"jsii-calc.StructA\"}", isOptional: true)]
+        [Amazon.JSII.Runtime.Deputy.JsiiOptional]
+        Amazon.JSII.Tests.CalculatorNamespace.IStructA OptionalStructA
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ImplictBaseOfBase.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.ImplictBaseOfBase")]
     public class ImplictBaseOfBase : Amazon.JSII.Tests.CalculatorNamespace.IImplictBaseOfBase
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Hello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceIncludesClasses/Hello.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClas
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.InterfaceInNamespaceIncludesClasses.Hello")]
     public class Hello : Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.IHello
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/Hello.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/InterfaceInNamespaceOnlyInterface/Hello.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterfac
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.InterfaceInNamespaceOnlyInterface.Hello")]
     public class Hello : Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterface.IHello
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/LoadBalancedFargateServiceProps.cs
@@ -6,7 +6,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.LoadBalancedFargateServiceProps")]
     public class LoadBalancedFargateServiceProps : Amazon.JSII.Tests.CalculatorNamespace.ILoadBalancedFargateServiceProps
     {
         /// <summary>The container port of the application load balancer attached to your Fargate service.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/NullShouldBeTreatedAsUndefinedData.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.NullShouldBeTreatedAsUndefinedData")]
     public class NullShouldBeTreatedAsUndefinedData : Amazon.JSII.Tests.CalculatorNamespace.INullShouldBeTreatedAsUndefinedData
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/OptionalStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.OptionalStruct")]
     public class OptionalStruct : Amazon.JSII.Tests.CalculatorNamespace.IOptionalStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SecondLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.SecondLevelStruct")]
     public class SecondLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.ISecondLevelStruct
     {
         /// <summary>It's long and required.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StableStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Stable
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.StableStruct")]
     public class StableStruct : Amazon.JSII.Tests.CalculatorNamespace.IStableStruct
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructA.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructA.cs
@@ -1,0 +1,44 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>We can serialize and deserialize structs without silently ignoring optional fields.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue(fqn: "jsii-calc.StructA")]
+    public class StructA : Amazon.JSII.Tests.CalculatorNamespace.IStructA
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string RequiredString
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalNumber", typeJson: "{\"primitive\":\"number\"}", isOptional: true, isOverride: true)]
+        public double? OptionalNumber
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalString", typeJson: "{\"primitive\":\"string\"}", isOptional: true, isOverride: true)]
+        public string OptionalString
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructAProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructAProxy.cs
@@ -1,0 +1,45 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>We can serialize and deserialize structs without silently ignoring optional fields.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IStructA), fullyQualifiedName: "jsii-calc.StructA")]
+    internal sealed class StructAProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IStructA
+    {
+        private StructAProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}")]
+        public string RequiredString
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalNumber", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
+        public double? OptionalNumber
+        {
+            get => GetInstanceProperty<double?>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalString", typeJson: "{\"primitive\":\"string\"}", isOptional: true)]
+        public string OptionalString
+        {
+            get => GetInstanceProperty<string>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructB.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructB.cs
@@ -1,0 +1,44 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiByValue(fqn: "jsii-calc.StructB")]
+    public class StructB : Amazon.JSII.Tests.CalculatorNamespace.IStructB
+    {
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}", isOverride: true)]
+        public string RequiredString
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalBoolean", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true, isOverride: true)]
+        public bool? OptionalBoolean
+        {
+            get;
+            set;
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalStructA", typeJson: "{\"fqn\":\"jsii-calc.StructA\"}", isOptional: true, isOverride: true)]
+        public Amazon.JSII.Tests.CalculatorNamespace.IStructA OptionalStructA
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructBProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructBProxy.cs
@@ -1,0 +1,45 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.</summary>
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IStructB), fullyQualifiedName: "jsii-calc.StructB")]
+    internal sealed class StructBProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IStructB
+    {
+        private StructBProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiProperty(name: "requiredString", typeJson: "{\"primitive\":\"string\"}")]
+        public string RequiredString
+        {
+            get => GetInstanceProperty<string>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalBoolean", typeJson: "{\"primitive\":\"boolean\"}", isOptional: true)]
+        public bool? OptionalBoolean
+        {
+            get => GetInstanceProperty<bool?>();
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiOptional]
+        [JsiiProperty(name: "optionalStructA", typeJson: "{\"fqn\":\"jsii-calc.StructA\"}", isOptional: true)]
+        public Amazon.JSII.Tests.CalculatorNamespace.IStructA OptionalStructA
+        {
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IStructA>();
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructUnionConsumer.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructUnionConsumer.cs
@@ -1,0 +1,37 @@
+using Amazon.JSII.Runtime.Deputy;
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <remarks>
+    /// stability: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), fullyQualifiedName: "jsii-calc.StructUnionConsumer")]
+    public class StructUnionConsumer : DeputyBase
+    {
+        protected StructUnionConsumer(ByRefValue reference): base(reference)
+        {
+        }
+
+        protected StructUnionConsumer(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "isStructA", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"struct\",\"type\":{\"union\":{\"types\":[{\"fqn\":\"jsii-calc.StructA\"},{\"fqn\":\"jsii-calc.StructB\"}]}}}]")]
+        public static bool IsStructA(object @struct)
+        {
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct});
+        }
+
+        /// <remarks>
+        /// stability: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "isStructB", returnsJson: "{\"type\":{\"primitive\":\"boolean\"}}", parametersJson: "[{\"name\":\"struct\",\"type\":{\"union\":{\"types\":[{\"fqn\":\"jsii-calc.StructA\"},{\"fqn\":\"jsii-calc.StructB\"}]}}}]")]
+        public static bool IsStructB(object @struct)
+        {
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructWithJavaReservedWords.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/StructWithJavaReservedWords.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.StructWithJavaReservedWords")]
     public class StructWithJavaReservedWords : Amazon.JSII.Tests.CalculatorNamespace.IStructWithJavaReservedWords
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SupportsNiceJavaBuilderProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/SupportsNiceJavaBuilderProps.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.SupportsNiceJavaBuilderProps")]
     public class SupportsNiceJavaBuilderProps : Amazon.JSII.Tests.CalculatorNamespace.ISupportsNiceJavaBuilderProps
     {
         /// <summary>Some number, like 42.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStruct.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/TopLevelStruct.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.TopLevelStruct")]
     public class TopLevelStruct : Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct
     {
         /// <summary>This is a required field.</summary>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UnionProperties.cs
@@ -5,7 +5,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <remarks>
     /// stability: Experimental
     /// </remarks>
-    [JsiiByValue]
+    [JsiiByValue(fqn: "jsii-calc.UnionProperties")]
     public class UnionProperties : Amazon.JSII.Tests.CalculatorNamespace.IUnionProperties
     {
         /// <remarks>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -152,7 +152,10 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.Statics": return software.amazon.jsii.tests.calculator.Statics.class;
             case "jsii-calc.StringEnum": return software.amazon.jsii.tests.calculator.StringEnum.class;
             case "jsii-calc.StripInternal": return software.amazon.jsii.tests.calculator.StripInternal.class;
+            case "jsii-calc.StructA": return software.amazon.jsii.tests.calculator.StructA.class;
+            case "jsii-calc.StructB": return software.amazon.jsii.tests.calculator.StructB.class;
             case "jsii-calc.StructPassing": return software.amazon.jsii.tests.calculator.StructPassing.class;
+            case "jsii-calc.StructUnionConsumer": return software.amazon.jsii.tests.calculator.StructUnionConsumer.class;
             case "jsii-calc.StructWithJavaReservedWords": return software.amazon.jsii.tests.calculator.StructWithJavaReservedWords.class;
             case "jsii-calc.Sum": return software.amazon.jsii.tests.calculator.Sum.class;
             case "jsii-calc.SupportsNiceJavaBuilder": return software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -96,7 +96,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number initialValue, java.lang.Number maximumValue) {
+        private Jsii$Proxy(final java.lang.Number initialValue, final java.lang.Number maximumValue) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.initialValue = initialValue;
             this.maximumValue = maximumValue;
@@ -114,14 +114,23 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getInitialValue() != null) {
-                obj.set("initialValue", om.valueToTree(this.getInitialValue()));
+                data.set("initialValue", om.valueToTree(this.getInitialValue()));
             }
             if (this.getMaximumValue() != null) {
-                obj.set("maximumValue", om.valueToTree(this.getMaximumValue()));
+                data.set("maximumValue", om.valueToTree(this.getMaximumValue()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.CalculatorProps"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -78,7 +78,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String readonlyProperty) {
+        private Jsii$Proxy(final java.lang.String readonlyProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
         }
@@ -90,9 +90,18 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DeprecatedStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -227,7 +227,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.time.Instant anotherRequired, java.lang.Boolean bool, software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive, java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional, java.lang.Object optionalAny, java.util.List<java.lang.String> optionalArray, java.lang.Number anumber, java.lang.String astring, java.util.List<java.lang.String> firstOptional) {
+        private Jsii$Proxy(final java.time.Instant anotherRequired, final java.lang.Boolean bool, final software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive, final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional, final java.lang.Object optionalAny, final java.util.List<java.lang.String> optionalArray, final java.lang.Number anumber, final java.lang.String astring, final java.util.List<java.lang.String> firstOptional) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.anotherRequired = java.util.Objects.requireNonNull(anotherRequired, "anotherRequired is required");
             this.bool = java.util.Objects.requireNonNull(bool, "bool is required");
@@ -287,25 +287,34 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("anotherRequired", om.valueToTree(this.getAnotherRequired()));
-            obj.set("bool", om.valueToTree(this.getBool()));
-            obj.set("nonPrimitive", om.valueToTree(this.getNonPrimitive()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("anotherRequired", om.valueToTree(this.getAnotherRequired()));
+            data.set("bool", om.valueToTree(this.getBool()));
+            data.set("nonPrimitive", om.valueToTree(this.getNonPrimitive()));
             if (this.getAnotherOptional() != null) {
-                obj.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
+                data.set("anotherOptional", om.valueToTree(this.getAnotherOptional()));
             }
             if (this.getOptionalAny() != null) {
-                obj.set("optionalAny", om.valueToTree(this.getOptionalAny()));
+                data.set("optionalAny", om.valueToTree(this.getOptionalAny()));
             }
             if (this.getOptionalArray() != null) {
-                obj.set("optionalArray", om.valueToTree(this.getOptionalArray()));
+                data.set("optionalArray", om.valueToTree(this.getOptionalArray()));
             }
-            obj.set("anumber", om.valueToTree(this.getAnumber()));
-            obj.set("astring", om.valueToTree(this.getAstring()));
+            data.set("anumber", om.valueToTree(this.getAnumber()));
+            data.set("astring", om.valueToTree(this.getAstring()));
             if (this.getFirstOptional() != null) {
-                obj.set("firstOptional", om.valueToTree(this.getFirstOptional()));
+                data.set("firstOptional", om.valueToTree(this.getFirstOptional()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DerivedStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -70,7 +70,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String baseLevelProperty) {
+        private Jsii$Proxy(final java.lang.String baseLevelProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
         }
@@ -82,9 +82,18 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DiamondInheritanceBaseLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -84,7 +84,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String firstMidLevelProperty, java.lang.String baseLevelProperty) {
+        private Jsii$Proxy(final java.lang.String firstMidLevelProperty, final java.lang.String baseLevelProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.firstMidLevelProperty = java.util.Objects.requireNonNull(firstMidLevelProperty, "firstMidLevelProperty is required");
             this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
@@ -102,10 +102,19 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
-            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
+            data.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DiamondInheritanceFirstMidLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -84,7 +84,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String secondMidLevelProperty, java.lang.String baseLevelProperty) {
+        private Jsii$Proxy(final java.lang.String secondMidLevelProperty, final java.lang.String baseLevelProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.secondMidLevelProperty = java.util.Objects.requireNonNull(secondMidLevelProperty, "secondMidLevelProperty is required");
             this.baseLevelProperty = java.util.Objects.requireNonNull(baseLevelProperty, "baseLevelProperty is required");
@@ -102,10 +102,19 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
-            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
+            data.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DiamondInheritanceSecondMidLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -112,7 +112,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String topLevelProperty, java.lang.String firstMidLevelProperty, java.lang.String baseLevelProperty, java.lang.String secondMidLevelProperty) {
+        private Jsii$Proxy(final java.lang.String topLevelProperty, final java.lang.String firstMidLevelProperty, final java.lang.String baseLevelProperty, final java.lang.String secondMidLevelProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.topLevelProperty = java.util.Objects.requireNonNull(topLevelProperty, "topLevelProperty is required");
             this.firstMidLevelProperty = java.util.Objects.requireNonNull(firstMidLevelProperty, "firstMidLevelProperty is required");
@@ -142,12 +142,21 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("topLevelProperty", om.valueToTree(this.getTopLevelProperty()));
-            obj.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
-            obj.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
-            obj.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("topLevelProperty", om.valueToTree(this.getTopLevelProperty()));
+            data.set("firstMidLevelProperty", om.valueToTree(this.getFirstMidLevelProperty()));
+            data.set("baseLevelProperty", om.valueToTree(this.getBaseLevelProperty()));
+            data.set("secondMidLevelProperty", om.valueToTree(this.getSecondMidLevelProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.DiamondInheritanceTopLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -94,7 +94,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String option1, java.lang.String option2) {
+        private Jsii$Proxy(final java.lang.String option1, final java.lang.String option2) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.option1 = option1;
             this.option2 = option2;
@@ -112,14 +112,23 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getOption1() != null) {
-                obj.set("option1", om.valueToTree(this.getOption1()));
+                data.set("option1", om.valueToTree(this.getOption1()));
             }
             if (this.getOption2() != null) {
-                obj.set("option2", om.valueToTree(this.getOption2()));
+                data.set("option2", om.valueToTree(this.getOption2()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.EraseUndefinedHashValuesOptions"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -70,7 +70,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String readonlyProperty) {
+        private Jsii$Proxy(final java.lang.String readonlyProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
         }
@@ -82,9 +82,18 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.ExperimentalStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -90,7 +90,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Boolean boom, java.lang.String prop) {
+        private Jsii$Proxy(final java.lang.Boolean boom, final java.lang.String prop) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.boom = java.util.Objects.requireNonNull(boom, "boom is required");
             this.prop = java.util.Objects.requireNonNull(prop, "prop is required");
@@ -108,10 +108,19 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("boom", om.valueToTree(this.getBoom()));
-            obj.set("prop", om.valueToTree(this.getProp()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("boom", om.valueToTree(this.getBoom()));
+            data.set("prop", om.valueToTree(this.getProp()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.ExtendsInternalInterface"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -78,7 +78,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String name) {
+        private Jsii$Proxy(final java.lang.String name) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.name = name;
         }
@@ -90,11 +90,20 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getName() != null) {
-                obj.set("name", om.valueToTree(this.getName()));
+                data.set("name", om.valueToTree(this.getName()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.Greetee"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -96,7 +96,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.time.Instant goo, java.lang.String bar, software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
+        private Jsii$Proxy(final java.time.Instant goo, final java.lang.String bar, final software.amazon.jsii.tests.calculator.baseofbase.Very foo) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.goo = java.util.Objects.requireNonNull(goo, "goo is required");
             this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
@@ -120,11 +120,20 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("goo", om.valueToTree(this.getGoo()));
-            obj.set("bar", om.valueToTree(this.getBar()));
-            obj.set("foo", om.valueToTree(this.getFoo()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("goo", om.valueToTree(this.getGoo()));
+            data.set("bar", om.valueToTree(this.getBar()));
+            data.set("foo", om.valueToTree(this.getFoo()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.ImplictBaseOfBase"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -70,7 +70,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number foo) {
+        private Jsii$Proxy(final java.lang.Number foo) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
         }
@@ -82,9 +82,18 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("foo", om.valueToTree(this.getFoo()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("foo", om.valueToTree(this.getFoo()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.InterfaceInNamespaceIncludesClasses.Hello"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -70,7 +70,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number foo) {
+        private Jsii$Proxy(final java.lang.Number foo) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.foo = java.util.Objects.requireNonNull(foo, "foo is required");
         }
@@ -82,9 +82,18 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("foo", om.valueToTree(this.getFoo()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("foo", om.valueToTree(this.getFoo()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.InterfaceInNamespaceOnlyInterface.Hello"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -201,7 +201,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number containerPort, java.lang.String cpu, java.lang.String memoryMiB, java.lang.Boolean publicLoadBalancer, java.lang.Boolean publicTasks) {
+        private Jsii$Proxy(final java.lang.Number containerPort, final java.lang.String cpu, final java.lang.String memoryMiB, final java.lang.Boolean publicLoadBalancer, final java.lang.Boolean publicTasks) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.containerPort = containerPort;
             this.cpu = cpu;
@@ -237,23 +237,32 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getContainerPort() != null) {
-                obj.set("containerPort", om.valueToTree(this.getContainerPort()));
+                data.set("containerPort", om.valueToTree(this.getContainerPort()));
             }
             if (this.getCpu() != null) {
-                obj.set("cpu", om.valueToTree(this.getCpu()));
+                data.set("cpu", om.valueToTree(this.getCpu()));
             }
             if (this.getMemoryMiB() != null) {
-                obj.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
+                data.set("memoryMiB", om.valueToTree(this.getMemoryMiB()));
             }
             if (this.getPublicLoadBalancer() != null) {
-                obj.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
+                data.set("publicLoadBalancer", om.valueToTree(this.getPublicLoadBalancer()));
             }
             if (this.getPublicTasks() != null) {
-                obj.set("publicTasks", om.valueToTree(this.getPublicTasks()));
+                data.set("publicTasks", om.valueToTree(this.getPublicTasks()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.LoadBalancedFargateServiceProps"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -92,7 +92,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument, java.lang.Object thisShouldBeUndefined) {
+        private Jsii$Proxy(final java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument, final java.lang.Object thisShouldBeUndefined) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
             this.thisShouldBeUndefined = thisShouldBeUndefined;
@@ -110,12 +110,21 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("arrayWithThreeElementsAndUndefinedAsSecondArgument", om.valueToTree(this.getArrayWithThreeElementsAndUndefinedAsSecondArgument()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("arrayWithThreeElementsAndUndefinedAsSecondArgument", om.valueToTree(this.getArrayWithThreeElementsAndUndefinedAsSecondArgument()));
             if (this.getThisShouldBeUndefined() != null) {
-                obj.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
+                data.set("thisShouldBeUndefined", om.valueToTree(this.getThisShouldBeUndefined()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.NullShouldBeTreatedAsUndefinedData"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -72,7 +72,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String field) {
+        private Jsii$Proxy(final java.lang.String field) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.field = field;
         }
@@ -84,11 +84,20 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
             if (this.getField() != null) {
-                obj.set("field", om.valueToTree(this.getField()));
+                data.set("field", om.valueToTree(this.getField()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.OptionalStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -96,7 +96,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String deeperRequiredProp, java.lang.String deeperOptionalProp) {
+        private Jsii$Proxy(final java.lang.String deeperRequiredProp, final java.lang.String deeperOptionalProp) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.deeperRequiredProp = java.util.Objects.requireNonNull(deeperRequiredProp, "deeperRequiredProp is required");
             this.deeperOptionalProp = deeperOptionalProp;
@@ -114,12 +114,21 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("deeperRequiredProp", om.valueToTree(this.getDeeperRequiredProp()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("deeperRequiredProp", om.valueToTree(this.getDeeperRequiredProp()));
             if (this.getDeeperOptionalProp() != null) {
-                obj.set("deeperOptionalProp", om.valueToTree(this.getDeeperOptionalProp()));
+                data.set("deeperOptionalProp", om.valueToTree(this.getDeeperOptionalProp()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.SecondLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -68,7 +68,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String readonlyProperty) {
+        private Jsii$Proxy(final java.lang.String readonlyProperty) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.readonlyProperty = java.util.Objects.requireNonNull(readonlyProperty, "readonlyProperty is required");
         }
@@ -80,9 +80,18 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("readonlyProperty", om.valueToTree(this.getReadonlyProperty()));
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.StableStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
@@ -1,0 +1,184 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * We can serialize and deserialize structs without silently ignoring optional fields.
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StructA")
+@software.amazon.jsii.Jsii.Proxy(StructA.Jsii$Proxy.class)
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface StructA extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getRequiredString();
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    default java.lang.Number getOptionalNumber() {
+        return null;
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    default java.lang.String getOptionalString() {
+        return null;
+    }
+
+    /**
+     * @return a {@link Builder} of {@link StructA}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * A builder for {@link StructA}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static final class Builder {
+        private java.lang.String requiredString;
+        private java.lang.Number optionalNumber;
+        private java.lang.String optionalString;
+
+        /**
+         * Sets the value of RequiredString
+         * @param requiredString the value to be set. This parameter is required.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder requiredString(java.lang.String requiredString) {
+            this.requiredString = requiredString;
+            return this;
+        }
+
+        /**
+         * Sets the value of OptionalNumber
+         * @param optionalNumber the value to be set.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder optionalNumber(java.lang.Number optionalNumber) {
+            this.optionalNumber = optionalNumber;
+            return this;
+        }
+
+        /**
+         * Sets the value of OptionalString
+         * @param optionalString the value to be set.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder optionalString(java.lang.String optionalString) {
+            this.optionalString = optionalString;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link StructA}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public StructA build() {
+            return new Jsii$Proxy(requiredString, optionalNumber, optionalString);
+        }
+    }
+
+    /**
+     * An implementation for {@link StructA}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements StructA {
+        private final java.lang.String requiredString;
+        private final java.lang.Number optionalNumber;
+        private final java.lang.String optionalString;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+            this.requiredString = this.jsiiGet("requiredString", java.lang.String.class);
+            this.optionalNumber = this.jsiiGet("optionalNumber", java.lang.Number.class);
+            this.optionalString = this.jsiiGet("optionalString", java.lang.String.class);
+        }
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(final java.lang.String requiredString, final java.lang.Number optionalNumber, final java.lang.String optionalString) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.requiredString = java.util.Objects.requireNonNull(requiredString, "requiredString is required");
+            this.optionalNumber = optionalNumber;
+            this.optionalString = optionalString;
+        }
+
+        @Override
+        public java.lang.String getRequiredString() {
+            return this.requiredString;
+        }
+
+        @Override
+        public java.lang.Number getOptionalNumber() {
+            return this.optionalNumber;
+        }
+
+        @Override
+        public java.lang.String getOptionalString() {
+            return this.optionalString;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("requiredString", om.valueToTree(this.getRequiredString()));
+            if (this.getOptionalNumber() != null) {
+                data.set("optionalNumber", om.valueToTree(this.getOptionalNumber()));
+            }
+            if (this.getOptionalString() != null) {
+                data.set("optionalString", om.valueToTree(this.getOptionalString()));
+            }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.StructA"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            StructA.Jsii$Proxy that = (StructA.Jsii$Proxy) o;
+
+            if (!requiredString.equals(that.requiredString)) return false;
+            if (this.optionalNumber != null ? !this.optionalNumber.equals(that.optionalNumber) : that.optionalNumber != null) return false;
+            return this.optionalString != null ? this.optionalString.equals(that.optionalString) : that.optionalString == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = this.requiredString.hashCode();
+            result = 31 * result + (this.optionalNumber != null ? this.optionalNumber.hashCode() : 0);
+            result = 31 * result + (this.optionalString != null ? this.optionalString.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
@@ -1,0 +1,184 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
+ * 
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StructB")
+@software.amazon.jsii.Jsii.Proxy(StructB.Jsii$Proxy.class)
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+public interface StructB extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    java.lang.String getRequiredString();
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    default java.lang.Boolean getOptionalBoolean() {
+        return null;
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    default software.amazon.jsii.tests.calculator.StructA getOptionalStructA() {
+        return null;
+    }
+
+    /**
+     * @return a {@link Builder} of {@link StructB}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * A builder for {@link StructB}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static final class Builder {
+        private java.lang.String requiredString;
+        private java.lang.Boolean optionalBoolean;
+        private software.amazon.jsii.tests.calculator.StructA optionalStructA;
+
+        /**
+         * Sets the value of RequiredString
+         * @param requiredString the value to be set. This parameter is required.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder requiredString(java.lang.String requiredString) {
+            this.requiredString = requiredString;
+            return this;
+        }
+
+        /**
+         * Sets the value of OptionalBoolean
+         * @param optionalBoolean the value to be set.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder optionalBoolean(java.lang.Boolean optionalBoolean) {
+            this.optionalBoolean = optionalBoolean;
+            return this;
+        }
+
+        /**
+         * Sets the value of OptionalStructA
+         * @param optionalStructA the value to be set.
+         * @return {@code this}
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public Builder optionalStructA(software.amazon.jsii.tests.calculator.StructA optionalStructA) {
+            this.optionalStructA = optionalStructA;
+            return this;
+        }
+
+        /**
+         * Builds the configured instance.
+         * @return a new instance of {@link StructB}
+         * @throws NullPointerException if any required attribute was not provided
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        public StructB build() {
+            return new Jsii$Proxy(requiredString, optionalBoolean, optionalStructA);
+        }
+    }
+
+    /**
+     * An implementation for {@link StructB}
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements StructB {
+        private final java.lang.String requiredString;
+        private final java.lang.Boolean optionalBoolean;
+        private final software.amazon.jsii.tests.calculator.StructA optionalStructA;
+
+        /**
+         * Constructor that initializes the object based on values retrieved from the JsiiObject.
+         * @param objRef Reference to the JSII managed object.
+         */
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+            this.requiredString = this.jsiiGet("requiredString", java.lang.String.class);
+            this.optionalBoolean = this.jsiiGet("optionalBoolean", java.lang.Boolean.class);
+            this.optionalStructA = this.jsiiGet("optionalStructA", software.amazon.jsii.tests.calculator.StructA.class);
+        }
+
+        /**
+         * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
+         */
+        private Jsii$Proxy(final java.lang.String requiredString, final java.lang.Boolean optionalBoolean, final software.amazon.jsii.tests.calculator.StructA optionalStructA) {
+            super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+            this.requiredString = java.util.Objects.requireNonNull(requiredString, "requiredString is required");
+            this.optionalBoolean = optionalBoolean;
+            this.optionalStructA = optionalStructA;
+        }
+
+        @Override
+        public java.lang.String getRequiredString() {
+            return this.requiredString;
+        }
+
+        @Override
+        public java.lang.Boolean getOptionalBoolean() {
+            return this.optionalBoolean;
+        }
+
+        @Override
+        public software.amazon.jsii.tests.calculator.StructA getOptionalStructA() {
+            return this.optionalStructA;
+        }
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("requiredString", om.valueToTree(this.getRequiredString()));
+            if (this.getOptionalBoolean() != null) {
+                data.set("optionalBoolean", om.valueToTree(this.getOptionalBoolean()));
+            }
+            if (this.getOptionalStructA() != null) {
+                data.set("optionalStructA", om.valueToTree(this.getOptionalStructA()));
+            }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.StructB"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
+            return obj;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            StructB.Jsii$Proxy that = (StructB.Jsii$Proxy) o;
+
+            if (!requiredString.equals(that.requiredString)) return false;
+            if (this.optionalBoolean != null ? !this.optionalBoolean.equals(that.optionalBoolean) : that.optionalBoolean != null) return false;
+            return this.optionalStructA != null ? this.optionalStructA.equals(that.optionalStructA) : that.optionalStructA == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = this.requiredString.hashCode();
+            result = 31 * result + (this.optionalBoolean != null ? this.optionalBoolean.hashCode() : 0);
+            result = 31 * result + (this.optionalStructA != null ? this.optionalStructA.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java
@@ -1,0 +1,38 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.StructUnionConsumer")
+public class StructUnionConsumer extends software.amazon.jsii.JsiiObject {
+
+    protected StructUnionConsumer(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected StructUnionConsumer(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * EXPERIMENTAL
+     * 
+     * @param struct This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.lang.Boolean isStructA(final java.lang.Object struct) {
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructUnionConsumer.class, "isStructA", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(struct, "struct is required") });
+    }
+
+    /**
+     * EXPERIMENTAL
+     * 
+     * @param struct This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static java.lang.Boolean isStructB(final java.lang.Object struct) {
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructUnionConsumer.class, "isStructB", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(struct, "struct is required") });
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -136,7 +136,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String defaultValue, java.lang.String assertValue, java.lang.String result, java.lang.String that) {
+        private Jsii$Proxy(final java.lang.String defaultValue, final java.lang.String assertValue, final java.lang.String result, final java.lang.String that) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.defaultValue = java.util.Objects.requireNonNull(defaultValue, "defaultValue is required");
             this.assertValue = assertValue;
@@ -166,18 +166,27 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("default", om.valueToTree(this.getDefaultValue()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("default", om.valueToTree(this.getDefaultValue()));
             if (this.getAssertValue() != null) {
-                obj.set("assert", om.valueToTree(this.getAssertValue()));
+                data.set("assert", om.valueToTree(this.getAssertValue()));
             }
             if (this.getResult() != null) {
-                obj.set("result", om.valueToTree(this.getResult()));
+                data.set("result", om.valueToTree(this.getResult()));
             }
             if (this.getThat() != null) {
-                obj.set("that", om.valueToTree(this.getThat()));
+                data.set("that", om.valueToTree(this.getThat()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.StructWithJavaReservedWords"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
@@ -98,7 +98,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Number bar, java.lang.String id) {
+        private Jsii$Proxy(final java.lang.Number bar, final java.lang.String id) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
             this.id = id;
@@ -116,12 +116,21 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("bar", om.valueToTree(this.getBar()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("bar", om.valueToTree(this.getBar()));
             if (this.getId() != null) {
-                obj.set("id", om.valueToTree(this.getId()));
+                data.set("id", om.valueToTree(this.getId()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.SupportsNiceJavaBuilderProps"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -129,7 +129,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.String required, java.lang.Object secondLevel, java.lang.String optional) {
+        private Jsii$Proxy(final java.lang.String required, final java.lang.Object secondLevel, final java.lang.String optional) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.required = java.util.Objects.requireNonNull(required, "required is required");
             this.secondLevel = java.util.Objects.requireNonNull(secondLevel, "secondLevel is required");
@@ -153,13 +153,22 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("required", om.valueToTree(this.getRequired()));
-            obj.set("secondLevel", om.valueToTree(this.getSecondLevel()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("required", om.valueToTree(this.getRequired()));
+            data.set("secondLevel", om.valueToTree(this.getSecondLevel()));
             if (this.getOptional() != null) {
-                obj.set("optional", om.valueToTree(this.getOptional()));
+                data.set("optional", om.valueToTree(this.getOptional()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.TopLevelStruct"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -125,7 +125,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(java.lang.Object bar, java.lang.Object foo) {
+        private Jsii$Proxy(final java.lang.Object bar, final java.lang.Object foo) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.bar = java.util.Objects.requireNonNull(bar, "bar is required");
             this.foo = foo;
@@ -143,12 +143,21 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
 
         @Override
         public com.fasterxml.jackson.databind.JsonNode $jsii$toJson() {
-            com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
-            com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-            obj.set("bar", om.valueToTree(this.getBar()));
+            final com.fasterxml.jackson.databind.ObjectMapper om = software.amazon.jsii.JsiiObjectMapper.INSTANCE;
+            final com.fasterxml.jackson.databind.node.ObjectNode data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+            data.set("bar", om.valueToTree(this.getBar()));
             if (this.getFoo() != null) {
-                obj.set("foo", om.valueToTree(this.getFoo()));
+                data.set("foo", om.valueToTree(this.getFoo()));
             }
+
+            final com.fasterxml.jackson.databind.node.ObjectNode struct = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            struct.set("fqn", om.valueToTree("jsii-calc.UnionProperties"));
+            struct.set("data", data);
+
+            final com.fasterxml.jackson.databind.node.ObjectNode obj = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+            obj.set("$jsii.struct", struct);
+
             return obj;
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -5883,6 +5883,110 @@ class StripInternal(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StripInternal"
         return jsii.set(self, "youSeeMe", value)
 
 
+@jsii.data_type(jsii_type="jsii-calc.StructA", jsii_struct_bases=[], name_mapping={'required_string': 'requiredString', 'optional_number': 'optionalNumber', 'optional_string': 'optionalString'})
+class StructA():
+    def __init__(self, *, required_string: str, optional_number: typing.Optional[jsii.Number]=None, optional_string: typing.Optional[str]=None):
+        """We can serialize and deserialize structs without silently ignoring optional fields.
+
+        :param required_string: 
+        :param optional_number: 
+        :param optional_string: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'required_string': required_string,
+        }
+        if optional_number is not None: self._values["optional_number"] = optional_number
+        if optional_string is not None: self._values["optional_string"] = optional_string
+
+    @property
+    def required_string(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('required_string')
+
+    @property
+    def optional_number(self) -> typing.Optional[jsii.Number]:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('optional_number')
+
+    @property
+    def optional_string(self) -> typing.Optional[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('optional_string')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'StructA(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
+@jsii.data_type(jsii_type="jsii-calc.StructB", jsii_struct_bases=[], name_mapping={'required_string': 'requiredString', 'optional_boolean': 'optionalBoolean', 'optional_struct_a': 'optionalStructA'})
+class StructB():
+    def __init__(self, *, required_string: str, optional_boolean: typing.Optional[bool]=None, optional_struct_a: typing.Optional["StructA"]=None):
+        """This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
+
+        :param required_string: 
+        :param optional_boolean: 
+        :param optional_struct_a: 
+
+        stability
+        :stability: experimental
+        """
+        self._values = {
+            'required_string': required_string,
+        }
+        if optional_boolean is not None: self._values["optional_boolean"] = optional_boolean
+        if optional_struct_a is not None: self._values["optional_struct_a"] = optional_struct_a
+
+    @property
+    def required_string(self) -> str:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('required_string')
+
+    @property
+    def optional_boolean(self) -> typing.Optional[bool]:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('optional_boolean')
+
+    @property
+    def optional_struct_a(self) -> typing.Optional["StructA"]:
+        """
+        stability
+        :stability: experimental
+        """
+        return self._values.get('optional_struct_a')
+
+    def __eq__(self, rhs) -> bool:
+        return isinstance(rhs, self.__class__) and rhs._values == self._values
+
+    def __ne__(self, rhs) -> bool:
+        return not (rhs == self)
+
+    def __repr__(self) -> str:
+        return 'StructB(%s)' % ', '.join(k + '=' + repr(v) for k, v in self._values.items())
+
+
 class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"):
     """Just because we can."""
     def __init__(self) -> None:
@@ -5910,6 +6014,34 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         input = TopLevelStruct(required=required, second_level=second_level, optional=optional)
 
         return jsii.sinvoke(cls, "roundTrip", [_positional, input])
+
+
+class StructUnionConsumer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructUnionConsumer"):
+    """
+    stability
+    :stability: experimental
+    """
+    @jsii.member(jsii_name="isStructA")
+    @classmethod
+    def is_struct_a(cls, struct: typing.Union["StructA", "StructB"]) -> bool:
+        """
+        :param struct: -
+
+        stability
+        :stability: experimental
+        """
+        return jsii.sinvoke(cls, "isStructA", [struct])
+
+    @jsii.member(jsii_name="isStructB")
+    @classmethod
+    def is_struct_b(cls, struct: typing.Union["StructA", "StructB"]) -> bool:
+        """
+        :param struct: -
+
+        stability
+        :stability: experimental
+        """
+        return jsii.sinvoke(cls, "isStructB", [struct])
 
 
 @jsii.data_type(jsii_type="jsii-calc.StructWithJavaReservedWords", jsii_struct_bases=[], name_mapping={'default': 'default', 'assert_': 'assert', 'result': 'result', 'that': 'that'})
@@ -7083,6 +7215,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         return jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AnonymousImplementationProvider", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnonymousImplementationProvider", "IAnonymouslyImplementMe", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "Implementation", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverridableProtectedMember", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructPassing", "StructWithJavaReservedWords", "Sum", "SupportsNiceJavaBuilder", "SupportsNiceJavaBuilderProps", "SupportsNiceJavaBuilderWithRequiredProps", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AnonymousImplementationProvider", "AsyncVirtualMethods", "AugmentableClass", "BinaryOperation", "Calculator", "CalculatorProps", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConstructorPassesThisOut", "Constructors", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnonymousImplementationProvider", "IAnonymouslyImplementMe", "IAnotherPublicInterface", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnsNumber", "IStableInterface", "ImplementInternalInterface", "Implementation", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "LoadBalancedFargateServiceProps", "Multiply", "Negate", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "Old", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverridableProtectedMember", "OverrideReturnsObject", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructA", "StructB", "StructPassing", "StructUnionConsumer", "StructWithJavaReservedWords", "Sum", "SupportsNiceJavaBuilder", "SupportsNiceJavaBuilderProps", "SupportsNiceJavaBuilderWithRequiredProps", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-python-runtime/src/jsii/_kernel/__init__.py
+++ b/packages/jsii-python-runtime/src/jsii/_kernel/__init__.py
@@ -119,10 +119,18 @@ def _make_reference_for_native(kernel, d):
     elif isinstance(d, list):
         return [_make_reference_for_native(kernel, i) for i in d]
 
-    mapping = python_jsii_mapping(d)
-    if mapping:
-        return {jsii_name: _make_reference_for_native(kernel, getattr(d, python_name)) for python_name, jsii_name in mapping.items()}
-    elif hasattr(d, "__jsii_type__"):
+    if hasattr(d, "__jsii_type__"):
+        typeFqn = getattr(d, "__jsii_type__")
+        mapping = python_jsii_mapping(d)
+        if mapping: # This means we are handling a data_type (aka Struct)
+            return {
+                "$jsii.struct": {
+                    "fqn": typeFqn,
+                    "data": {
+                        jsii_name: _make_reference_for_native(kernel, getattr(d, python_name)) for python_name, jsii_name in mapping.items()
+                    }
+                }
+            }
         return d
     elif isinstance(d, (int, type(None), str, float, bool, datetime.datetime)):
         return d

--- a/packages/jsii-python-runtime/tests/test_compliance.py
+++ b/packages/jsii-python-runtime/tests/test_compliance.py
@@ -48,6 +48,9 @@ from jsii_calc import (
     StructPassing,
     TopLevelStruct,
     SecondLevelStruct,
+    StructA,
+    StructB,
+    StructUnionConsumer
 )
 from scope.jsii_calc_lib import IFriendly, EnumFromScopedModule, Number
 
@@ -953,3 +956,19 @@ def test_structEquality():
     assert b == c
     assert a != 5
     assert a != d
+
+def test_correctly_handling_struct_unions():
+    a0 = StructA(required_string='Present!', optional_string='Bazinga!')
+    a1 = StructA(required_string='Present!', optional_number=1337)
+    b0 = StructB(required_string='Present!', optional_boolean=True)
+    b1 = StructB(required_string='Present!', optional_struct_a=a1)
+
+    assert StructUnionConsumer.is_struct_a(a0)
+    assert StructUnionConsumer.is_struct_a(a1)
+    assert not StructUnionConsumer.is_struct_a(b0)
+    assert not StructUnionConsumer.is_struct_a(b1)
+
+    assert not StructUnionConsumer.is_struct_b(a0)
+    assert not StructUnionConsumer.is_struct_b(a1)
+    assert StructUnionConsumer.is_struct_b(b0)
+    assert StructUnionConsumer.is_struct_b(b1)

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1200,6 +1200,20 @@ exports[`jsii-tree --all 1`] = `
  │   │     │ └─┬ input
  │   │     │   └── type: jsii-calc.TopLevelStruct
  │   │     └── returns: jsii-calc.TopLevelStruct
+ │   ├─┬ class StructUnionConsumer (experimental)
+ │   │ └─┬ members
+ │   │   ├─┬ static isStructA(struct) method (experimental)
+ │   │   │ ├── static
+ │   │   │ ├─┬ parameters
+ │   │   │ │ └─┬ struct
+ │   │   │ │   └── type: jsii-calc.StructA | jsii-calc.StructB
+ │   │   │ └── returns: boolean
+ │   │   └─┬ static isStructB(struct) method (experimental)
+ │   │     ├── static
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ struct
+ │   │     │   └── type: jsii-calc.StructA | jsii-calc.StructB
+ │   │     └── returns: boolean
  │   ├─┬ class Sum (experimental)
  │   │ ├── base: CompositeOperation
  │   │ └─┬ members
@@ -1805,6 +1819,34 @@ exports[`jsii-tree --all 1`] = `
  │   │     ├── abstract
  │   │     ├── immutable
  │   │     └── type: string
+ │   ├─┬ interface StructA (experimental)
+ │   │ └─┬ members
+ │   │   ├─┬ requiredString property (experimental)
+ │   │   │ ├── abstract
+ │   │   │ ├── immutable
+ │   │   │ └── type: string
+ │   │   ├─┬ optionalNumber property (experimental)
+ │   │   │ ├── abstract
+ │   │   │ ├── immutable
+ │   │   │ └── type: Optional<number>
+ │   │   └─┬ optionalString property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: Optional<string>
+ │   ├─┬ interface StructB (experimental)
+ │   │ └─┬ members
+ │   │   ├─┬ requiredString property (experimental)
+ │   │   │ ├── abstract
+ │   │   │ ├── immutable
+ │   │   │ └── type: string
+ │   │   ├─┬ optionalBoolean property (experimental)
+ │   │   │ ├── abstract
+ │   │   │ ├── immutable
+ │   │   │ └── type: Optional<boolean>
+ │   │   └─┬ optionalStructA property (experimental)
+ │   │     ├── abstract
+ │   │     ├── immutable
+ │   │     └── type: Optional<jsii-calc.StructA>
  │   ├─┬ interface StructWithJavaReservedWords (experimental)
  │   │ └─┬ members
  │   │   ├─┬ default property (experimental)
@@ -2119,6 +2161,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class Statics
  │   ├── class StripInternal
  │   ├── class StructPassing
+ │   ├── class StructUnionConsumer
  │   ├─┬ class Sum
  │   │ └── base: CompositeOperation
  │   ├─┬ class SupportsNiceJavaBuilder
@@ -2208,6 +2251,8 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── interface OptionalStruct
  │   ├── interface SecondLevelStruct
  │   ├── interface StableStruct
+ │   ├── interface StructA
+ │   ├── interface StructB
  │   ├── interface StructWithJavaReservedWords
  │   ├── interface SupportsNiceJavaBuilderProps
  │   ├── interface TopLevelStruct
@@ -2789,6 +2834,10 @@ exports[`jsii-tree --members 1`] = `
  │   │   ├── <initializer>() initializer
  │   │   ├── static howManyVarArgsDidIPass(_positional,inputs) method
  │   │   └── static roundTrip(_positional,input) method
+ │   ├─┬ class StructUnionConsumer
+ │   │ └─┬ members
+ │   │   ├── static isStructA(struct) method
+ │   │   └── static isStructB(struct) method
  │   ├─┬ class Sum
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -3043,6 +3092,16 @@ exports[`jsii-tree --members 1`] = `
  │   ├─┬ interface StableStruct
  │   │ └─┬ members
  │   │   └── readonlyProperty property
+ │   ├─┬ interface StructA
+ │   │ └─┬ members
+ │   │   ├── requiredString property
+ │   │   ├── optionalNumber property
+ │   │   └── optionalString property
+ │   ├─┬ interface StructB
+ │   │ └─┬ members
+ │   │   ├── requiredString property
+ │   │   ├── optionalBoolean property
+ │   │   └── optionalStructA property
  │   ├─┬ interface StructWithJavaReservedWords
  │   │ └─┬ members
  │   │   ├── default property
@@ -3245,6 +3304,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class Statics
  │   ├── class StripInternal
  │   ├── class StructPassing
+ │   ├── class StructUnionConsumer
  │   ├── class Sum
  │   ├── class SupportsNiceJavaBuilder
  │   ├── class SupportsNiceJavaBuilderWithRequiredProps
@@ -3306,6 +3366,8 @@ exports[`jsii-tree --types 1`] = `
  │   ├── interface OptionalStruct
  │   ├── interface SecondLevelStruct
  │   ├── interface StableStruct
+ │   ├── interface StructA
+ │   ├── interface StructB
  │   ├── interface StructWithJavaReservedWords
  │   ├── interface SupportsNiceJavaBuilderProps
  │   ├── interface TopLevelStruct

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -96,6 +96,7 @@ Array [
   "Statics",
   "StripInternal",
   "StructPassing",
+  "StructUnionConsumer",
   "Sum",
   "SupportsNiceJavaBuilder",
   "SupportsNiceJavaBuilderWithRequiredProps",


### PR DESCRIPTION
When deserializing structures in a Union context, the Kernel used to try
options in an arbitrary order (actually - the declaration order which
often is alphanumerically sorted). In addition, it would ignore any
additional property encountered silently.

In cases where several of the union's possibilities had overlapping
required properties, the first attempted option would succeed, even if a
subsequent option would have consumed more properties. A pathologic case
of this is when the first candidate is a type with only optional
properties; as such a type would *always* successfully deserialize
anything, possibly ignoring all properties.

In order to address this, the `structs` can now be passed into the
Kernel by wrapping the object in a decorator box:
```js
{
  "$jsii.struct": {
    "fqn": "fully.qualified.struct.TypeName",
    "data": {
      /* the actual data included in the struct instance */
    }
  }
}
```

This enables "native" languages to correctly communicate the intended
type to the Kernel, so it can make an appropriate deserialization
decision.

The encoding of structs from the Kernel to "native" languages has not
changed: those are still passed by-reference in order to maximize the
compatibility; and to avoid undeterministic behavior in case where union
of structs are returned.

Fixes #822
Fixes aws/aws-cdk#3917
Fixes aws/aws-cdk#2013

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
