### PR TITLE
chore: require es6 import style

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -20,6 +20,15 @@ extends:
   - plugin:@typescript-eslint/recommended-requiring-type-checking
   - plugin:import/typescript
 
+settings:
+  import/parsers:
+    '@typescript-eslint/parser': ['.ts', '.tsx']
+  import/resolver:
+    node: {}
+    typescript:
+      directory: ./**/tsconfig.json
+
+
 rules:
   # Custom Configurations
 
@@ -75,6 +84,9 @@ rules:
     - error
 
   '@typescript-eslint/no-for-in-array':
+    - error
+
+  '@typescript-eslint/no-require-imports':
     - error
 
   '@typescript-eslint/no-unused-vars':
@@ -146,6 +158,9 @@ rules:
     - devDependencies: ['**/test/**'] # Only allow importing devDependencies from tests
       optionalDependencies: false     # Disallow importing optional dependencies (those shouldn't be used here)
       peerDependencies: false         # Disallow importing peer dependencies (those shouldn't be used here)
+
+  'import/no-unresolved':
+    - error
 
   'max-len':
     - error

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@typescript-eslint/parser": "^2.11.0",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.19.1",
+    "eslint-import-resolver-node": "^0.3.2",
+    "eslint-import-resolver-typescript": "^2.0.0",
     "lerna": "^3.19.0"
   },
   "repository": {

--- a/packages/@jsii/dotnet-analyzers/lib/index.ts
+++ b/packages/@jsii/dotnet-analyzers/lib/index.ts
@@ -1,3 +1,3 @@
-import path = require('path');
+import * as path from 'path';
 
 export const repository = path.resolve(__dirname, path.join('..', 'bin', 'Release', 'NuGet'));

--- a/packages/@jsii/dotnet-jsonmodel/lib/index.ts
+++ b/packages/@jsii/dotnet-jsonmodel/lib/index.ts
@@ -1,3 +1,3 @@
-import path = require('path');
+import * as path from 'path';
 
 export const repository = path.resolve(__dirname, path.join('..', 'bin', 'Release', 'NuGet'));

--- a/packages/@jsii/dotnet-runtime-test/lib/index.ts
+++ b/packages/@jsii/dotnet-runtime-test/lib/index.ts
@@ -1,3 +1,3 @@
-import path = require('path');
+import * as path from 'path';
 
 export const repository = path.resolve(__dirname, path.join('..', 'bin', 'Release', 'NuGet'));

--- a/packages/@jsii/dotnet-runtime/lib/index.ts
+++ b/packages/@jsii/dotnet-runtime/lib/index.ts
@@ -1,3 +1,3 @@
-import path = require('path');
+import * as path from 'path';
 
 export const repository = path.resolve(__dirname, path.join('..', 'bin', 'Release', 'NuGet'));

--- a/packages/@jsii/dotnet-runtime/package.json
+++ b/packages/@jsii/dotnet-runtime/package.json
@@ -40,6 +40,7 @@
     "@jsii/dotnet-jsonmodel": "^0.20.11",
     "@jsii/runtime": "^0.20.11",
     "@types/node": "^10.17.9",
+    "@types/semver": "^6.2.0",
     "jsii-build-tools": "^0.20.11",
     "semver": "^6.3.0",
     "typescript": "~3.7.3"

--- a/packages/@jsii/java-runtime/lib/index.ts
+++ b/packages/@jsii/java-runtime/lib/index.ts
@@ -1,4 +1,4 @@
-import path = require('path');
+import * as path from 'path';
 
 export const maven = {
     groupId: 'software.amazon.jsii',

--- a/packages/@jsii/kernel/lib/api.ts
+++ b/packages/@jsii/kernel/lib/api.ts
@@ -125,17 +125,15 @@ export interface CreateRequest {
   readonly overrides?: Override[];
 }
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CreateResponse extends AnnotatedObjRef {}
-/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface DelRequest {
   readonly objref: ObjRef;
 }
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DelResponse {}
-/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface GetRequest {
   readonly objref: ObjRef;
@@ -163,9 +161,8 @@ export interface SetRequest {
   readonly value: any;
 }
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SetResponse { }
-/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface StaticInvokeRequest {
   readonly fqn: string;
@@ -201,9 +198,8 @@ export interface EndResponse {
   readonly result: any;
 }
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CallbacksRequest { }
-/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface CallbacksResponse {
   readonly callbacks: Callback[];
@@ -227,9 +223,8 @@ export interface NamingResponse {
   readonly naming: { readonly [language: string]: { readonly [key: string]: any } | undefined };
 }
 
-/* eslint-disable @typescript-eslint/no-empty-interface */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StatsRequest { }
-/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export interface StatsResponse {
   readonly objectCount: number;

--- a/packages/@jsii/kernel/lib/kernel.ts
+++ b/packages/@jsii/kernel/lib/kernel.ts
@@ -8,7 +8,7 @@ import * as vm from 'vm';
 import * as api from './api';
 import { TOKEN_REF } from './api';
 import { ObjectTable, tagJsiiConstructor } from './objects';
-import wire = require('./serialization');
+import * as wire from './serialization';
 
 export class Kernel {
   /**
@@ -46,6 +46,7 @@ export class Kernel {
     // let loaded modules to use the native node "require" method.
     // I wonder if webpack has some pragma that allows opting-out at certain points
     // in the code.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const moduleLoad = require('module').Module._load;
     const nodeRequire = (p: string) => moduleLoad(p, module, false);
 

--- a/packages/@jsii/kernel/lib/objects.ts
+++ b/packages/@jsii/kernel/lib/objects.ts
@@ -1,4 +1,4 @@
-import spec = require('@jsii/spec');
+import * as spec from '@jsii/spec';
 import * as api from './api';
 import { EMPTY_OBJECT_FQN } from './serialization';
 

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -1,8 +1,8 @@
-import childProcess = require('child_process');
-import fs = require('fs-extra');
+import * as childProcess from 'child_process';
+import * as fs from 'fs-extra';
 import { join } from 'path';
-import path = require('path');
-import vm = require('vm');
+import * as path from 'path';
+import * as vm from 'vm';
 import { api, Kernel } from '../lib';
 import { Callback, ObjRef, TOKEN_REF, TOKEN_INTERFACES, TOKEN_MAP, WireStruct, TOKEN_STRUCT } from '../lib/api';
 import { closeRecording, recordInteraction } from './recording';
@@ -10,8 +10,11 @@ import { closeRecording, recordInteraction } from './recording';
 /* eslint-disable require-atomic-updates */
 
 // extract versions of fixtures
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const calcBaseVersion = require('@scope/jsii-calc-base/package.json').version.replace(/\+.+$/, '');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const calcLibVersion = require('@scope/jsii-calc-lib/package.json').version.replace(/\+.+$/, '');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const calcVersion = require('jsii-calc/package.json').version.replace(/\+.+$/, '');
 
 // Do this so that regexes stringify nicely in approximate tests

--- a/packages/@jsii/runtime/lib/program.ts
+++ b/packages/@jsii/runtime/lib/program.ts
@@ -1,4 +1,4 @@
-import packageInfo = require('../package.json');
+import * as packageInfo from '../package.json';
 import { KernelHost } from './host';
 import { InputOutput } from './in-out';
 

--- a/packages/@jsii/runtime/test/kernel-host.test.ts
+++ b/packages/@jsii/runtime/test/kernel-host.test.ts
@@ -1,8 +1,8 @@
-import child = require('child_process');
-import fs = require('fs');
+import * as child from 'child_process';
+import * as fs from 'fs';
 import { api } from '@jsii/kernel';
-import spec = require('@jsii/spec');
-import path = require('path');
+import * as spec from '@jsii/spec';
+import * as path from 'path';
 import { KernelHost, InputOutput, Input, Output } from '../lib';
 
 test('can load libraries from within a callback', () => {

--- a/packages/@jsii/runtime/test/playback.test.ts
+++ b/packages/@jsii/runtime/test/playback.test.ts
@@ -1,8 +1,8 @@
-import child = require('child_process');
-import fs = require('fs');
-import os = require('os');
-import path = require('path');
-import process = require('process');
+import * as child from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as process from 'process';
 
 import { InputOutput, KernelHost, Input, Output } from '../lib';
 

--- a/packages/@jsii/spec/lib/validate-assembly.ts
+++ b/packages/@jsii/spec/lib/validate-assembly.ts
@@ -1,12 +1,11 @@
-import jsonschema = require('jsonschema');
+import { Schema, Validator } from 'jsonschema';
 import { Assembly } from './assembly';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-export const schema: jsonschema.Schema = require('../schema/jsii-spec.schema.json');
-/* eslint-enable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+export const schema: Schema = require('../schema/jsii-spec.schema.json');
 
 export function validateAssembly(obj: any): Assembly {
-  const validator = new jsonschema.Validator();
+  const validator = new Validator();
   validator.addSchema(schema); // For definitions
   const result = validator.validate(obj, schema, { nestedErrors: true } as any); // nestedErrors does exist but is not in the TypeScript definitions
   if (result.valid) { return obj; }

--- a/packages/codemaker/lib/case-utils.ts
+++ b/packages/codemaker/lib/case-utils.ts
@@ -1,5 +1,5 @@
 import { default as camelcase } from 'camelcase';
-import decamelize = require('decamelize');
+import * as decamelize from 'decamelize';
 
 const COMMON_ABBREVIATIONS = [
   'KiB',

--- a/packages/codemaker/test/case-utils.test.ts
+++ b/packages/codemaker/test/case-utils.test.ts
@@ -1,4 +1,4 @@
-import caseUtils = require('../lib/case-utils');
+import * as caseUtils from '../lib/case-utils';
 
 test('toCamelCase', () => {
   expect(caseUtils.toCamelCase('EXAMPLE_VALUE')).toBe('exampleValue');

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -15,7 +15,7 @@ import { promisify } from 'util';
 import { IFriendlyRandomGenerator, IRandomNumberGenerator, Multiply } from './calculator';
 
 const bundled = require('@fixtures/jsii-calc-bundled');
-import base = require('@scope/jsii-calc-base');
+import * as base from '@scope/jsii-calc-base';
 
 const readFile = promisify(fs.readFile);
 

--- a/packages/jsii-calc/rosetta/default.ts-fixture
+++ b/packages/jsii-calc/rosetta/default.ts-fixture
@@ -1,3 +1,3 @@
-import calc = require('.');
+import * as calc from '.';
 
 /// here

--- a/packages/jsii-calc/rosetta/with-calculator.ts-fixture
+++ b/packages/jsii-calc/rosetta/with-calculator.ts-fixture
@@ -1,4 +1,4 @@
-import calc = require('.');
+import * as calc from '.';
 const calculator = new calc.Calculator();
 
 /// here

--- a/packages/jsii-calc/test/test.calc.ts
+++ b/packages/jsii-calc/test/test.calc.ts
@@ -1,4 +1,4 @@
-import calcLib = require('@scope/jsii-calc-lib');
+import * as calcLib from '@scope/jsii-calc-lib';
 import * as assert from 'assert';
 import { Add, Calculator, Multiply, Negate, Power, Sum } from '../lib';
 import { composition } from '../lib';

--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -1,8 +1,8 @@
-import fs = require('fs-extra');
-import reflect = require('jsii-reflect');
-import spec = require('@jsii/spec');
-import log4js = require('log4js');
-import yargs = require('yargs');
+import * as fs from 'fs-extra';
+import * as reflect from 'jsii-reflect';
+import * as spec from '@jsii/spec';
+import * as log4js from 'log4js';
+import * as yargs from 'yargs';
 import { compareAssemblies } from '../lib';
 import { classifyDiagnostics, formatDiagnostic, hasErrors } from '../lib/diagnostics';
 import { DownloadFailure, downloadNpmPackage, showDownloadFailure } from '../lib/util';

--- a/packages/jsii-diff/lib/classes-ifaces.ts
+++ b/packages/jsii-diff/lib/classes-ifaces.ts
@@ -1,5 +1,5 @@
-import reflect = require('jsii-reflect');
-import log4js = require('log4js');
+import * as reflect from 'jsii-reflect';
+import * as log4js from 'log4js';
 import { compareStabilities } from './stability';
 import { Analysis, FailedAnalysis, isSuperType } from './type-analysis';
 import { ComparisonContext } from './types';
@@ -94,9 +94,9 @@ function describeOptionalValueMatchingFailure(origType: reflect.OptionalValue, u
   const updaDescr = reflect.OptionalValue.describe(updatedType);
   if (origDescr !== updaDescr) {
     return `${updaDescr} (formerly ${origDescr}): ${analysis.reasons.join(', ')}`;
-  } 
+  }
   return `${updaDescr}: ${analysis.reasons.join(', ')}`;
-  
+
 }
 
 function compareMethod<T extends (reflect.Method | reflect.Initializer)>(

--- a/packages/jsii-diff/lib/enums.ts
+++ b/packages/jsii-diff/lib/enums.ts
@@ -1,4 +1,4 @@
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import { compareStabilities } from './stability';
 import { ComparisonContext } from './types';
 

--- a/packages/jsii-diff/lib/index.ts
+++ b/packages/jsii-diff/lib/index.ts
@@ -1,6 +1,6 @@
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import { Stability } from '@jsii/spec';
-import log4js = require('log4js');
+import * as log4js from 'log4js';
 import { compareReferenceType, compareStruct } from './classes-ifaces';
 import { compareEnum } from './enums';
 import { ComparisonContext, ComparisonOptions, describeType, Mismatches } from './types';

--- a/packages/jsii-diff/lib/stability.ts
+++ b/packages/jsii-diff/lib/stability.ts
@@ -1,5 +1,5 @@
-import reflect = require('jsii-reflect');
-import spec = require('@jsii/spec');
+import * as reflect from 'jsii-reflect';
+import * as spec from '@jsii/spec';
 import { ApiElement, ComparisonContext } from './types';
 
 export function compareStabilities(original: reflect.Documentable & ApiElement, updated: reflect.Documentable, context: ComparisonContext) {

--- a/packages/jsii-diff/lib/type-analysis.ts
+++ b/packages/jsii-diff/lib/type-analysis.ts
@@ -1,4 +1,4 @@
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import { flatMap } from './util';
 
 /**

--- a/packages/jsii-diff/lib/types.ts
+++ b/packages/jsii-diff/lib/types.ts
@@ -1,4 +1,4 @@
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import { Stability } from '@jsii/spec';
 
 export interface ComparisonOptions {

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -1,9 +1,9 @@
-import childProcess = require('child_process');
-import fs = require('fs-extra');
-import log4js = require('log4js');
-import os = require('os');
-import path = require('path');
-import util = require('util');
+import * as childProcess from 'child_process';
+import * as fs from 'fs-extra';
+import * as log4js from 'log4js';
+import * as os from 'os';
+import * as path from 'path';
+import * as util from 'util';
 
 const LOG = log4js.getLogger('jsii-diff');
 

--- a/packages/jsii-diff/package.json
+++ b/packages/jsii-diff/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@jsii/spec": "^0.20.11",
+    "fs-extra": "^8.1.0",
     "jsii-reflect": "^0.20.11",
     "log4js": "^6.1.0",
     "typescript": "~3.7.3",

--- a/packages/jsii-diff/test/util.ts
+++ b/packages/jsii-diff/test/util.ts
@@ -1,5 +1,5 @@
 import { sourceToAssemblyHelper } from 'jsii';
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import { compareAssemblies } from '../lib';
 import { Mismatches } from '../lib/types';
 

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import path = require('path');
-import process = require('process');
-import yargs = require('yargs');
+import * as path from 'path';
+import * as process from 'process';
+import * as yargs from 'yargs';
 import { Rosetta } from 'jsii-rosetta';
-import logging = require('../lib/logging');
+import * as logging from '../lib/logging';
 import { Timers } from '../lib/timer';
 import { VERSION_DESC } from '../lib/version';
 import { findJsiiModules, updateAllNpmIgnores } from '../lib/npm-modules';
@@ -92,7 +92,7 @@ import { ALL_BUILDERS, TargetName } from '../lib/targets';
     .strict()
     .argv;
 
-  logging.level = argv.verbose !== undefined ? argv.verbose : 0;
+  logging.configure({ level: argv.verbose !== undefined ? argv.verbose : 0 });
 
   // Default to 4 threads in case of concurrency, good enough for most situations
   logging.debug('command line arguments:', argv);

--- a/packages/jsii-pacmak/lib/builder.ts
+++ b/packages/jsii-pacmak/lib/builder.ts
@@ -1,5 +1,5 @@
-import path = require('path');
-import logging = require('./logging');
+import * as path from 'path';
+import * as logging from './logging';
 import { JsiiModule } from './packaging';
 import { TargetConstructor, Target } from './target';
 import { Scratch } from './util';

--- a/packages/jsii-pacmak/lib/generator.ts
+++ b/packages/jsii-pacmak/lib/generator.ts
@@ -2,7 +2,7 @@ import * as clone from 'clone';
 import { CodeMaker } from 'codemaker';
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
-import reflect = require('jsii-reflect');
+import * as reflect from 'jsii-reflect';
 import * as spec from '@jsii/spec';
 import * as path from 'path';
 import { VERSION_DESC } from './version';

--- a/packages/jsii-pacmak/lib/logging.ts
+++ b/packages/jsii-pacmak/lib/logging.ts
@@ -9,9 +9,11 @@ export const LEVEL_INFO: number = Level.INFO;
 export const LEVEL_VERBOSE: number = Level.VERBOSE;
 
 /** The minimal logging level for messages to be emitted. */
-/* eslint-disable prefer-const */
 export let level = Level.QUIET;
-/* eslint-enable prefer-const */
+
+export function configure({ level: newLevel }: { level: Level }) {
+  level = newLevel;
+}
 
 export function warn(fmt: string, ...args: any[]) {
   log(Level.WARN, fmt, ...args);

--- a/packages/jsii-pacmak/lib/markdown.ts
+++ b/packages/jsii-pacmak/lib/markdown.ts
@@ -1,4 +1,4 @@
-import commonmark = require('commonmark');
+import * as commonmark from 'commonmark';
 
 /**
  * Convert MarkDown to RST
@@ -22,8 +22,6 @@ export function md2rst(text: string) {
   function textOf(node: commonmark.Node) {
     return node.literal ?? '';
   }
-
-  // let lastParaLine: number; // Where the last paragraph ended, in order to add ::
 
   /* eslint-disable @typescript-eslint/camelcase */
   pump(ast, {

--- a/packages/jsii-pacmak/lib/npm-modules.ts
+++ b/packages/jsii-pacmak/lib/npm-modules.ts
@@ -1,9 +1,9 @@
-import fs = require('fs-extra');
-import path = require('path');
-import spec = require('@jsii/spec');
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as spec from '@jsii/spec';
 import { resolveDependencyDirectory } from './util';
 
-import logging = require('../lib/logging');
+import * as logging from '../lib/logging';
 import { JsiiModule } from './packaging';
 import { topologicalSort } from './toposort';
 

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -1,8 +1,8 @@
 import { Scratch, shell } from './util';
-import logging = require('../lib/logging');
-import reflect = require('jsii-reflect');
-import os = require('os');
-import path = require('path');
+import * as logging from '../lib/logging';
+import * as reflect from 'jsii-reflect';
+import * as os from 'os';
+import * as path from 'path';
 
 const SHARED_TS = new reflect.TypeSystem();
 

--- a/packages/jsii-pacmak/lib/target.ts
+++ b/packages/jsii-pacmak/lib/target.ts
@@ -1,10 +1,10 @@
-import fs = require('fs-extra');
-import reflect = require('jsii-reflect');
-import spec = require('@jsii/spec');
-import path = require('path');
+import * as fs from 'fs-extra';
+import * as reflect from 'jsii-reflect';
+import * as spec from '@jsii/spec';
+import * as path from 'path';
 
 import { IGenerator } from './generator';
-import logging = require('./logging');
+import * as logging from './logging';
 import { resolveDependencyDirectory } from './util';
 import { Rosetta } from 'jsii-rosetta';
 

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
 import * as path from 'path';
 import * as logging from '../logging';
-import xmlbuilder = require('xmlbuilder');
+import * as xmlbuilder from 'xmlbuilder';
 import { PackageInfo, Target, TargetOptions, findLocalBuildDirs } from '../target';
 import { shell, Scratch, setExtend, filterAsync } from '../util';
 import { DotNetGenerator } from './dotnet/dotnetgenerator';
@@ -124,9 +124,8 @@ export class DotnetBuilder implements TargetBuilder {
 
     // If dotnet-jsonmodel is checked-out and we can find a local repository, add it to the list.
     try {
-      /* eslint-disable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
+      // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
       const jsiiDotNetJsonModel = require('@jsii/dotnet-jsonmodel');
-      /* eslint-enable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
       localRepos.push(jsiiDotNetJsonModel.repository);
     } catch {
       // Couldn't locate @jsii/dotnet-jsonmodel, which is owkay!
@@ -134,9 +133,8 @@ export class DotnetBuilder implements TargetBuilder {
 
     // If dotnet-runtime is checked-out and we can find a local repository, add it to the list.
     try {
-      /* eslint-disable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
+      // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
       const jsiiDotNetRuntime = require('@jsii/dotnet-runtime');
-      /* eslint-enable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
       localRepos.push(jsiiDotNetRuntime.repository);
     } catch {
       // Couldn't locate @jsii/dotnet-runtime, which is owkay!
@@ -242,7 +240,7 @@ export default class Dotnet extends Target {
     this.generator = new DotNetGenerator(assembliesCurrentlyBeingCompiled);
   }
 
-  /* eslint-disable @typescript-eslint/require-await */
+  // eslint-disable-next-line @typescript-eslint/require-await
   public async build(_sourceDir: string, _outDir: string): Promise<void> {
     throw new Error('Should not be called; use builder instead');
   }

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -1,9 +1,9 @@
 import { CodeMaker } from 'codemaker';
 import { Assembly } from '@jsii/spec';
-import path = require('path');
-import xmlbuilder = require('xmlbuilder');
+import * as path from 'path';
+import * as xmlbuilder from 'xmlbuilder';
 import { DotNetNameUtils } from './nameutils';
-import logging = require('../../logging');
+import * as logging from '../../logging';
 import { nextMajorVersion } from '../../util';
 
 // Represents a dependency in the dependency tree.

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1,12 +1,12 @@
-import clone = require('clone');
+import * as clone from 'clone';
 import { toPascalCase } from 'codemaker/lib/case-utils';
-import fs = require('fs-extra');
-import reflect = require('jsii-reflect');
-import spec = require('@jsii/spec');
-import path = require('path');
-import xmlbuilder = require('xmlbuilder');
+import * as fs from 'fs-extra';
+import * as reflect from 'jsii-reflect';
+import * as spec from '@jsii/spec';
+import * as path from 'path';
+import * as xmlbuilder from 'xmlbuilder';
 import { Generator } from '../generator';
-import logging = require('../logging');
+import * as logging from '../logging';
 import { md2html } from '../markdown';
 import { PackageInfo, Target, findLocalBuildDirs } from '../target';
 import { shell, Scratch, slugify, setExtend, prefixMarkdownTsCodeBlocks } from '../util';
@@ -14,9 +14,8 @@ import { VERSION, VERSION_DESC } from '../version';
 import { TargetBuilder, BuildOptions } from '../builder';
 import { JsiiModule } from '../packaging';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
 const spdxLicenseList = require('spdx-license-list');
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 const BUILDER_CLASS_NAME = 'Builder';
 const SAMPLES_DISCLAIMER = '// This example is in TypeScript, examples in Java are coming soon.';
@@ -1856,9 +1855,8 @@ interface MavenDependency {
  */
 function findJavaRuntimeLocalRepository() {
   try {
-    /* eslint-disable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
     const javaRuntime = require('jsii-java-runtime');
-    /* eslint-enable @typescript-eslint/no-var-requires,import/no-extraneous-dependencies */
     return javaRuntime.repository;
   } catch {
     return undefined;

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1,4 +1,4 @@
-import path = require('path');
+import * as path from 'path';
 
 import { CodeMaker, toSnakeCase } from 'codemaker';
 import * as escapeStringRegexp from 'escape-string-regexp';
@@ -15,9 +15,8 @@ import { Translation, Rosetta, typeScriptSnippetFromSource } from 'jsii-rosetta'
 
 const INCOMPLETE_DISCLAIMER = '# Example automatically generated. See https://github.com/aws/jsii/issues/826';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
 const spdxLicenseList = require('spdx-license-list');
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export default class Python extends Target {
   protected readonly generator: PythonGenerator;

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -1,10 +1,10 @@
 import { spawn, SpawnOptions } from 'child_process';
-import fs = require('fs-extra');
-import spec = require('@jsii/spec');
-import os = require('os');
-import path = require('path');
-import semver = require('semver');
-import logging = require('./logging');
+import * as fs from 'fs-extra';
+import * as spec from '@jsii/spec';
+import * as os from 'os';
+import * as path from 'path';
+import * as semver from 'semver';
+import * as logging from './logging';
 
 export interface ShellOptions extends SpawnOptions {
   /**
@@ -27,7 +27,7 @@ export function resolveDependencyDirectory(packageDir: string, dependencyName: s
 }
 
 export async function shell(cmd: string, args: string[], options: ShellOptions): Promise<string> {
-  /* eslint-disable @typescript-eslint/require-await */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async function spawn1() {
     logging.debug(cmd, args.join(' '), JSON.stringify(options));
     return new Promise<string>((ok, ko) => {

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -43,6 +43,7 @@
     "fs-extra": "^8.1.0",
     "jsii-reflect": "^0.20.11",
     "jsii-rosetta": "^0.20.11",
+    "semver": "^7.0.0",
     "spdx-license-list": "^6.1.0",
     "xmlbuilder": "^13.0.2",
     "yargs": "^15.0.2"
@@ -58,6 +59,7 @@
     "@types/jest": "^24.0.23",
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^10.17.9",
+    "@types/semver": "^6.2.0",
     "@types/yargs": "^13.0.3",
     "eslint": "^6.7.2",
     "jest": "^24.9.0",

--- a/packages/jsii-pacmak/test/npm-modules.test.ts
+++ b/packages/jsii-pacmak/test/npm-modules.test.ts
@@ -1,4 +1,4 @@
-import mockfs = require('mock-fs');
+import * as mockfs from 'mock-fs';
 import { findJsiiModules } from '../lib/npm-modules';
 
 test('findJsiiModules is sorted topologically', async () => {

--- a/packages/jsii-reflect/bin/jsii-tree.ts
+++ b/packages/jsii-reflect/bin/jsii-tree.ts
@@ -1,5 +1,5 @@
-import colors = require('colors/safe');
-import yargs = require('yargs');
+import * as colors from 'colors/safe';
+import * as yargs from 'yargs';
 import { TypeSystem, TypeSystemTree } from '../lib';
 
 async function main() {

--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { ClassType } from './class';
 import { Dependency } from './dependency';
 import { EnumType } from './enum';

--- a/packages/jsii-reflect/lib/callable.ts
+++ b/packages/jsii-reflect/lib/callable.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';
 import { Overridable } from './overridable';

--- a/packages/jsii-reflect/lib/class.ts
+++ b/packages/jsii-reflect/lib/class.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Initializer } from './initializer';
 import { InterfaceType } from './interface';

--- a/packages/jsii-reflect/lib/dependency.ts
+++ b/packages/jsii-reflect/lib/dependency.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { TypeSystem } from './type-system';
 
 export class Dependency {

--- a/packages/jsii-reflect/lib/docs.ts
+++ b/packages/jsii-reflect/lib/docs.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Stability } from '@jsii/spec';
 import { TypeSystem } from './type-system';
 

--- a/packages/jsii-reflect/lib/enum.ts
+++ b/packages/jsii-reflect/lib/enum.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';
 import { Type } from './type';

--- a/packages/jsii-reflect/lib/interface.ts
+++ b/packages/jsii-reflect/lib/interface.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Method } from './method';
 import { Property } from './property';

--- a/packages/jsii-reflect/lib/method.ts
+++ b/packages/jsii-reflect/lib/method.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Callable } from './callable';
 import { Documentable } from './docs';

--- a/packages/jsii-reflect/lib/optional-value.ts
+++ b/packages/jsii-reflect/lib/optional-value.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { TypeReference } from './type-ref';
 import { TypeSystem } from './type-system';
 

--- a/packages/jsii-reflect/lib/parameter.ts
+++ b/packages/jsii-reflect/lib/parameter.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Callable } from './callable';
 import { Docs, Documentable } from './docs';
 import { OptionalValue } from './optional-value';

--- a/packages/jsii-reflect/lib/property.ts
+++ b/packages/jsii-reflect/lib/property.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';
 import { OptionalValue } from './optional-value';

--- a/packages/jsii-reflect/lib/reference-type.ts
+++ b/packages/jsii-reflect/lib/reference-type.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { InterfaceType } from './interface';
 import { Method } from './method';

--- a/packages/jsii-reflect/lib/tree.ts
+++ b/packages/jsii-reflect/lib/tree.ts
@@ -1,4 +1,4 @@
-import colors = require('colors/safe');
+import * as colors from 'colors/safe';
 import { Stability } from '@jsii/spec';
 import { AsciiTree } from 'oo-ascii-tree';
 import { Assembly } from './assembly';

--- a/packages/jsii-reflect/lib/type-ref.ts
+++ b/packages/jsii-reflect/lib/type-ref.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Type } from './type';
 import { TypeSystem } from './type-system';
 

--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -1,6 +1,6 @@
-import fs = require('fs');
-import jsii = require('@jsii/spec');
-import path = require('path');
+import * as fs from 'fs';
+import * as jsii from '@jsii/spec';
+import * as path from 'path';
 import { promisify } from 'util';
 import { Assembly } from './assembly';
 import { ClassType } from './class';
@@ -33,21 +33,18 @@ export class TypeSystem {
    * NOT have to declare a JSII dependency on any of the packages.
    */
   public async loadNpmDependencies(packageRoot: string, options: { validate?: boolean } = {}): Promise<void> {
-    /* eslint-disable @typescript-eslint/no-var-requires */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
     const pkg = require(path.resolve(packageRoot, 'package.json'));
-    /* eslint-enable @typescript-eslint/no-var-requires */
 
     for (const dep of dependenciesOf(pkg)) {
       // Filter jsii dependencies
       const depPkgJsonPath = require.resolve(`${dep}/package.json`, { paths: [packageRoot] });
-      /* eslint-disable @typescript-eslint/no-var-requires */
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
       const depPkgJson = require(depPkgJsonPath);
-      /* eslint-enable @typescript-eslint/no-var-requires */
       if (!depPkgJson.jsii) { continue; }
 
-      /* eslint-disable no-await-in-loop */
+      // eslint-disable-next-line no-await-in-loop
       await this.loadModule(path.dirname(depPkgJsonPath), options);
-      /* eslint-enable no-await-in-loop */
     }
   }
 
@@ -118,9 +115,8 @@ export class TypeSystem {
         const depDir = require.resolve(`${name}/package.json`, {
           paths: [moduleDirectory]
         });
-        /* eslint-disable no-await-in-loop */
+        // eslint-disable-next-line no-await-in-loop
         await _loadModule.call(this, path.dirname(depDir));
-        /* eslint-enable no-await-in-loop */
       }
 
       return root;

--- a/packages/jsii-reflect/lib/type.ts
+++ b/packages/jsii-reflect/lib/type.ts
@@ -1,4 +1,4 @@
-import jsii = require('@jsii/spec');
+import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { ClassType } from './class';
 import { Docs, Documentable } from './docs';

--- a/packages/jsii-reflect/test/independent.test.ts
+++ b/packages/jsii-reflect/test/independent.test.ts
@@ -1,5 +1,5 @@
 import { PackageInfo, sourceToAssemblyHelper } from 'jsii';
-import reflect = require('../lib');
+import * as reflect from '../lib';
 
 test('get full github source location for a class or method', async () => {
   // WHEN

--- a/packages/jsii-reflect/test/jsii-tree.test.ts
+++ b/packages/jsii-reflect/test/jsii-tree.test.ts
@@ -1,5 +1,5 @@
-import childProcess = require('child_process');
-import path = require('path');
+import * as childProcess from 'child_process';
+import * as path from 'path';
 import { promisify } from 'util';
 
 const exec = promisify(childProcess.exec);

--- a/packages/jsii-reflect/test/type-system.test.ts
+++ b/packages/jsii-reflect/test/type-system.test.ts
@@ -1,6 +1,6 @@
-import spec = require('@jsii/spec');
+import * as spec from '@jsii/spec';
 import { Stability } from '@jsii/spec';
-import path = require('path');
+import * as path from 'path';
 import { TypeSystem } from '../lib';
 import { typeSystemFromSource } from './util';
 

--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -1,11 +1,11 @@
-import fs = require('fs-extra');
-import yargs = require('yargs');
+import * as fs from 'fs-extra';
+import * as yargs from 'yargs';
 import { TranslateResult, DEFAULT_TABLET_NAME, translateTypeScript } from '../lib';
 import { PythonVisitor } from '../lib/languages/python';
 import { VisualizeAstVisitor } from '../lib/languages/visualize';
 import { extractSnippets } from '../lib/commands/extract';
-import logging = require('../lib/logging');
-import path = require('path');
+import * as logging from '../lib/logging';
+import * as path from 'path';
 import { readTablet as readTablet } from '../lib/commands/read';
 import { translateMarkdown } from '../lib/commands/convert';
 import { File, printDiagnostics, isErrorDiagnostic } from '../lib/util';
@@ -79,6 +79,7 @@ function main() {
     .demandCommand()
     .help()
     .strict()  // Error on wrong command
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     .version(require('../package.json').version)
     .showHelpOnFail(false)
     .argv;
@@ -93,7 +94,7 @@ function main() {
  */
 function wrapHandler<A extends { verbose?: number }, R>(handler: (x: A) => Promise<R>) {
   return (argv: A) => {
-    logging.level = argv.verbose !== undefined ? argv.verbose : 0;
+    logging.configure({ level: argv.verbose !== undefined ? argv.verbose : 0 });
     handler(argv).catch(e => { throw e; });
   };
 }

--- a/packages/jsii-rosetta/examples/controlflow.ts
+++ b/packages/jsii-rosetta/examples/controlflow.ts
@@ -1,4 +1,4 @@
-import lib = require('@aws-cdk/lib');
+import * as lib from '@aws-cdk/lib';
 
 /**
  * This squares a value

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -1,8 +1,8 @@
 import { loadAssemblies, allTypeScriptSnippets } from '../jsii/assemblies';
-import logging = require('../logging');
-import os = require('os');
-import path = require('path');
-import ts = require('typescript');
+import * as logging from '../logging';
+import * as os from 'os';
+import * as path from 'path';
+import * as ts from 'typescript';
 import { LanguageTablet, TranslatedSnippet } from '../tablets/tablets';
 import { Translator } from '../translate';
 import { TypeScriptSnippet } from '../snippet';

--- a/packages/jsii-rosetta/lib/commands/extract_worker.ts
+++ b/packages/jsii-rosetta/lib/commands/extract_worker.ts
@@ -2,9 +2,9 @@
  * Pool worker for extract.ts
  */
 import { TypeScriptSnippet } from '../snippet';
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { singleThreadedTranslateAll } from './extract';
-import worker = require('worker_threads');
+import * as worker from 'worker_threads';
 import { TranslatedSnippetSchema } from '../tablets/schema';
 
 export interface TranslateRequest {

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -1,5 +1,5 @@
-import fs = require('fs-extra');
-import path = require('path');
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { TypeScriptSnippet, SnippetParameters } from './snippet';
 
 /**

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -1,6 +1,6 @@
-import spec = require('@jsii/spec');
-import fs = require('fs-extra');
-import path = require('path');
+import * as spec from '@jsii/spec';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { TypeScriptSnippet, typeScriptSnippetFromSource, updateParameters, SnippetParameters } from '../snippet';
 import { extractTypescriptSnippetsFromMarkdown } from '../markdown/extract-snippets';
 import { fixturize } from '../fixtures';

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { AstRenderer } from '../renderer';
 
 export function isStructInterface(name: string) {

--- a/packages/jsii-rosetta/lib/jsii/packages.ts
+++ b/packages/jsii-rosetta/lib/jsii/packages.ts
@@ -8,6 +8,7 @@
 export function resolvePackage(packageName: string) {
   try {
     const resolved = require.resolve(`${packageName}/package.json`, { paths: [process.cwd()] });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require(resolved);
   } catch {
     return undefined;

--- a/packages/jsii-rosetta/lib/languages/default.ts
+++ b/packages/jsii-rosetta/lib/languages/default.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { AstRenderer, AstHandler, nimpl } from '../renderer';
 import { OTree } from '../o-tree';
 import { ImportStatement } from '../typescript/imports';

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { AstRenderer, nimpl } from '../renderer';
 import { isStructType, parameterAcceptsUndefined, propertiesOfStruct, StructProperty, structPropertyAcceptsUndefined } from '../jsii/jsii-utils';
 import { NO_SYNTAX, OTree, renderTree } from '../o-tree';
@@ -130,9 +130,8 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
     const originalIdentifier = node.text;
 
     const explodedParameter = context.currentContext.explodedParameter;
-    /* eslint-disable max-len */
+    // eslint-disable-next-line max-len
     if (context.currentContext.tailPositionArgument && explodedParameter && explodedParameter.type && explodedParameter.variableName === originalIdentifier) {
-    /* eslint-enable max-len */
       return new OTree([],
         propertiesOfStruct(explodedParameter.type, context).map(prop => new OTree([prop.name, '=', prop.name])),
         { separator: ', ' });

--- a/packages/jsii-rosetta/lib/languages/visualize.ts
+++ b/packages/jsii-rosetta/lib/languages/visualize.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { AstRenderer, AstHandler, nimpl } from '../renderer';
 import { OTree } from '../o-tree';
 import { ImportStatement } from '../typescript/imports';

--- a/packages/jsii-rosetta/lib/logging.ts
+++ b/packages/jsii-rosetta/lib/logging.ts
@@ -1,4 +1,4 @@
-import util = require('util');
+import * as util from 'util';
 
 export enum Level {
   WARN = -1,
@@ -11,9 +11,11 @@ export const LEVEL_INFO: number = Level.INFO;
 export const LEVEL_VERBOSE: number = Level.VERBOSE;
 
 /** The minimal logging level for messages to be emitted. */
-/* eslint-disable prefer-const */
 export let level = Level.QUIET;
-/* eslint-enable prefer-const */
+
+export function configure({ level: newLevel }: { level: Level }) {
+  level = newLevel;
+}
 
 export function warn(fmt: string, ...args: any[]) {
   log(Level.WARN, fmt, ...args);

--- a/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
+++ b/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
@@ -1,4 +1,4 @@
-import cm = require('commonmark');
+import * as cm from 'commonmark';
 import { visitCommonMarkTree } from '../markdown/markdown';
 import { TypeScriptSnippet } from '../snippet';
 import { ReplaceTypeScriptTransform } from './replace-typescript-transform';

--- a/packages/jsii-rosetta/lib/markdown/markdown-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/markdown-renderer.ts
@@ -1,4 +1,4 @@
-import cm = require('commonmark');
+import * as cm from 'commonmark';
 import { cmNodeChildren, CommonMarkRenderer, prefixLines, RendererContext } from './markdown';
 
 /* eslint-disable @typescript-eslint/camelcase */
@@ -117,9 +117,8 @@ function para(x: string) {
  * Collapse paragraph markers
  */
 function collapsePara(x: string, brk = '\n\n') {
-  /* eslint-disable no-control-regex */
+  // eslint-disable-next-line no-control-regex
   return x.replace(/^\u001d+/, '').replace(/\u001d+$/, '').replace(/\u001d+/g, brk);
-  /* eslint-enable no-control-regex */
 }
 
 function determineItemPrefix(listNode: cm.Node, index: number) {

--- a/packages/jsii-rosetta/lib/markdown/markdown.ts
+++ b/packages/jsii-rosetta/lib/markdown/markdown.ts
@@ -1,4 +1,4 @@
-import cm = require('commonmark');
+import * as cm from 'commonmark';
 
 export function transformMarkdown(source: string, renderer: CommonMarkRenderer, transform?: CommonMarkVisitor) {
   const parser = new cm.Parser();

--- a/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
@@ -1,4 +1,4 @@
-import cm = require('commonmark');
+import * as cm from 'commonmark';
 import { CommonMarkVisitor } from './markdown';
 import { CodeBlock } from './types';
 

--- a/packages/jsii-rosetta/lib/markdown/structure-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/structure-renderer.ts
@@ -1,4 +1,4 @@
-import cm = require('commonmark');
+import * as cm from 'commonmark';
 import { CommonMarkRenderer, prefixLines, RendererContext } from './markdown';
 
 /* eslint-disable @typescript-eslint/camelcase */

--- a/packages/jsii-rosetta/lib/o-tree.ts
+++ b/packages/jsii-rosetta/lib/o-tree.ts
@@ -158,9 +158,8 @@ export class OTreeSink {
    * Marks can be used to query about things that have been written to output.
    */
   public mark(): SinkMark {
-    /* eslint-disable @typescript-eslint/no-this-alias */
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
-    /* eslint-enable @typescript-eslint/no-this-alias */
     const markIndex = this.fragments.length;
 
     return {

--- a/packages/jsii-rosetta/lib/renderer.ts
+++ b/packages/jsii-rosetta/lib/renderer.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { NO_SYNTAX, OTree, UnknownSyntax } from './o-tree';
 import { commentRangeFromTextRange, extractMaskingVoidExpression, extractShowingVoidExpression, nodeChildren,
   repeatNewlines, scanText } from './typescript/ast-utils';

--- a/packages/jsii-rosetta/lib/rosetta.ts
+++ b/packages/jsii-rosetta/lib/rosetta.ts
@@ -1,6 +1,6 @@
-import fs = require('fs-extra');
-import path = require('path');
-import spec = require('@jsii/spec');
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as spec from '@jsii/spec';
 import { DEFAULT_TABLET_NAME, LanguageTablet, Translation } from './tablets/tablets';
 import { allTypeScriptSnippets } from './jsii/assemblies';
 import { TargetLanguage } from './languages';

--- a/packages/jsii-rosetta/lib/tablets/key.ts
+++ b/packages/jsii-rosetta/lib/tablets/key.ts
@@ -1,4 +1,4 @@
-import crypto = require('crypto');
+import * as crypto from 'crypto';
 import { TypeScriptSnippet } from '../snippet';
 
 /**

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -1,9 +1,10 @@
-import fs = require('fs-extra');
+import * as fs from 'fs-extra';
 import { TabletSchema, TranslatedSnippetSchema, TranslationSchema, ORIGINAL_SNIPPET_KEY } from './schema';
 import { snippetKey } from './key';
 import { TargetLanguage } from '../languages';
 import { TypeScriptSnippet } from '../snippet';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const TOOL_VERSION = require('../../package.json').version;
 
 export const DEFAULT_TABLET_NAME = '.jsii.tabl.json';

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -1,5 +1,5 @@
-import logging = require('./logging');
-import ts = require('typescript');
+import * as logging from './logging';
+import * as ts from 'typescript';
 import { AstRenderer, AstHandler, AstRendererOptions } from './renderer';
 import { renderTree, Span, spanContains } from './o-tree';
 import { TypeScriptCompiler, CompilationResult } from './typescript/ts-compiler';

--- a/packages/jsii-rosetta/lib/typescript/ast-utils.ts
+++ b/packages/jsii-rosetta/lib/typescript/ast-utils.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { Span } from '../o-tree';
 
 export interface MarkedSpan {
@@ -103,10 +103,10 @@ export function nodeChildren(node: ts.Node): ts.Node[] {
  * Looks like SyntaxList nodes appear in the printed AST, but they don't actually appear
  */
 export function nodeOfType<A>(syntaxKind: ts.SyntaxKind, children?: AstMatcher<A>): AstMatcher<A>;
-/* eslint-disable max-len */
-export function nodeOfType<S extends keyof CapturableNodes, N extends string, A>(capture: N, capturableNodeType: S, children?: AstMatcher<A>): AstMatcher<Omit<A, N> & {[key in N]: CapturableNodes[S]}>;
+// eslint-disable-next-line max-len
+export function nodeOfType<S extends keyof CapturableNodes, N extends string, A>(capture: N, capturableNodeType: S, children?: AstMatcher<A>): AstMatcher<Omit<A, N> & { [key in N]: CapturableNodes[S] }>;
+// eslint-disable-next-line max-len
 export function nodeOfType<S extends keyof CapturableNodes, N extends string, A>(syntaxKindOrCaptureName: ts.SyntaxKind | N, nodeTypeOrChildren?: S | AstMatcher<A>, children?: AstMatcher<A>): AstMatcher<A> | AstMatcher<A & { [key in N]: CapturableNodes[S] }> {
-/* eslint-enable max-len */
   const capturing = typeof syntaxKindOrCaptureName === 'string';  // Determine which overload we're in (SyntaxKind is a number)
 
   const realNext = (capturing ? children : nodeTypeOrChildren as AstMatcher<A>) || DONE;

--- a/packages/jsii-rosetta/lib/typescript/imports.ts
+++ b/packages/jsii-rosetta/lib/typescript/imports.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { AstRenderer } from '../renderer';
 import { allOfType, matchAst, nodeOfType, stringFromLiteral } from './ast-utils';
 
@@ -58,7 +58,7 @@ export function analyzeImportDeclaration(node: ts.ImportDeclaration, context: As
 
   const elements: ImportBinding[] = [];
   if (namedBindings) {
-    elements.push(...namedBindings.specifiers.map(spec => 
+    elements.push(...namedBindings.specifiers.map(spec =>
     // regular import { name }, renamed import { propertyName, name }
       spec.propertyName ? {
         sourceName: context.textOf(spec.propertyName),

--- a/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
+++ b/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 
 export class TypeScriptCompiler {
   private readonly realHost: ts.CompilerHost;

--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -1,5 +1,5 @@
 import { VisualizeAstVisitor } from './languages/visualize';
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { translateTypeScript } from './translate';
 
 export function startsWithUppercase(x: string): boolean {

--- a/packages/jsii-rosetta/test/jsii/assemblies.test.ts
+++ b/packages/jsii-rosetta/test/jsii/assemblies.test.ts
@@ -1,7 +1,7 @@
-import mockfs = require('mock-fs');
-import spec = require('@jsii/spec');
+import * as mockfs from 'mock-fs';
+import * as spec from '@jsii/spec';
 import { allTypeScriptSnippets } from '../../lib/jsii/assemblies';
-import path = require('path');
+import * as path from 'path';
 import { SnippetParameters } from '../../lib/snippet';
 
 test('Extract snippet from README', () => {

--- a/packages/jsii-rosetta/test/python/imports.test.ts
+++ b/packages/jsii-rosetta/test/python/imports.test.ts
@@ -3,7 +3,7 @@ import { expectPython } from './python';
 
 test('import/require', () =>
   expectPython(`
-  import mod = require('@scope/some-module');
+  import * as mod from '@scope/some-module';
   `, `
   import scope.some_module as mod
   `)

--- a/packages/jsii-rosetta/test/rosetta.test.ts
+++ b/packages/jsii-rosetta/test/rosetta.test.ts
@@ -1,5 +1,5 @@
 import { Rosetta, LanguageTablet, TranslatedSnippet, TypeScriptSnippet, DEFAULT_TABLET_NAME } from '../lib';
-import mockfs = require('mock-fs');
+import * as mockfs from 'mock-fs';
 import { TargetLanguage } from '../lib/languages';
 import { fakeAssembly } from './jsii/assemblies.test';
 

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -1,10 +1,10 @@
-import log4js = require('log4js');
-import path = require('path');
-import process = require('process');
-import yargs = require('yargs');
+import * as log4js from 'log4js';
+import * as path from 'path';
+import * as process from 'process';
+import * as yargs from 'yargs';
 import { Compiler, DIAGNOSTICS } from '../lib/compiler';
 import { loadProjectInfo } from '../lib/project-info';
-import utils = require('../lib/utils');
+import * as utils from '../lib/utils';
 import { VERSION } from '../lib/version';
 
 (async () => {
@@ -28,6 +28,7 @@ import { VERSION } from '../lib/version';
       desc: 'Treat warnings as errors'
     })
     .help()
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     .version(`${VERSION}, typescript ${require('typescript/package.json').version}`)
     .argv;
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1,24 +1,24 @@
-import colors = require('colors/safe');
-import crypto = require('crypto');
+import * as colors from 'colors/safe';
+import * as crypto from 'crypto';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 import deepEqual = require('deep-equal');
-import fs = require('fs-extra');
-import spec = require('@jsii/spec');
-import log4js = require('log4js');
-import path = require('path');
-import semver = require('semver');
-import ts = require('typescript');
+import * as fs from 'fs-extra';
+import * as spec from '@jsii/spec';
+import * as log4js from 'log4js';
+import * as path from 'path';
+import * as semver from 'semver';
+import * as ts from 'typescript';
 import { JSII_DIAGNOSTICS_CODE } from './compiler';
 import { getReferencedDocParams, parseSymbolDocumentation } from './docs';
 import { Diagnostic, EmitResult, Emitter } from './emitter';
-import literate = require('./literate');
+import * as literate from './literate';
 import { ProjectInfo } from './project-info';
 import { isReservedName } from './reserved-words';
 import { Validator } from './validator';
 import { SHORT_VERSION, VERSION } from './version';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const sortJson = require('sort-json');
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 const LOG = log4js.getLogger('jsii/assembler');
 
@@ -485,9 +485,8 @@ export class Assembler implements Emitter {
         continue;
       }
 
-      /* eslint-disable no-await-in-loop */
+      // eslint-disable-next-line no-await-in-loop
       const ref = await this._typeReference(base, type.symbol.valueDeclaration);
-      /* eslint-enable no-await-in-loop */
 
       if (!spec.isNamedTypeReference(ref)) {
         this._diagnostic(base.symbol.valueDeclaration,
@@ -581,7 +580,7 @@ export class Assembler implements Emitter {
           continue;
         }
 
-        /* eslint-disable no-await-in-loop */
+        // eslint-disable-next-line no-await-in-loop
         if (ts.isMethodDeclaration(memberDecl) || ts.isMethodSignature(memberDecl)) {
           await this._visitMethod(member, jsiiType, ctx.replaceStability(jsiiType.docs?.stability));
         } else if (ts.isPropertyDeclaration(memberDecl)
@@ -610,9 +609,8 @@ export class Assembler implements Emitter {
         if (signature) {
           for (const param of signature.getParameters()) {
             jsiiType.initializer.parameters = jsiiType.initializer.parameters ?? [];
-            /* eslint-disable no-await-in-loop */
+            // eslint-disable-next-line no-await-in-loop
             jsiiType.initializer.parameters.push(await this._toParameter(param, ctx.replaceStability(jsiiType.docs?.stability)));
-            /* eslint-enable no-await-in-loop */
             jsiiType.initializer.variadic = jsiiType.initializer?.parameters?.some(p => !!p.variadic) || undefined;
             jsiiType.initializer.protected = (ts.getCombinedModifierFlags(ctorDeclaration) & ts.ModifierFlags.Protected) !== 0
               || undefined;
@@ -626,9 +624,8 @@ export class Assembler implements Emitter {
       if (signature) {
         for (const param of signature.getParameters()) {
           if (ts.isParameterPropertyDeclaration(param.valueDeclaration, param.valueDeclaration.parent) && !this._isPrivateOrInternal(param)) {
-            /* eslint-disable no-await-in-loop */
+            // eslint-disable-next-line no-await-in-loop
             await this._visitProperty(param, jsiiType, memberEmitContext);
-            /* eslint-enable no-await-in-loop */
           }
         }
       }
@@ -861,19 +858,19 @@ export class Assembler implements Emitter {
           continue;
         }
 
-        /* eslint-disable no-await-in-loop */
         if (ts.isMethodDeclaration(member.valueDeclaration) || ts.isMethodSignature(member.valueDeclaration)) {
+          // eslint-disable-next-line no-await-in-loop
           await this._visitMethod(member, jsiiType, ctx.replaceStability(jsiiType.docs?.stability));
         } else if (ts.isPropertyDeclaration(member.valueDeclaration)
           || ts.isPropertySignature(member.valueDeclaration)
           || ts.isAccessor(member.valueDeclaration)) {
+          // eslint-disable-next-line no-await-in-loop
           await this._visitProperty(member, jsiiType, ctx.replaceStability(jsiiType.docs?.stability));
         } else {
           this._diagnostic(member.valueDeclaration,
             ts.DiagnosticCategory.Warning,
             `Ignoring un-handled ${ts.SyntaxKind[member.valueDeclaration.kind]} member`);
         }
-        /* eslint-enable no-await-in-loop */
       }
     }
 
@@ -1251,9 +1248,8 @@ export class Assembler implements Emitter {
           optional = true;
           continue;
         }
-        /* eslint-disable no-await-in-loop */
+        // eslint-disable-next-line no-await-in-loop
         const resolvedType = await this._typeReference(subType, declaration);
-        /* eslint-enable no-await-in-loop */
         if (types.find(ref => deepEqual(ref, resolvedType)) != null) {
           continue;
         }

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1,13 +1,13 @@
-import Case = require('case');
-import colors = require('colors/safe');
-import fs = require('fs-extra');
-import log4js = require('log4js');
-import path = require('path');
-import ts = require('typescript');
+import * as Case from 'case';
+import * as colors from 'colors/safe';
+import * as fs from 'fs-extra';
+import * as log4js from 'log4js';
+import * as path from 'path';
+import * as ts from 'typescript';
 import { Assembler } from './assembler';
 import { EmitResult, Emitter } from './emitter';
 import { ProjectInfo } from './project-info';
-import utils = require('./utils');
+import * as utils from './utils';
 
 const COMPILER_OPTIONS: ts.CompilerOptions = {
   alwaysStrict: true,
@@ -16,7 +16,7 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
   experimentalDecorators: true,
   inlineSourceMap: true,
   inlineSources: true,
-  lib: ['lib.es2016.d.ts'],
+  lib: ['lib.es2018.d.ts'],
   module: ts.ModuleKind.CommonJS,
   noEmitOnError: true,
   noFallthroughCasesInSwitch: true,
@@ -30,7 +30,7 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
   strictNullChecks: true,
   strictPropertyInitialization: true,
   stripInternal: true,
-  target: ts.ScriptTarget.ES2017
+  target: ts.ScriptTarget.ES2018
 };
 
 const LOG = log4js.getLogger('jsii/compiler');
@@ -256,9 +256,8 @@ export class Compiler implements Emitter {
     for (const tsconfigFile of await Promise.all(Array.from(dependencyNames).map(depName => this.findMonorepoPeerTsconfig(depName)))) {
       if (!tsconfigFile) { continue; }
 
-      /* eslint-disable @typescript-eslint/no-var-requires */
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
       const tsconfig = require(tsconfigFile);
-      /* eslint-enable @typescript-eslint/no-var-requires */
 
       // Add references to any TypeScript package we find that is 'composite' enabled.
       // Make it relative.

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -30,8 +30,8 @@
  *
  * https://github.com/Microsoft/tsdoc/blob/master/api-demo/src/advancedDemo.ts
  */
-import spec = require('@jsii/spec');
-import ts = require('typescript');
+import * as spec from '@jsii/spec';
+import * as ts from 'typescript';
 
 /**
  * Tags that we recognize

--- a/packages/jsii/lib/emitter.ts
+++ b/packages/jsii/lib/emitter.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 
 /**
  * An object that is capable of emitting stuff.

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -6,10 +6,10 @@
  * well put it in one reusable place.
  */
 
-import fs = require('fs-extra');
-import spec = require('@jsii/spec');
-import os = require('os');
-import path = require('path');
+import * as fs from 'fs-extra';
+import * as spec from '@jsii/spec';
+import * as os from 'os';
+import * as path from 'path';
 import { DiagnosticCategory } from 'typescript';
 import { Compiler } from './compiler';
 import { loadProjectInfo, ProjectInfo } from './project-info';

--- a/packages/jsii/lib/literate.ts
+++ b/packages/jsii/lib/literate.ts
@@ -56,8 +56,8 @@
  *     console.log(x);
  *     ```
  */
-import fs = require('fs-extra');
-import path = require('path');
+import * as fs from 'fs-extra';
+import * as path from 'path';
 
 /**
  * Convert an annotated TypeScript source file to MarkDown
@@ -86,10 +86,9 @@ export async function includeAndRenderExamples(lines: string[], loader: FileLoad
     const m = regex.exec(line);
     if (m) {
       // Found an include
-      /* eslint-disable no-await-in-loop */
       const filename = m[2];
+      // eslint-disable-next-line no-await-in-loop
       const source = await loader(filename);
-      /* eslint-enable no-await-in-loop */
       // 'lit' source attribute will make snippet compiler know to extract the same source
       const imported = typescriptSourceToMarkdown(source, [`lit=${filename}`]);
       ret.push(...imported);
@@ -191,9 +190,8 @@ function markdownify(lines: string[], codeBlockAnnotations: string[]): string[] 
    */
   function flushTS() {
     if (typescriptLines.length !== 0) {
-      /* eslint-disable prefer-template */
+      // eslint-disable-next-line prefer-template
       ret.push('```ts' + (codeBlockAnnotations.length > 0 ? ' ' + codeBlockAnnotations.join(' ') : ''), ...typescriptLines, '```');
-      /* eslint-enable prefer-template */
       typescriptLines.splice(0); // Clear
     }
   }

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -1,13 +1,12 @@
-import fs = require('fs-extra');
-import spec = require('@jsii/spec');
-import log4js = require('log4js');
-import path = require('path');
-import semver = require('semver');
+import * as fs from 'fs-extra';
+import * as spec from '@jsii/spec';
+import * as log4js from 'log4js';
+import * as path from 'path';
+import * as semver from 'semver';
 import { parsePerson, parseRepository } from './utils';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const spdx: Set<string> = require('spdx-license-list/simple');
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 const LOG = log4js.getLogger('jsii/package-info');
 
@@ -53,9 +52,8 @@ export interface ProjectInfo {
 
 export async function loadProjectInfo(projectRoot: string, { fixPeerDependencies }: { fixPeerDependencies: boolean }): Promise<ProjectInfo> {
   const packageJsonPath = path.join(projectRoot, 'package.json');
-  /* eslint-disable @typescript-eslint/no-var-requires */
+  // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
   const pkg = require(packageJsonPath);
-  /* eslint-enable @typescript-eslint/no-var-requires */
 
   let bundleDependencies: { [name: string]: string } | undefined;
   for (const name of pkg.bundleDependencies ?? pkg.bundledDependencies ?? []) {
@@ -175,9 +173,8 @@ async function _loadDependencies(dependencies: { [name: string]: string | spec.P
     }
     const pkg = _tryResolveAssembly(name, localPackage, searchPath);
     LOG.debug(`Resolved dependency ${name} to ${pkg}`);
-    /* eslint-disable no-await-in-loop */
+    // eslint-disable-next-line no-await-in-loop
     const assm = await loadAndValidateAssembly(pkg);
-    /* eslint-enable no-await-in-loop */
     if (!version.intersects(new semver.Range(assm.version))) {
       throw new Error(`Declared dependency on version ${versionString} of ${name}, but version ${assm.version} was found`);
     }
@@ -185,9 +182,8 @@ async function _loadDependencies(dependencies: { [name: string]: string | spec.P
     transitiveAssemblies[assm.name] = assm;
     const pkgDir = path.dirname(pkg);
     if (assm.dependencies) {
-      /* eslint-disable no-await-in-loop */
+      // eslint-disable-next-line no-await-in-loop
       await _loadDependencies(assm.dependencies, pkgDir, transitiveAssemblies);
-      /* eslint-enable no-await-in-loop */
     }
   }
   return assemblies;
@@ -294,6 +290,7 @@ function _resolveVersion(dep: spec.PackageVersion | string | undefined, searchPa
   const localPackage = path.resolve(searchPath, matches[1]);
   return {
     // Rendering as a caret version to maintain uniformity against the "standard".
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     version: `^${require(path.join(localPackage, 'package.json')).version}`,
     localPackage,
   };

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -1,5 +1,5 @@
-import log4js = require('log4js');
-import ts = require('typescript');
+import * as log4js from 'log4js';
+import * as ts from 'typescript';
 import { DIAGNOSTICS } from './compiler';
 
 /**

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,12 +1,11 @@
-import Case = require('case');
-import spec = require('@jsii/spec');
-import ts = require('typescript');
+import * as Case from 'case';
+import * as spec from '@jsii/spec';
+import * as ts from 'typescript';
 import { Diagnostic, EmitResult, Emitter } from './emitter';
 import { ProjectInfo } from './project-info';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const deepEqual = require('deep-equal');
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export class Validator implements Emitter {
   public static VALIDATIONS: ValidationFunction[] = _defaultValidations();

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -39,7 +39,7 @@
     "deep-equal": "^1.1.1",
     "fs-extra": "^8.1.0",
     "log4js": "^6.1.0",
-    "semver": "^6.3.0",
+    "semver": "^7.0.0",
     "sort-json": "^2.0.0",
     "spdx-license-list": "^6.1.0",
     "typescript": "~3.7.3",

--- a/packages/jsii/test/docs.test.ts
+++ b/packages/jsii/test/docs.test.ts
@@ -1,4 +1,4 @@
-import spec = require('@jsii/spec');
+import * as spec from '@jsii/spec';
 import { Stability } from '@jsii/spec';
 import { sourceToAssemblyHelper as compile } from '../lib';
 
@@ -307,7 +307,7 @@ test('stability is inherited from parent type', async () => {
   ];
 
   for (const [tag, stability] of stabilities) {
-    /* eslint-disable no-await-in-loop */
+    // eslint-disable-next-line no-await-in-loop
     const assembly = await compile(`
       /**
        * ${tag}
@@ -342,12 +342,12 @@ test('@example can contain @ sign', async () => {
      *
      * @example
      *
-     * import x = require('@banana');
+     * import * as x from '@banana';
      */
     export class Foo {
     }
   `);
 
   const classType = assembly.types!['testpkg.Foo'] as spec.ClassType;
-  expect(classType.docs!.example).toBe('import x = require(\'@banana\');');
+  expect(classType.docs!.example).toBe('import * as x from \'@banana\';');
 });

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -1,6 +1,6 @@
-import fs = require('fs-extra');
-import path = require('path');
-import ts = require('typescript');
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as ts from 'typescript';
 import { Compiler } from '../lib/compiler';
 import { ProjectInfo } from '../lib/project-info';
 

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -1,8 +1,8 @@
-import clone = require('clone');
-import fs = require('fs-extra');
-import spec = require('@jsii/spec');
-import os = require('os');
-import path = require('path');
+import * as clone from 'clone';
+import * as fs from 'fs-extra';
+import * as spec from '@jsii/spec';
+import * as os from 'os';
+import * as path from 'path';
 import { loadProjectInfo } from '../lib/project-info';
 import { VERSION } from '../lib/version';
 
@@ -110,9 +110,8 @@ describe('loadProjectInfo', () => {
 
   test('loads with missing peerDependency (when auto-fixing)', () => _withTestProject(async projectRoot => {
     await loadProjectInfo(projectRoot, { fixPeerDependencies: true });
-    /* eslint-disable @typescript-eslint/no-var-requires */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
     const info = require(path.join(projectRoot, 'package.json'));
-    /* eslint-enable @typescript-eslint/no-var-requires */
     expect(info.peerDependencies[TEST_DEP_ASSEMBLY.name]).toBe('^1.2.3');
   }, info => {
     delete info.peerDependencies[TEST_DEP_ASSEMBLY.name];
@@ -129,9 +128,8 @@ describe('loadProjectInfo', () => {
 
   test('loads with inconsistent peerDependency (when auto-fixing)', () => _withTestProject(async projectRoot => {
     await loadProjectInfo(projectRoot, { fixPeerDependencies: true });
-    /* eslint-disable @typescript-eslint/no-var-requires */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
     const info = require(path.join(projectRoot, 'package.json'));
-    /* eslint-enable @typescript-eslint/no-var-requires */
     expect(info.peerDependencies[TEST_DEP_ASSEMBLY.name]).toBe('^1.2.3');
   }, info => {
     info.peerDependencies[TEST_DEP_ASSEMBLY.name] = '^42.1337.0';

--- a/packages/oo-ascii-tree/test/tree.test.ts
+++ b/packages/oo-ascii-tree/test/tree.test.ts
@@ -1,5 +1,5 @@
-import fs = require('fs');
-import path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 import { promisify } from 'util';
 import { AsciiTree } from '../lib';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,6 +1233,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -3151,6 +3156,17 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
+eslint-import-resolver-typescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.0.0.tgz#e95f126cc12d3018b9cc11692b4dbfd3e17d3ea6"
+  integrity sha512-bT5Frpl8UWoHBtY25vKUOMoVIMlJQOMefHLyQ4Tz3MQpIZ2N6yYKEEIHMo38bszBNUuMBW6M3+5JNYxeiGFH4w==
+  dependencies:
+    debug "^4.1.1"
+    is-glob "^4.0.1"
+    resolve "^1.12.0"
+    tiny-glob "^0.2.6"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz#cdf0b40d623032274ccd2abd7e64c4e524d6e19c"
@@ -3841,6 +3857,11 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
+globalyzer@^0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.4.tgz#bc8e273afe1ac7c24eea8def5b802340c5cc534f"
+  integrity sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
@@ -3854,6 +3875,11 @@ globby@^9.2.0:
     ignore "^4.0.3"
     pify "^4.0.1"
     slash "^2.0.0"
+
+globrex@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.3"
@@ -7049,6 +7075,11 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
+  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -7727,6 +7758,14 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-glob@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.6.tgz#9e056e169d9788fe8a734dfa1ff02e9b92ed7eda"
+  integrity sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==
+  dependencies:
+    globalyzer "^0.1.0"
+    globrex "^0.1.1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -7811,6 +7850,16 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
Per benmosher/eslint-plugin-import#1244, the `eslint/import` plug-in does not currently support the `import X = require(Y);` syntax, causing extraneous imports in this form to be ignored by the linter.

1. Update `import` rule's configuration so it works better with `@types/*` packages.
2. Adds rule to prefer `import X from Y` style.
3. Adds the missing dependency declarations that were identified.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
