### PR TITLE
fix(pacmak): fix a couple of issues related to java generation

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -49,7 +49,9 @@ export class JavaBuilder implements TargetBuilder {
 
     if (!options.codeOnly && modules.length > 0) {
       // Need a module to get a target
-      const pomDirectory = await this.generateAggregatePom(moduleDirectories);
+      const pomDirectory = modules.length > 1
+        ? await this.generateAggregatePom(moduleDirectories)
+        : moduleDirectories[0].directory;
       const target = this.makeTarget(modules[0], options);
 
       await target.build(pomDirectory, singleOutputDir);
@@ -1089,11 +1091,10 @@ class JavaGenerator extends Generator {
 
     // Fields
     for (const prop of structType.allProperties) {
-      const methodName = JavaGenerator.safeJavaMethodName(prop.name);
       const fieldName = this.code.toCamelCase(JavaGenerator.safeJavaPropertyName(prop.name));
       this.code.line();
       const setter: spec.Method = {
-        name: methodName,
+        name: fieldName,
         docs: {
           stability: prop.spec.docs && prop.spec.docs.stability,
           returns: '{@code this}',
@@ -1106,8 +1107,8 @@ class JavaGenerator extends Generator {
       };
       this.addJavaDocs(setter);
       this.emitStabilityAnnotations(prop.spec);
-      this.code.openBlock(`public ${BUILDER_CLASS_NAME} ${methodName}(final ${this.toJavaType(prop.type.spec!)} ${fieldName})`);
-      this.code.line(`this.${structParamName}${firstStruct.optional ? '()' : ''}.${methodName}(${fieldName});`);
+      this.code.openBlock(`public ${BUILDER_CLASS_NAME} ${fieldName}(final ${this.toJavaType(prop.type.spec!)} ${fieldName})`);
+      this.code.line(`this.${structParamName}${firstStruct.optional ? '()' : ''}.${fieldName}(${fieldName});`);
       this.code.line('return this;');
       this.code.closeBlock();
     }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1105,12 +1105,14 @@ class JavaGenerator extends Generator {
           docs: prop.spec.docs,
         }],
       };
-      this.addJavaDocs(setter);
-      this.emitStabilityAnnotations(prop.spec);
-      this.code.openBlock(`public ${BUILDER_CLASS_NAME} ${fieldName}(final ${this.toJavaType(prop.type.spec!)} ${fieldName})`);
-      this.code.line(`this.${structParamName}${firstStruct.optional ? '()' : ''}.${fieldName}(${fieldName});`);
-      this.code.line('return this;');
-      this.code.closeBlock();
+      for (const javaType of this.toJavaTypes(prop.type.spec!)) {
+        this.addJavaDocs(setter);
+        this.emitStabilityAnnotations(prop.spec);
+        this.code.openBlock(`public ${BUILDER_CLASS_NAME} ${fieldName}(final ${javaType} ${fieldName})`);
+        this.code.line(`this.${structParamName}${firstStruct.optional ? '()' : ''}.${fieldName}(${fieldName});`);
+        this.code.line('return this;');
+        this.code.closeBlock();
+      }
     }
 
     // Final build method


### PR DESCRIPTION
Generating the aggregate POM could result in building a cyclic POM module tree,
as the aggregate POM file would then be replacing the module's own POM. This
stops aggregate-packaging single modules.

Also addresses an issue with the builder method names being generated
inconsistently across the Struct & Class builders, resulting in invalid
call forwarding being attempted.

Finally, it correctly generates overloads for Class builder methods.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
