### PR TITLE
fix(java): missing remarks in builder documentation

### DIFF
--- a/packages/jsii-calc/lib/calculator.ts
+++ b/packages/jsii-calc/lib/calculator.ts
@@ -232,8 +232,21 @@ export class Power extends composition.CompositeOperation {
  * Properties for Calculator.
  */
 export interface CalculatorProps {
-    readonly initialValue?: number
-    readonly maximumValue?: number
+    /**
+     * The initial value of the calculator.
+     *
+     * NOTE: Any number works here, it's fine.
+     *
+     * @default 0
+     */
+    readonly initialValue?: number;
+
+    /**
+     * The maximum value the calculator can store.
+     *
+     * @default none
+     */
+    readonly maximumValue?: number;
 }
 
 /**

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1422,7 +1422,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/calculator.ts",
-        "line": 260
+        "line": 273
       },
       "methods": [
         {
@@ -1432,7 +1432,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 299
+            "line": 312
           },
           "name": "add",
           "parameters": [
@@ -1451,7 +1451,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 306
+            "line": 319
           },
           "name": "mul",
           "parameters": [
@@ -1470,7 +1470,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 320
+            "line": 333
           },
           "name": "neg"
         },
@@ -1481,7 +1481,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 313
+            "line": 326
           },
           "name": "pow",
           "parameters": [
@@ -1500,7 +1500,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 339
+            "line": 352
           },
           "name": "readUnionValue",
           "returns": {
@@ -1520,7 +1520,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 327
+            "line": 340
           },
           "name": "expression",
           "overrides": "jsii-calc.composition.CompositeOperation",
@@ -1536,7 +1536,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 289
+            "line": 302
           },
           "name": "operationsLog",
           "type": {
@@ -1556,7 +1556,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 284
+            "line": 297
           },
           "name": "operationsMap",
           "type": {
@@ -1580,7 +1580,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 279
+            "line": 292
           },
           "name": "curr",
           "type": {
@@ -1594,7 +1594,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 294
+            "line": 307
           },
           "name": "maxValue",
           "optional": true,
@@ -1609,7 +1609,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 334
+            "line": 347
           },
           "name": "unionProperty",
           "optional": true,
@@ -1649,12 +1649,15 @@
         {
           "abstract": true,
           "docs": {
-            "stability": "experimental"
+            "default": "0",
+            "remarks": "NOTE: Any number works here, it's fine.",
+            "stability": "experimental",
+            "summary": "The initial value of the calculator."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 235
+            "line": 242
           },
           "name": "initialValue",
           "optional": true,
@@ -1665,12 +1668,14 @@
         {
           "abstract": true,
           "docs": {
-            "stability": "experimental"
+            "default": "none",
+            "stability": "experimental",
+            "summary": "The maximum value the calculator can store."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 236
+            "line": 249
           },
           "name": "maximumValue",
           "optional": true,
@@ -11743,5 +11748,5 @@
     }
   },
   "version": "0.20.8",
-  "fingerprint": "w4S74J2aEQiII5p1/vLG5rXFrtvbxUP1mra7ZGBd4so="
+  "fingerprint": "sZ6Jp7HsZKHGh8JYB08PYxyFX0bYBgK1FMDhzjtPjVQ="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
@@ -20,7 +20,7 @@ public interface VeryBaseProps extends software.amazon.jsii.JsiiSerializable {
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link VeryBaseProps#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -21,7 +21,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link BaseProps#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -31,7 +31,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
         }
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link BaseProps#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -51,7 +51,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         private java.util.List<java.lang.String> firstOptional;
 
         /**
-         * Sets the value of Anumber
+         * Sets the value of {@link MyFirstStruct#getAnumber}
          * @param anumber An awesome number value. This parameter is required.
          * @return {@code this}
          */
@@ -63,7 +63,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Astring
+         * Sets the value of {@link MyFirstStruct#getAstring}
          * @param astring A string value. This parameter is required.
          * @return {@code this}
          */
@@ -75,7 +75,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of FirstOptional
+         * Sets the value of {@link MyFirstStruct#getFirstOptional}
          * @param firstOptional the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -54,7 +54,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         private java.lang.Boolean optional3;
 
         /**
-         * Sets the value of Optional1
+         * Sets the value of {@link StructWithOnlyOptionals#getOptional1}
          * @param optional1 The first optional!.
          * @return {@code this}
          */
@@ -66,7 +66,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         }
 
         /**
-         * Sets the value of Optional2
+         * Sets the value of {@link StructWithOnlyOptionals#getOptional2}
          * @param optional2 the value to be set.
          * @return {@code this}
          */
@@ -78,7 +78,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
         }
 
         /**
-         * Sets the value of Optional3
+         * Sets the value of {@link StructWithOnlyOptionals#getOptional3}
          * @param optional3 the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -1422,7 +1422,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/calculator.ts",
-        "line": 260
+        "line": 273
       },
       "methods": [
         {
@@ -1432,7 +1432,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 299
+            "line": 312
           },
           "name": "add",
           "parameters": [
@@ -1451,7 +1451,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 306
+            "line": 319
           },
           "name": "mul",
           "parameters": [
@@ -1470,7 +1470,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 320
+            "line": 333
           },
           "name": "neg"
         },
@@ -1481,7 +1481,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 313
+            "line": 326
           },
           "name": "pow",
           "parameters": [
@@ -1500,7 +1500,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 339
+            "line": 352
           },
           "name": "readUnionValue",
           "returns": {
@@ -1520,7 +1520,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 327
+            "line": 340
           },
           "name": "expression",
           "overrides": "jsii-calc.composition.CompositeOperation",
@@ -1536,7 +1536,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 289
+            "line": 302
           },
           "name": "operationsLog",
           "type": {
@@ -1556,7 +1556,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 284
+            "line": 297
           },
           "name": "operationsMap",
           "type": {
@@ -1580,7 +1580,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 279
+            "line": 292
           },
           "name": "curr",
           "type": {
@@ -1594,7 +1594,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 294
+            "line": 307
           },
           "name": "maxValue",
           "optional": true,
@@ -1609,7 +1609,7 @@
           },
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 334
+            "line": 347
           },
           "name": "unionProperty",
           "optional": true,
@@ -1649,12 +1649,15 @@
         {
           "abstract": true,
           "docs": {
-            "stability": "experimental"
+            "default": "0",
+            "remarks": "NOTE: Any number works here, it's fine.",
+            "stability": "experimental",
+            "summary": "The initial value of the calculator."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 235
+            "line": 242
           },
           "name": "initialValue",
           "optional": true,
@@ -1665,12 +1668,14 @@
         {
           "abstract": true,
           "docs": {
-            "stability": "experimental"
+            "default": "none",
+            "stability": "experimental",
+            "summary": "The maximum value the calculator can store."
           },
           "immutable": true,
           "locationInModule": {
             "filename": "lib/calculator.ts",
-            "line": 236
+            "line": 249
           },
           "name": "maximumValue",
           "optional": true,
@@ -11743,5 +11748,5 @@
     }
   },
   "version": "0.20.8",
-  "fingerprint": "w4S74J2aEQiII5p1/vLG5rXFrtvbxUP1mra7ZGBd4so="
+  "fingerprint": "sZ6Jp7HsZKHGh8JYB08PYxyFX0bYBgK1FMDhzjtPjVQ="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorProps.cs
@@ -9,7 +9,11 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiByValue(fqn: "jsii-calc.CalculatorProps")]
     public class CalculatorProps : Amazon.JSII.Tests.CalculatorNamespace.ICalculatorProps
     {
+        /// <summary>The initial value of the calculator.</summary>
         /// <remarks>
+        /// NOTE: Any number works here, it's fine.
+        /// default:
+        /// 0
         /// stability: Experimental
         /// </remarks>
         [JsiiOptional]
@@ -20,7 +24,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             set;
         }
 
+        /// <summary>The maximum value the calculator can store.</summary>
         /// <remarks>
+        /// default:
+        /// none
         /// stability: Experimental
         /// </remarks>
         [JsiiOptional]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/CalculatorPropsProxy.cs
@@ -13,7 +13,11 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
         }
 
+        /// <summary>The initial value of the calculator.</summary>
         /// <remarks>
+        /// NOTE: Any number works here, it's fine.
+        /// default:
+        /// 0
         /// stability: Experimental
         /// </remarks>
         [JsiiOptional]
@@ -23,7 +27,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             get => GetInstanceProperty<double?>();
         }
 
+        /// <summary>The maximum value the calculator can store.</summary>
         /// <remarks>
+        /// default:
+        /// none
         /// stability: Experimental
         /// </remarks>
         [JsiiOptional]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ICalculatorProps.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ICalculatorProps.cs
@@ -9,7 +9,11 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiInterface(nativeType: typeof(ICalculatorProps), fullyQualifiedName: "jsii-calc.CalculatorProps")]
     public interface ICalculatorProps
     {
+        /// <summary>The initial value of the calculator.</summary>
         /// <remarks>
+        /// NOTE: Any number works here, it's fine.
+        /// default:
+        /// 0
         /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "initialValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]
@@ -22,7 +26,10 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             }
         }
 
+        /// <summary>The maximum value the calculator can store.</summary>
         /// <remarks>
+        /// default:
+        /// none
         /// stability: Experimental
         /// </remarks>
         [JsiiProperty(name: "maximumValue", typeJson: "{\"primitive\":\"number\"}", isOptional: true)]

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -249,10 +249,16 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
         }
 
         /**
+         * The initial value of the calculator.
+         * 
+         * <p>NOTE: Any number works here, it's fine.</p>
+         * 
+         * Default: 0
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}
-         * @param initialValue This parameter is required.
+         * @param initialValue The initial value of the calculator. This parameter is required.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder initialValue(final java.lang.Number initialValue) {
@@ -261,10 +267,14 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
         }
 
         /**
+         * The maximum value the calculator can store.
+         * 
+         * Default: none
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}
-         * @param maximumValue This parameter is required.
+         * @param maximumValue The maximum value the calculator can store. This parameter is required.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         public Builder maximumValue(final java.lang.Number maximumValue) {

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -12,6 +12,12 @@ package software.amazon.jsii.tests.calculator;
 public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
 
     /**
+     * The initial value of the calculator.
+     * 
+     * <p>NOTE: Any number works here, it's fine.</p>
+     * 
+     * Default: 0
+     * 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -20,6 +26,10 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
     }
 
     /**
+     * The maximum value the calculator can store.
+     * 
+     * Default: none
+     * 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -43,8 +53,9 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         private java.lang.Number maximumValue;
 
         /**
-         * Sets the value of InitialValue
-         * @param initialValue the value to be set.
+         * Sets the value of {@link CalculatorProps#getInitialValue}
+         * @param initialValue The initial value of the calculator.
+         *                     <p>NOTE: Any number works here, it's fine.</p>
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -54,8 +65,8 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of MaximumValue
-         * @param maximumValue the value to be set.
+         * Sets the value of {@link CalculatorProps#getMaximumValue}
+         * @param maximumValue The maximum value the calculator can store.
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
@@ -31,7 +31,7 @@ public interface ChildStruct982 extends software.amazon.jsii.JsiiSerializable, s
         private java.lang.String foo;
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link ChildStruct982#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -42,7 +42,7 @@ public interface ChildStruct982 extends software.amazon.jsii.JsiiSerializable, s
         }
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link ChildStruct982#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
@@ -32,7 +32,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
         private java.lang.Object unionProperty;
 
         /**
-         * Sets the value of UnionProperty
+         * Sets the value of {@link ConfusingToJacksonStruct#getUnionProperty}
          * @param unionProperty the value to be set.
          * @return {@code this}
          */
@@ -43,7 +43,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
         }
 
         /**
-         * Sets the value of UnionProperty
+         * Sets the value of {@link ConfusingToJacksonStruct#getUnionProperty}
          * @param unionProperty the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -34,7 +34,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
         private java.lang.String readonlyProperty;
 
         /**
-         * Sets the value of ReadonlyProperty
+         * Sets the value of {@link DeprecatedStruct#getReadonlyProperty}
          * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          * @deprecated well, yeah

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -80,7 +80,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         private java.util.List<java.lang.String> firstOptional;
 
         /**
-         * Sets the value of AnotherRequired
+         * Sets the value of {@link DerivedStruct#getAnotherRequired}
          * @param anotherRequired the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -91,7 +91,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of Bool
+         * Sets the value of {@link DerivedStruct#getBool}
          * @param bool the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -102,7 +102,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of NonPrimitive
+         * Sets the value of {@link DerivedStruct#getNonPrimitive}
          * @param nonPrimitive An example of a non primitive property. This parameter is required.
          * @return {@code this}
          */
@@ -113,7 +113,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of AnotherOptional
+         * Sets the value of {@link DerivedStruct#getAnotherOptional}
          * @param anotherOptional This is optional.
          * @return {@code this}
          */
@@ -124,7 +124,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of OptionalAny
+         * Sets the value of {@link DerivedStruct#getOptionalAny}
          * @param optionalAny the value to be set.
          * @return {@code this}
          */
@@ -135,7 +135,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of OptionalArray
+         * Sets the value of {@link DerivedStruct#getOptionalArray}
          * @param optionalArray the value to be set.
          * @return {@code this}
          */
@@ -146,7 +146,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of Anumber
+         * Sets the value of {@link DerivedStruct#getAnumber}
          * @param anumber An awesome number value. This parameter is required.
          * @return {@code this}
          */
@@ -158,7 +158,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of Astring
+         * Sets the value of {@link DerivedStruct#getAstring}
          * @param astring A string value. This parameter is required.
          * @return {@code this}
          */
@@ -170,7 +170,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         }
 
         /**
-         * Sets the value of FirstOptional
+         * Sets the value of {@link DerivedStruct#getFirstOptional}
          * @param firstOptional the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -30,7 +30,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
         private java.lang.String baseLevelProperty;
 
         /**
-         * Sets the value of BaseLevelProperty
+         * Sets the value of {@link DiamondInheritanceBaseLevelStruct#getBaseLevelProperty}
          * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -31,7 +31,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
         private java.lang.String baseLevelProperty;
 
         /**
-         * Sets the value of FirstMidLevelProperty
+         * Sets the value of {@link DiamondInheritanceFirstMidLevelStruct#getFirstMidLevelProperty}
          * @param firstMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -42,7 +42,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
         }
 
         /**
-         * Sets the value of BaseLevelProperty
+         * Sets the value of {@link DiamondInheritanceFirstMidLevelStruct#getBaseLevelProperty}
          * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -31,7 +31,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
         private java.lang.String baseLevelProperty;
 
         /**
-         * Sets the value of SecondMidLevelProperty
+         * Sets the value of {@link DiamondInheritanceSecondMidLevelStruct#getSecondMidLevelProperty}
          * @param secondMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -42,7 +42,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
         }
 
         /**
-         * Sets the value of BaseLevelProperty
+         * Sets the value of {@link DiamondInheritanceSecondMidLevelStruct#getBaseLevelProperty}
          * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -33,7 +33,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         private java.lang.String secondMidLevelProperty;
 
         /**
-         * Sets the value of TopLevelProperty
+         * Sets the value of {@link DiamondInheritanceTopLevelStruct#getTopLevelProperty}
          * @param topLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -44,7 +44,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         }
 
         /**
-         * Sets the value of FirstMidLevelProperty
+         * Sets the value of {@link DiamondInheritanceTopLevelStruct#getFirstMidLevelProperty}
          * @param firstMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -55,7 +55,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         }
 
         /**
-         * Sets the value of BaseLevelProperty
+         * Sets the value of {@link DiamondInheritanceTopLevelStruct#getBaseLevelProperty}
          * @param baseLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -66,7 +66,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
         }
 
         /**
-         * Sets the value of SecondMidLevelProperty
+         * Sets the value of {@link DiamondInheritanceTopLevelStruct#getSecondMidLevelProperty}
          * @param secondMidLevelProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -41,7 +41,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
         private java.lang.String option2;
 
         /**
-         * Sets the value of Option1
+         * Sets the value of {@link EraseUndefinedHashValuesOptions#getOption1}
          * @param option1 the value to be set.
          * @return {@code this}
          */
@@ -52,7 +52,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
         }
 
         /**
-         * Sets the value of Option2
+         * Sets the value of {@link EraseUndefinedHashValuesOptions#getOption2}
          * @param option2 the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -30,7 +30,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
         private java.lang.String readonlyProperty;
 
         /**
-         * Sets the value of ReadonlyProperty
+         * Sets the value of {@link ExperimentalStruct#getReadonlyProperty}
          * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -37,7 +37,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
         private java.lang.String prop;
 
         /**
-         * Sets the value of Boom
+         * Sets the value of {@link ExtendsInternalInterface#getBoom}
          * @param boom the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -48,7 +48,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
         }
 
         /**
-         * Sets the value of Prop
+         * Sets the value of {@link ExtendsInternalInterface#getProp}
          * @param prop the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -38,7 +38,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String name;
 
         /**
-         * Sets the value of Name
+         * Sets the value of {@link Greetee#getName}
          * @param name The name of the greetee.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -32,7 +32,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
-         * Sets the value of Goo
+         * Sets the value of {@link ImplictBaseOfBase#getGoo}
          * @param goo the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -43,7 +43,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         }
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link ImplictBaseOfBase#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -53,7 +53,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
         }
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link ImplictBaseOfBase#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -30,7 +30,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         private java.lang.Number foo;
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link Hello#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -30,7 +30,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
         private java.lang.Number foo;
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link Hello#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -103,8 +103,9 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         private java.lang.Boolean publicTasks;
 
         /**
-         * Sets the value of ContainerPort
+         * Sets the value of {@link LoadBalancedFargateServiceProps#getContainerPort}
          * @param containerPort The container port of the application load balancer attached to your Fargate service.
+         *                      <p>Corresponds to container port mapping.</p>
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -114,8 +115,9 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         }
 
         /**
-         * Sets the value of Cpu
+         * Sets the value of {@link LoadBalancedFargateServiceProps#getCpu}
          * @param cpu The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments.
+         *            <p>This default is set in the underlying FargateTaskDefinition construct.</p>
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -125,8 +127,16 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         }
 
         /**
-         * Sets the value of MemoryMiB
+         * Sets the value of {@link LoadBalancedFargateServiceProps#getMemoryMiB}
          * @param memoryMiB The amount (in MiB) of memory used by the task.
+         *                  <p>This field is required and you must use one of the following values, which determines your range of valid values
+         *                  for the cpu parameter:</p>
+         *                  <p>0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)</p>
+         *                  <p>1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)</p>
+         *                  <p>2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)</p>
+         *                  <p>Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)</p>
+         *                  <p>Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)</p>
+         *                  <p>This default is set in the underlying FargateTaskDefinition construct.</p>
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
@@ -136,7 +146,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         }
 
         /**
-         * Sets the value of PublicLoadBalancer
+         * Sets the value of {@link LoadBalancedFargateServiceProps#getPublicLoadBalancer}
          * @param publicLoadBalancer Determines whether the Application Load Balancer will be internet-facing.
          * @return {@code this}
          */
@@ -147,7 +157,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
         }
 
         /**
-         * Sets the value of PublicTasks
+         * Sets the value of {@link LoadBalancedFargateServiceProps#getPublicTasks}
          * @param publicTasks Determines whether your Fargate Service will be assigned a public IP address.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
@@ -32,7 +32,7 @@ public interface NestedStruct extends software.amazon.jsii.JsiiSerializable {
         private java.lang.Number numberProp;
 
         /**
-         * Sets the value of NumberProp
+         * Sets the value of {@link NestedStruct#getNumberProp}
          * @param numberProp When provided, must be > 0. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -39,7 +39,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
         private java.lang.Object thisShouldBeUndefined;
 
         /**
-         * Sets the value of ArrayWithThreeElementsAndUndefinedAsSecondArgument
+         * Sets the value of {@link NullShouldBeTreatedAsUndefinedData#getArrayWithThreeElementsAndUndefinedAsSecondArgument}
          * @param arrayWithThreeElementsAndUndefinedAsSecondArgument the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -50,7 +50,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
         }
 
         /**
-         * Sets the value of ThisShouldBeUndefined
+         * Sets the value of {@link NullShouldBeTreatedAsUndefinedData#getThisShouldBeUndefined}
          * @param thisShouldBeUndefined the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -32,7 +32,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String field;
 
         /**
-         * Sets the value of Field
+         * Sets the value of {@link OptionalStruct#getField}
          * @param field the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
@@ -32,7 +32,7 @@ public interface ParentStruct982 extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String foo;
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link ParentStruct982#getFoo}
          * @param foo the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
@@ -46,7 +46,7 @@ public interface RootStruct extends software.amazon.jsii.JsiiSerializable {
         private software.amazon.jsii.tests.calculator.NestedStruct nestedStruct;
 
         /**
-         * Sets the value of StringProp
+         * Sets the value of {@link RootStruct#getStringProp}
          * @param stringProp May not be empty. This parameter is required.
          * @return {@code this}
          */
@@ -57,7 +57,7 @@ public interface RootStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of NestedStruct
+         * Sets the value of {@link RootStruct#getNestedStruct}
          * @param nestedStruct the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -43,7 +43,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
         private java.lang.String deeperOptionalProp;
 
         /**
-         * Sets the value of DeeperRequiredProp
+         * Sets the value of {@link SecondLevelStruct#getDeeperRequiredProp}
          * @param deeperRequiredProp It's long and required. This parameter is required.
          * @return {@code this}
          */
@@ -54,7 +54,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
         }
 
         /**
-         * Sets the value of DeeperOptionalProp
+         * Sets the value of {@link SecondLevelStruct#getDeeperOptionalProp}
          * @param deeperOptionalProp It's long, but you'll almost never pass it.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -28,7 +28,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String readonlyProperty;
 
         /**
-         * Sets the value of ReadonlyProperty
+         * Sets the value of {@link StableStruct#getReadonlyProperty}
          * @param readonlyProperty the value to be set. This parameter is required.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
@@ -50,7 +50,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String optionalString;
 
         /**
-         * Sets the value of RequiredString
+         * Sets the value of {@link StructA#getRequiredString}
          * @param requiredString the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -61,7 +61,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of OptionalNumber
+         * Sets the value of {@link StructA#getOptionalNumber}
          * @param optionalNumber the value to be set.
          * @return {@code this}
          */
@@ -72,7 +72,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of OptionalString
+         * Sets the value of {@link StructA#getOptionalString}
          * @param optionalString the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
@@ -50,7 +50,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
         private software.amazon.jsii.tests.calculator.StructA optionalStructA;
 
         /**
-         * Sets the value of RequiredString
+         * Sets the value of {@link StructB#getRequiredString}
          * @param requiredString the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -61,7 +61,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of OptionalBoolean
+         * Sets the value of {@link StructB#getOptionalBoolean}
          * @param optionalBoolean the value to be set.
          * @return {@code this}
          */
@@ -72,7 +72,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of OptionalStructA
+         * Sets the value of {@link StructB#getOptionalStructA}
          * @param optionalStructA the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -57,7 +57,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         private java.lang.String that;
 
         /**
-         * Sets the value of DefaultValue
+         * Sets the value of {@link StructWithJavaReservedWords#getDefaultValue}
          * @param defaultValue the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -68,7 +68,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         }
 
         /**
-         * Sets the value of AssertValue
+         * Sets the value of {@link StructWithJavaReservedWords#getAssertValue}
          * @param assertValue the value to be set.
          * @return {@code this}
          */
@@ -79,7 +79,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         }
 
         /**
-         * Sets the value of Result
+         * Sets the value of {@link StructWithJavaReservedWords#getResult}
          * @param result the value to be set.
          * @return {@code this}
          */
@@ -90,7 +90,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
         }
 
         /**
-         * Sets the value of That
+         * Sets the value of {@link StructWithJavaReservedWords#getThat}
          * @param that the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
@@ -89,6 +89,8 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
         }
 
         /**
+         * Some number, like 42.
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}
@@ -101,6 +103,10 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
         }
 
         /**
+         * An `id` field here is terrible API design, because the constructor of `SupportsNiceJavaBuilder` already has a parameter named `id`.
+         * 
+         * <p>But here we are, doing it like we didn't care.</p>
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
@@ -45,7 +45,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
         private java.lang.String id;
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link SupportsNiceJavaBuilderProps#getBar}
          * @param bar Some number, like 42. This parameter is required.
          * @return {@code this}
          */
@@ -56,8 +56,9 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
         }
 
         /**
-         * Sets the value of Id
+         * Sets the value of {@link SupportsNiceJavaBuilderProps#getId}
          * @param id An `id` field here is terrible API design, because the constructor of `SupportsNiceJavaBuilder` already has a parameter named `id`.
+         *           <p>But here we are, doing it like we didn't care.</p>
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
@@ -81,6 +81,8 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
         }
 
         /**
+         * Some number, like 42.
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}
@@ -93,6 +95,10 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
         }
 
         /**
+         * An `id` field here is terrible API design, because the constructor of `SupportsNiceJavaBuilder` already has a parameter named `id`.
+         * 
+         * <p>But here we are, doing it like we didn't care.</p>
+         * 
          * EXPERIMENTAL
          * 
          * @return {@code this}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -52,7 +52,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         private java.lang.String optional;
 
         /**
-         * Sets the value of Required
+         * Sets the value of {@link TopLevelStruct#getRequired}
          * @param required This is a required field. This parameter is required.
          * @return {@code this}
          */
@@ -63,7 +63,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of SecondLevel
+         * Sets the value of {@link TopLevelStruct#getSecondLevel}
          * @param secondLevel A union to really stress test our serialization. This parameter is required.
          * @return {@code this}
          */
@@ -74,7 +74,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of SecondLevel
+         * Sets the value of {@link TopLevelStruct#getSecondLevel}
          * @param secondLevel A union to really stress test our serialization. This parameter is required.
          * @return {@code this}
          */
@@ -85,7 +85,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Optional
+         * Sets the value of {@link TopLevelStruct#getOptional}
          * @param optional You don't have to pass this.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -39,7 +39,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         private java.lang.Object foo;
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link UnionProperties#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -50,7 +50,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link UnionProperties#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -61,7 +61,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Bar
+         * Sets the value of {@link UnionProperties#getBar}
          * @param bar the value to be set. This parameter is required.
          * @return {@code this}
          */
@@ -72,7 +72,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link UnionProperties#getFoo}
          * @param foo the value to be set.
          * @return {@code this}
          */
@@ -83,7 +83,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
         }
 
         /**
-         * Sets the value of Foo
+         * Sets the value of {@link UnionProperties#getFoo}
          * @param foo the value to be set.
          * @return {@code this}
          */

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -664,8 +664,8 @@ class CalculatorProps():
     def __init__(self, *, initial_value: typing.Optional[jsii.Number]=None, maximum_value: typing.Optional[jsii.Number]=None):
         """Properties for Calculator.
 
-        :param initial_value: 
-        :param maximum_value: 
+        :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
+        :param maximum_value: The maximum value the calculator can store. Default: none
 
         stability
         :stability: experimental
@@ -677,7 +677,13 @@ class CalculatorProps():
 
     @property
     def initial_value(self) -> typing.Optional[jsii.Number]:
-        """
+        """The initial value of the calculator.
+
+        NOTE: Any number works here, it's fine.
+
+        default
+        :default: 0
+
         stability
         :stability: experimental
         """
@@ -685,7 +691,11 @@ class CalculatorProps():
 
     @property
     def maximum_value(self) -> typing.Optional[jsii.Number]:
-        """
+        """The maximum value the calculator can store.
+
+        default
+        :default: none
+
         stability
         :stability: experimental
         """
@@ -8021,8 +8031,8 @@ class Calculator(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_t
         """Creates a Calculator object.
 
         :param props: Initialization properties.
-        :param initial_value: 
-        :param maximum_value: 
+        :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
+        :param maximum_value: The maximum value the calculator can store. Default: none
 
         stability
         :stability: experimental


### PR DESCRIPTION
The Javadoc entries for setting methods on the generated `Builder`
classes did not represent the `remarks` section of the `docs` object,
resulting in only partial documentation being available on the builders.

This makes sure the `remarks` section gets rendered correctly in all the
locations that previously ignored it, and the fix is demonstrated good
by virtue of the changes it induced in the regression test improvements.

Fixes #1094

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
