### PR TITLE
fix(rosetta): properly escape C# comments as XML

### DIFF
--- a/packages/jsii-rosetta/lib/markdown/escapes.ts
+++ b/packages/jsii-rosetta/lib/markdown/escapes.ts
@@ -1,0 +1,73 @@
+export interface Escaper {
+  /**
+   * Escape for use in XML/HTML text
+   */
+  text(x: string | null): string;
+
+  /**
+   * Escape for use in XML/HTML attributes
+   */
+  attribute(x: string | null): string;
+
+  /**
+   * Re-escape a string that has been escaped for text to be escaped for attributes
+   *
+   * Conceptually this unescapes text back to raw and re-escapes for attributes,
+   * but for speed in practice we just do the additional escapes.
+   */
+  text2attr(x: string | null): string;
+}
+
+/**
+ * Make a generic XML escaper
+ */
+export function makeXmlEscaper(): Escaper {
+  const attr: Escapes = [...TEXT, ...ATTR_ADDL];
+
+  return {
+    text: (x) => escapeText(TEXT, x),
+    attribute: (x) => escapeText(attr, x),
+    text2attr: (x) => escapeText(ATTR_ADDL, x)
+  };
+}
+
+/**
+ * Make a Java specific escaper
+ *
+ * This one also escapes '@' because that triggers parsing of comment directives
+ * in Java.
+ */
+export function makeJavaEscaper(): Escaper {
+  const javaText: Escapes = [...TEXT, [new RegExp('@', 'g'), '&#64;']];
+  const javaAttr: Escapes = [...javaText, ...ATTR_ADDL];
+
+  return {
+    text: (x) => escapeText(javaText, x),
+    attribute: (x) => escapeText(javaAttr, x),
+    text2attr: (x) => escapeText(ATTR_ADDL, x)
+  };
+}
+
+type Escapes = Array<[RegExp, string]>;
+
+const TEXT: Escapes = [
+  [new RegExp('&', 'g'), '&amp;'],
+  [new RegExp('<', 'g'), '&lt;'],
+  [new RegExp('>', 'g'), '&gt;'],
+];
+
+// Additional escapes (in addition to the text escapes) which need to be escaped inside attributes.
+const ATTR_ADDL: Escapes = [
+  [new RegExp('"', 'g'), '&quot;'],
+  [new RegExp("'", 'g'), '&apos;'],
+];
+
+function escapeText(set: Escapes, what: string | null): string {
+  if (!what) { return ''; }
+
+  for (const [re, repl] of set) {
+    what = what.replace(re, repl);
+  }
+
+  return what;
+}

--- a/packages/jsii-rosetta/lib/markdown/javadoc-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/javadoc-renderer.ts
@@ -1,6 +1,9 @@
 import * as cm from 'commonmark';
 import { RendererContext } from './markdown';
 import { MarkdownRenderer, collapsePara, para, stripTrailingWhitespace, stripPara } from './markdown-renderer';
+import { makeJavaEscaper } from './escapes';
+
+const ESCAPE = makeJavaEscaper();
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -16,7 +19,7 @@ export class JavaDocRenderer extends MarkdownRenderer {
   }
 
   public code(node: cm.Node, _context: RendererContext) {
-    return `<code>${escapeCharacters(node.literal)}</code>`;
+    return `<code>${ESCAPE.text(node.literal)}</code>`;
   }
 
   /**
@@ -30,15 +33,15 @@ export class JavaDocRenderer extends MarkdownRenderer {
    */
   /* eslint-disable-next-line @typescript-eslint/camelcase */
   public code_block(node: cm.Node, _context: RendererContext) {
-    return para(`<blockquote><pre>\n${escapeCharacters(node.literal)}</pre></blockquote>`);
+    return para(`<blockquote><pre>\n${ESCAPE.text(node.literal)}</pre></blockquote>`);
   }
 
   public text(node: cm.Node, _context: RendererContext) {
-    return escapeCharacters(node.literal) || '';
+    return ESCAPE.text(node.literal) ?? '';
   }
 
   public link(node: cm.Node, context: RendererContext) {
-    return `<a href="${node.destination || ''}">${context.content()}</a>`;
+    return `<a href="${ESCAPE.attribute(node.destination) ?? ''}">${context.content()}</a>`;
   }
 
   public document(_node: cm.Node, context: RendererContext) {
@@ -60,7 +63,7 @@ export class JavaDocRenderer extends MarkdownRenderer {
   }
 
   public image(node: cm.Node, context: RendererContext) {
-    return `<img alt="${context.content()}" src="${node.destination || ''}">`;
+    return `<img alt="${ESCAPE.text2attr(context.content())}" src="${ESCAPE.attribute(node.destination) ?? ''}">`;
   }
 
   public emph(_node: cm.Node, context: RendererContext) {
@@ -75,13 +78,6 @@ export class JavaDocRenderer extends MarkdownRenderer {
   public thematic_break(_node: cm.Node, _context: RendererContext) {
     return para('<hr>');
   }
-}
-
-/**
- * Escape the characters that need escaping in JavaDoc HTML
- */
-function escapeCharacters(x: string | null): string {
-  return x ? x.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/@/g, '&#64;') : '';
 }
 
 function collapseParaJava(x: string) {

--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -34,6 +34,7 @@
     "commonmark": "^0.29.0",
     "fs-extra": "^8.1.0",
     "typescript": "~3.7.4",
+    "xmldom": "^0.2.1",
     "yargs": "^15.1.0"
   },
   "jest": {

--- a/packages/jsii-rosetta/test/markdown/javadoc.test.ts
+++ b/packages/jsii-rosetta/test/markdown/javadoc.test.ts
@@ -76,6 +76,19 @@ if (x &lt; 3) {
   `);
 });
 
+test('quotes are escaped inside attributes', () => {
+  expectOutput(`
+  ['tis but a "scratch"](http://bla.ck/"kni"gh&t)
+
+  ![nay merely a "flesh wound" &cet](http://bla.ck/"kni"gh&t.jpg)
+  `, `
+<a href="http://bla.ck/%22kni%22gh&amp;t">'tis but a "scratch"</a>
+<p>
+<img alt="nay merely a &quot;flesh wound&quot; &amp;cet" src="http://bla.ck/%22kni%22gh&amp;t.jpg">
+  `);
+});
+
+
 function expectOutput(source: string, expected: string) {
   if (DEBUG) {
     // tslint:disable-next-line:no-console

--- a/packages/jsii-rosetta/test/markdown/xmldoccomments.test.ts
+++ b/packages/jsii-rosetta/test/markdown/xmldoccomments.test.ts
@@ -45,6 +45,43 @@ if (x < 3) {
   `);
 });
 
+test('quotes are escaped inside attributes', () => {
+  expectOutput(`
+  ['tis but a "scratch"](http://bla.ck/"kni"gh&t)
+
+  ![nay merely a "flesh wound" &cet](http://bla.ck/"kni"gh&t.jpg)
+  `, `
+<a href="http://bla.ck/%22kni%22gh&amp;t">'tis but a "scratch"</a>
+
+<img alt="nay merely a &quot;flesh wound&quot; &amp;cet" src="http://bla.ck/%22kni%22gh&amp;t.jpg" />
+  `);
+});
+
+
+test('convert header properly', () => {
+  expectOutput(`
+  <!--BEGIN STABILITY BANNER-->
+
+  ---
+
+  ![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)
+
+  ---
+  <!--END STABILITY BANNER-->
+  `, `
+<!--BEGIN STABILITY BANNER-->
+
+<hr />
+
+<img alt="Stability: Stable" src="https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge" />
+
+<hr />
+
+  <!--END STABILITY BANNER-->
+  `);
+});
+
+
 function expectOutput(source: string, expected: string) {
   if (DEBUG) {
     // tslint:disable-next-line:no-console

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/xmldom@^0.1.29":
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.29.tgz#c4428b0ca86d3b881475726fd94980b38a27c381"
+  integrity sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=
+
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
@@ -8527,6 +8532,11 @@ xmlbuilder@^13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
   integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
+
+xmldom@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.2.1.tgz#cac9465066f161e1c3302793ea4dbe59c518274f"
+  integrity sha512-kXXiYvmblIgEemGeB75y97FyaZavx6SQhGppLw5TKWAD2Wd0KAly0g23eVLh17YcpxZpnFym1Qk/eaRjy1APPg==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
The C# compiler will completely drop comment blocks that aren't
well-formed XML; the `<img>` tag we were outputting wasn't, and
so namespace headings weren't being generated.

At the same time, pay more attention to escaping of arbitrary
HTML and the text inside attributes to minimize the chances
of things going wrong in the future.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
