### PR TITLE
chore: drop dotnet-sdk 2.2

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -12,9 +12,9 @@ COPY gpg/mono.asc /tmp/mono.asc
 RUN rpm --import "https://packages.microsoft.com/keys/microsoft.asc"                                                    \
   && rpm -Uvh "https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm"                                \
   && rpm --import /tmp/mono.asc && rm -f /tmp/mono.asc                                                                  \
-  && curl -sSL "https://download.mono-project.com/repo/centos6-stable.repo"                                             \
-      | tee /etc/yum.repos.d/mono-centos6-stable.repo                                                                   \
-  && yum -y install dotnet-sdk-3.0 dotnet-sdk-2.2 mono-devel powershell                                                 \
+  && curl -sSL "https://download.mono-project.com/repo/centos7-stable.repo"                                             \
+      | tee /etc/yum.repos.d/mono-centos7-stable.repo                                                                   \
+  && yum -y install dotnet-sdk-3.0 mono-devel powershell                                                                \
   && yum clean all && rm -rf /var/cache/yum                                                                             \
   && dotnet help
 

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -10,9 +10,9 @@ required in order to package [jsii] projects in all supported languages.
 SDK             | Version
 ----------------|-------------------------------------------
 `OpenJDK 8`     | Amazon Corretto `>= 8.222.10.2`
-`.NET SDK`      | `>= 3.0.100` and `>= 2.2.402`
+`.NET SDK`      | `>= 3.0.100`
 `mono`          | `>= 6.0.0.319`
-`Javascript`    | `node >= 10.16.3` with `npm >= 6.9.0`
+`Javascript`    | `node >= 10.17.0` with `npm >= 6.9.0`
 `PowerShell`    | `pwsh >= 6.2.3`
 `Python 3`      | `python3 >= 3.7.4` with `pip3 >= 19.3`
 `Ruby`          | `ruby >= 2.4.7p357`


### PR DESCRIPTION
Since `jsii` now requires `netcoreapp3.0` as the target, there is no
point in bloating the `Docker` image with `2.X` support anymore for all
customers. Those interested in that runtime are still abel to install it
as part of a derived image or in their application's code.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
