### PR TITLE
fix(rosetta): "Rosetta configured for live conversion to undefined"

### DIFF
--- a/packages/jsii-rosetta/lib/rosetta.ts
+++ b/packages/jsii-rosetta/lib/rosetta.ts
@@ -109,8 +109,8 @@ export class Rosetta {
     }
 
     if (!this.options.liveConversion) { return undefined; }
-    if (!this.options.targetLanguages?.includes(targetLang)) {
-      throw new Error(`Rosetta configured for live conversion to ${this.options.targetLanguages}, but requested ${targetLang}`);
+    if (this.options.targetLanguages && !this.options.targetLanguages.includes(targetLang)) {
+      throw new Error(`Rosetta configured for live conversion to ${this.options.targetLanguages.join(', ')}, but requested ${targetLang}`);
     }
 
     // See if we're going to live-convert it with full source information


### PR DESCRIPTION
An incorrect update to optional chaining changed the criteria for the
target overlap test in Rosetta live conversions and triggered the error
in the regular case instead of only in cases where restricts have to be
enforced.

Reverted to the previous syntax with achieves the correct result.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
