### PR TITLE
fix(dotnet/roslyn): analyzer target framework

### DIFF
--- a/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
+++ b/packages/jsii-dotnet-analyzers/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <PackageId>Amazon.JSII.Analyzers</PackageId>
         <Title>.NET Roslyn Analyzers for JSII</Title>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
     </PropertyGroup>


### PR DESCRIPTION
The Roslyn analyzer target framework must be set to `netstandard2.0` or
it will not successfully load up in Visual Studio.

Fixes aws/aws-cdk#5189

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
