### PR TITLE
fix(jsii): unable to depend on modules with private declarations

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -20,7 +20,7 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
   module: ts.ModuleKind.CommonJS,
   noEmitOnError: true,
   noFallthroughCasesInSwitch: true,
-  noImplicitAny: true,
+  noImplicitAny: false, // temporarily "false" until we upgrade typescript in order to solve #994
   noImplicitReturns: true,
   noImplicitThis: true,
   noUnusedLocals: true,


### PR DESCRIPTION
Due to a TypeScript [bug], it was impossible to write a jsii module that takes a dependency on a module that has private type declarations in their d.ts file since they are untyped by definition.

This temporary fix sets `noImplicitAny` to `false` in order to disable this check and enable the dependency use case until we upgrade to the 3.7.x version-line.

Fixes #994

[bug]: https://github.com/microsoft/TypeScript/issues/33894

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
