### PR TITLE
fix(pacmak): occasional EISDIR failure

### DIFF
--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -58,7 +58,13 @@ export class JsiiModule {
       // tarball name. otherwise, there can be a lot of extra noise there
       // from scripts that emit to STDOUT.
       const lines = out.trim().split(os.EOL);
-      return path.resolve(tmpdir, lines[lines.length - 1].trim());
+      const lastLine = lines[lines.length - 1].trim();
+
+      if (!lastLine.endsWith('.tgz') && !lastLine.endsWith('.tar.gz')) {
+        throw new Error(`npm pack did not produce tarball from ${this.moduleDirectory} into ${tmpdir} (output was ${JSON.stringify(lines)})`);
+      }
+
+      return path.resolve(tmpdir, lastLine);
     });
   }
 

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -52,7 +52,10 @@ export async function shell(cmd: string, args: string[], options: ShellOptions):
         stderr.push(Buffer.from(chunk));
       });
       child.once('error', ko);
-      child.once('exit', (code, signal) => {
+
+      // Muse use CLOSE instead of EXIT; EXIT may fire while there is still data in the
+      // I/O pipes, which we will miss if we return at that point.
+      child.once('close', (code, signal) => {
         const out = Buffer.concat(stdout).toString('utf-8');
         if (code === 0) { return ok(out); }
         const err = Buffer.concat(stderr).toString('utf-8');

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -53,7 +53,7 @@ export async function shell(cmd: string, args: string[], options: ShellOptions):
       });
       child.once('error', ko);
 
-      // Muse use CLOSE instead of EXIT; EXIT may fire while there is still data in the
+      // Must use CLOSE instead of EXIT; EXIT may fire while there is still data in the
       // I/O pipes, which we will miss if we return at that point.
       child.once('close', (code, signal) => {
         const out = Buffer.concat(stdout).toString('utf-8');


### PR DESCRIPTION
There was a race condition in capturing the output of `npm pack`.
Ocassionally we would miss the output, not get a tarball name, combine
the empty string with a directory, and then get an EISDIR error when
trying to copy the tarball as a file (but giving it a directory name).

This race has been in there forever, but it became easier to trigger
since we started running a lot of `npm pack`s in parallel.

The solution is to wait for a different event on the `ChildProcess`
object.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
