### PR TITLE
fix(python): pin dependency version to the exact match

### DIFF
--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/python/setup.py
@@ -30,7 +30,7 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.20.2",
+        "jsii~=0.20.2,<0.21.0",
         "publication>=0.0.3"
     ],
     "classifiers": [

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
@@ -30,9 +30,9 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.20.2",
+        "jsii~=0.20.2,<0.21.0",
         "publication>=0.0.3",
-        "scope.jsii-calc-base-of-base~=0.20.2"
+        "scope.jsii-calc-base-of-base==0.20.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
@@ -30,9 +30,9 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.20.2",
+        "jsii~=0.20.2,<0.21.0",
         "publication>=0.0.3",
-        "scope.jsii-calc-base~=0.20.2"
+        "scope.jsii-calc-base==0.20.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
@@ -30,11 +30,11 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.20.2",
+        "jsii~=0.20.2,<0.21.0",
         "publication>=0.0.3",
-        "scope.jsii-calc-base~=0.20.2",
-        "scope.jsii-calc-base-of-base~=0.20.2",
-        "scope.jsii-calc-lib~=0.20.2"
+        "scope.jsii-calc-base==0.20.2",
+        "scope.jsii-calc-base-of-base==0.20.2",
+        "scope.jsii-calc-lib==0.20.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",


### PR DESCRIPTION
This will make it easier for downstream consumers to revert to an older version of closures.
This is a temporary fix until we make further changes to forward the *exact* requirement that
was expressed on the source package.

Barring this, frighting one's way out of problems such as aws/aws-cdk#4957 is extremely
challenging.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
