### PR TITLE
feat(jsii-diff): make assembly validation optional

### DIFF
--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -18,7 +18,7 @@ async function main(): Promise<number> {
     .option('experimental-errors', { alias: 'e', type: 'boolean', default: false, desc: 'Error on experimental API changes' })
     .option('ignore-file', { alias: 'i', type: 'string', desc: 'Ignore API changes with keys from file (file may be missing)' })
     .option('keys', { alias: 'k', type: 'boolean', default: false, desc: 'Show diagnostic suppression keys' })
-    .option('validate', { alias: 'd', type: 'boolean', default: true, desc: 'Validate the assemblies that are being loaded' })
+    .option('validate', { alias: 'd', type: 'boolean', default: false, desc: 'Validate the assemblies that are being loaded' })
     .usage('$0 <original> [updated]', 'Compare two JSII assemblies.', args => args
       .positional('original', {
         description: 'Original assembly (file, package or "npm:package@version")',


### PR DESCRIPTION
Assembly validation is taking the majority of the time of doing the
API compatibility check, and the assemblies are almost guaranteed to
be correct.

Make it possible to skip the check for performance purposes.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
