### PR TITLE
chore: ignore jsii-calc and @scope/* in package.sh

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -14,7 +14,7 @@ mkdir -p ${distdir}
 lerna run package --stream
 
 # collect all "dist" directories into "pack"
-for dist in $(lerna exec "[ -d ./dist ] && echo \${PWD}/dist || true"); do
+for dist in $(lerna exec --ignore=jsii-calc --ignore=@scope/\* "[ -d ./dist ] && echo \${PWD}/dist || true"); do
   echo "collecting ${dist}..."
   rsync -av ${dist}/ ${distdir}/
 done


### PR DESCRIPTION
Those packages contain no artifacts that should be published, and considering them may cause leftover artifacts from tests to be part of the release artifacts, which breaks integration tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
