### PR TITLE
Handle Python Dependency Versions Correctly

### DIFF
--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -42,6 +42,7 @@
     "jsii-reflect": "^0.20.8",
     "jsii-rosetta": "^0.20.8",
     "jsii-spec": "^0.20.8",
+    "semver": "^6.3.0",
     "spdx-license-list": "^6.1.0",
     "xmlbuilder": "^13.0.2",
     "yargs": "^15.0.2"
@@ -54,6 +55,7 @@
     "@types/jest": "^24.0.23",
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^10.17.6",
+    "@types/semver": "^6.2.0",
     "@types/yargs": "^13.0.3",
     "@typescript-eslint/eslint-plugin": "^2.9.0",
     "@typescript-eslint/parser": "^2.9.0",

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
@@ -32,7 +32,7 @@ kwargs = json.loads("""
     "install_requires": [
         "jsii~=0.20.8",
         "publication>=0.0.3",
-        "scope.jsii-calc-base-of-base~=0.20.8"
+        "scope.jsii-calc-base-of-base==0.20.8"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
@@ -32,7 +32,7 @@ kwargs = json.loads("""
     "install_requires": [
         "jsii~=0.20.8",
         "publication>=0.0.3",
-        "scope.jsii-calc-base~=0.20.8"
+        "scope.jsii-calc-base==0.20.8"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
@@ -32,9 +32,9 @@ kwargs = json.loads("""
     "install_requires": [
         "jsii~=0.20.8",
         "publication>=0.0.3",
-        "scope.jsii-calc-base~=0.20.8",
-        "scope.jsii-calc-base-of-base~=0.20.8",
-        "scope.jsii-calc-lib~=0.20.8"
+        "scope.jsii-calc-base==0.20.8",
+        "scope.jsii-calc-base-of-base==0.20.8",
+        "scope.jsii-calc-lib==0.20.8"
     ],
     "classifiers": [
         "Intended Audience :: Developers",


### PR DESCRIPTION
Change logic of python dependency version ranges. Parse semver number either as specific version or range and output to setup.py.

Fix #676

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
