### PR TITLE
chore(rosetta): remove 'commonmark' from public API

### DIFF
--- a/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
+++ b/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
@@ -1,8 +1,8 @@
 import cm = require('commonmark');
 import { visitCommonMarkTree } from '../markdown/markdown';
-import { CodeBlock } from '../markdown/replace-code-renderer';
 import { TypeScriptSnippet } from '../snippet';
 import { ReplaceTypeScriptTransform } from './replace-typescript-transform';
+import { CodeBlock } from './types';
 
 export type TypeScriptReplacer = (code: TypeScriptSnippet) => CodeBlock | undefined;
 

--- a/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
@@ -1,12 +1,8 @@
 import cm = require('commonmark');
 import { CommonMarkVisitor } from './markdown';
+import { CodeBlock } from './types';
 
 export type CodeReplacer = (code: CodeBlock) => CodeBlock;
-
-export interface CodeBlock {
-  source: string;
-  language: string;
-}
 
 /**
  * Renderer that replaces code blocks in a MarkDown document

--- a/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
@@ -1,5 +1,6 @@
-import { ReplaceCodeTransform, CodeBlock } from "./replace-code-renderer";
+import { ReplaceCodeTransform } from "./replace-code-renderer";
 import { TypeScriptSnippet, typeScriptSnippetFromSource, parseKeyValueList } from "../snippet";
+import { CodeBlock } from "./types";
 
 export type TypeScriptReplacer = (code: TypeScriptSnippet) => CodeBlock | undefined;
 

--- a/packages/jsii-rosetta/lib/markdown/types.ts
+++ b/packages/jsii-rosetta/lib/markdown/types.ts
@@ -1,0 +1,5 @@
+export interface CodeBlock {
+  source: string;
+  language: string;
+}
+

--- a/packages/jsii-rosetta/lib/rosetta.ts
+++ b/packages/jsii-rosetta/lib/rosetta.ts
@@ -8,7 +8,7 @@ import { Translator } from './translate';
 import { isError } from 'util';
 import { transformMarkdown } from './markdown/markdown';
 import { MarkdownRenderer } from './markdown/markdown-renderer';
-import { CodeBlock } from './markdown/replace-code-renderer';
+import { CodeBlock } from './markdown/types';
 import { TypeScriptSnippet } from './snippet';
 import { printDiagnostics } from './util';
 import { ReplaceTypeScriptTransform } from './markdown/replace-typescript-transform';


### PR DESCRIPTION
Move imports around so that `require('commonmark')` no longer
appears in any `.d.ts` file that is reachable from `index.d.ts`.

It would break downstream TypeScript compilation because
`@types/commonmark` is in `devDependencies`.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
