### PR TITLE
fix(rosetta): crashes on behavioral interfaces

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -96,12 +96,25 @@ async function translateAll(snippets: IterableIterator<TypeScriptSnippet>, inclu
 export function singleThreadedTranslateAll(snippets: IterableIterator<TypeScriptSnippet>, includeCompilerDiagnostics: boolean): TranslateAllResult {
   const translatedSnippets = new Array<TranslatedSnippet>();
 
+  const failures = new Array<ts.Diagnostic>();
+
   const translator = new Translator(includeCompilerDiagnostics);
   for (const block of snippets) {
-    translatedSnippets.push(translator.translate(block));
+    try {
+      translatedSnippets.push(translator.translate(block));
+    } catch(e) {
+      failures.push({
+        category: ts.DiagnosticCategory.Error,
+        code: 999,
+        messageText: `Error translating snippet: ${e}\n${block.completeSource}`,
+        file: undefined,
+        start: undefined,
+        length: undefined,
+      });
+    }
   }
 
-  return { translatedSnippets, diagnostics: translator.diagnostics };
+  return { translatedSnippets, diagnostics: [...translator.diagnostics, ...failures] };
 }
 
 /**

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -106,7 +106,7 @@ export function singleThreadedTranslateAll(snippets: IterableIterator<TypeScript
       failures.push({
         category: ts.DiagnosticCategory.Error,
         code: 999,
-        messageText: `Error translating snippet: ${e}\n${block.completeSource}`,
+        messageText: `rosetta: error translating snippet: ${e}\n${block.completeSource}`,
         file: undefined,
         start: undefined,
         length: undefined,

--- a/packages/jsii-rosetta/lib/languages/csharp.ts
+++ b/packages/jsii-rosetta/lib/languages/csharp.ts
@@ -270,7 +270,7 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
     const canSet = renderer.currentContext.inStructInterface || !isReadOnly(node);
 
     return new OTree([
-      !renderer.currentContext.inRegularInterface ? visibility(node) + ' ' : NO_SYNTAX,
+      !renderer.currentContext.inRegularInterface ? `${visibility(node)} ` : NO_SYNTAX,
       this.renderTypeNode(node.type, node.questionToken !== undefined, renderer),
       ' ',
       renderer.updateContext({ propertyOrMethod: true }).convert(node.name),

--- a/packages/jsii-rosetta/lib/languages/csharp.ts
+++ b/packages/jsii-rosetta/lib/languages/csharp.ts
@@ -25,6 +25,11 @@ interface CSharpLanguageContext {
   readonly inStructInterface: boolean;
 
   /**
+   * So we know how to render property signatures
+   */
+  readonly inRegularInterface: boolean;
+
+  /**
    * So we know how to render property assignments
    */
   readonly inKeyValueList: boolean;
@@ -53,9 +58,12 @@ interface CSharpLanguageContext {
 type CSharpRenderer = AstRenderer<CSharpLanguageContext>;
 
 export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
+  public readonly language = 'csharp';
+
   public readonly defaultContext = {
     propertyOrMethod: false,
     inStructInterface: false,
+    inRegularInterface: false,
     inKeyValueList: false,
     stringAsIdentifier: false,
     identifierAsString: false,
@@ -134,6 +142,17 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
 
   public methodDeclaration(node: ts.MethodDeclaration, renderer: CSharpRenderer): OTree {
     return this.functionLike(node, renderer);
+  }
+
+  public methodSignature(node: ts.MethodSignature, renderer: CSharpRenderer): OTree {
+    return new OTree([
+      this.renderTypeNode(node.type, false, renderer),
+      ' ',
+      renderer.updateContext({ propertyOrMethod: true }).convert(node.name),
+      '(',
+      new OTree([], renderer.convertAll(node.parameters), { separator: ', ' }),
+      ');'
+    ], [], { canBreakLine: true });
   }
 
   // tslint:disable-next-line:max-line-length
@@ -248,13 +267,15 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
   }
 
   public propertySignature(node: ts.PropertySignature, renderer: CSharpRenderer): OTree {
+    const canSet = renderer.currentContext.inStructInterface || !isReadOnly(node);
+
     return new OTree([
-      visibility(node),
-      ' ',
+      !renderer.currentContext.inRegularInterface ? visibility(node) + ' ' : NO_SYNTAX,
       this.renderTypeNode(node.type, node.questionToken !== undefined, renderer),
       ' ',
       renderer.updateContext({ propertyOrMethod: true }).convert(node.name),
-      ';',
+      ' ',
+      canSet ? '{ get; set; }' : '{ get; }',
     ], [], { canBreakLine: true });
   }
 
@@ -308,7 +329,7 @@ export class CSharpVisitor extends DefaultVisitor<CSharpLanguageContext> {
       ...this.classHeritage(node, renderer),
       '\n{',
     ],
-    renderer.convertAll(node.members),
+    renderer.updateContext({ inRegularInterface: true }).convertAll(node.members),
     {
       indent: 4,
       canBreakLine: true,
@@ -503,7 +524,7 @@ function typeNameFromType(type: ts.Type, fallback: string): string {
 }
 
 function csharpTypeName(jsTypeName: string | undefined): string {
-  if (jsTypeName === undefined) { return '???'; }
+  if (jsTypeName === undefined) { return 'void'; }
   switch (jsTypeName) {
     case 'number': return 'int';
     case 'any': return 'object';

--- a/packages/jsii-rosetta/lib/languages/default.ts
+++ b/packages/jsii-rosetta/lib/languages/default.ts
@@ -5,12 +5,14 @@ import { ImportStatement } from '../typescript/imports';
 import { isStructInterface, isStructType } from '../jsii/jsii-utils';
 import { mapElementType, typeWithoutUndefinedUnion } from '../typescript/types';
 import { voidExpressionString } from '../typescript/ast-utils';
+import { TargetLanguage } from '.';
 
 /**
  * A basic visitor that applies for most curly-braces-based languages
  */
 export abstract class DefaultVisitor<C> implements AstHandler<C> {
   public abstract readonly defaultContext: C;
+  public abstract readonly language: TargetLanguage;
 
   public abstract mergeContext(old: C, update: C): C;
 
@@ -240,6 +242,10 @@ export abstract class DefaultVisitor<C> implements AstHandler<C> {
     return this.notImplemented(node, context);
   }
 
+  public methodSignature(node: ts.MethodSignature, context: AstRenderer<C>): OTree {
+    return this.notImplemented(node, context);
+  }
+
   public asExpression(node: ts.AsExpression, context: AstRenderer<C>): OTree {
     return this.notImplemented(node, context);
   }
@@ -284,7 +290,7 @@ export abstract class DefaultVisitor<C> implements AstHandler<C> {
   }
 
   private notImplemented(node: ts.Node, context: AstRenderer<C>) {
-    context.reportUnsupported(node);
+    context.reportUnsupported(node, this.language);
     return nimpl(node, context);
   }
 }

--- a/packages/jsii-rosetta/lib/languages/java.ts
+++ b/packages/jsii-rosetta/lib/languages/java.ts
@@ -267,14 +267,13 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
 
   public methodSignature(node: ts.MethodSignature, renderer: JavaRenderer): OTree {
     return new OTree([
-        this.renderTypeNode(node.type, renderer, 'void'),
-        ' ',
-        renderer.convert(node.name),
-        '(',
-        new OTree([], renderer.convertAll(node.parameters), { separator: ', ' }),
-        ');',
-      ], [], { canBreakLine: true },
-    );
+      this.renderTypeNode(node.type, renderer, 'void'),
+      ' ',
+      renderer.convert(node.name),
+      '(',
+      new OTree([], renderer.convertAll(node.parameters), { separator: ', ' }),
+      ');',
+    ], [], { canBreakLine: true });
   }
 
   public parameterDeclaration(node: ts.ParameterDeclaration, renderer: JavaRenderer): OTree {

--- a/packages/jsii-rosetta/lib/languages/java.ts
+++ b/packages/jsii-rosetta/lib/languages/java.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import { DefaultVisitor } from './default';
 import { AstRenderer } from '../renderer';
-import { OTree } from '../o-tree';
+import { OTree, NO_SYNTAX } from '../o-tree';
 import { builtInTypeName, mapElementType, typeWithoutUndefinedUnion } from '../typescript/types';
 import { isReadOnly, matchAst, nodeOfType, quoteStringLiteral, visibility } from '../typescript/ast-utils';
 import { ImportStatement } from '../typescript/imports';
@@ -72,11 +72,17 @@ interface InsideTypeDeclaration {
    * Needed to correctly generate the constructor.
    */
   readonly typeName: ts.Node | undefined;
+
+  /**
+   * Is this an interface (true) or a class (unset/false)
+   */
+  readonly isInterface?: boolean;
 }
 
 type JavaRenderer = AstRenderer<JavaContext>;
 
 export class JavaVisitor extends DefaultVisitor<JavaContext> {
+  public readonly language = 'java';
   public readonly defaultContext = {};
 
   public mergeContext(old: JavaContext, update: Partial<JavaContext>): JavaContext {
@@ -110,11 +116,34 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
     return this.renderClassDeclaration(node, renderer);
   }
 
+  public regularInterfaceDeclaration(node: ts.InterfaceDeclaration, renderer: JavaRenderer): OTree {
+    return new OTree(
+      [
+        'public ',
+        'interface ',
+        renderer.convert(node.name),
+        ...this.typeHeritage(node, renderer.updateContext({ ignorePropertyPrefix: true })),
+        ' {',
+      ],
+      renderer
+        .updateContext({ insideTypeDeclaration: { typeName: node.name, isInterface: true } })
+        .convertAll(node.members),
+      {
+        indent: 4,
+        canBreakLine: true,
+        suffix: '\n}',
+      },
+    );
+  }
+
   public propertySignature(node: ts.PropertySignature, renderer: JavaRenderer): OTree {
     const propertyType = this.renderTypeNode(node.type, renderer, 'Object');
     const propertyName = renderer.convert(node.name);
 
-    const field = new OTree(
+    const isClass = !renderer.currentContext.insideTypeDeclaration?.isInterface;
+    const blockSep = isClass ? ' ' : ';';
+
+    const field = isClass ? new OTree(
       [],
       [
         'private ',
@@ -126,16 +155,16 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
       {
         canBreakLine: true,
       },
-    );
+    ) : NO_SYNTAX;
 
     const getter = new OTree(
       [],
       [
-        'public ',
+        isClass ? 'public ' : NO_SYNTAX,
         propertyType,
         ' ',
-        `get${capitalize(renderer.textOf(node.name))}() `,
-        this.renderBlock([
+        `get${capitalize(renderer.textOf(node.name))}()${blockSep}`,
+        isClass ? this.renderBlock([
           new OTree(
             [
               '\n',
@@ -146,17 +175,19 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
               ';',
             ],
           ),
-        ]),
+        ]) : NO_SYNTAX,
       ],
       {
         canBreakLine: true,
       },
     );
 
-    const setter = new OTree(
+    const hasSetter = isClass || !isReadOnly(node);
+
+    const setter = hasSetter ? new OTree(
       [],
       [
-        'public ',
+        isClass ? 'public ' : NO_SYNTAX,
         renderer.convert(renderer.currentContext.insideTypeDeclaration!.typeName),
         ' ',
         propertyName, // don't prefix the setter with `set` - makes it more aligned with JSII builders
@@ -164,8 +195,8 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
         propertyType,
         ' ',
         propertyName,
-        ') ',
-        this.renderBlock([
+        `)${blockSep}`,
+        isClass ? this.renderBlock([
           new OTree(
             [
               '\n',
@@ -186,12 +217,12 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
               'return this;',
             ],
           ),
-        ]),
+        ]) : NO_SYNTAX,
       ],
       {
         canBreakLine: true,
       },
-    );
+    ) : NO_SYNTAX;
 
     return new OTree([], [field, getter, setter], { canBreakLine: true, separator: '\n' });
   }
@@ -232,6 +263,18 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
     return this.renderProcedure(node, renderer,
       node.name,
       this.renderTypeNode(node.type, renderer, 'void'));
+  }
+
+  public methodSignature(node: ts.MethodSignature, renderer: JavaRenderer): OTree {
+    return new OTree([
+        this.renderTypeNode(node.type, renderer, 'void'),
+        ' ',
+        renderer.convert(node.name),
+        '(',
+        new OTree([], renderer.convertAll(node.parameters), { separator: ', ' }),
+        ');',
+      ], [], { canBreakLine: true },
+    );
   }
 
   public parameterDeclaration(node: ts.ParameterDeclaration, renderer: JavaRenderer): OTree {
@@ -472,8 +515,14 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
 
   public propertyAssignment(node: ts.PropertyAssignment, renderer: JavaRenderer): OTree {
     return renderer.currentContext.inKeyValueList
-      ? this.singlePropertyInJavaScriptObjectLiteralToJavaMap(node, renderer)
-      : this.singlePropertyInJavaScriptObjectLiteralToFluentSetters(node, renderer);
+      ? this.singlePropertyInJavaScriptObjectLiteralToJavaMap(node.name, node.initializer, renderer)
+      : this.singlePropertyInJavaScriptObjectLiteralToFluentSetters(node.name, node.initializer, renderer);
+  }
+
+  public shorthandPropertyAssignment(node: ts.ShorthandPropertyAssignment, renderer: JavaRenderer): OTree {
+    return renderer.currentContext.inKeyValueList
+      ? this.singlePropertyInJavaScriptObjectLiteralToJavaMap(node.name, node.name, renderer)
+      : this.singlePropertyInJavaScriptObjectLiteralToFluentSetters(node.name, node.name, renderer);
   }
 
   public propertyAccessExpression(node: ts.PropertyAccessExpression, renderer: JavaRenderer): OTree {
@@ -530,13 +579,13 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
     );
   }
 
-  private singlePropertyInJavaScriptObjectLiteralToJavaMap(node: ts.PropertyAssignment, renderer: JavaRenderer): OTree {
+  private singlePropertyInJavaScriptObjectLiteralToJavaMap(name: ts.Node, initializer: ts.Node, renderer: JavaRenderer): OTree {
     return new OTree(
       [],
       [
-        renderer.updateContext({ identifierAsString: true }).convert(node.name),
+        renderer.updateContext({ identifierAsString: true }).convert(name),
         ', ',
-        renderer.updateContext({ inKeyValueList: false }).convert(node.initializer),
+        renderer.updateContext({ inKeyValueList: false }).convert(initializer),
       ],
       {
         canBreakLine: true,
@@ -544,14 +593,14 @@ export class JavaVisitor extends DefaultVisitor<JavaContext> {
     );
   }
 
-  private singlePropertyInJavaScriptObjectLiteralToFluentSetters(node: ts.PropertyAssignment, renderer: JavaRenderer): OTree {
+  private singlePropertyInJavaScriptObjectLiteralToFluentSetters(name: ts.Node, initializer: ts.Node, renderer: JavaRenderer): OTree {
     return new OTree(
       [],
       [
         '.',
-        renderer.updateContext({ stringLiteralAsIdentifier: true }).convert(node.name),
+        renderer.updateContext({ stringLiteralAsIdentifier: true }).convert(name),
         '(',
-        renderer.updateContext({ inNewExprWithObjectLiteralAsLastArg: false }).convert(node.initializer),
+        renderer.updateContext({ inNewExprWithObjectLiteralAsLastArg: false }).convert(initializer),
         ')',
       ],
       {

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -69,6 +69,7 @@ export interface PythonVisitorOptions {
 }
 
 export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
+  public readonly language = 'python';
   public readonly defaultContext = {};
 
   public constructor(private readonly options: PythonVisitorOptions = {}) {
@@ -438,6 +439,11 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
   }
 
   public propertySignature(_node: ts.PropertySignature, _context: PythonVisitorContext): OTree {
+    // Does not represent in Python
+    return NO_SYNTAX;
+  }
+
+  public methodSignature(_node: ts.MethodSignature, _context: PythonVisitorContext): OTree {
     // Does not represent in Python
     return NO_SYNTAX;
   }

--- a/packages/jsii-rosetta/lib/languages/visualize.ts
+++ b/packages/jsii-rosetta/lib/languages/visualize.ts
@@ -138,6 +138,10 @@ export class VisualizeAstVisitor implements AstHandler<void> {
     return this.defaultNode('propertySignature', node, context);
   }
 
+  public methodSignature(node: ts.MethodSignature, context: AstRenderer<void>): OTree {
+    return this.defaultNode('methodSignature', node, context);
+  }
+
   public asExpression(node: ts.AsExpression, context: AstRenderer<void>): OTree {
     return this.defaultNode('asExpression', node, context);
   }

--- a/packages/jsii-rosetta/test/translations.test.ts
+++ b/packages/jsii-rosetta/test/translations.test.ts
@@ -85,9 +85,8 @@ function makeTests() {
 
         testConstructor(`to ${supportedLanguage.name}`, () => {
           const expected = fs.readFileSync(languageFile, { encoding: 'utf-8' });
-          const translation = translator.renderUsing(supportedLanguage.visitor);
-
           try {
+            const translation = translator.renderUsing(supportedLanguage.visitor);
             expect(stripEmptyLines(translation)).toEqual(stripEmptyLines(stripCommonWhitespace(expected)));
           } catch(e) {
             anyFailed = true;

--- a/packages/jsii-rosetta/test/translations/calls/default_struct_fields.cs
+++ b/packages/jsii-rosetta/test/translations/calls/default_struct_fields.cs
@@ -1,7 +1,7 @@
 class Struct
 {
-    public string? X;
-    public string? Y;
+    public string? X { get; set; }
+    public string? Y { get; set; }
 }
 public void Foo(Struct s)
 {

--- a/packages/jsii-rosetta/test/translations/calls/shorthand_property.cs
+++ b/packages/jsii-rosetta/test/translations/calls/shorthand_property.cs
@@ -1,0 +1,2 @@
+string foo = "hello";
+CallFunction(new Struct { Foo = foo });

--- a/packages/jsii-rosetta/test/translations/calls/shorthand_property.java
+++ b/packages/jsii-rosetta/test/translations/calls/shorthand_property.java
@@ -1,0 +1,2 @@
+String foo = "hello";
+callFunction(Map.of("foo", foo));

--- a/packages/jsii-rosetta/test/translations/calls/shorthand_property.py
+++ b/packages/jsii-rosetta/test/translations/calls/shorthand_property.py
@@ -1,0 +1,2 @@
+foo = "hello"
+call_function(foo=foo)

--- a/packages/jsii-rosetta/test/translations/calls/shorthand_property.ts
+++ b/packages/jsii-rosetta/test/translations/calls/shorthand_property.ts
@@ -1,0 +1,2 @@
+const foo = 'hello';
+callFunction({ foo });

--- a/packages/jsii-rosetta/test/translations/calls/will_type_deep_structs_directly_if_type_info_is_available.cs
+++ b/packages/jsii-rosetta/test/translations/calls/will_type_deep_structs_directly_if_type_info_is_available.cs
@@ -1,16 +1,16 @@
 class BaseDeeperStruct
 {
-    public int A;
+    public int A { get; set; }
 }
 class DeeperStruct : BaseDeeperStruct
 {
-    public int B;
+    public int B { get; set; }
 }
 
 class OuterStruct
 {
-    public int Foo;
-    public DeeperStruct Deeper;
+    public int Foo { get; set; }
+    public DeeperStruct Deeper { get; set; }
 }
 
 public void Foo(int x, OuterStruct outer)

--- a/packages/jsii-rosetta/test/translations/classes/class_with_props_argument.cs
+++ b/packages/jsii-rosetta/test/translations/classes/class_with_props_argument.cs
@@ -1,7 +1,7 @@
 class MyClassProps
 {
-    public string Prop1;
-    public int Prop2;
+    public string Prop1 { get; set; }
+    public int Prop2 { get; set; }
 }
 
 class MyClass : cdk.SomeOtherClass

--- a/packages/jsii-rosetta/test/translations/expressions/struct_assignment.cs
+++ b/packages/jsii-rosetta/test/translations/expressions/struct_assignment.cs
@@ -1,6 +1,6 @@
 class Test
 {
-    public string Key;
+    public string Key { get; set; }
 }
 
 Test x = new Test { Key = "value" };

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.cs
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.cs
@@ -1,0 +1,4 @@
+interface IThing
+{
+    void DoAThing();
+}

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.java
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.java
@@ -1,0 +1,3 @@
+public interface IThing {
+    void doAThing();
+}

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.ts
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_method.ts
@@ -1,0 +1,3 @@
+interface IThing {
+  doAThing(): void;
+}

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.cs
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.cs
@@ -1,0 +1,4 @@
+interface IThing
+{
+    string ThingArn { get; }
+}

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.java
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.java
@@ -1,0 +1,3 @@
+public interface IThing {
+    String getThingArn();
+}

--- a/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.ts
+++ b/packages/jsii-rosetta/test/translations/interfaces/interface_with_props.ts
@@ -1,0 +1,3 @@
+interface IThing {
+  readonly thingArn: string;
+}


### PR DESCRIPTION
Behavioral interfaces (`ISomething`) weren't translated at all, and used
to crash the Java translator. Add translations for them.

Make the `jsii-rosetta` command-line tool more robust against errors in
the translator: catch and report the error, instead of crashing.

Add support for shorthand property assignments in object literals
(`someFunction({ foo });`) for Java as well, which wasn't covered
by any test yet.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
