### PR TITLE
fix: Move jsii-spec to Dependencies in jsii-config

### DIFF
--- a/packages/jsii-config/package.json
+++ b/packages/jsii-config/package.json
@@ -27,11 +27,11 @@
     "eslint": "^6.6.0",
     "jest": "^24.9.0",
     "jest-expect-message": "^1.0.2",
-    "jsii-spec": "^0.20.7",
     "typescript": "~3.6.4"
   },
   "dependencies": {
     "inquirer": "^7.0.0",
+    "jsii-spec": "^0.20.7",
     "yargs": "^14.2.0"
   },
   "jest": {


### PR DESCRIPTION
Moves jsii-spec to dependencies in package.json instead of devDependencies for jsii-config. This was causing a missing dependency error at runtime.

Fixes #1030 
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
