### PR TITLE
docs(spec): initial pass on a jsii specification

### DIFF
--- a/docs/specifications/1-introduction.md
+++ b/docs/specifications/1-introduction.md
@@ -1,0 +1,205 @@
+# Introduction
+
+This document provides a high level overview of *jsii*, starting with it's
+design tenets. It introduces the concepts and components that compose *jsii*.
+
+
+## Updating the Specification
+
+### Introduction
+
+The *jsii* specification follows the guiding principles of an RFC. It is a
+living document that describes the current understanding of how the various
+[components](#components) of *jsii* are operating, as well as the approaches
+used to ensure consistent behavior across the various supported languages.
+
+The document is mastered with the *jsii* codebase, making it easy to determine
+what specification was in place at the time of a give *jsii* release (by ways of
+referring to the `vX.Y.Z` git tag). A single version of the specification is
+considered **active** at any given time: the version of the specification that
+is represented on the `HEAD` commit of the `master` branch of the [`aws/jsii`]
+repository. The **active** specification must be the base version for any update
+proposal.
+
+[`aws/jsii`]: https://github.com/aws/jsii
+
+The process to update the specification is intended to be as lightweight as
+possible, while ensuring sufficient conversation takes place before implementing
+significant (and breaking) changes. Since the process to update the
+specification is part of the specification itself, it is amenable to be changed
+following the process described in the currently **active** specification.
+
+### Process
+
+While the general process for updating the specification is to create a GitHub
+pull request against the [`aws/jsii`] repository, the exact requirements for
+what should be included in the pull request vary depending on the type of update
+that is proposed:
+
+- [:warning: Changing Behavior](#new-behavior) describes the process to be
+  followed when introducing changes to the behavior of any component of *jsii*:
+  new features, breaking changes to existing features, ...
+- [:mag: Addressing Gaps](#addressing-gaps) is the process used for adding
+  specification around existing but un-specified behavior.
+- [:thumbsup: Trivial Changes](#trivial) explains how to propose changes that
+  improve the specification without changing it's meaning.
+
+#### <a id="new-behavior"/> :warning: Changing Behavior
+
+If the change is **not backwards compatible** (it is a breaking change to an
+existing feature, or it is a new feature that requires all runtime libraries
+implement support immediately), a new RFC should be created in the
+[`awslabs/aws-cdk-rfcs`] repository, following the [RFC Process]. This ensures
+enough time is spent considering alternatives to breaking changes, and to create
+consensus that the change is desirable before time is spent implementing it.
+
+[`awslabs/aws-cdk-rfcs`]: https://github.com/awslabs/aws-cdk-rfcs
+[RFC Process]: https://github.com/aws/aws-cdk-rfcs#what-the-process-is
+
+> While going through the RFC process upfront is **strongly recommended**,
+> contributors may choose not to file an RFC for a behavior change. In this case
+> however, any core maintainer may decide that an RFC is required and block the
+> contribution until the RFC process has been followed.
+>
+> It is worth noting that a draft pull request with proposed modifications to
+> the specification (and possibly a proof-of-concept implementation), can b
+
+When the RFC is **ready**, a GitHub pull request is created that must contain:
+
+- Relevant additions or modifications to the specification documents
+- Relevant additions or modifications to the compliance suite
+- Implementation of the new behavior, including new or updated tests in all the
+  language bindings
+
+The pull request's body must reference the RFC if there has been one, and
+otherwise must include all discussion necessary to explain the reasoning behind
+the proposal (including alternatives considered, risks, ...).
+
+#### <a id="addressing-gaps"/> :mag: Addressing Gaps
+
+Proposal that increase the specification's coverage (desribing behavior that
+already exists) are handled as GitHub pull request that must contain the
+following elements:
+
+- Relevant additions to the specification documents
+- New compliance test(s) that enshrine the described behavior
+- Implementation of the new compliance test(s) for all *Generally Available*
+  language bindings
+
+The pull request body should provide pointers to any and all elements that can
+be used to verify that the behavior that is described is indeed what is
+currently implemented.
+
+#### <a id="trivial"/> :thumbsup: Trivial Changes
+
+Proposal of trivial changes, such as correcting typos in the document, or
+re-phrasing elements of the specification without altering the meaning
+(typically to improve clarity) are handled in a simple GitHub pull request.
+
+
+## Design Tenets (unless you know better ones)
+
+* *jsii* APIs strive to feel idiomatic in all supported languages.
+* *jsii* applications behave identically regardless of the language they are
+  written in. It favors correctness over performance.
+* *jsii* **does not** attempt to support all TypeScript idioms (many features of
+  TypeScript cannot be expressed in some target languages).
+  * Unsupported idioms will cause a compile-time error to be emitted.
+  * When prohibiting an idiom, *jsii* strives to provide an error message that
+    gives the user insight into why the pattern cannot be supported.
+* *jsii* does not force API design opinions on the developer:
+  * Reserved names are limited to a minimum.
+  * TypeScript API design patterns that are known to result in poor developer
+    experience when represented in other languages will cause warnings to be
+    issued, but the developer is ultimately entitled to decide whether they want
+    to take or leave the advice.
+* *jsii* produces artifacts compatible with idiomatic tools whenever possible:
+  * Generated libraries can be easily published to the "standard" package
+    repository for the language.
+  * Standard tools can be used to work with the generated libraries, and do not
+    require any special configuration.
+
+
+## Annotations
+
+Annotations are present in the *jsii* specification to provide additional
+information to the reader that is non-normative. Those take the form of
+block-quotes that use the following chart:
+
+- > :construction: Is used to annotate parts of the specification that are known
+  > to be partially or incorrectly implemented in the current releases. Those
+  > are known issues in the current implementation that will be addressed in the
+  > future.
+
+- > :question: Is used to annotate open questions. They are typically in parts
+  > of the specification that is likely to change in future releases, and that
+  > may be good candidates for introducing RFCs.
+
+- > :warning: Is used to draw the reader's attention on specific points. They
+  > are used primarily to help the reader identify areas of the specification
+  > that, when incorrectly implemented, may result in hard-to-troubleshoot bugs;
+  > or to identify behavior that is intentionally undefined.
+
+- > :information_source: Is used to provide additional context which may not be
+  > obvious to the reader. They typically contain trivia that can help the
+  > reader understand the motivation for certain behaviors that are not always
+  > intuitive.
+
+## Concepts
+
+*jsii* allows developers to author code once in **TypeScript**, while allowing
+use in a variety of other programming languages (including **C#**, **Java** and
+**Python**).
+
+### Assemblies
+
+The *jsii Assembly* document contains a specific representation of the API
+exported by the **TypeScript** module. Similar to a header file in the **C++**
+world, it contains only information about the signatures of APIs (type names
+with method and property signatures, associated documentation elements, ...) and
+no implementation.
+
+The *npm* package produced as a result of compiling the **TypeScript** source
+remains the source of truth with respects to implementation of the API.
+
+### Host & Kernel
+
+The [*jsii* runtime architecture] defines two processes:
+
+1. The *host* process runs the users' code native environment (a Java virtual
+   machine, the .NET Runtime, ...).
+2. The *kernel* process hosts the **JavaScript** code from the standard *npm*
+   package.
+
+The *host* process is responsible for starting the *kernel* process as needed. A
+designated *host runtime library* provides helper functions that will perform
+the necessary initialization when needed, so the *host* app does not need to
+include any special boilerplate code.
+
+The two processes exchange messages over a designated communication channel (for
+example, using pipes), using a *kernel API* that is standardized in the *jsii
+specification*.
+
+[*jsii* runtime architecture]: ../runtime-architecture.md
+
+
+## Components
+
+Several tools are involved in making this possible:
+
+* [`jsii`] is a modified **TypeScript** compiler. In addition to generating
+  **JavaScript** code from the source, it produces a *jsii Assembly* document.
+* [`jsii-pacmak`] generates language bindings from a package compiled using
+  `jsii`. It generates code in *host* languages that expose the API declared in
+  the *jsii Assembly* document.
+* *Host runtime libraries* centralize features used by code generated by
+  [`jsii-pacmak`], such as primitives to interact with the *kernel* process, so
+  that this code does not need to be duplicated in every generated module.
+* [`@jsii/kernel`] (and [`@jsii/runtime`]) provide the functionality exposed by
+  the *kernel* process, and allow the *host* code to seamlessly interact with
+  the **JavaScript** implementation.
+
+[`jsii`]: ../../../packages/jsii
+[`jsii-pacmak`]: ../../../packages/jsii-pacmak
+[`@jsii/kernel`]: ../../../packages/@jsii/kernel
+[`@jsii/runtime`]: ../../../packages/@jsii/runtime

--- a/docs/specifications/2-type-system.md
+++ b/docs/specifications/2-type-system.md
@@ -1,0 +1,316 @@
+# The *jsii* type system
+
+## Preamble
+The base language for authoring *jsii* libraries for re-use from other languages
+is **TypeScript**, which compiles to **JavaScript**. Consequently, the base type
+system that *jsii* sources from is that of **TypeScript**.
+
+When used from another language than **TypeScript** or **JavaScript**, *jsii*
+libraries are running the **JavaScript** code in a child *node* process, and
+data is exchanged using **JSON**-based protocol.
+
+This document describes how **TypeScript** types map into the *jsii* type
+system.
+
+The API represented by the *jsii* assembly only covers declarations that are
+exported from the main file in the **TypeScript** project (as specified in the
+`package.json` file by the `types` attribute). Restrictions described in this
+document only apply to such declarations, the rest of the module can leverage
+any **TypeScript** feature.
+
+## Basic Types
+
+### Introduction
+In order to build useful programs, the simplest units of data need to be
+modeled: booleans, numbers, strings, etc... Those basic building blocks are the
+foundations on which APIs stand. *jsii* supports much of the same types that
+**TypeScript** and **JavaScript** support, although with notable differences.
+
+### Boolean
+The *jsii* type system mirrors **TypeScript**'s `boolean`, which is the simplest
+primitive data types, with only two supported values: `true` and `false`.
+
+### Number
+The *jsii* type system mirrors **TypeScript**'s `number`. All numbers are
+floating point values.
+
+### String
+The *jsii* type system mirrors **TypeScript**'s `string`. Strings are used to
+represent textual data.
+
+### List
+**TypeScript** arrays (`Array<T>`, `T[]`, `ReadonlyArray<T>` and `readonly T[]`)
+are represented as *lists* in the *jsii* type model. Lists are shared between
+the *node* process and the host process by-value, meaning a copy of the array is
+produced each time it is passed through the process boundary.
+
+> :information_source: Items in the list may be passed by-reference (according
+> to their type's specification), in which case mutating operations performed on
+> those may be visible across the process boundary.
+
+### Enum
+As in many languages, `enum` can be used to represent a group of related
+constants. Whle **TypeScript** `enum` entries are associated with a value that
+is either a `string` or a `number`, the *jsii* type system does not allow for
+those to be down-casted to their value type (e.g: a `string`-valued `enum` entry
+cannot be directly passed into a `string` parameter).
+
+> :information_source: Unlike in certain languages such as **Java**, `enum`
+> types cannot declare new properties or methods.
+
+### Any and Unknown
+**TypeScript** defines two opaque types: `any` and `unknown` that can be used to
+represent a value of arbitary type. The difference between them is that while
+`any` is assignable to any other type, `unknown` requires a type assertion or
+explicit cast to be performed before it can be assigned.
+
+> :information_source: It is important to note that, contrary to the other types
+> in the **TypeScript** type system, `any` and `unknown` types are inherently
+> `null`-able.
+
+### Void
+As in most languages, the `void` type is used to denote a method does not return
+anything.
+
+### Null and Undefined
+**JavaScript** differentiates `undefined` and `null` values. While `undefined`
+denotes that *no value* has been set, `null` denotes an intentional signal of
+there being *no data*. Most other programming languages (particularly statically
+typed languages) however lack this distinction, and the *jsii* type model
+consequently considers `null` and `undefined` are semantically equivalent.
+
+> :information_source: Unlike certain other programming languages, such as
+> **Java**, **TypeScript** does not allow `null` (or `undefined`) values unless
+> the type signature expressedly supports that (with the exception of `any` and
+> `unknown`, which are implicitly `null`-able, as was discussed earlier).
+
+### Object
+**TypeScript**'s `object` type denotes anything that is not a *primitive* type,
+meaning anything other than a `number`, `srting`, `boolean`, `biging`, `symbol`,
+`null` or `undefined`.
+
+In the *jsii* type model, `object` indicates a block of structured data that can
+be shared by-value across the process boundary. As a consequence, they may not
+include any method.
+
+> :construction: This type is called `Json` in the current implementation.
+
+> :question: The by-value nature of `object` is problematic because
+> **TypeScript** makes no guarantee with respects to the absence of methods on
+> `object`, and properties may be dynamic.
+
+### Promises
+*jsii* supports asynchronous methods, and the **TypeScript** `Promise<T>` type
+has to be used as the result of `async` methods. Promises can only be used as
+the result type of methods, not as the type of a property or parameter.
+
+### Unsupported **TypeScript** basic types
+Due to how such types cannot be represented in many other programming languages,
+the *jsii* type model does not support the following **TypeScript** entities:
+- Tuples, a group of arbitrarily-typed values, often used as the result type for
+  multi-valued functions.
+- The `never` type, which is used as the return type of functions that will not
+  yield control back to their invoker (infinite loops, `process.exit()`, ...).
+- `bigint` and `symbol` don't have equivalents in many other programming
+  languages and are generally of limited value in API design.
+
+
+## Complex Types
+The goal of *jsii* is to enable cross-language re-use of class libraries.
+**TypeScript** enables representing classic object-oriented concepts such as
+*classes*, *interfaces* and such. The *jsii* type system supports some
+additional nuances on top of those, to better represent **TypeScript** and
+**JavaScript** idioms in a way that enables generating convenient APIs in other
+languages.
+
+### Classes
+Exported **TypeScript** classes are represented in the *jsii* type system, with
+the following restrictions from plain **TypeScript**:
+- Methods overloads are not supported.
+- Overridden methods or properties must retain the exact same type signature as
+  the one declared in a parent type. The **jsii** type system strictly enforces
+  the [Liskov substitution principle].
+
+[Liskov substitution principle]: https://en.wikipedia.org/wiki/Liskov_substitution_principle
+
+### Interfaces & Structs
+Exported **TypeScript** interfaces are interpreted as one of two entities in the
+*jsii* type system:
+- If the `interface` name is prefixed with an `I` (e.g: `ISomething`), it is
+  interpreted as a *behavioral interface*.
+- Otherwise (e.g: `Something`), it is interpreted as a *struct*.
+
+#### Behavioral Interfaces
+*Behavioral interfaces* are the usual object-oriented interface: they can extend
+other *behavioral interfaces*, and can be extended by *classes*. They may
+however not extend *structs*.
+
+#### Structs
+*Structs* are used to model the **JavaScript** idiom of receiving options as an
+object literal passed as the last parameter of a function. They are a formal
+description of a bag of properties, and are not meant to be implemented by other
+types. Since those types are used as inputs, they can be handled as pure-data,
+immutable objects, and the following restrictions apply:
+- A *struct* cannot declare any *method*: they must be kept behavior-free.
+- All properties declared by a *struct* must be `readonly`. The values of the
+  properties may however be mutable.
+
+*Structs* may extend one or more other *structs*, but cannot extend or be
+extended by *behavioral interfaces*, and may not be implemented by *classes*.
+
+### Type Unions
+In certain cases, several different kinds of values are acceptable for a given
+parameter or return type. **TypeScript** models those cases using *type unions*,
+which are represented as `TypeA | TypeB`. The *jsii* type model supports those,
+however most other statically typed languages do not have such a concept, making
+those parameters or return values difficult to use from those languages, as the
+value has to be declared using the most generic reference type available (for
+example, in **Java**, those are returned as `java.lang.Object`).
+
+When used as inputs (parameters, or properties of a *struct*), it may be
+possible to generate method overloads that will allow for a convenient API in
+languages that support overloards.
+
+In general however, *type unions* are discouraged and should only be used when
+there is no alternate way to model the API.
+
+
+## Serialization Behavior
+
+When values are passed between the *host* process and the `node` process, they
+are serialized as JSON documents. They can be passed by value or by reference,
+depending on the type of the value as well as the declared type of the transfer
+point (method return type, property type, argument type, ...).
+
+The table below describes the serialization behavior applied for each possible
+*declared* type (rows) for a value of a given dynamic type (columns). The :x:
+sign expresses cases that are illegal and should cause immediate failure. The
+term *primitive* encompasses `boolean`, `string`, and `number`.
+
+&nbsp;      | `undefined` | `Date`      | *primitive* | `Array`     | *instance*  | `object`
+------------|-------------|-------------|-------------|-------------|-------------|-------------
+`void`      | `undefined` | `undefined` | `undefined` | `undefined` | `undefined` | `undefined`
+`Date`      | `undefined` | [Date]      | :x:         | :x:         | :x:         | :x:
+*primitive* | `undefined` | :x:         | [Identity]  | :x:         | :x:         | :x:
+`enum`      | `undefined` | :x:         | [Enum]      | :x:         | :x:         | :x:
+`List`      | `undefined` | :x:         | :x:         | [Array]     | :x:         | :x:
+`Map`       | `undefined` | :x:         | :x:         | :x:         | :x:         | [Mapping]
+`interface` | `undefined` | :x:         | :x:         | :x:         | [Reference] | [Reference]
+`struct`    | `undefined` | :x:         | :x:         | :x:         | :x:         | [Value]
+`class`     | `undefined` | :x:         | :x:         | :x:         | [Reference] | [Reference]
+`any`       | `undefined` | [Date]      | [Identity]  | [Array]     | [Reference] | [Mapping]
+
+
+> :warning: The serialization behavior around `undefined` values is affected by
+> the `optional` attribute of the declared type. As discussed earlier, the `any`
+> type is implicitly `optional`; but all other types' serialization process will
+> only allow serialization of `undefined` if they were declared `optional`.
+
+
+### Array Serialization
+[Array]: #array-serialization
+
+Arrays are serialized into the standard JSON representation for them. Each value
+in the array is serialized according to the behavior dictated by the declared
+element type of the list, combined with the dynamic type of the value itself.
+
+### Date Serialization
+[Date]: #date-serialization
+
+JSON has no standard expression for `Date`. A special JSON object representation
+is used to allow unambiguously conveying a date. The wrapper has a single key
+(`$jsii.date`) with the [ISO 8601-1] UTC representation of the `Date` value:
+
+```json
+{ "$jsii.date": "2020-01-20T14:04:00.000Z" }
+```
+
+[ISO 8601-1]: https://www.iso.org/obp/ui#iso:std:iso:8601:-1:ed-1:v1:en
+
+### Enum Serialization
+[Enum]: #enum-serialization
+
+In **JavaScript**, `enum` entries are represented by their value equivalent. In
+order to support statically typed representations in other languages, these are
+serialized using a dedicated wrapper object, using a single key (`$jsii.enum`)
+with the fully qualified name of the `enum` entry:
+
+```json
+{ "$jsii.enum": "@scope/module.EnumType.ENTRY_NAME" }
+```
+
+### Identity Serialization
+[Identity]: #identity-serialization
+
+The identity serialization is achieved by using the standard JSON representation
+of the primitive type. JSON strings are expressed using the `UTF-8` character
+set.
+
+### Mapping Serialization
+[Mapping]: #mapping-serialization
+
+Key-value pairs are passed by-value between the processes and is wrapped using a
+single-key (`$jsii.map`) associated with the JSON representation of the encoded
+object; where values are serialized according to the behavior dictated by the
+element type of the mapping, combined with the dynamic type of the value itself:
+
+```json
+{
+  "$jsii.map": {
+    "foo": {
+      "date": { "$jsii.date": "2020-01-20T14:04:00.000Z" },
+      "map": { "$jsii.map": {} }
+    }
+  }
+}
+```
+
+### Reference Serialization
+[Reference]: #reference-serialization
+
+Objects serialized by reference are passed using a special object that provides
+sufficient information to tie back to the instance within it's owning process.
+It includes a `$jsii.byref` key associated with a string that uniquely
+identifies the instance, and an optional `$jsii.interfaces` key that provides a
+list of interfaces that the object implements.
+
+```js
+{
+  "$jsii.byref": "@scope/module.Foo@1337",
+  "$jsii.interfaces": ["@scope/module.IBar", "@scope/module.IBaz"]
+}
+```
+
+### Value Serialization
+[Value]: #value-serialization
+
+*Structs* can be serialized by-value. In those cases, the value is wrapped using
+a special object that encapsulates the type information for the provided data as
+well as the *struct*'s members.
+
+The wrapper uses a single `$jsii.struct` key with a `fqn` key that indicates the
+fully qualified name of the *struct* type, and a `data` key that contains the
+members of the *struct*, serialized according to the behavior described in this
+document.
+
+```js
+{
+  "$jsii.struct": {
+    "fqn": "@scope/module.StructType",
+    "data": {
+      "enumValue": { "$jsii.enum": "@scope/module.EnumType.ENTRY_NAME" },
+      "stringProperty": "Hello, I'm a string!"
+    }
+  }
+}
+```
+
+## References
+
+The [**TypeScript** Handbook] describes the language's type system and syntax
+elements that serve as the basis for the *jsii* type system. Additionally, the
+**JavaScript** type system is described in the [**JavaScript** Fundamentals]
+document.
+
+[**JavaScript** Fundamentals]: https://javascript.info/types
+[**TypeScript** Handbook]: https://www.typescriptlang.org/docs/handbook/basic-types.html

--- a/docs/specifications/3-kernel-api.md
+++ b/docs/specifications/3-kernel-api.md
@@ -1,0 +1,610 @@
+# The *jsii* kernel API
+This document describes the API for the `@jsii/kernel` module, which is to be
+used by all *host* libraries. It provides the fundational features necesarry for
+*host* processes to interact with the original module's code.
+
+> :construction: Currently, `@jsii/kernel` contains the bulk of the logic,
+> however a separate `@jsii/runtime` package owns the dialogue between the
+> *host* and *kernel* processes. The `@jsii/runtime` is a very thin glue layer
+> and it will eventually be merged into `@jsii/kernel`.
+
+## Errors
+Most of the calls described in this document may result in an error being
+raised. It is the responsibility of the *host* runtime library to deal with such
+errors correctly: action retries, propagate the error to the *host* app's code,
+and so on.
+
+Error responses are signaled by the `error` key:
+
+```ts
+export interface ErrorResponse {
+  /** A simple message describing what happened. */
+  message: string;
+  /** Whenever possible, the stack trace of the error. */
+  stack?: string;
+}
+```
+
+Where possible, the *host* runtime libraries should make sure to affix their own
+stack trace information where relevant to the *kernel* process's stack trace
+when such errors are propagated to *host* app's code, in order to offer as much
+relevant context information as possible.
+
+## Initialization - the `hello` message
+The *host* library is responsible for spawning the `node` process that will run
+the original module's code. This `node` process runs the `@jsii/kernel`
+application, and API messages are exchanged of the `node` processes' standard
+input and output pipes.
+
+Upon initialization, the `@jsii/kernel` process introduces itself to the *host*
+application by emitting a single JSON message:
+
+```js
+{
+  // The package name@version of the @jsii/kernel in use
+  "hello": "@jsii/runtime@0.21.1",
+}
+```
+
+Any additional key present on the `hello` message will be silently ignored by a
+*host* library that does not know how to process it, ensuring forward
+compatibility of this message, if and when new attributes are added.
+
+> :construction: In the future, this message may be augmented with additional
+> keys to enable feature negotiation between the *host* application and the
+> `@jsii/kernel`.
+
+## General Kernel API
+Once the `hello` handshake is complete, a sequence of request and responses are
+exchanged with the `@jsii/kernel`. Requests take the form of JSON-encoded
+messages that all follow the following pattern:
+
+```ts
+interface Request {
+  /**
+   * This field discriminates the various request types.
+   */
+  api: 'load'               // Loading jsii assemblies into the Kernel
+    | 'naming'              // Obtaining naming information for loaded assemblies
+    | 'stats'               // Obtaining statistics about the Kernel usage
+    | 'create'              // Creating objects
+    | 'del'                 // Destroying objects
+    | 'invoke' | 'sinvoke'  // Invoking methods (and static methods)
+    | 'get'    | 'sget'     // Invoking getters (and static getters)
+    | 'set'    | 'sset'     // Invoking setters (and static setters)
+    | 'begin' | 'end'       // Asynchronous method invocation
+    ;
+
+  // ... request-type specific fields ...
+}
+```
+
+### Loading *jsii* assemblies into the Kernel
+Before any *jsii* type can be used, the assembly that provides it must be loaded
+into the kernel. Similarly, all dependencies of a given *jsii* module must have
+been loaded into the kernel before the module itself can be loaded (the
+`@jsii/kernel` do not perofrm any kind of dependency resolution).
+
+Loading new assemblies into the `@jsii/kernel` is done using the `load` API:
+
+```ts
+interface LoadRequest {
+  /** The name of the assembly being loaded */
+  name: string;
+  /** The version of the assembly being loaded */
+  version: string;
+  /** The local path to the npm package for the assembly */
+  tarball: string;
+
+  // The discriminator
+  api: 'load';
+}
+```
+
+The response to the `load` call provides some high level information pertaining
+to the loaded assembly, which may be used by the *host* app to validate the
+result of the operation:
+
+```ts
+interface LoadResponse {
+  /** The name of the assembly that was just loaded */
+  assembly: string;
+  /** The number of types the assembly declared */
+  types: number;
+}
+```
+
+Once a module is loaded, all the types it declares immediately become available.
+
+### Obtaining naming information for loaded assemblies
+In certain cases, *host* runtime libraries may need to obtain naming information
+from assemblies in order to determine the translation table from a *jsii*
+fully-qualified name to a *host*-native name. This can be retrieved using the
+`naming` call:
+
+```ts
+export interface NamingRequest {
+  /** The name of the assembly for which naming is requested */
+  assembly: string;
+
+  // The discriminator
+  api: 'naming';
+}
+```
+
+In response to the `naming` call, the `@jsii/kernel` returns the configuration
+block for each language supported by the named `assembly`:
+
+```ts
+export interface NamingResponse {
+  /** The naming information for the requested assembly. */
+  naming: {
+    /**
+     * For each language, provides the jsii configuration block. The content of
+     * this configuration block is specified by each language implementation.
+     */
+    [language: string]: { [key: string]: any };
+  };
+}
+```
+
+### Obtaining statistics about the Kernel usage
+The `stats` call can be used to obtain information about the current `Kernel`
+instance, which can be leveraged by unit tests or in order to produce metrics
+for tracking the health of a long-running *jsii* app.
+
+```ts
+export interface StatsRequest {
+  // The discriminator
+  api: 'stats';
+}
+```
+
+The response to the `stats` call contains synthetic information about the
+current state of the `Kernel`:
+
+```ts
+export interface StatsResponse {
+  /** The number of object reference currently tracked by the Kernel */
+  objectCount: number;
+}
+```
+
+### Creating objects
+Most *jsii* workflows start with creating instances of objects. This can mean
+creating a pure **JavaScript** object, instantiating a sub-class of some
+**JavaScript** class, or even creating a pure-*host* instance that implements
+a collection of *behavioral interfaces*.
+
+Creating objects is achieved using the `create` API, which accepts the following
+parameters:
+
+```ts
+interface CreateRequest {
+  /** The jsii fully qualified name of the class */
+  fqn: string;
+  /** Any arguments to provide to the constructor */
+  args?: any[];
+  /** Additional interfaces implemented in the host app */
+  interfaces?: string[];
+  /** Any methods or property overridden in the host app */
+  overrides?: Override[];
+
+  // The discriminator
+  api: 'create';
+}
+```
+
+The response to the object call is a decorated `ObjectReference` object (which
+is a common parameter to other calls in the `@jsii/kernel` API, used to refer
+to a particular instance):
+
+```ts
+interface ObjectReference {
+  /** A handle that uniquely idenfies an instance */
+  '$jsii.byref': string;
+}
+
+interface CreateResponse extends ObjectReference {
+  /** The list of interfaces implemented by the instance */
+  '$jsii.interfaces'?: string[];
+}
+```
+
+The value of the `'$jsii.byref'` field of the `ObjectReference` type is
+formatted in the following way:
+
+```
+@aws-cdk/core.Stack@10003
+└────────┬────────┘ └─┬─┘
+         │            └─ Opaque numeric identifier
+         └─ Object instance's base class' jsii fully qualified name
+```
+
+The first part of the reference identifier can have the special un-qualified
+value `Object` to denote the absence of a *jsii*-known base class (for example
+when the object *only* implements a *jsii* interface).
+
+#### Additional Interfaces
+Sometimes, the *host* app will extend a *jsii* class and implement new *jsii*
+interfaces that were not present on the original type. Such interfaces must be
+declared by providing their *jsii* fully qualified name as an entry in the
+`interfaces` list.
+
+Providing interfaces in this list that are implicitly present from another
+delcaration (either because they are already implemented by the class denoted by
+the `fqn` field, or because another entry in the `interfaces` list extends it)
+is valid, but not necessary. The `@jsii/kernel` is responsible for correctly
+handling redundant declarations.
+
+**:warning:** while declared `interfaces` may contain redundant declarations of
+members already declared by other `interfaces` or by the type denoted by `fqn`,
+undefined behavior results if any such declaration is not identical to the
+others (e.g: property `foo` declared with type `boolean` on one of the
+`interfaces`, and with type `string` on another).
+
+#### Overrides
+For any method that is implemented or overridden from the *host* app, the
+`create` call must specify an `override` entry. This will inform the Kernel that
+calls to these methods must be relayed to the *host* app for execution, instead
+of executing the original library's version.
+
+An optional `cookie` string can be provided. This string will be recorded on the
+**Javascript** proxying implementation, and will be provided to the **host** app
+with any *callback* request. This information can be used, for example, to
+improve the performance of implementation lookups in the *host* app, where the
+necessary reflection calls would otherwise be prohibitively expensive.
+
+Override declarations adhere to the following schema:
+
+```ts
+interface MethodOverride {
+  /** The name of the overridden method */
+  method: string;
+  /** An arbitrary override cookie string */
+  cookie?: string;
+}
+
+interface PropertyOverride {
+  /** The name of the overridden property */
+  property: string;
+  /** An arbitrary override cookie string */
+  cookie?: string;
+}
+
+type Override = MethodOverride | PropertyOverride;
+```
+
+#### A note about callbacks
+All `@jsii/runtime` calls that interact with object instances (that is, any call
+except for `load`, `naming` and `stats`; as well as the `del` call since *jsii*
+does not support customized destructors or finalizers) may result in the need to
+execute code that is defined in the *host* app, when the code path traverses a
+method or property that was implemented or overridden in the *host* app.
+
+Such cases will result in a callback request substituting itself to the response
+of the original call being made; execution fo which will resume once the
+callback response is provided.
+
+A callback request is sent from the `@jsii/kernel`'s `node` process to the
+*host* app and has the following schema:
+
+```ts
+interface CallbackRequest {
+  /** Callback requests are identified by the presence of the `callback` key */
+  callback: Callback;
+}
+
+interface CallbackBase {
+  /** A unique identifier for this callback request */
+  cbid: string;
+  /** The object on which the callback must be executed */
+  objref: ObjectReference;
+  /** The callback cookie, if one was specified */
+  cookie?: string;
+}
+
+interface InvokeCallback extends CallbackBase {
+  /** The name of the host method to be invoked */
+  method: string;
+}
+
+interface GetCallback extends CallbackBase {
+  /** The name of the property to be read */
+  property: string;
+}
+
+interface SetCallback extends CallbackBase {
+  /** The name of the property to be written to */
+  property: string;
+  /** The value to be set */
+  value: any;
+}
+
+type Callback = InvokeCallback | GetCallback | SetCallback;
+```
+
+In order to fulfill the callback request, the *host* app may need to perform
+futher API calls (loading new assemblies, creating new instances, invoking
+methods - including delegating to the `super` implementation, ...). Such calls
+will behave as they otherwise would (including the possible introduction of
+further callback requests).
+
+Once the *host* happ has fulfilled the request, it must signal the result of
+that execution back to the `@jsii/kernel` process by using the `complete` call:
+
+```ts
+interface CompleteBase {
+  /** The callback ID from the corresponding request */
+  cbid: string;
+
+  // The discriminator
+  api: `complete`;
+}
+
+interface CallbackSuccess extends CompleteBase {
+  /** The result of the execution (`undefined` if void) */
+  result: any;
+}
+
+interface CallbackFailure extends CompleteBase {
+  /** The error that was raised during fulfilling */
+  err: string;
+}
+
+type CompleteRequest = CallbackSuccess | CallbackFailure;
+```
+
+As discussed earlier, the response to the `complete` call is the result of
+resuming execution of the code path that triggered the callback request. This
+may be another callback request, or the final result of that call.
+
+The `callbacks` call may be used to determine the list of all outstanding
+callback requests:
+
+```ts
+interface CallbacksRequest {
+  // The discriminator
+  api: 'callbacks';
+}
+```
+
+This call results in a list of outstanding callbacks:
+
+```ts
+interface CallbacksResponse {
+  /** The list of outstanding callback requests */
+  callbacks: Callback[];
+}
+```
+
+### Destroying Objects
+Once the *host* app no longer needs a particular object, it can be discarded.
+This can happen for example when the *host* reference to an object is garbage
+collected or freed. In order to allow the **JavaScript** process to also
+recclaim the associated memory footprint, the `del` API must be used:
+
+```ts
+interface DelRequest {
+  /** The object reference that can be released */
+  objref: ObjectReference;
+
+  // The discriminator
+  api: 'del';
+}
+```
+
+> **:warning:** Failure to use the `del` API will result in memory leakage as
+> the **JavaScript** process accumulates garbage in it's Kernel instance. This
+> can eventually result in a *Javascript heap out of memory* error, and the
+> abnormal termination of the `node` process, and consequently of the *host* app.
+
+> :construction: The existing *host* runtime libraries do not implement this
+> behavior!
+
+> :question: There is currently no provision for the `node` process to inform
+> the *host* app about object references it dropped. This mechanism is necessary
+> in order to support garbage collection of resources that involve
+> *host*-implemented code (in such cases, the *host* app must hold on to any
+> instance it passed to **JavaScript** until it is no longer reachable from
+> there).
+
+Upon successfully deleting an object reference, the `@jsii/kernel` will return
+an empty response object:
+
+```ts
+export interface DelResponse {}
+```
+
+### Invoking methods (and static methods)
+Invoking methods is done via the `invoke` call:
+
+```ts
+interface InvokeRequest {
+  /** The object reference on which a method is invoked */
+  objref: ObjectReference;
+  /** The name of the method being invoked */
+  method: string;
+  /** Any arguments passed to the method invocation */
+  args?: any[];
+
+  // The discriminator
+  api: 'invoke';
+}
+```
+
+Static method invocations do not have a receiving instance, and instead are
+implemented by way of the `sinvoke` call:
+
+```ts
+interface StaticInvokeRequest {
+  /** The jsii fully qualified name of the declaring type */
+  fqn: string;
+  /** The name of the static method being invoked */
+  method: string;
+  /** Any arguments passed to the method invocation */
+  args?: any[];
+
+  // The discriminator
+  api: 'sinvoke';
+}
+```
+
+Note that, unlike in certain programming languages such as **Java**, it is
+illegal to attempt invoking a static method on the static type of some instance
+using the `invoke` call. All static invocations *must* be done using `sinvoke`.
+
+Both the `invoke` and `sinvoke` calls result in the same response:
+
+```ts
+interface InvokeResponse {
+  /** The result of the method invokation. */
+  result: any;
+}
+```
+
+When the method's return type is `void`, the `result` value should typicaly be
+`undefined`, however it may not be (**TypeScript** may in certain circumstances
+allow returning a value from a `void` method): the *host* app should ignore such
+values.
+
+#### Asynchronous method invocation
+The `invoke` call can only be used to invoke *synchronous* methods. In order to
+invoke *asynchronous* methods, the `begin` and `end` calls must be used instead.
+Once the *host* app has entered an asynchronous workflow (after it made the
+first `begin` call), and until it has completed all asynchronous operations
+(after all `begin` calss were matched with an `end` call), no *synchronous*
+operation (including synchronous callbacks) may be initiated.
+
+```ts
+interface BeginRequest {
+  /** The object reference on which an asynchronous method is invoked */
+  objref: ObjectReference;
+  /** The name of the method being invoked */
+  method: string;
+  /** Any arguments passed to the method invocation */
+  args?: any[];
+
+  // The discriminator
+  api: 'begin';
+}
+```
+
+> :construction: There is no static form of this call. Should there be one?
+
+The `begin` call results in a promise being made:
+
+```ts
+interface BeginResponse {
+  /**
+   * An opaque string that uniquely idenfies the promised result of this
+   * invocation.
+   */
+  promiseid: string;
+}
+```
+
+Whenever the *host* app needs to obtain the promised value (possibly in a
+blocking way), it makes the corresponding `end` call:
+
+```ts
+interface EndRequest {
+  /** The promiseid that was returned from the corresponding `begin` call. */
+  promiseid: string;
+
+  // The discriminator
+  api: 'end';
+}
+```
+
+This will result in the promise being awaited and then resolved:
+
+```ts
+interface EndResponse {
+  /** The resolved value of the promise */
+  result: any;
+}
+```
+
+> **:warning:** All `begin` calls must be matched with an `end` call. Failure to
+> do so may result in unhandled promise rejections that might cause the
+> application to terminate in certain environments.
+
+### Invoking getters (and static getters)
+In order to obtain the value of properties, the `get` call is used:
+
+```ts
+interface GetRequest {
+  /** The object reference on which a poperty is read */
+  objref: ObjectReference;
+  /** The name of the property being read */
+  property: string;
+
+  // The discriminator
+  api: 'get';
+}
+```
+
+When operating on static properties, or in order to obtain the value of `enum`
+constants, the `sget` API must be used instead:
+
+```ts
+interface StaticGetRequest {
+  /** The jsii fully qualified name of the declaring type */
+  fqn: ObjectReference;
+  /** The name of the property being read */
+  property: string;
+
+  // The discriminator
+  api: 'sget';
+}
+```
+
+Both the `get` and `sget` calls result in the same response:
+
+```ts
+interface GetResponse {
+  /** The value of the property. */
+  result: any;
+}
+```
+
+### Invoking setters (and static setters)
+In order to change the value of a property, the `set` call is used:
+
+```ts
+interface SetRequest {
+  /** The object reference on which a poperty is written to */
+  objref: ObjectReference;
+  /** The name of the property being written to */
+  property: string;
+  /** The value that is written to the property */
+  value: any;
+
+  // The discriminator
+  api: 'set';
+}
+```
+
+When operating on static properties, the `sset` API must be used instead:
+
+```ts
+interface StaticSetRequest {
+  /** The jsii fully qualified name of the declaring type */
+  fqn: ObjectReference;
+  /** The name of the property being written to */
+  property: string;
+  /** The value that is written to the property */
+  value: any;
+
+  // The discriminator
+  api: 'sset';
+}
+```
+
+Both the `set` and `sset` calls result in the same response, which is an empty
+object:
+
+```ts
+interface SetResponse {}
+```

--- a/docs/specifications/4-standard-compliance-suite.md
+++ b/docs/specifications/4-standard-compliance-suite.md
@@ -1,0 +1,500 @@
+# Standard Compliance Suite
+
+## Goal
+The goal of the standard compliance suite is to be a normative description of
+the behaviors that all language runtime implementations (*host runtime library*
+in combination with *code generation*) must implement. This description takes
+the form of a collection of test cases that must be re-implemented in each
+*host* language, so that compliance can be asserted.
+
+Since the goal of *jsii* is to expose a single Object-Oriented API to multiple
+programming languages, it is important to ensure the behavior is consistent
+across all of them. This can be achieved by making sure that the interactions
+between the *host* and *kernel* processes are the same for a given use-case.
+
+## Format
+In order to assert whether a new runtime implementation is correct, a formal
+compliance test suite is defined, that all language runtimes must fully
+implement before they can be deemed eligible for General Availability.
+
+This document describes these tests, as well as a general approach for ensuring
+conformance requirements are met in a systematic manner.
+
+### Categories
+Test cases in the standard compliance suite are grouped by categories, which
+help implementors direct their effort in the early stages of the implementation
+of new language bindings. Each category is declared in an `H3` title (a line
+that starts with `### `) within the [`## Test Suite`] title. A description of
+the category immediately follows the opening title. The category ends with the
+end of the document, or whenever another `H2` title is reached.
+
+[`## Test Suite`]: #test-suite
+
+### Test Case
+Within a category title, test cases are delimited by `H4` (`#### `) titles,
+which correspond to the test case name. The test case name should be kept
+concise (dieally within 75 characters) and try to be as descriptive as possible.
+
+Immediately after the `H4` title is an english language description of the test
+case that explains the property the test is designed to validate in as much
+detail as possible. As much as possible, test case descriptions should be
+self-sufficient.
+
+After the attributes table, a **TypeScript** block of code describes the
+canonical form of the test. It includes any type declaration that is used by the
+test (so the code example is self-contained). Assertions performed by the test
+should be written in the form of [`jest`] expectations.
+
+> :question: The assertion code is intended as a formal representation of the
+> tests' normative procedure. It is not currently executed against the *kernel*,
+> but this could be achieved in the future. Additionally, we might be able to
+> automatically transliterate the tests to other languages using
+> [`jsii-rosetta`].
+
+[`jest`]: https://jestjs.io/docs/en/getting-started
+[`jsii-rosetta`]: ../../../packages/jsii-rosetta
+
+Finally, another code block details the sequence of messages that should be
+exchanged between the *host* and `node` processes during the execution of the
+test case, such that implementations can assert coherent behavior.
+
+Initial messages corresponding to the `hello` and `load` calls can be omitted at
+the beginning of the kernel trace. Those messages are typically identicall
+across tests and there is little value in asserting around those. Any `load`
+call happening after the first call that is neither the `hello` message or
+another `load` call **must** however be included.
+
+The dialogue is the sequence of JSON formatted messages, from the perspective of
+the *host* app, using the following notation:
+
+* Messages sent by the *host* runtime to the `node` process:
+  ```
+  > { "api": "foo" }
+  ```
+* Messages received by the *host* runtime from the `node` process:
+  ```
+  < { "result": "bar" }
+  ```
+* Comments to improve readability of the trace:
+  ```
+  # Comment continues until the end of the line
+  ```
+* Blank lines can be added to logically group trace elements
+
+> :question: is there a need to support some form of a capture mechanism to
+> provision for non-deterministric results, or non-normative elements such as
+> the exact Object IDs issued for created instances?
+
+<details><summary>Show Template</summary>
+
+Below is the template markdown to copy-paste when introducing a new test case in
+the compliance suite. New tests should always be added at the very end of the
+category they belong to, right after the last test in said category.
+
+````md
+### Test Category
+#### Test Case Name
+
+A short english language description of what property this test verifies. The
+description should include enough detail for a reader to be able to understand
+the test without having to search for any additional information. Prefer a long,
+unambiguous description to a terse one that could be subject to interpretation.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export class Foo { /* ... */ }
+
+// WHEN
+const bar = new Foo().bar();
+
+// THEN
+expect(bar.baz).toBeUndefined();
+```
+
+##### Reference Kernel Messaging
+```
+## You can omit the initial hello/load messages
+# < { "hello": "@jsii/runtime@1.2.3" }
+# > { "load": { "name": "test-case-001", "version": "1.2.3", "tarball": "/tmp/jsii-kernel-test/lib.tgz" } }
+# < { "assembly": "test-case-001", "types": 3 }
+```
+</details>
+````
+</details>
+
+## Compliance
+In order to be able to assert compliance of language binding libraries to the
+standard test suite, implementations are responsible for providing a test
+harness (typically as part of the runtime library) that can produce a
+standardized test report in the form of a JSON document that follows the
+following schema:
+
+```ts
+interface TestReport {
+  /** The report is broken down by test category, using the name as-is */
+  [category: string]: {
+    /** For each test in the category, using it's name as-is */
+    [test: string]: {
+      /** Whether the test passed or failed */
+      status: 'PASS' | 'FAIL';
+      /** The kernel messages captured during the test */
+      kernelTrace: Array<KernelMessage>;
+    };
+  };
+}
+
+interface KernelMessage {
+  /** The direction the message was sent (Host -> Kernel / Kernel -> Host) */
+  direction: 'FromKernel' | 'ToKernel';
+  /** The message, as a JSON object */
+  message: { [key: string]: unknown };
+}
+```
+
+The `@jsii/compliance` package provides the necessary tools to consume such a
+test report, together with the Markdown document describing the compliance suite,
+and procuces a report describing compliance test coverage as well as information
+about any non-conformant test result.
+
+> :construction: The `@jsii/compliance` tool does not exist yet.
+
+> :question: Should a "somewhat standard" format such as XUnit test report be
+> used instead of rolling our own JSON document?
+
+## Test Suite
+
+### Legacy
+This section is due to contain all compliance tests that were implemented before
+the *jsii specification* was initially written. They are going to be gradually
+replaced by more focused tests with better descriptions.
+
+#### Type Unions are correctly disambiguated by the Kernel
+In certain cases, two or more types in a *Type Union* can overlap in such a way
+that they are all valid structural types for the value. Statically typed
+languages however will not be satisfied with structural typing only, and require
+the correct declared type to be preserved.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export interface BluePill {
+  readonly offeredTo: string;
+  readonly makesYouForgetTheMatrix?: boolean;
+}
+export interface RedPill {
+  readonly offeredTo: string;
+  readonly makesYouExitTheMatrix?: boolean;
+}
+export class Morpheus {
+  public static isBlue(pill: BluePill | RedPill): pill is BluePill {
+    const keys = new Set(Object.keys(pill));
+    switch (keys.size) {
+      case 1:
+        return keys.has('offeredTo');
+      case 2:
+      return keys.has('offeredTo') && keys.has('makesYouForgetTheMatrix');
+      default:
+        return false;
+    }
+  }
+  public static isRed(pill: BluePill | RedPill): pill is RedPill {
+    const keys = new Set(Object.keys(pill));
+    switch (keys.size) {
+      case 1:
+        return keys.has('offeredTo');
+      case 2:
+        return keys.has('offeredTo') && keys.has('makesYouExitTheMatrix');
+      default:
+        return false;
+    }
+  }
+  private constructor(){}
+}
+export class Neo {
+  public readonly tookBlue: boolean;
+  public readonly tookRed: boolean;
+
+  public constructor(public readonly pill: BluePill | RedPill) {
+    this.tookBlue = pill.offeredTo == 'Neo' && Morpheus.isBlue(pill);
+    this.tookRed = pill.offeredTo == 'Neo' && Morpheus.isRed(pill);
+  }
+}
+
+// WHEN
+const bluePillA = new Neo({ offeredTo: 'not Neo' });
+const bluePillB = new Neo({ offeredTo: 'Neo', makesYouForgetTheMatrix: true });
+const redPillA = new Neo({ offeredTo: 'not Neo' });
+const redPillB = new Neo({ offeredTo: 'Neo', makesYouExitTheMatrix: true });
+
+// THEN
+expect(bluePillA.pill instanceof BluePill).toBeTruthy();
+expect(bluePillA.tookBlue).toBeFalsy();
+expect(bluePillA.tookRed).toBeFalsy();
+
+expect(bluePillB.pill instanceof BluePill).toBeTruthy();
+expect(bluePillA.tookBlue).toBeTruthy();
+expect(bluePillA.tookRed).toBeFalsy();
+
+expect(redPillA.pill instanceof RedPill).toBeTruthy();
+expect(bluePillA.tookBlue).toBeFalsy();
+expect(bluePillA.tookRed).toBeFalsy();
+
+expect(redPillB.pill instanceof RedPill).toBeTruthy();
+expect(bluePillA.tookBlue).toBeFalsy();
+expect(bluePillA.tookRed).toBeTruthy();
+```
+
+##### Kernel Trace
+```
+```
+</details>
+
+#### Partially initialized object consumption
+When a constructor passes `this` out from **JavaScript** to the *host* app, the
+reference must be correctly identified and passed across.
+
+> :construction: The .NET Runtime does not currently honor object identity,
+> meaning that despite the same object reference is returned twice, two distinct
+> proxies exist for it in the *host* .NET app.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export abstract class PartiallyInitializedThisConsumer {
+  public abstract consumePartiallyInitializedThis(obj: ConstructorPassesThisOut): void;
+}
+export class ConstructorPassesThisOut {
+  public constructor(consumer: PartiallyInitializedThisConsumer) {
+    consumer.consumePartiallyInitializedThis(this);
+  }
+}
+
+// WHEN
+class MyConsumer extends PartiallyInitializedThisConsumer {
+  public obj?: ConstructorPassesThisOut = null;
+
+  public consumePartiallyInitializedThis(obj: ConstructorPassesThisOut) {
+    this.obj = obj;
+  }
+}
+const consumer = new MyConsumer();
+const object = new ConstructorPassesThisOut(consumer);
+
+// THEN
+expect(consumer.obj).toBe(object);
+```
+
+##### Kernel Trace
+```
+# < {"hello":"@jsii/runtime@..."}
+# > {"api":"load","name":"...","version":"...","tarball":"..."}
+# < {"ok":{"assembly":"...","types":2}}
+
+> {"api":"create","fqn":"test.PartiallyInitializedThisConsumer","args":[],"overrides":[{"method":"consumePartiallyInitializedThis"}],"interfaces":[]}
+< {"ok":{"$jsii.byref":"test.PartiallyInitializedThisConsumer@10000"}}
+> {"api":"create","fqn":"test.ConstructorPassesThisOut","args":[{"$jsii.byref":"test.PartiallyInitializedThisConsumer@10000","$jsii.interfaces":[]}],"overrides":[],"interfaces":[]}
+< {"callback":{"cbid":"jsii::callback::20000","invoke":{"objref":{"$jsii.byref":"test.PartiallyInitializedThisConsumer@10000"},"method":"consumePartiallyInitializedThis","args":[{"$jsii.byref":"test.ConstructorPassesThisOut@10001"}]}}}
+> {"complete":{"api":"complete","cbid":"jsii::callback::20000"}}
+< {"ok":{"$jsii.byref":"test.ConstructorPassesThisOut@10001"}}
+```
+</details>
+
+### Interfaces
+Tests in this section ensure correct behavior of *behavioral interfaces*.
+
+#### Host app can implement an interface "from scratch"
+It is possible for a "pure" host interface implementation to be passed across
+the language boundary, it's methods and properties can be used by **JavaScript**
+code within the Kernel process.
+
+> :construction: The .NET Runtime currently requires that pure interfaces
+> implementations extend from `Amazon.JSII.Rutime.Deputy.DepytyBase`.
+
+> :construction: The Python Runtime currently expects a somewhat un-pythonic way
+> to implement interfaces, which requires decorating the implementing class with
+> `@jsii.implements("implemented-type.JsiiInterfaceFQN")`.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export interface IBehavioralInterface {
+  methodCall(): string;
+  readonly property: number;
+}
+export class InterfaceConsumer {
+  constructor(private readonly iface: IBehavioralInterface) { }
+
+  public composeResult() {
+    return `${this.iface.methodCall()} / ${this.iface.property}`;
+  }
+}
+
+// WHEN
+class Implementation implements IBehavioralInterface {
+  public readonly property = 1337;
+  public methodCall() { return "Hello!"; }
+}
+const impl = new Implementation();
+const consumer = new InterfaceConsumer(impl);
+
+// THEN
+expect(consumer.composeResult()).toBe("Hello! / 1337")
+```
+
+##### Kernel Trace
+```
+# < {"hello":"@jsii/runtime@..."}
+# > {"api":"load","name":"...","version":"...","tarball":"..."}
+# < {"ok":{"assembly":"...","types":2}}
+
+> {"api":"create","fqn":"Object","args":[],"overrides":[{"method":"methodCall"},{"property":"property"}],"interfaces":["test.IBehavioralInterface"]}
+< {"ok":{"$jsii.byref":"Object@10000","$jsii.interfaces":["test.IBehavioralInterface"]}}
+> {"api":"create","fqn":"test.InterfaceConsumer","args":[{"$jsii.byref":"Object@10000","$jsii.interfaces":[]}],"overrides":[],"interfaces":[]}
+< {"ok":{"$jsii.byref":"test.InterfaceConsumer@10001"}}
+> {"api":"invoke","objref":{"$jsii.byref":"test.InterfaceConsumer@10001"},"method":"composeResult","args":[]}
+< {"callback":{"cbid":"jsii::callback::20000","invoke":{"objref":{"$jsii.byref":"Object@10000","$jsii.interfaces":["test.IBehavioralInterface"]},"method":"methodCall","args":[]}}}
+> {"complete":{"api":"complete","cbid":"jsii::callback::20000","result":"Hello!"}}
+< {"callback":{"cbid":"jsii::callback::20001","get":{"objref":{"$jsii.byref":"Object@10000","$jsii.interfaces":["test.IBehavioralInterface"]},"property":"property"}}}
+> {"complete":{"api":"complete","cbid":"jsii::callback::20001","result":1337.0}}
+< {"ok":{"result":"Hello! / 1337"}}
+```
+</details>
+
+### Structs & Keyword Arguments
+
+#### Ambiguous arguments are handled correctly
+When a method accepts both a positional parameter named `foo` and a struct
+parameter with a property named `foo`, the respective values are passed in the
+correct parameter location when calling into the **JavaScript** code.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export interface StructType {
+  readonly foo: string;
+}
+export class ClassType {
+  public constructor(
+    public readonly foo: number,
+    public readonly opts: StructType,
+  ) {}
+}
+
+// WHEN
+var result = new ClassType('Bazinga!', { foo: 1337 });
+
+// THEN
+expect(typeof result.foo).toBe(1337);
+expect(typeof result.opts.foo).toBe('Bazinga!');
+```
+
+##### Kernel Trace
+```
+# < {"hello":"@jsii/runtime@..."}
+# > {"api":"load","name":"...","version":"...","tarball":"..."}
+# < {"ok":{"assembly":"...","types":2}}
+
+> {"api":"create","fqn":"test.ClassType","args":[1337.0,{"$jsii.struct":{"fqn":"test.StructType","data":{"foo":"Bazinga!"}}}],"overrides":[],"interfaces":[]}
+< {"ok":{"$jsii.byref":"test.ClassType@10000"}}
+> {"api":"get","objref":{"$jsii.byref":"test.ClassType@10000"},"property":"foo"}
+< {"ok":{"value":1337}}
+> {"api":"get","objref":{"$jsii.byref":"test.ClassType@10000"},"property":"opts"}
+< {"ok":{"value":{"$jsii.byref":"Object@10001","$jsii.interfaces":["test.StructType"]}}}
+> {"api":"get","objref":{"$jsii.byref":"Object@10001"},"property":"foo"}
+< {"ok":{"value":"Bazinga!"}}
+```
+</details>
+
+### Collections
+Tests in this section ensure correct behavior of collections (`List` and `Map`).
+
+#### Struct elements of `List` are deserialized to the correct apparent type
+When the declared element type of a `List` is a *struct*, the resulting list
+must contain elements of the correct static type. This is a requirement for
+statically typed languages such as Java where type parameters are reified.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export interface StructType {
+  readonly property: string;
+}
+export class StructProvider {
+  public static provide(): StructType[] {
+    return [{ property: 'value' }];
+  }
+}
+
+// WHEN
+const items = StructProvider.provide();
+
+// THEN
+expect(items.length).toBeGreaterThan(0);
+for (const item of items) {
+  expect(item instanceof StructType).toBeTruthy();
+}
+```
+
+##### Kernel Trace
+```
+# < {"hello":"@jsii/runtime@..."}
+# > {"api":"load","name":"...","version":"...","tarball":"..."}
+# < {"ok":{"assembly":"...","types":2}}
+
+> {"api":"sinvoke","fqn":"test.StructProvider","method":"provide","args":[]}
+< {"ok":{"result":[{"$jsii.byref":"Object@10000","$jsii.interfaces":["test.StructType"]}]}}
+```
+</details>
+
+#### Struct elements of `Map` are deserialized to the correct apparent type
+When the declared element type of a `Map` is a *struct*, the resulting list
+must contain elements of the correct static type. This is a requirement for
+statically typed languages such as Java where type parameters are reified.
+
+<details><summary>Show test</summary>
+
+##### Reference Implementation
+```ts
+// GIVEN
+export interface StructType {
+  readonly property: string;
+}
+export class StructProvider {
+  public static provide(): { [key: string]: StructType } {
+    return { foo: { property: 'value' } };
+  }
+}
+
+// WHEN
+const items = StructProvider.provide();
+
+// THEN
+expect(items.length).toBeGreaterThan(0);
+for (const item of Object.values(items)) {
+  expect(item instanceof StructType).toBeTruthy();
+}
+```
+
+##### Kernel Trace
+```
+# < {"hello":"@jsii/runtime@..."}
+# > {"api":"load","name":"...","version":"...","tarball":"..."}
+# < {"ok":{"assembly":"...","types":2}}
+
+> {"api":"sinvoke","fqn":"test.StructProvider","method":"provide","args":[]}
+< {"ok":{"result":{"$jsii.map":{"foo":{"$jsii.byref":"Object@10000","$jsii.interfaces":["test.StructType"]}}}}}
+```
+</details>

--- a/docs/specifications/5-new-language-intake.md
+++ b/docs/specifications/5-new-language-intake.md
@@ -1,0 +1,138 @@
+# New Language Intake
+This document outlines the process to be followed when introducing a new *jsii*
+target language, including an estimated timeline (the exact timeline may vary
+significantly depending on the specifics of the language being added).
+
+The estimated total duration for the process is 4 to 6 months.
+
+## Planning
+
+**:alarm_clock: Estimated Duration:** 2 weeks
+
+The first step is to study the *jsii* specification, as well as existing
+language implementations, in order to have the knowledge necessary to write a
+new language support proposal [RFC]. The [RFC] document produced will evolve and
+be polished as development of the new language support progresses, but the
+following elements must be present before any implementation begins:
+
+* Identification of the language's standard package repository
+* Proposal for the binding's configuration block
+* Sample API representations in the proposed language
+  + In particular, any element from the *jsii* type model that does not
+    naturally map into the proposed new language needs to be represented
+  + Where several options exist, links to prior art are instrumental to validate
+    the direction chosen
+* Toolchain and platform requirements
+
+[RFC]: https://github.com/awslabs/aws-cdk-rfcs#readme
+
+## Code Generation (`jsii-pacmak`)
+
+**:alarm_clock: Estimated Duration:** 4 to 6 weeks
+
+The necessary code must be added to [`jsii-pacmak`] in order to map the *jsii*
+assembly's declared types into the proposed language. While this code ought to
+leverage the new language's *host* runtime library, we begin with writing the
+code generator in order to ensure the appropriate developer experience is
+achieved in the new language before writing the back-end components.
+
+Code generators are authored in **TypeScript**.
+
+The necessary reserved words need to be registered in the `jsii` compiler, so
+that warnings are produced when identifiers are used in **TypeScript** code that
+require slugification or escaping in the target language (and will hence cause a
+degraded developer experience).
+
+[`jsii-pacmak`]: ../../packages/jsii-pacmak
+
+## Runtime Library
+
+**:alarm_clock: Estimated Duration:** 4 to 6 weeks
+
+Now that the appropriate developer experience has been identified, the *host*
+runtime library supporting the generated code can be written. This component
+must be written in the new language.
+
+> :construction: A reference architecture for *host* runtime libraries is to be
+> developed, in order to ensure consistent naming and behavior across all the
+> runtimes, reducing the cost of maintaining many of those.
+
+## Building & Packaging
+
+**:alarm_clock: Estimated Duration:** 2 weeks
+
+Once code is generated and it has a *host* runtime library to rely on,
+[`jsii-pacmak`] needs to receive the additional logic required to compile and
+package the generated libraries as required, producing ready-to-publish
+artifacts.
+
+The necessary toolchain needs to be added to the [`jsii/superchain`] *Docker*
+image, so that `jsii` customers can rely on this to build artifacts for any of
+the supported languages.
+
+In addition to this, standardized *Amazon CodePipeline* actions need to be
+developed in order to support publishing to the relevant idiomatic package
+managers.
+
+[`jsii/superchain`]: ../../superchain
+
+## Compliance Tests
+
+**:alarm_clock: Estimated Duration:** 6 weeks
+
+The full standard compliance suite must be implemented for the new language.
+Leveraging the new code generator, *host* runtime library and compilation logic,
+the tests demonstrate that the new library behaves consistently with all other
+language bindings.
+
+While it is possible to declare *developer preview* on a new language before all
+the tests pass, full compliance is a pre-requisite to declaring *general
+availability* of the new language.
+
+## Documentation
+
+**:alarm_clock: Estimated Duration:** 1 week
+
+The necessary documentation needs to be provided to support customers who want
+to onboard the new language. This also includes updating [`jsii-config`] with
+support for the new languages' configuration block.
+
+[`jsii-config`]: ../../packages/jsii-config
+
+## Developer Preview
+
+**:alarm_clock: Recommended Duration:** 4 to 8 weeks
+
+It is possible to declare *Developer Preview* for a new language support as soon
+as the code generation and *host* runtime library are mature enough to be useful,
+and cover the majority of use-cases. While certain edge-cases may still be
+un-covered at the beginning of *Developer Preview*, a clear plan should exist
+that ensures a path exists to address any known gaps. It is required to have
+implemented most of the standard compliance suite prior to declaring *Developer
+Preview*.
+
+During the *Developer Preview* phase, user experience studies should be
+conducted to validate assumptions made during the code generator's design. If
+any significant change is dictated by the results of the user experience studies,
+fluback studies should be performed in order to confirm that the desired impact
+has been achieved.
+
+> :construction: A standard set of user experience sutdy tasks is going to be
+> developed, ensuring the learnings from previous experiences is factored into
+> subsequent studies conducted.
+
+Finally, it is essential to give time to the community to use & vet the new
+language support prior to considering *General Availability*. A minimum of a
+full month without a major bug reported is advised. During this period,
+intentional hands-on usage of the product msut be performed by engineers
+familiar with the new language as well as engineers unfamilar with it. This
+ensures the new experience is considered holistically, in a manner un-biased by
+knowledge of the implementation.
+
+## General Availability
+
+Once the new language support has been *Developer Preview* for long enough and
+the engineers involved have gained confidence that the API is stable, covers all
+known use-cases reliably, and behaves consistently with other *Generally
+Available* languages, the new support can be considered for *General
+Availability*.


### PR DESCRIPTION
## Reviewing Guide

This Pull Request introduces a collection of documents under `docs/specification/` that are effectively an RFC for the *jsii* technology.

### Foundational Elements

Since the specified behavior is due to evolve over time, the essential elements to nail down are the following:

1. Design Tenets (in `1-introduction.md`)
1. Updating the specification (in `1-introduction.md`)
1. Standard Compliance Suite (in `4-standard-compliance-suite.md`)
   + This is the core of the compliance & coverage plan
1. New language intake (in `5-new-language-intake.md`)

### Current Specification

Once the foundational elements are agreed upon (at least by the core team), the rest of the specification will be open for a review period (like any other RFC), before it is finally merged.

### Frequently Asked Questions

#### Why several documents and not just one?

There are presently several distinct documents, but this is merely a way to make the PR easier to assess in fragments, and the documents may be merged into a single `specification.md` document before merging.

In particular, GitHub's PR review UI has the "viewed" toggle that allows one to stop reviewing and come back to it later without having lost state of where they left off. This Feld particularly appealing, especially as the initial version of this document is large.

#### What are the block quotes for?

The documents attempt to specify the _current_ behavior of the *jsii* components and uses block-quotes introduced by a specific emoji:

- :construction: introduces remarks about behaviors that are not yet conform to the specification, where the current implementation is not homogenous, etc...
- :question: introduces remarks about open questions, or elements of the specification that may need re-designing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
