### PR TITLE
feat(superchain): upgrade maven to 3.6.3

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux:2
 
-# Install deltarpm as it can speed up the upgrade processes
-RUN yum -y install deltarpm
+# Install deltarpm as it can speed up the upgrade processes, and tar as it's needed for installing Maven
+RUN yum -y install deltarpm tar
 
 # Install .NET Core, mono & PowerShell
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true                                                                                    \
@@ -35,11 +35,31 @@ RUN amazon-linux-extras install ruby2.4                                         
 ENV BUNDLE_SILENCE_ROOT_WARNING=1                                                                                       \
 	  PATH="$GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH"
 
-  # Install JDK8 (Corretto)
-RUN amazon-linux-extras install corretto8                                                                               \
-  && yum -y install maven                                                                                               \
+# Install JDK8 (Corretto)
+RUN amazon-linux-extras enable corretto8                                                                                \
+  && yum -y install java-1.8.0-amazon-corretto-devel                                                                    \
   && yum clean all && rm -rf /var/cache/yum
+
+# Install Maven
+ENV M2_VERSION 3.6.3
+RUN curl -sL https://www.apache.org/dist/maven/maven-3/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz     \
+         -o /tmp/apache-maven.tar.gz                                                                                    \
+  && curl -sL https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.asc                \
+          -o /tmp/apache-maven.tar.gz.asc                                                                               \
+  && mkdir -p /tmp/gpg-maven && chmod go-rwx /tmp/gpg-maven                                                             \
+  && curl -sL https://www.apache.org/dist/maven/KEYS | gpg --homedir /tmp/gpg-maven --import                            \
+  && gpg --homedir /tmp/gpg-maven --verify /tmp/apache-maven.tar.gz.asc /tmp/apache-maven.tar.gz                        \
+  && mkdir -p /usr/local && (cd /usr/local && tar xzf /tmp/apache-maven.tar.gz)                                         \
+  && mv /usr/local/apache-maven-${M2_VERSION} /usr/local/apache-maven                                                   \
+  && for BIN in $(find /usr/local/apache-maven/bin -type f -executable);                                                \
+     do                                                                                                                 \
+       ln -s $BIN /usr/local/bin/$(basename $BIN);                                                                      \
+     done                                                                                                               \
+  && rm -rf /tmp/apache-maven.tar.gz /tmp/apache-maven.tar.gz.asc /tmp/gpg-maven
 COPY m2-settings.xml /root/.m2/settings.xml
+ENV M2_HOME=/usr/local/apache-maven                                                                                     \
+    M2=/usr/local/apache-maven/bin                                                                                      \
+    MAVEN_OPTS="-Xms256m -Xmx512m"
 
 # Install Docker
 RUN amazon-linux-extras install docker                                                                                  \
@@ -47,7 +67,7 @@ RUN amazon-linux-extras install docker                                          
 VOLUME /var/lib/docker
 
 # Install shared dependencies
-RUN yum -y install awscli git gzip openssl rsync tar unzip which zip                                                    \
+RUN yum -y install awscli git gzip openssl rsync unzip which zip                                                        \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install Node 8+
@@ -81,5 +101,8 @@ LABEL org.opencontainers.image.created=${BUILD_TIMESTAMP}                       
 # Upgrade all packages that weren't up-to-date just yet (last so it risks invalidating cache less)
 RUN yum -y upgrade                                                                                                      \
   && yum clean all && rm -rf /var/cache/yum
+
+# Add the source used to build this Docker image (to facilitate re-builds, forensics)
+COPY . /docker-source
 
 CMD ["/bin/bash"]

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -44,7 +44,7 @@ RUN amazon-linux-extras enable corretto8                                        
 ENV M2_VERSION 3.6.3
 RUN curl -sL https://www.apache.org/dist/maven/maven-3/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz     \
          -o /tmp/apache-maven.tar.gz                                                                                    \
-  && curl -sL https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz.asc                \
+  && curl -sL https://www.apache.org/dist/maven/maven-3/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz.asc\
           -o /tmp/apache-maven.tar.gz.asc                                                                               \
   && mkdir -p /tmp/gpg-maven && chmod go-rwx /tmp/gpg-maven                                                             \
   && curl -sL https://www.apache.org/dist/maven/KEYS | gpg --homedir /tmp/gpg-maven --import                            \

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -27,6 +27,7 @@ Tool / Utility | Version
 `docker`       | `>= 18.06.1-ce`
 `git`          | `>= 2.17.2`
 `make`         | `>= 3.82`
+`maven`        | `>= 3.6.3`
 `openssl`      | `>= 1.0.2k-fips`
 `rsync`        | `>= 3.1.2-4`
 `yarn`         | `>= 1.19.1`

--- a/superchain/build-local.sh
+++ b/superchain/build-local.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+###
+# This script can be used to build a jsii/superchain:local image from a locally
+# checked out version of the Dockerfile. It is made to build an image as similar
+# as possible to what would be built in the CI/CD infrastructure (in that it'll
+# include similar labels).
+###
+
+# Obtain the currently checked out commit ID
+COMMIT_ID=$(git rev-parse HEAD)
+
+if [[ ! -z $(git status --short) ]]; then
+  # IF there are changes or untracked file, note the tree is dirty
+  COMMIT_ID=${COMMIT_ID}+dirty
+else
+  # Otherwise, note that this was built locally
+  COMMIT_ID=${COMMIT_ID}+local
+fi
+
+# Now on to building the image
+docker build                                                                    \
+  --pull                                                                        \
+  --build-arg BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')                  \
+  --build-arg COMMIT_ID=${COMMIT_ID}                                            \
+  -t "jsii/superchain:local"                                                    \
+  .


### PR DESCRIPTION
This involves installing maven from tarball instead of installing it from
the RPM repositories provided in the AmazonLinux 2 base image. This is
somewhat unfortunate, but is (currently) the only way to get a recent build
of maven without depending on third-party repositories which would need
vetting before they can be safely used.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
