### PR TITLE
chore: resolve a large number of warnings in csharp codebase

### DIFF
--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Response/GetResponse.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Response/GetResponse.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace Amazon.JSII.JsonModel.Api.Response
 {

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Response/NamingResponse.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Api/Response/NamingResponse.cs
@@ -1,5 +1,4 @@
-﻿using Amazon.JSII.JsonModel.Converters;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/TypeConverter.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/TypeConverter.cs
@@ -1,6 +1,5 @@
 ﻿using Amazon.JSII.JsonModel.Spec;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 
 namespace Amazon.JSII.JsonModel.Converters

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/TypeDictionaryConverter.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/TypeDictionaryConverter.cs
@@ -1,27 +1,24 @@
-﻿using Amazon.JSII.JsonModel.Spec;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Amazon.JSII.JsonModel.Converters
 {
-    class TypeDictionaryConverter : JsonConverter
+    internal sealed class TypeDictionaryConverter : JsonConverter
     {
         public override bool CanRead => true;
 
         public override bool CanWrite => false;
 
-        public override bool CanConvert(System.Type objectType)
+        public override bool CanConvert(Type objectType)
         {
             throw new NotImplementedException();
         }
 
-        public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            JObject untypedDictionary = JObject.Load(reader);
+            var untypedDictionary = JObject.Load(reader);
 
             return untypedDictionary.Properties().ToDictionary(p => p.Name, p => Util.ConvertToDerivedType(p.Value));
         }

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/Util.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Converters/Util.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Amazon.JSII.JsonModel.Converters
 {
-    static class Util
+    internal static class Util
     {
         internal static Spec.Type ConvertToDerivedType(JToken token)
         {
@@ -14,27 +14,18 @@ namespace Amazon.JSII.JsonModel.Converters
                 throw new ArgumentException($"Unexpected token type: {token.Type}", nameof(token));
             }
 
-            if (token["kind"] is JToken kindToken)
+            if (!(token["kind"] is {} kindToken))
+                throw new ArgumentException($"Unexpected child token: '{token["kind"]}'", nameof(token));
+            
+            var kind = kindToken.ToObject<TypeKind>();
+
+            return kind switch
             {
-                TypeKind kind = kindToken.ToObject<TypeKind>();
-
-                switch (kind)
-                {
-                    case TypeKind.Enum:
-                        return token.ToObject<EnumType>();
-
-                    case TypeKind.Class:
-                        return token.ToObject<ClassType>();
-
-                    case TypeKind.Interface:
-                        return token.ToObject<InterfaceType>();
-
-                    default:
-                        throw new ArgumentException($"Unknown kind {kind} on type {token.ToString(Formatting.Indented)}", nameof(token));
-                }
-            }
-
-            throw new ArgumentException($"Unexpected child token: '{token["kind"]}'", nameof(token));
+                TypeKind.Enum => (Spec.Type) token.ToObject<EnumType>(),
+                TypeKind.Class => token.ToObject<ClassType>(),
+                TypeKind.Interface => token.ToObject<InterfaceType>(),
+                _ => throw new ArgumentException($"Unknown kind {kind} on type {token.ToString(Formatting.Indented)}", nameof(token))
+            };
         }
     }
 }

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/JsonDictionaryBase.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/JsonDictionaryBase.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace Amazon.JSII.JsonModel
 {
-    public abstract class JsonDictionaryBase<TKey, TValue> : IEnumerable, IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary<TKey, TValue>
+    public abstract class JsonDictionaryBase<TKey, TValue> : IDictionary<TKey, TValue>
     {
-        readonly IDictionary<TKey, TValue> _members = new Dictionary<TKey, TValue>();
+        private readonly IDictionary<TKey, TValue> _members = new Dictionary<TKey, TValue>();
 
         #region IDictionary implementation
 

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/ClassType.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/ClassType.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace Amazon.JSII.JsonModel.Spec
 {

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/DependencyRoot.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/DependencyRoot.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 
 namespace Amazon.JSII.JsonModel.Spec

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/InterfaceType.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/InterfaceType.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace Amazon.JSII.JsonModel.Spec
 {

--- a/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
+++ b/packages/jsii-dotnet-jsonmodel/src/Amazon.JSII.JsonModel/Spec/Method.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 
 namespace Amazon.JSII.JsonModel.Spec
 {

--- a/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/jsii-dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Amazon.JSII.Runtime.Deputy;
 using Amazon.JSII.Tests.CalculatorNamespace;
 using CompositeOperation = Amazon.JSII.Tests.CalculatorNamespace.composition.CompositeOperation;
@@ -53,7 +52,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             // number
             types.NumberProperty = 1234;
-            Assert.Equal((double) 1234, types.NumberProperty);
+            Assert.Equal(1234d, types.NumberProperty);
 
             // date
             types.DateProperty = UnixEpoch.AddMilliseconds(123);
@@ -61,13 +60,13 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             // json
             types.JsonProperty = JObject.Parse(@"{ ""Foo"": 123 }");
-            Assert.Equal((double) 123, types.JsonProperty["Foo"].Value<double>());
+            Assert.Equal(123d, types.JsonProperty["Foo"].Value<double>());
         }
 
         [Fact(DisplayName = Prefix + nameof(Dates))]
         public void Dates()
         {
-            AllTypes types = new AllTypes();
+            var types = new AllTypes();
 
             // strong type
             types.DateProperty = UnixEpoch.AddMilliseconds(123);
@@ -91,7 +90,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             IDictionary<string, Number> map = new Dictionary<string, Number>();
             map["Foo"] = new Number(123);
             types.MapProperty = map;
-            Assert.Equal((double) 123, types.MapProperty["Foo"].Value);
+            Assert.Equal(123d, types.MapProperty["Foo"].Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(ComplexCollectionTypes))]
@@ -122,7 +121,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             // number
             types.AnyProperty = 12;
-            Assert.Equal((double) 12, types.AnyProperty);
+            Assert.Equal(12d, types.AnyProperty);
 
             // date
             types.AnyProperty = UnixEpoch.AddSeconds(1234);
@@ -144,7 +143,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             var @object = (IDictionary<string, object>) types.AnyProperty;
             var array = (object[]) @object["Goo"];
             var innerObject = (IDictionary<string, object>) array[1];
-            Assert.Equal((double) 123, innerObject["World"]);
+            Assert.Equal(123d, innerObject["World"]);
 
             // array
             types.AnyProperty = new[] {"Hello", "World"};
@@ -153,7 +152,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             // array of any
             types.AnyArrayProperty = new object[] {"Hybrid", new Number(12), 123, false};
-            Assert.Equal((double) 123, types.AnyArrayProperty[2]);
+            Assert.Equal(123d, types.AnyArrayProperty[2]);
 
             // map
             IDictionary<string, object> map = new Dictionary<string, object>();
@@ -164,14 +163,14 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             // map of any
             map["Goo"] = 19289812;
             types.AnyMapProperty = map;
-            Assert.Equal((double) 19289812, types.AnyMapProperty["Goo"]);
+            Assert.Equal(19289812d, types.AnyMapProperty["Goo"]);
 
             // classes
-            Multiply mult = new Multiply(new Number(10), new Number(20));
+            var mult = new Multiply(new Number(10), new Number(20));
             types.AnyProperty = mult;
             Assert.Same(types.AnyProperty, mult);
             Assert.IsType<Multiply>(types.AnyProperty);
-            Assert.Equal((double) 200, ((Multiply) types.AnyProperty).Value);
+            Assert.Equal(200d, ((Multiply) types.AnyProperty).Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(UnionTypes))]
@@ -181,13 +180,13 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             // single valued property
             types.UnionProperty = 1234;
-            Assert.Equal((double) 1234, types.UnionProperty);
+            Assert.Equal(1234d, types.UnionProperty);
 
             types.UnionProperty = "Hello";
             Assert.Equal("Hello", types.UnionProperty);
 
             types.UnionProperty = new Multiply(new Number(2), new Number(12));
-            Assert.Equal((double) 24, ((Multiply) types.UnionProperty).Value);
+            Assert.Equal(24d, ((Multiply) types.UnionProperty).Value);
 
             // NOTE: union collections are untyped in C# (System.Object)
 
@@ -211,8 +210,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(CreateObjectAndCtorOverloads))]
         public void CreateObjectAndCtorOverloads()
         {
-            // TODO: Generator should create a parameterless constructor.
-            new Calculator(null);
+            new Calculator();
             var calc = new Calculator(new CalculatorProps() {
                 InitialValue = 100
             });
@@ -222,56 +220,53 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(GetSetPrimitiveProperties))]
         public void GetSetPrimitiveProperties()
         {
-            Number number = new Number(20);
-            Assert.Equal((double) 20, number.Value);
-            Assert.Equal((double) 40, number.DoubleValue);
-            Assert.Equal((double) -30, new Negate(new Add(new Number(20), new Number(10))).Value);
-            Assert.Equal((double) 20, new Multiply(new Add(new Number(5), new Number(5)), new Number(2)).Value);
-            Assert.Equal((double) 3 * 3 * 3 * 3, new Power(new Number(3), new Number(4)).Value);
-            Assert.Equal((double) 999, new Power(new Number(999), new Number(1)).Value);
-            Assert.Equal((double) 1, new Power(new Number(999), new Number(0)).Value);
+            var number = new Number(20);
+            Assert.Equal(20d, number.Value);
+            Assert.Equal(40d, number.DoubleValue);
+            Assert.Equal(-30d, new Negate(new Add(new Number(20), new Number(10))).Value);
+            Assert.Equal(20d, new Multiply(new Add(new Number(5), new Number(5)), new Number(2)).Value);
+            Assert.Equal(3d * 3d * 3d * 3d, new Power(new Number(3), new Number(4)).Value);
+            Assert.Equal(999d, new Power(new Number(999), new Number(1)).Value);
+            Assert.Equal(1d, new Power(new Number(999), new Number(0)).Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(CallMethods))]
         public void CallMethods()
         {
-            // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator();
 
             calc.Add(10);
-            Assert.Equal((double) 10, calc.Value);
+            Assert.Equal(10d, calc.Value);
 
             calc.Mul(2);
-            Assert.Equal((double) 20, calc.Value);
+            Assert.Equal(20d, calc.Value);
 
             calc.Pow(5);
-            Assert.Equal((double) 20 * 20 * 20 * 20 * 20, calc.Value);
+            Assert.Equal(20d * 20d * 20d * 20d * 20d, calc.Value);
 
             calc.Neg();
-            Assert.Equal((double) -3200000, calc.Value);
+            Assert.Equal(-3200000d, calc.Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(UnmarkshallIntoAbstractType))]
         public void UnmarkshallIntoAbstractType()
         {
-            // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator();
 
             calc.Add(120);
-            Value_ value = calc.Curr;
-            Assert.Equal((double) 120, value.Value);
+            var value = calc.Curr;
+            Assert.Equal(120d, value.Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(GetAndSetNotPrimitiveProperties))]
         public void GetAndSetNotPrimitiveProperties()
         {
-            // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator();
 
             calc.Add(3200000);
             calc.Neg();
             calc.Curr = new Multiply(new Number(2), calc.Curr);
-            Assert.Equal((double) -6400000, calc.Value);
+            Assert.Equal(-6400000d, calc.Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(GetAndSetEnumValues))]
@@ -312,11 +307,13 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(Arrays))]
         public void Arrays()
         {
-            Sum sum = new Sum();
-            sum.Parts = new Value_[] {new Number(5), new Number(10), new Multiply(new Number(2), new Number(3))};
-            Assert.Equal((double) 10 + 5 + (2 * 3), sum.Value);
-            Assert.Equal((double) 5, sum.Parts[0].Value);
-            Assert.Equal((double) 6, sum.Parts[2].Value);
+            var sum = new Sum
+            {
+                Parts = new Value_[] {new Number(5), new Number(10), new Multiply(new Number(2), new Number(3))}
+            };
+            Assert.Equal(10d + 5d + 2d * 3d, sum.Value);
+            Assert.Equal(5d, sum.Parts[0].Value);
+            Assert.Equal(6d, sum.Parts[2].Value);
             Assert.Equal("(((0 + 5) + 10) + (2 * 3))", sum.ToString());
         }
 
@@ -324,7 +321,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         public void Maps()
         {
             // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator(new CalculatorProps());
 
             calc.Add(10);
             calc.Add(20);
@@ -332,7 +329,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             Assert.Collection(
                 calc.OperationsMap["add"],
                 val => { },
-                val => Assert.Equal((double) 30, val.Value)
+                val => Assert.Equal(30d, val.Value)
             );
             Assert.Collection(
                 calc.OperationsMap["mul"],
@@ -355,31 +352,30 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(Exceptions))]
         public void Exceptions()
         {
-            Calculator calc = new Calculator(new CalculatorProps
+            var calc = new Calculator(new CalculatorProps
             {
                 InitialValue = 20,
                 MaximumValue = 30,
             });
 
             calc.Add(3);
-            Assert.Equal((double) 23, calc.Value);
+            Assert.Equal(23d, calc.Value);
 
             Assert.Throws<JsiiException>(() => calc.Add(10));
 
             calc.MaxValue = 40;
             calc.Add(10);
-            Assert.Equal((double) 33, calc.Value);
+            Assert.Equal(33d, calc.Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(UnionProperties))]
         public void UnionProperties()
         {
-            // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator();
 
             calc.UnionProperty = new Multiply(new Number(9), new Number(3));
             Assert.IsType<Multiply>(calc.UnionProperty);
-            Assert.Equal((double) 9 * 3, calc.ReadUnionValue());
+            Assert.Equal(9d * 3, calc.ReadUnionValue());
 
             calc.UnionProperty = new Power(new Number(10), new Number(3));
             Assert.IsType<Power>(calc.UnionProperty);
@@ -388,49 +384,42 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(SubClassing))]
         public void SubClassing()
         {
-            // TODO: Generator should create a parameterless constructor.
-            Calculator calc = new Calculator(new CalculatorProps());
+            var calc = new Calculator();
 
             calc.Curr = new AddTen(33);
             calc.Neg();
-            Assert.Equal((double) -43, calc.Value);
+            Assert.Equal(-43d, calc.Value);
         }
 
-        [Fact(DisplayName = Prefix + nameof(TestJSObjectLiteralToNative))]
-        public void TestJSObjectLiteralToNative()
+        [Fact(DisplayName = Prefix + nameof(TestJsObjectLiteralToNative))]
+        public void TestJsObjectLiteralToNative()
         {
-            JSObjectLiteralToNative obj = new JSObjectLiteralToNative();
-            JSObjectLiteralToNativeClass obj2 = obj.ReturnLiteral();
+            var obj = new JSObjectLiteralToNative();
+            var obj2 = obj.ReturnLiteral();
 
             Assert.Equal("Hello", obj2.PropA);
-            Assert.Equal((double) 102, obj2.PropB);
-        }
-
-        [Fact(DisplayName = Prefix + nameof(TestFluentApiWithDerivedClasses), Skip = "There is no fluent API for C#")]
-        public void TestFluentApiWithDerivedClasses()
-        {
-            throw new NotImplementedException();
+            Assert.Equal(102d, obj2.PropB);
         }
 
         [Fact(DisplayName = Prefix + nameof(CreationOfNativeObjectsFromJavaScriptObjects))]
         public void CreationOfNativeObjectsFromJavaScriptObjects()
         {
-            AllTypes types = new AllTypes();
+            var types = new AllTypes();
 
-            Number jsObj = new Number(44);
+            var jsObj = new Number(44);
             types.AnyProperty = jsObj;
-            object unmarshalledJSObj = types.AnyProperty;
+            var unmarshalledJSObj = types.AnyProperty;
             Assert.IsType<Number>(unmarshalledJSObj);
 
-            AddTen nativeObj = new AddTen(10);
+            var nativeObj = new AddTen(10);
             types.AnyProperty = nativeObj;
 
-            object result1 = types.AnyProperty;
+            var result1 = types.AnyProperty;
             Assert.Same(nativeObj, result1);
 
-            MulTen nativeObj2 = new MulTen(20);
+            var nativeObj2 = new MulTen(20);
             types.AnyProperty = nativeObj2;
-            object unmarshalledNativeObj = types.AnyProperty;
+            var unmarshalledNativeObj = types.AnyProperty;
             Assert.IsType<MulTen>(unmarshalledNativeObj);
             Assert.Same(nativeObj2, unmarshalledNativeObj);
         }
@@ -447,37 +436,37 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         public void AsyncOverrides_CallAsyncMethod()
         {
             AsyncVirtualMethods obj = new AsyncVirtualMethods();
-            Assert.Equal((double) 128, obj.CallMe());
-            Assert.Equal((double) 528, obj.OverrideMe(44));
+            Assert.Equal(128d, obj.CallMe());
+            Assert.Equal(528d, obj.OverrideMe(44));
         }
 
         [Fact(DisplayName = Prefix + nameof(AsyncOverrides_OverrideAsyncMethod))]
         public void AsyncOverrides_OverrideAsyncMethod()
         {
             OverrideAsyncMethods obj = new OverrideAsyncMethods();
-            Assert.Equal((double) 4452, obj.CallMe());
+            Assert.Equal(4452d, obj.CallMe());
         }
 
         [Fact(DisplayName = Prefix + nameof(AsyncOverrides_OverrideAsyncMethodByParentClass))]
         public void AsyncOverrides_OverrideAsyncMethodByParentClass()
         {
             OverrideAsyncMethodsByBaseClass obj = new OverrideAsyncMethodsByBaseClass();
-            Assert.Equal((double) 4452, obj.CallMe());
+            Assert.Equal(4452d, obj.CallMe());
         }
 
         [Fact(DisplayName = Prefix + nameof(AsyncOverrides_OverrideCallsSuper))]
         public void AsyncOverrides_OverrideCallsSuper()
         {
             OverrideCallsSuper obj = new OverrideCallsSuper();
-            Assert.Equal((double) 1441, obj.OverrideMe(12));
-            Assert.Equal((double) 1209, obj.CallMe());
+            Assert.Equal(1441d, obj.OverrideMe(12));
+            Assert.Equal(1209d, obj.CallMe());
         }
 
         [Fact(DisplayName = Prefix + nameof(AsyncOverrides_TwoOverrides))]
         public void AsyncOverrides_TwoOverrides()
         {
             TwoOverrides obj = new TwoOverrides();
-            Assert.Equal((double) 684, obj.CallMe());
+            Assert.Equal(684d, obj.CallMe());
         }
 
         [Fact(DisplayName = Prefix + nameof(AsyncOverrides_OverrideThrows))]
@@ -597,28 +586,28 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         public void SyncOverrides_SyncOverrides()
         {
             SyncOverrides obj = new SyncOverrides();
-            Assert.Equal((double) 10 * 5, obj.CallerIsMethod());
+            Assert.Equal(10d * 5, obj.CallerIsMethod());
 
             // affect the result
             obj.Multiplier = 5;
-            Assert.Equal((double) 10 * 5 * 5, obj.CallerIsMethod());
+            Assert.Equal(10d * 5 * 5, obj.CallerIsMethod());
 
             // verify callbacks are invoked from a property
-            Assert.Equal((double) 10 * 5 * 5, obj.CallerIsProperty);
+            Assert.Equal(10d * 5 * 5, obj.CallerIsProperty);
 
             // and from an async method
             obj.Multiplier = 3;
-            Assert.Equal((double) 10 * 5 * 3, obj.CallerIsAsync());
+            Assert.Equal(10d * 5 * 3, obj.CallerIsAsync());
         }
 
         [Fact(DisplayName = Prefix + nameof(SyncOverrides_CallsSuper))]
         public void SyncOverrides_CallsSuper()
         {
             SyncOverrides obj = new SyncOverrides();
-            Assert.Equal((double) 10 * 5, obj.CallerIsProperty);
+            Assert.Equal(10d * 5, obj.CallerIsProperty);
 
             obj.ReturnSuper = true; // js code returns n * 2
-            Assert.Equal((double) 10 * 2, obj.CallerIsProperty);
+            Assert.Equal(10d * 2, obj.CallerIsProperty);
         }
 
         [Fact(DisplayName = Prefix + nameof(SyncOverrides_CallsDoubleAsyncMethodFails))]
@@ -668,11 +657,11 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             // friendlyRandomGenerator = multiply; // <-- shouldn't compile
             Assert.Equal("Hello, I am a binary operation. What's your name?", friendly.Hello());
             Assert.Equal("Goodbye from Multiply!", friendlier.Goodbye());
-            Assert.Equal((double) 89, randomNumberGenerator.Next());
+            Assert.Equal(89d, randomNumberGenerator.Next());
 
             friendlyRandomGenerator = new DoubleTrouble();
             Assert.Equal("world", friendlyRandomGenerator.Hello());
-            Assert.Equal((double) 12, friendlyRandomGenerator.Next());
+            Assert.Equal(12d, friendlyRandomGenerator.Next());
 
             Polymorphism poly = new Polymorphism();
             Assert.Equal("oh, Hello, I am a binary operation. What's your name?", poly.SayHello(friendly));
@@ -705,16 +694,16 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             NumberGenerator generatorBoundToPSubclassedObject = new NumberGenerator(subclassedNative);
             Assert.Same(subclassedNative, generatorBoundToPSubclassedObject.Generator);
             generatorBoundToPSubclassedObject.IsSameGenerator(subclassedNative);
-            Assert.Equal((double) 10000, generatorBoundToPSubclassedObject.NextTimes100());
+            Assert.Equal(10000d, generatorBoundToPSubclassedObject.NextTimes100());
 
             // when we invoke nextTimes100 again, it will use the objref and call into the same object.
-            Assert.Equal((double) 20000, generatorBoundToPSubclassedObject.NextTimes100());
+            Assert.Equal(20000d, generatorBoundToPSubclassedObject.NextTimes100());
 
             NumberGenerator generatorBoundToPureNative = new NumberGenerator(pureNative);
             Assert.Same(pureNative, generatorBoundToPureNative.Generator);
             generatorBoundToPureNative.IsSameGenerator(pureNative);
-            Assert.Equal((double) 100000, generatorBoundToPureNative.NextTimes100());
-            Assert.Equal((double) 200000, generatorBoundToPureNative.NextTimes100());
+            Assert.Equal(100000d, generatorBoundToPureNative.NextTimes100());
+            Assert.Equal(200000d, generatorBoundToPureNative.NextTimes100());
         }
 
         [Fact(DisplayName = Prefix + nameof(TestLiteralInterface))]
@@ -726,7 +715,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             IFriendlyRandomGenerator gen = obj.GiveMeFriendlyGenerator();
             Assert.Equal("giveMeFriendlyGenerator", gen.Hello());
-            Assert.Equal((double) 42, gen.Next());
+            Assert.Equal(42d, gen.Next());
         }
 
         [Fact(DisplayName = Prefix + nameof(TestInterfaceParameter))]
@@ -866,16 +855,16 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         public void NullShouldBeTreatedAsUndefined()
         {
             // ctor
-            var obj = new NullShouldBeTreatedAsUndefined("param1", null);
+            var obj = new NullShouldBeTreatedAsUndefined("param1");
 
             // method argument
-            obj.GiveMeUndefined(null);
+            obj.GiveMeUndefined();
 
             // inside object
             obj.GiveMeUndefinedInsideAnObject(new NullShouldBeTreatedAsUndefinedData
             {
                 ThisShouldBeUndefined = null,
-                ArrayWithThreeElementsAndUndefinedAsSecondArgument = new[] {"hello", null, "world"}
+                ArrayWithThreeElementsAndUndefinedAsSecondArgument = new object[] {"hello", null, "world"}
             });
 
             // property
@@ -887,7 +876,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         public void OptionalAndVariadicArgumentsTest()
         {
             // ctor
-            var objWithOptionalProvided = new NullShouldBeTreatedAsUndefined("param1", null);
+            new NullShouldBeTreatedAsUndefined("param1", null);
             var objWithoutOptionalProvided = new NullShouldBeTreatedAsUndefined("param1");
 
             // method argument called with null value
@@ -900,28 +889,28 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             var variadicClassNoParams = new VariadicMethod();
 
             // Array with null value in constructor params
-            var variadicClassNullParams = new VariadicMethod(null);
+            new VariadicMethod(null);
 
             // Array with one value in constructor params
-            var variadicClassOneParam = new VariadicMethod(1);
+            new VariadicMethod(1);
 
             // Array with multiple values in constructor params
-            var variadicClassMultipleParams = new VariadicMethod(1, 2, 3, 4);
+            new VariadicMethod(1, 2, 3, 4);
 
             // Variadic parameter with null passed
-            variadicClassNoParams.AsArray(Double.MinValue, null);
+            variadicClassNoParams.AsArray(double.MinValue, null);
 
             // Variadic parameter with default value used
-            variadicClassNoParams.AsArray(Double.MinValue);
+            variadicClassNoParams.AsArray(double.MinValue);
 
             var list = new List<double>();
 
             // Variadic parameter with array with no value
-            variadicClassNoParams.AsArray(Double.MinValue, list.ToArray());
+            variadicClassNoParams.AsArray(double.MinValue, list.ToArray());
 
             // Variadic parameter with array with one value
             list.Add(1d);
-            variadicClassNoParams.AsArray(Double.MinValue, list.ToArray());
+            variadicClassNoParams.AsArray(double.MinValue, list.ToArray());
 
             // Variadic parameter with array with multiple value
             list.Add(2d);
@@ -930,13 +919,13 @@ namespace Amazon.JSII.Runtime.IntegrationTests
             list.Add(5d);
             list.Add(6d);
 
-            variadicClassNoParams.AsArray(Double.MinValue, list.ToArray());
+            variadicClassNoParams.AsArray(double.MinValue, list.ToArray());
         }
 
         [Fact(DisplayName = Prefix + nameof(JsiiAgent))]
         public void JsiiAgent()
         {
-            Assert.Equal("DotNet/" + Environment.Version.ToString() + "/.NETCoreApp,Version=v3.0/1.0.0.0", JsiiAgent_.JsiiAgent);
+            Assert.Equal("DotNet/" + Environment.Version + "/.NETCoreApp,Version=v3.0/1.0.0.0", JsiiAgent_.JsiiAgent);
         }
 
         [Fact(DisplayName = Prefix + nameof(ReceiveInstanceOfPrivateClass))]
@@ -1166,9 +1155,9 @@ namespace Amazon.JSII.Runtime.IntegrationTests
 
             public int Multiplier { get; set; } = 1;
 
-            public bool ReturnSuper { get; set; } = false;
+            public bool ReturnSuper { get; set; }
 
-            public bool CallAsync { get; set; } = false;
+            public bool CallAsync { get; set; }
 
             public override string TheProperty
             {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/AnonymousObject.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/AnonymousObject.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Dynamic;
-using System.Reflection.Emit;
-
 namespace Amazon.JSII.Runtime.Deputy
 {
     internal sealed class AnonymousObject : DeputyBase

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
@@ -6,7 +6,6 @@ using Amazon.JSII.Runtime.Services.Converters;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -21,7 +20,7 @@ namespace Amazon.JSII.Runtime.Deputy
         /// argument. So for the protected constructor, we pass DeputyProps instead of object[] to
         /// prevent overload ambiguity.
         /// </summary>
-        public sealed class DeputyProps
+        protected sealed class DeputyProps
         {
             public DeputyProps(object[] arguments = null)
             {
@@ -31,30 +30,28 @@ namespace Amazon.JSII.Runtime.Deputy
             public object[] Arguments { get; }
         }
 
-        const BindingFlags StaticMemberFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
-        const BindingFlags InstanceMemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private const BindingFlags StaticMemberFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+        private const BindingFlags InstanceMemberFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
         protected DeputyBase(DeputyProps props = null)
         {
-            props = props ?? new DeputyProps();
-
-            System.Type type = GetType();
+            var type = GetType();
 
             // If this is a native object, it won't have any jsii metadata.
-            JsiiClassAttribute attribute = ReflectionUtils.GetClassAttribute(type);
-            string fullyQualifiedName = attribute?.FullyQualifiedName ?? "Object";
-            Parameter[] parameters = attribute?.Parameters ?? new Parameter[] { };
+            var attribute = ReflectionUtils.GetClassAttribute(type);
+            var fullyQualifiedName = attribute?.FullyQualifiedName ?? "Object";
+            var parameters = attribute?.Parameters ?? new Parameter[] { };
 
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IClient client = serviceProvider.GetRequiredService<IClient>();
-            CreateResponse response = client.Create(
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var client = serviceProvider.GetRequiredService<IClient>();
+            var response = client.Create(
                 fullyQualifiedName,
-                ConvertArguments(parameters, props.Arguments),
+                ConvertArguments(parameters, props?.Arguments ?? new object[]{ }),
                 GetOverrides()
             );
 
             Reference = new ByRefValue(response["$jsii.byref"] as string);
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
             referenceMap.AddNativeReference(Reference, this, true);
 
             Override[] GetOverrides()
@@ -71,7 +68,7 @@ namespace Amazon.JSII.Runtime.Deputy
 
                     if ((inheritedAttribute != null && uninheritedAttribute == null) || uninheritedAttribute?.IsOverride == true)
                     {
-                        yield return new Override(method: inheritedAttribute.Name);
+                        yield return new Override(method: (inheritedAttribute ?? uninheritedAttribute).Name);
                     }
                 }
             }
@@ -85,7 +82,7 @@ namespace Amazon.JSII.Runtime.Deputy
 
                     if ((inheritedAttribute != null && uninheritedAttribute == null) || uninheritedAttribute?.IsOverride == true)
                     {
-                        yield return new Override(property: inheritedAttribute.Name);
+                        yield return new Override(property: (inheritedAttribute ?? uninheritedAttribute).Name);
                     }
                 }
             }
@@ -95,12 +92,10 @@ namespace Amazon.JSII.Runtime.Deputy
         {
             Reference = reference ?? throw new ArgumentNullException(nameof(reference));
 
-            if (!(reference.IsProxy))
-            {
-                IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-                IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
-                referenceMap.AddNativeReference(Reference, this);
-            }
+            if (reference.IsProxy) return;
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            referenceMap.AddNativeReference(Reference, this);
         }
 
         public ByRefValue Reference { get; }
@@ -112,8 +107,8 @@ namespace Amazon.JSII.Runtime.Deputy
             type = type ?? throw new ArgumentNullException(nameof(type));
             propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
 
-            JsiiClassAttribute classAttribute = ReflectionUtils.GetClassAttribute(type);
-            JsiiPropertyAttribute propertyAttribute = GetStaticPropertyAttribute(type, propertyName);
+            var classAttribute = ReflectionUtils.GetClassAttribute(type);
+            var propertyAttribute = GetStaticPropertyAttribute(type, propertyName);
 
             return GetPropertyCore<T>(
                 propertyAttribute,
@@ -125,7 +120,7 @@ namespace Amazon.JSII.Runtime.Deputy
         {
             propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
 
-            JsiiPropertyAttribute propertyAttribute = GetInstancePropertyAttribute(propertyName);
+            var propertyAttribute = GetInstancePropertyAttribute(propertyName);
 
             return GetPropertyCore<T>(
                 propertyAttribute,
@@ -133,15 +128,15 @@ namespace Amazon.JSII.Runtime.Deputy
             );
         }
 
-        static T GetPropertyCore<T>(JsiiPropertyAttribute propertyAttribute, Func<IClient, GetResponse> getFunc)
+        private static T GetPropertyCore<T>(JsiiPropertyAttribute propertyAttribute, Func<IClient, GetResponse> getFunc)
         {
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IClient client = serviceProvider.GetRequiredService<IClient>();
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var client = serviceProvider.GetRequiredService<IClient>();
 
-            GetResponse response = getFunc(client);
+            var response = getFunc(client);
 
-            IJsiiToFrameworkConverter converter = serviceProvider.GetRequiredService<IJsiiToFrameworkConverter>();
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var converter = serviceProvider.GetRequiredService<IJsiiToFrameworkConverter>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
             if (!converter.TryConvert(propertyAttribute, typeof(T), referenceMap, response.Value, out object frameworkValue))
             {
                 throw new ArgumentException($"Could not convert value '{response.Value}' for property '{propertyAttribute.Name}'", nameof(getFunc));
@@ -159,8 +154,8 @@ namespace Amazon.JSII.Runtime.Deputy
             type = type ?? throw new ArgumentNullException(nameof(type));
             propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
 
-            JsiiClassAttribute classAttribute = ReflectionUtils.GetClassAttribute(type);
-            JsiiPropertyAttribute propertyAttribute = GetStaticPropertyAttribute(type, propertyName);
+            var classAttribute = ReflectionUtils.GetClassAttribute(type);
+            var propertyAttribute = GetStaticPropertyAttribute(type, propertyName);
 
             SetPropertyCore(
                 value,
@@ -173,7 +168,7 @@ namespace Amazon.JSII.Runtime.Deputy
         {
             propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
 
-            JsiiPropertyAttribute propertyAttribute = GetInstancePropertyAttribute(propertyName);
+            var propertyAttribute = GetInstancePropertyAttribute(propertyName);
 
             SetPropertyCore(
                 value,
@@ -182,17 +177,17 @@ namespace Amazon.JSII.Runtime.Deputy
             );
         }
 
-        static void SetPropertyCore<T>(T value, JsiiPropertyAttribute propertyAttribute, Action<IClient, object> setAction)
+        private static void SetPropertyCore<T>(T value, JsiiPropertyAttribute propertyAttribute, Action<IClient, object> setAction)
         {
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IFrameworkToJsiiConverter converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
             if (!converter.TryConvert(propertyAttribute, referenceMap, value, out object jsiiValue))
             {
                 throw new ArgumentException($"Could not set property '{propertyAttribute.Name}' to '{value}'", nameof(value));
             }
 
-            IClient client = serviceProvider.GetRequiredService<IClient>();
+            var client = serviceProvider.GetRequiredService<IClient>();
             setAction(client, jsiiValue);
         }
 
@@ -212,8 +207,8 @@ namespace Amazon.JSII.Runtime.Deputy
 
         protected static T InvokeStaticMethod<T>(System.Type type, System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = null)
         {
-            JsiiMethodAttribute methodAttribute = GetStaticMethodAttribute(type, methodName, parameterTypes);
-            JsiiClassAttribute classAttribute = ReflectionUtils.GetClassAttribute(type);
+            var methodAttribute = GetStaticMethodAttribute(type, methodName, parameterTypes);
+            var classAttribute = ReflectionUtils.GetClassAttribute(type);
 
             return InvokeMethodCore<T>(
                 methodAttribute,
@@ -229,7 +224,7 @@ namespace Amazon.JSII.Runtime.Deputy
 
         protected T InvokeInstanceMethod<T>(System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = null)
         {
-            JsiiMethodAttribute methodAttribute = GetInstanceMethodAttribute(methodName, parameterTypes);
+            var methodAttribute = GetInstanceMethodAttribute(methodName, parameterTypes);
 
             return InvokeMethodCore<T>(
                 methodAttribute,
@@ -247,19 +242,19 @@ namespace Amazon.JSII.Runtime.Deputy
             );
         }
 
-        static T InvokeMethodCore<T>(
+        private static T InvokeMethodCore<T>(
             JsiiMethodAttribute methodAttribute,
             object[] arguments,
             Func<IClient, object[], BeginResponse> beginFunc,
             Func<IClient, object[], InvokeResponse> invokeFunc
         )
         {
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IClient client = serviceProvider.GetRequiredService<IClient>();
-            IJsiiToFrameworkConverter converter = serviceProvider.GetRequiredService<IJsiiToFrameworkConverter>();
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var client = serviceProvider.GetRequiredService<IClient>();
+            var converter = serviceProvider.GetRequiredService<IJsiiToFrameworkConverter>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
 
-            object result = GetResult();
+            var result = GetResult();
             if (!converter.TryConvert(methodAttribute.Returns, typeof(T), referenceMap, result, out object frameworkValue))
             {
                 throw new ArgumentException($"Could not convert result '{result}' for method '{methodAttribute.Name}'", nameof(result));
@@ -269,36 +264,36 @@ namespace Amazon.JSII.Runtime.Deputy
 
             object GetResult()
             {
-                object[] args = ConvertArguments(methodAttribute.Parameters, arguments);
+                var args = ConvertArguments(methodAttribute.Parameters, arguments);
 
                 if (methodAttribute.IsAsync)
                 {
-                    BeginResponse beginResponse = beginFunc(client, args);
+                    var beginResponse = beginFunc(client, args);
 
                     InvokeCallbacks();
 
                     return client.End(beginResponse.PromiseId).Result;
                 }
 
-                InvokeResponse invokeResponse = invokeFunc(client, args);
+                var invokeResponse = invokeFunc(client, args);
 
                 return invokeResponse.Result;
             }
         }
 
-        static void InvokeCallbacks()
+        private static void InvokeCallbacks()
         {
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
-            IClient client = serviceProvider.GetRequiredService<IClient>();
-            IFrameworkToJsiiConverter converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var serviceProvider = ServiceContainer.ServiceProvider;
+            var client = serviceProvider.GetRequiredService<IClient>();
+            var converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
 
-            CallbacksResponse callbacks = client.Callbacks();
+            var callbacks = client.Callbacks();
             while (callbacks.Callbacks.Any())
             {
-                foreach (Callback callback in callbacks.Callbacks)
+                foreach (var callback in callbacks.Callbacks)
                 {
-                    object result = callback.InvokeCallback(referenceMap, converter, out string error);
+                    var result = callback.InvokeCallback(referenceMap, converter, out var error);
 
                     client.Complete(callback.CallbackId, error, result);
                 }
@@ -311,11 +306,11 @@ namespace Amazon.JSII.Runtime.Deputy
 
         #region ConvertArguments
 
-        static object[] ConvertArguments(Parameter[] parameters, params object[] arguments)
+        private static object[] ConvertArguments(Parameter[] parameters, params object[] arguments)
         {
-            IServiceProvider serviceProvider = ServiceContainer.ServiceProvider;
+            var serviceProvider = ServiceContainer.ServiceProvider;
 
-            if (parameters == null && arguments == null)
+            if ((parameters == null || parameters.Length == 0) && (arguments == null || arguments.Length == 0))
             {
                 return new object[] { };
             }
@@ -332,7 +327,7 @@ namespace Amazon.JSII.Runtime.Deputy
             if (parameters.Length > 0 && parameters.Last().IsVariadic)
             {
                 // Last parameter is variadic, let's explode the .NET attributes
-                Array variadicValues = arguments.Last() as Array;
+                var variadicValues = arguments.Last() as Array;
 
                 // We remove the last argument (the variadic array);
                 cleanedArgs.RemoveAt(cleanedArgs.Count - 1);
@@ -343,7 +338,7 @@ namespace Amazon.JSII.Runtime.Deputy
                     // We save the last parameter to backfill the parameters list
                     var lastParameter = cleanedParams.Last();
 
-                    for (int i = 0; i < variadicValues.Length; i++)
+                    for (var i = 0; i < variadicValues.Length; i++)
                     {
                         // Backfill the arguments
                         cleanedArgs.Add(variadicValues.GetValue(i));
@@ -355,8 +350,8 @@ namespace Amazon.JSII.Runtime.Deputy
                 }
             }
 
-            IFrameworkToJsiiConverter converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
-            IReferenceMap referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
+            var converter = serviceProvider.GetRequiredService<IFrameworkToJsiiConverter>();
+            var referenceMap = serviceProvider.GetRequiredService<IReferenceMap>();
 
             return cleanedParams.Zip(cleanedArgs, (parameter, frameworkArgument) =>
             {
@@ -373,28 +368,28 @@ namespace Amazon.JSII.Runtime.Deputy
 
         #region GetPropertyAttribute
 
-        static JsiiPropertyAttribute GetStaticPropertyAttribute(System.Type type, string propertyName)
+        private static JsiiPropertyAttribute GetStaticPropertyAttribute(System.Type type, string propertyName)
         {
             return GetPropertyAttributeCore(type, propertyName, StaticMemberFlags);
         }
 
-        JsiiPropertyAttribute GetInstancePropertyAttribute(string propertyName)
+        private JsiiPropertyAttribute GetInstancePropertyAttribute(string propertyName)
         {
             return GetPropertyAttributeCore(GetType(), propertyName, InstanceMemberFlags);
         }
 
-        static JsiiPropertyAttribute GetPropertyAttributeCore(System.Type type, string propertyName, BindingFlags bindingFlags)
+        private static JsiiPropertyAttribute GetPropertyAttributeCore(System.Type type, string propertyName, BindingFlags bindingFlags)
         {
             type = type ?? throw new ArgumentNullException(nameof(type));
             propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
 
-            PropertyInfo propertyInfo = type.GetProperty(propertyName, bindingFlags);
+            var propertyInfo = type.GetProperty(propertyName, bindingFlags);
             if (propertyInfo == null)
             {
                 throw new ArgumentException($"Property {propertyName} does not exist", nameof(propertyName));
             }
 
-            JsiiPropertyAttribute attribute = propertyInfo.GetCustomAttribute<JsiiPropertyAttribute>();
+            var attribute = propertyInfo.GetCustomAttribute<JsiiPropertyAttribute>();
             if (attribute == null)
             {
                 throw new ArgumentException($"Property {propertyName} is missing JsiiPropertyAttribute", nameof(propertyName));
@@ -407,29 +402,29 @@ namespace Amazon.JSII.Runtime.Deputy
 
         #region GetMethodAttribute
 
-        static JsiiMethodAttribute GetStaticMethodAttribute(System.Type type, string methodName, System.Type[] parameterTypes)
+        private static JsiiMethodAttribute GetStaticMethodAttribute(System.Type type, string methodName, System.Type[] parameterTypes)
         {
             return GetMethodAttributeCore(type, methodName, parameterTypes, StaticMemberFlags);
         }
 
-        JsiiMethodAttribute GetInstanceMethodAttribute(string methodName, System.Type[] parameterTypes)
+        private JsiiMethodAttribute GetInstanceMethodAttribute(string methodName, System.Type[] parameterTypes)
         {
             return GetMethodAttributeCore(GetType(), methodName, parameterTypes, InstanceMemberFlags);
         }
 
-        static JsiiMethodAttribute GetMethodAttributeCore(System.Type type, string methodName, System.Type[] parameterTypes, BindingFlags bindingFlags)
+        private static JsiiMethodAttribute GetMethodAttributeCore(System.Type type, string methodName, System.Type[] parameterTypes, BindingFlags bindingFlags)
         {
             methodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
             type = type ?? throw new ArgumentNullException(nameof(type));
             parameterTypes = parameterTypes ?? throw new ArgumentException(nameof(parameterTypes));
 
-            MethodInfo methodInfo = type.GetMethod(methodName, bindingFlags, null, parameterTypes, new ParameterModifier[0]);
+            var methodInfo = type.GetMethod(methodName, bindingFlags, null, parameterTypes, new ParameterModifier[0]);
             if (methodInfo == null)
             {
                 throw new ArgumentException($"Method {methodName} does not exist", nameof(methodName));
             }
 
-            JsiiMethodAttribute methodAttribute = methodInfo.GetCustomAttribute<JsiiMethodAttribute>();
+            var methodAttribute = methodInfo.GetCustomAttribute<JsiiMethodAttribute>();
             if (methodAttribute == null)
             {
                 throw new ArgumentException($"Method {methodName} is missing JsiiMethodAttribute", nameof(methodName));

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/ReflectionUtils.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/ReflectionUtils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using Amazon.JSII.Runtime.Deputy;
@@ -9,9 +9,9 @@ namespace Amazon.JSII.Runtime
     {
         public static FieldInfo GetEnumMember(Type enumType, string name)
         {
-            FieldInfo fieldInfo = enumType.GetFields().FirstOrDefault(field =>
+            var fieldInfo = enumType.GetFields().FirstOrDefault(field =>
             {
-                JsiiEnumMemberAttribute attribute = field.GetCustomAttribute<JsiiEnumMemberAttribute>();
+                var attribute = field.GetCustomAttribute<JsiiEnumMemberAttribute>();
 
                 return attribute != null && attribute.Name == name;
             });
@@ -26,7 +26,7 @@ namespace Amazon.JSII.Runtime
 
         public static MethodInfo GetNativeMethod(Type classType, string name)
         {
-            MethodInfo methodInfo = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(method =>
+            var methodInfo = classType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(method =>
             {
                 JsiiMethodAttribute attribute = method.GetCustomAttribute<JsiiMethodAttribute>();
 
@@ -44,7 +44,7 @@ namespace Amazon.JSII.Runtime
 
         public static PropertyInfo GetNativeProperty(Type classType, string name)
         {
-            PropertyInfo propertyInfo = classType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(property =>
+            var propertyInfo = classType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(property =>
             {
                 JsiiPropertyAttribute attribute = property.GetCustomAttribute<JsiiPropertyAttribute>();
 

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Client.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Client.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Amazon.JSII.JsonModel.Api;
 using Amazon.JSII.JsonModel.Api.Request;
@@ -74,16 +74,6 @@ namespace Amazon.JSII.Runtime.Services
             {
                 string requestJson = JsonConvert.SerializeObject(requestObject);
                 _runtime.WriteRequest(requestJson);
-
-                /*
-                if (requestObject is LoadRequest)
-                {
-                    JObject logEntry = JObject.FromObject(requestObject);
-                    logEntry["assembly"]["code"] = "<omitted for brevity>";
-                    requestJson = JsonConvert.SerializeObject(logEntry);
-                }
-                */
-
                 _logger.LogTrace($"> {requestJson}");
             }
             catch (IOException exception)

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using Amazon.JSII.JsonModel.Spec;
 using Amazon.JSII.Runtime.Deputy;
-using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using Type = System.Type;
 

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/IFrameworkToJsiiConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/IFrameworkToJsiiConverter.cs
@@ -1,5 +1,4 @@
 ﻿using Amazon.JSII.JsonModel.Spec;
-using Newtonsoft.Json.Linq;
 
 namespace Amazon.JSII.Runtime.Services.Converters
 {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/JsiiToFrameworkConverter.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/JsiiToFrameworkConverter.cs
@@ -230,12 +230,12 @@ namespace Amazon.JSII.Runtime.Services.Converters
 
             if (value is JObject jsonObject)
             {
-                System.Type elementType = _types.GetFrameworkType(elementTypeInstance, false);
-                System.Type dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), elementType);
+                var elementType = _types.GetFrameworkType(elementTypeInstance, false);
+                var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), elementType);
 
-                ConstructorInfo dictionaryConstructor = dictionaryType.GetConstructor(new System.Type[] { });
-                MethodInfo dictionaryAddMethod = dictionaryType.GetMethod("Add", new System.Type[] { typeof(string), elementType });
-                object dictionary = dictionaryConstructor.Invoke(new object[] { });
+                var dictionaryConstructor = dictionaryType.GetConstructor(new System.Type[] { });
+                var dictionaryAddMethod = dictionaryType.GetMethod("Add", new [] { typeof(string), elementType });
+                var dictionary = dictionaryConstructor.Invoke(new object[] { });
 
                 if (jsonObject.ContainsKey("$jsii.map"))
                 {
@@ -249,7 +249,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                         throw new ArgumentException("Could not convert all elements of map", nameof(value));
                     }
 
-                    dictionaryAddMethod.Invoke(dictionary, new object[] { property.Name, convertedElement });
+                    dictionaryAddMethod.Invoke(dictionary, new [] { property.Name, convertedElement });
                 }
 
                 result = dictionary;

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IClient.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IClient.cs
@@ -1,9 +1,6 @@
-﻿using Amazon.JSII.JsonModel.Api;
+using Amazon.JSII.JsonModel.Api;
 using Amazon.JSII.JsonModel.Api.Request;
 using Amazon.JSII.JsonModel.Api.Response;
-using Amazon.JSII.JsonModel.Spec;
-using System;
-using System.Collections.Generic;
 
 namespace Amazon.JSII.Runtime.Services
 {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IJsiiRuntimeProvider.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IJsiiRuntimeProvider.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Amazon.JSII.Runtime.Services
+﻿namespace Amazon.JSII.Runtime.Services
 {
     internal interface IJsiiRuntimeProvider
     {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ILoadedPackageSet.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/ILoadedPackageSet.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Amazon.JSII.Runtime.Services
+﻿namespace Amazon.JSII.Runtime.Services
 {
     internal interface ILoadedPackageSet
     {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IResourceExtractor.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IResourceExtractor.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Reflection;
 
 namespace Amazon.JSII.Runtime.Services

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IRuntime.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/IRuntime.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Amazon.JSII.Runtime.Services
+﻿namespace Amazon.JSII.Runtime.Services
 {
     internal interface IRuntime
     {

--- a/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/JsiiRuntimeProvider.cs
+++ b/packages/jsii-dotnet-runtime/src/Amazon.JSII.Runtime/Services/JsiiRuntimeProvider.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Amazon.JSII.Runtime.Services
 {


### PR DESCRIPTION
Removing a host of unused `Using` statements, replacing verbose variable
typings with the `var` keyword, using more expressive syntax for certain
patterns, and resolving a couple of "potential null access" problems.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
