### PR TITLE
fix(superchain): bad permissions on ~/.ssh/config

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -63,6 +63,7 @@ RUN curl -sSL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.r
 
 # Install some configuration
 COPY ssh_config /root/.ssh/config
+RUN chmod 600 /root/.ssh/config
 COPY dockerd-entrypoint.sh /usr/local/bin/
 ENV CHARSET=UTF-8                                                                                                       \
     LC_ALL=C.UTF-8


### PR DESCRIPTION
`/root/.ssh/config` must have the correct permissions or otherwise certain operations such as `git clone` will fail in certain environments.

Fixes #1138

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
