### PR TITLE
fix(reflect): failure to load assembly from "npm pack"

### DIFF
--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -108,7 +108,9 @@ export class TypeSystem {
       }
 
       const root = this.addAssembly(asm, { isRoot });
-      const bundled: string[] = pkg.bundledDependencies ?? pkg.bundleDependencies ?? [];
+      // Using || instead of ?? because npmjs.com will alter the package.json file and possibly put `false` in pkg.bundleDependencies.
+      // This is actually non compliant to the package.json specification, but that's how it is...
+      const bundled: string[] = pkg.bundledDependencies || pkg.bundleDependencies || [];
 
       for (const name of dependenciesOf(pkg)) {
         if (bundled.includes(name)) { continue; }


### PR DESCRIPTION
When the `package.json` file is the result of extracting a tarball
obtained from `npm pack`, it may have been processed by `npmjs.com`
during publishing, which can cause the `bundleDependencies` property to
appear with the value `false`. The null-coalescing (`??`) operator does
not rescue this properly and this results in a `TypeError`.

This is fixed by using `||` chaining instead of a null-coalescing, which
rescues from all falsey values in this case.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
