### PR TITLE
fix: generate non-overlapping artifacts

### DIFF
--- a/tools/jsii-build-tools/bin/package-js
+++ b/tools/jsii-build-tools/bin/package-js
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -euo pipefail
+
 rm -fr dist/js
-mkdir -p dist/js
-mv $(npm pack) dist/js
+
+package_name=$(node -p "require('./package.json').name")
+target_file="dist/js/${package_name/\//-}.tgz"
+
+mkdir -p $(dirname ${target_file})
+
+mv $(npm pack) ${target_file}

--- a/tools/jsii-build-tools/bin/package-python
+++ b/tools/jsii-build-tools/bin/package-python
@@ -3,5 +3,5 @@ set -euo pipefail
 
 rm -rf dist/python
 mkdir -p dist/python
-mv *.whl dist/python
-mv *.tar.gz dist/python
+cp *.whl dist/python
+cp *.tar.gz dist/python


### PR DESCRIPTION
The @jsii/spec and jsii-spec packages would generate the same build
artifact, causing only one of them (jsii-spec) to be considered. This
ensures distinct artifact names are generated for each.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
