### PR TITLE
fix: depend on python-3.8-supporting version of cattrs

### DIFF
--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
 
     install_requires=[
         "attrs>=18.2",
-        "cattrs",
+        "cattrs>=1.0.0",
         "importlib_resources ; python_version < '3.7'",
         "python-dateutil",
         "typing_extensions>=3.6.4",


### PR DESCRIPTION
Fixes #913

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
