### PR TITLE
chore: add test loading current assembly

### DIFF
--- a/packages/@jsii/spec/test/previous-assemblies/0.21.2.jsii.json
+++ b/packages/@jsii/spec/test/previous-assemblies/0.21.2.jsii.json
@@ -1,0 +1,7780 @@
+{
+  "author": {
+    "name": "Amazon Web Services",
+    "organization": true,
+    "roles": [
+      "author"
+    ],
+    "url": "https://aws.amazon.com"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-applicationautoscaling": "1.22.0",
+    "@aws-cdk/aws-certificatemanager": "1.22.0",
+    "@aws-cdk/aws-ec2": "1.22.0",
+    "@aws-cdk/aws-ecs": "1.22.0",
+    "@aws-cdk/aws-elasticloadbalancingv2": "1.22.0",
+    "@aws-cdk/aws-events": "1.22.0",
+    "@aws-cdk/aws-events-targets": "1.22.0",
+    "@aws-cdk/aws-iam": "1.22.0",
+    "@aws-cdk/aws-route53": "1.22.0",
+    "@aws-cdk/aws-route53-targets": "1.22.0",
+    "@aws-cdk/aws-servicediscovery": "1.22.0",
+    "@aws-cdk/aws-sqs": "1.22.0",
+    "@aws-cdk/core": "1.22.0"
+  },
+  "dependencyClosure": {
+    "@aws-cdk/assets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.Assets",
+          "packageId": "Amazon.CDK.Assets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-assets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.assets"
+        },
+        "js": {
+          "npm": "@aws-cdk/assets"
+        },
+        "python": {
+          "distName": "aws-cdk.assets",
+          "module": "aws_cdk.assets"
+        }
+      }
+    },
+    "@aws-cdk/aws-apigateway": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.APIGateway",
+          "packageId": "Amazon.CDK.AWS.APIGateway",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "apigateway",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.apigateway"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-apigateway"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-apigateway",
+          "module": "aws_cdk.aws_apigateway"
+        }
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ApplicationAutoScaling",
+          "packageId": "Amazon.CDK.AWS.ApplicationAutoScaling",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "applicationautoscaling",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.applicationautoscaling"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-applicationautoscaling"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-applicationautoscaling",
+          "module": "aws_cdk.aws_applicationautoscaling"
+        }
+      }
+    },
+    "@aws-cdk/aws-autoscaling": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.AutoScaling",
+          "packageId": "Amazon.CDK.AWS.AutoScaling",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "autoscaling",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.autoscaling"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-autoscaling"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-autoscaling",
+          "module": "aws_cdk.aws_autoscaling"
+        }
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.AutoScaling.Common",
+          "packageId": "Amazon.CDK.AWS.AutoScaling.Common",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "autoscaling-common",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.autoscaling.common"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-autoscaling-common"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-autoscaling-common",
+          "module": "aws_cdk.aws_autoscaling_common"
+        }
+      }
+    },
+    "@aws-cdk/aws-autoscaling-hooktargets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.AutoScaling.HookTargets",
+          "packageId": "Amazon.CDK.AWS.AutoScaling.HookTargets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "autoscaling-hooktargets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.autoscaling.hooktargets"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-autoscaling-hooktargets"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-autoscaling-hooktargets",
+          "module": "aws_cdk.aws_autoscaling_hooktargets"
+        }
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CertificateManager",
+          "packageId": "Amazon.CDK.AWS.CertificateManager",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "certificatemanager",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.certificatemanager"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-certificatemanager"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-certificatemanager",
+          "module": "aws_cdk.aws_certificatemanager"
+        }
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CloudFormation",
+          "packageId": "Amazon.CDK.AWS.CloudFormation",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cloudformation",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.cloudformation"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-cloudformation"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-cloudformation",
+          "module": "aws_cdk.aws_cloudformation"
+        }
+      }
+    },
+    "@aws-cdk/aws-cloudfront": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CloudFront",
+          "packageId": "Amazon.CDK.AWS.CloudFront",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cloudfront",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.cloudfront"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-cloudfront"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-cloudfront",
+          "module": "aws_cdk.aws_cloudfront"
+        }
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CloudWatch",
+          "packageId": "Amazon.CDK.AWS.CloudWatch",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cloudwatch",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.cloudwatch"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-cloudwatch"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-cloudwatch",
+          "module": "aws_cdk.aws_cloudwatch"
+        }
+      }
+    },
+    "@aws-cdk/aws-codebuild": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CodeBuild",
+          "packageId": "Amazon.CDK.AWS.CodeBuild",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "codebuild",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.codebuild"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-codebuild"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-codebuild",
+          "module": "aws_cdk.aws_codebuild"
+        }
+      }
+    },
+    "@aws-cdk/aws-codecommit": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CodeCommit",
+          "packageId": "Amazon.CDK.AWS.CodeCommit",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "codecommit",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.codecommit"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-codecommit"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-codecommit",
+          "module": "aws_cdk.aws_codecommit"
+        }
+      }
+    },
+    "@aws-cdk/aws-codepipeline": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.CodePipeline",
+          "packageId": "Amazon.CDK.AWS.CodePipeline",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "codepipeline",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.codepipeline"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-codepipeline"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-codepipeline",
+          "module": "aws_cdk.aws_codepipeline"
+        }
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.EC2",
+          "packageId": "Amazon.CDK.AWS.EC2",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "ec2",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.ec2"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-ec2"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-ec2",
+          "module": "aws_cdk.aws_ec2"
+        }
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ECR",
+          "packageId": "Amazon.CDK.AWS.ECR",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "ecr",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.ecr"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-ecr"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-ecr",
+          "module": "aws_cdk.aws_ecr"
+        }
+      }
+    },
+    "@aws-cdk/aws-ecr-assets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Ecr.Assets",
+          "packageId": "Amazon.CDK.ECR.Assets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "ecr-assets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.ecr.assets"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-ecr-assets"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-ecr-assets",
+          "module": "aws_cdk.aws_ecr_assets"
+        }
+      }
+    },
+    "@aws-cdk/aws-ecs": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ECS",
+          "packageId": "Amazon.CDK.AWS.ECS",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "ecs",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.ecs"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-ecs"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-ecs",
+          "module": "aws_cdk.aws_ecs"
+        }
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ElasticLoadBalancing",
+          "packageId": "Amazon.CDK.AWS.ElasticLoadBalancing",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "elasticloadbalancing",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.elasticloadbalancing"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-elasticloadbalancing"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-elasticloadbalancing",
+          "module": "aws_cdk.aws_elasticloadbalancing"
+        }
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ElasticLoadBalancingV2",
+          "packageId": "Amazon.CDK.AWS.ElasticLoadBalancingV2",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "elasticloadbalancingv2",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.elasticloadbalancingv2"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-elasticloadbalancingv2"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-elasticloadbalancingv2",
+          "module": "aws_cdk.aws_elasticloadbalancingv2"
+        }
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Events",
+          "packageId": "Amazon.CDK.AWS.Events",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "events",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.events"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-events"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-events",
+          "module": "aws_cdk.aws_events"
+        }
+      }
+    },
+    "@aws-cdk/aws-events-targets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Events.Targets",
+          "packageId": "Amazon.CDK.AWS.Events.Targets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "events-targets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.events.targets"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-events-targets"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-events-targets",
+          "module": "aws_cdk.aws_events_targets"
+        }
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.IAM",
+          "packageId": "Amazon.CDK.AWS.IAM",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "iam",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.iam"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-iam"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-iam",
+          "module": "aws_cdk.aws_iam"
+        }
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.KMS",
+          "packageId": "Amazon.CDK.AWS.KMS",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "kms",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.kms"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-kms"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-kms",
+          "module": "aws_cdk.aws_kms"
+        }
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Lambda",
+          "packageId": "Amazon.CDK.AWS.Lambda",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "lambda",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.lambda"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-lambda"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-lambda",
+          "module": "aws_cdk.aws_lambda"
+        }
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Logs",
+          "packageId": "Amazon.CDK.AWS.Logs",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "logs",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.logs"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-logs"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-logs",
+          "module": "aws_cdk.aws_logs"
+        }
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Route53",
+          "packageId": "Amazon.CDK.AWS.Route53",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "route53",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.route53"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-route53"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-route53",
+          "module": "aws_cdk.aws_route53"
+        }
+      }
+    },
+    "@aws-cdk/aws-route53-targets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.Route53.Targets",
+          "packageId": "Amazon.CDK.AWS.Route53.Targets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "route53-targets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.route53.targets"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-route53-targets"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-route53-targets",
+          "module": "aws_cdk.aws_route53_targets"
+        }
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.S3",
+          "packageId": "Amazon.CDK.AWS.S3",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "s3",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.s3"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-s3"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-s3",
+          "module": "aws_cdk.aws_s3"
+        }
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.S3.Assets",
+          "packageId": "Amazon.CDK.AWS.S3.Assets",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "s3-assets",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.s3.assets"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-s3-assets"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-s3-assets",
+          "module": "aws_cdk.aws_s3_assets"
+        }
+      }
+    },
+    "@aws-cdk/aws-sam": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SAM",
+          "packageId": "Amazon.CDK.AWS.SAM",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "sam",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.sam"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-sam"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-sam",
+          "module": "aws_cdk.aws_sam"
+        }
+      }
+    },
+    "@aws-cdk/aws-secretsmanager": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SecretsManager",
+          "packageId": "Amazon.CDK.AWS.SecretsManager",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "secretsmanager",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.secretsmanager"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-secretsmanager"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-secretsmanager",
+          "module": "aws_cdk.aws_secretsmanager"
+        }
+      }
+    },
+    "@aws-cdk/aws-servicediscovery": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.ServiceDiscovery",
+          "packageId": "Amazon.CDK.AWS.ServiceDiscovery",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "servicediscovery",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.servicediscovery"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-servicediscovery"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-servicediscovery",
+          "module": "aws_cdk.aws_servicediscovery"
+        }
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SNS",
+          "packageId": "Amazon.CDK.AWS.SNS",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "sns",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.sns"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-sns"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-sns",
+          "module": "aws_cdk.aws_sns"
+        }
+      }
+    },
+    "@aws-cdk/aws-sns-subscriptions": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SNS.Subscriptions",
+          "packageId": "Amazon.CDK.AWS.SNS.Subscriptions",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "sns-subscriptions",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.sns.subscriptions"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-sns-subscriptions"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-sns-subscriptions",
+          "module": "aws_cdk.aws_sns_subscriptions"
+        }
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SQS",
+          "packageId": "Amazon.CDK.AWS.SQS",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "sqs",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.sqs"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-sqs"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-sqs",
+          "module": "aws_cdk.aws_sqs"
+        }
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.SSM",
+          "packageId": "Amazon.CDK.AWS.SSM",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "ssm",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.ssm"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-ssm"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-ssm",
+          "module": "aws_cdk.aws_ssm"
+        }
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.AWS.StepFunctions",
+          "packageId": "Amazon.CDK.AWS.StepFunctions",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "stepfunctions",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.services.stepfunctions"
+        },
+        "js": {
+          "npm": "@aws-cdk/aws-stepfunctions"
+        },
+        "python": {
+          "distName": "aws-cdk.aws-stepfunctions",
+          "module": "aws_cdk.aws_stepfunctions"
+        }
+      }
+    },
+    "@aws-cdk/core": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK",
+          "packageId": "Amazon.CDK",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "core",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.core"
+        },
+        "js": {
+          "npm": "@aws-cdk/core"
+        },
+        "python": {
+          "distName": "aws-cdk.core",
+          "module": "aws_cdk.core"
+        }
+      }
+    },
+    "@aws-cdk/cx-api": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.CXAPI",
+          "packageId": "Amazon.CDK.CXAPI",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-cx-api",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.cxapi"
+        },
+        "js": {
+          "npm": "@aws-cdk/cx-api"
+        },
+        "python": {
+          "distName": "aws-cdk.cx-api",
+          "module": "aws_cdk.cx_api"
+        }
+      }
+    },
+    "@aws-cdk/region-info": {
+      "targets": {
+        "dotnet": {
+          "assemblyOriginatorKeyFile": "../../key.snk",
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK.RegionInfo",
+          "packageId": "Amazon.CDK.RegionInfo",
+          "signAssembly": true
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-region-info",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.regioninfo"
+        },
+        "js": {
+          "npm": "@aws-cdk/region-info"
+        },
+        "python": {
+          "distName": "aws-cdk.region-info",
+          "module": "aws_cdk.region_info"
+        }
+      }
+    }
+  },
+  "description": "CDK Constructs for AWS ECS",
+  "docs": {
+    "stability": "stable"
+  },
+  "homepage": "https://github.com/aws/aws-cdk",
+  "jsiiVersion": "0.21.2 (build 4370756)",
+  "keywords": [
+    "aws",
+    "cdk",
+    "constructs",
+    "ecs",
+    "ecs-patterns"
+  ],
+  "license": "Apache-2.0",
+  "name": "@aws-cdk/aws-ecs-patterns",
+  "readme": {
+    "markdown": "# CDK Construct library for higher-level ECS Constructs\n<!--BEGIN STABILITY BANNER-->\n\n---\n\n![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)\n\n\n---\n<!--END STABILITY BANNER-->\n\nThis library provides higher-level Amazon ECS constructs which follow common architectural patterns. It contains:\n\n* Application Load Balanced Services\n* Network Load Balanced Services\n* Queue Processing Services\n* Scheduled Tasks (cron jobs)\n* Additional Examples\n\n## Application Load Balanced Services\n\nTo define an Amazon ECS service that is behind an application load balancer, instantiate one of the following:\n\n* `ApplicationLoadBalancedEc2Service`\n\n```ts\nconst loadBalancedEcsService = new ecsPatterns.ApplicationLoadBalancedEc2Service(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry('test'),\n    environment: {\n      TEST_ENVIRONMENT_VARIABLE1: \"test environment variable 1 value\",\n      TEST_ENVIRONMENT_VARIABLE2: \"test environment variable 2 value\"\n    },\n  },\n  desiredCount: 2,\n});\n```\n\n* `ApplicationLoadBalancedFargateService`\n\n```ts\nconst loadBalancedFargateService = new ecsPatterns.ApplicationLoadBalancedFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  cpu: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n});\n```\n\nInstead of providing a cluster you can specify a VPC and CDK will create a new ECS cluster.\nIf you deploy multiple services CDK will only create one cluster per VPC.\n\nYou can omit `cluster` and `vpc` to let CDK create a new VPC with two AZs and create a cluster inside this VPC.\n\nAdditionally, if more than one application target group are needed, instantiate one of the following:\n\n* `ApplicationMultipleTargetGroupsEc2Service`\n\n```ts\n// One application load balancer with one listener and two target groups.\nconst loadBalancedEc2Service = new ApplicationMultipleTargetGroupsEc2Service(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 256,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n  targetGroups: [\n    {\n      containerPort: 80,\n    },\n    {\n      containerPort: 90,\n      pathPattern: 'a/b/c',\n      priority: 10\n    }\n  ]\n});\n```\n\n* `ApplicationMultipleTargetGroupsFargateService`\n\n```ts\n// One application load balancer with one listener and two target groups.\nconst loadBalancedFargateService = new ApplicationMultipleTargetGroupsFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  cpu: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n  targetGroups: [\n    {\n      containerPort: 80,\n    },\n    {\n      containerPort: 90,\n      pathPattern: 'a/b/c',\n      priority: 10\n    }\n  ]\n});\n```\n\n## Network Load Balanced Services\n\nTo define an Amazon ECS service that is behind a network load balancer, instantiate one of the following:\n\n* `NetworkLoadBalancedEc2Service`\n\n```ts\nconst loadBalancedEcsService = new ecsPatterns.NetworkLoadBalancedEc2Service(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry('test'),\n    environment: {\n      TEST_ENVIRONMENT_VARIABLE1: \"test environment variable 1 value\",\n      TEST_ENVIRONMENT_VARIABLE2: \"test environment variable 2 value\"\n    },\n  },\n  desiredCount: 2,\n});\n```\n\n* `NetworkLoadBalancedFargateService`\n\n```ts\nconst loadBalancedFargateService = new ecsPatterns.NetworkLoadBalancedFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  cpu: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n});\n```\n\nThe CDK will create a new Amazon ECS cluster if you specify a VPC and omit `cluster`. If you deploy multiple services the CDK will only create one cluster per VPC.\n\nIf `cluster` and `vpc` are omitted, the CDK creates a new VPC with subnets in two Availability Zones and a cluster within this VPC.\n\nAdditionally, if more than one network target group is needed, instantiate one of the following:\n\n* NetworkMultipleTargetGroupsEc2Service\n\n```ts\n// Two network load balancers, each with their own listener and target group.\nconst loadBalancedEc2Service = new NetworkMultipleTargetGroupsEc2Service(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 256,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n  loadBalancers: [\n    {\n      name: 'lb1',\n      listeners: [\n        {\n          name: 'listener1'\n        }\n      ]\n    },\n    {\n      name: 'lb2',\n      listeners: [\n        {\n          name: 'listener2'\n        }\n      ]\n    }\n  ],\n  targetGroups: [\n    {\n      containerPort: 80,\n      listener: 'listener1'\n    },\n    {\n      containerPort: 90,\n      listener: 'listener2'\n    }\n  ]\n});\n```\n\n* NetworkMultipleTargetGroupsFargateService\n\n```ts\n// Two network load balancers, each with their own listener and target group.\nconst loadBalancedFargateService = new NetworkMultipleTargetGroupsFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n  loadBalancers: [\n    {\n      name: 'lb1',\n      listeners: [\n        {\n          name: 'listener1'\n        }\n      ]\n    },\n    {\n      name: 'lb2',\n      listeners: [\n        {\n          name: 'listener2'\n        }\n      ]\n    }\n  ],\n  targetGroups: [\n    {\n      containerPort: 80,\n      listener: 'listener1'\n    },\n    {\n      containerPort: 90,\n      listener: 'listener2'\n    }\n  ]\n});\n```\n\n## Queue Processing Services\n\nTo define a service that creates a queue and reads from that queue, instantiate one of the following:\n\n* `QueueProcessingEc2Service`\n\n```ts\nconst queueProcessingEc2Service = new QueueProcessingEc2Service(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  image: ecs.ContainerImage.fromRegistry('test'),\n  command: [\"-c\", \"4\", \"amazon.com\"],\n  enableLogging: false,\n  desiredTaskCount: 2,\n  environment: {\n    TEST_ENVIRONMENT_VARIABLE1: \"test environment variable 1 value\",\n    TEST_ENVIRONMENT_VARIABLE2: \"test environment variable 2 value\"\n  },\n  queue,\n  maxScalingCapacity: 5\n});\n```\n\n* `QueueProcessingFargateService`\n\n```ts\nconst queueProcessingFargateService = new QueueProcessingFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 512,\n  image: ecs.ContainerImage.fromRegistry('test'),\n  command: [\"-c\", \"4\", \"amazon.com\"],\n  enableLogging: false,\n  desiredTaskCount: 2,\n  environment: {\n    TEST_ENVIRONMENT_VARIABLE1: \"test environment variable 1 value\",\n    TEST_ENVIRONMENT_VARIABLE2: \"test environment variable 2 value\"\n  },\n  queue,\n  maxScalingCapacity: 5\n});\n```\n\n## Scheduled Tasks\n\nTo define a task that runs periodically, instantiate an `ScheduledEc2Task`:\n\n```ts\n// Instantiate an Amazon EC2 Task to run at a scheduled interval\nconst ecsScheduledTask = new ScheduledEc2Task(stack, 'ScheduledTask', {\n  cluster,\n  scheduledEc2TaskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),\n    memoryLimitMiB: 256,\n    environment: { name: 'TRIGGER', value: 'CloudWatch Events' },\n  },\n  schedule: events.Schedule.expression('rate(1 minute)')\n});\n```\n\n## Additional Examples\n\nIn addition to using the constructs, users can also add logic to customize these constructs:\n\n### Add Schedule-Based Auto-Scaling to an ApplicationLoadBalancedFargateService\n\n```ts\nimport { Schedule } from '@aws-cdk/aws-applicationautoscaling';\nimport { ApplicationLoadBalancedFargateService, ApplicationLoadBalancedFargateServiceProps } from './application-load-balanced-fargate-service';\n\nconst loadBalancedFargateService = new ApplicationLoadBalancedFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  desiredCount: 1,\n  cpu: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n});\n\nconst scalableTarget = loadBalancedFargateService.service.autoScaleTaskCount({\n  minCapacity: 5,\n  maxCapacity: 20,\n});\n\nscalableTarget.scaleOnSchedule('DaytimeScaleDown', {\n  schedule: Schedule.cron({ hour: '8', minute: '0'}),\n  minCapacity: 1,\n});\n\nscalableTarget.scaleOnSchedule('EveningRushScaleUp', {\n  schedule: Schedule.cron({ hour: '20', minute: '0'}),\n  minCapacity: 10,\n});\n```\n\n### Add Metric-Based Auto-Scaling to an ApplicationLoadBalancedFargateService\n\n```ts\nimport { ApplicationLoadBalancedFargateService } from './application-load-balanced-fargate-service';\n\nconst loadBalancedFargateService = new ApplicationLoadBalancedFargateService(stack, 'Service', {\n  cluster,\n  memoryLimitMiB: 1024,\n  desiredCount: 1,\n  cpu: 512,\n  taskImageOptions: {\n    image: ecs.ContainerImage.fromRegistry(\"amazon/amazon-ecs-sample\"),\n  },\n});\n\nconst scalableTarget = loadBalancedFargateService.service.autoScaleTaskCount({\n  minCapacity: 1,\n  maxCapacity: 20,\n});\n\nscalableTarget.scaleOnCpuUtilization('CpuScaling', {\n  targetUtilizationPercent: 50,\n});\n\nscalableTarget.scaleOnMemoryUtilization('MemoryScaling', {\n  targetUtilizationPercent: 50,\n});\n```"
+  },
+  "repository": {
+    "directory": "packages/@aws-cdk/aws-ecs-patterns",
+    "type": "git",
+    "url": "https://github.com/aws/aws-cdk.git"
+  },
+  "schema": "jsii/0.10.0",
+  "targets": {
+    "dotnet": {
+      "assemblyOriginatorKeyFile": "../../key.snk",
+      "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/master/logo/default-256-dark.png",
+      "namespace": "Amazon.CDK.AWS.ECS.Patterns",
+      "packageId": "Amazon.CDK.AWS.ECS.Patterns",
+      "signAssembly": true
+    },
+    "java": {
+      "maven": {
+        "artifactId": "ecs-patterns",
+        "groupId": "software.amazon.awscdk"
+      },
+      "package": "software.amazon.awscdk.services.ecs.patterns"
+    },
+    "js": {
+      "npm": "@aws-cdk/aws-ecs-patterns"
+    },
+    "python": {
+      "distName": "aws-cdk.aws-ecs-patterns",
+      "module": "aws_cdk.aws_ecs_patterns"
+    }
+  },
+  "types": {
+    "@aws-cdk/aws-ecs-patterns.ApplicationListenerProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define an application listener."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationListenerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 286
+      },
+      "name": "ApplicationListenerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Name of the listener."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 290
+          },
+          "name": "name",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No certificate associated with the load balancer, if using\nthe HTTP protocol. For HTTPS, a DNS-validated certificate will be\ncreated for the load balancer's specified domain name.",
+            "remarks": "Setting this option will set the load balancer protocol to HTTPS.",
+            "stability": "stable",
+            "summary": "Certificate Manager certificate to associate with the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 318
+          },
+          "name": "certificate",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-certificatemanager.ICertificate"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Determined from protocol if known.",
+            "stability": "stable",
+            "summary": "The port on which the listener listens for requests."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 308
+          },
+          "name": "port",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "ApplicationProtocol.HTTP. If a certificate is specified, the protocol will be\nset by default to ApplicationProtocol.HTTPS.",
+            "remarks": "The load balancer port is determined from the protocol (port 80 for\nHTTP, port 443 for HTTPS).  A domain name and zone must be also be\nspecified if using HTTPS.",
+            "stability": "stable",
+            "summary": "The protocol for connections from clients to the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 301
+          },
+          "name": "protocol",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationProtocol"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedEc2Service": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "An EC2 service running on an ECS cluster fronted by an application load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedEc2Service",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationLoadBalancedEc2Service class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedEc2ServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+        "line": 70
+      },
+      "name": "ApplicationLoadBalancedEc2Service",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 75
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2Service"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 Task Definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 79
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedEc2ServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ApplicationLoadBalancedEc2Service service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedEc2ServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+        "line": 8
+      },
+      "name": "ApplicationLoadBalancedEc2ServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 38
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The hard limit (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 50
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under contention, Docker attempts to keep the\ncontainer memory within the limit. If the container requires more memory,\nit can consume up to the value specified by the Memory property or all of\nthe available memory on the container instance—whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 64
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. TaskDefinition or TaskImageOptions must be specified, but not both.."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-load-balanced-ecs-service.ts",
+            "line": 17
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedFargateService": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A Fargate service running on an ECS cluster fronted by an application load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedFargateService",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationLoadBalancedFargateService class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedFargateServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+        "line": 72
+      },
+      "name": "ApplicationLoadBalancedFargateService",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 77
+          },
+          "name": "assignPublicIp",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 82
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateService"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 86
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedFargateServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ApplicationLoadBalancedFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedFargateServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+        "line": 8
+      },
+      "name": "ApplicationLoadBalancedFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 66
+          },
+          "name": "assignPublicIp",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 37
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25 vCPU)\n\n1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values: 512 (.5 vCPU)\n\n2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)\n\nBetween 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) - Available cpu values: 2048 (2 vCPU)\n\nBetween 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 59
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. TaskDefinition or TaskImageOptions must be specified, but not both."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-load-balanced-fargate-service.ts",
+            "line": 16
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for ApplicationLoadBalancedEc2Service and ApplicationLoadBalancedFargateService services."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationLoadBalancedServiceBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/application-load-balanced-service-base.ts",
+        "line": 245
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Adds service as a target of the target group."
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 368
+          },
+          "name": "addServiceAsTarget",
+          "parameters": [
+            {
+              "name": "service",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.BaseService"
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 372
+          },
+          "name": "createAWSLogDriver",
+          "parameters": [
+            {
+              "name": "prefix",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.AwsLogDriver"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 358
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        }
+      ],
+      "name": "ApplicationLoadBalancedServiceBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 275
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 250
+          },
+          "name": "desiredCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The listener for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 260
+          },
+          "name": "listener",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationListener"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Application Load Balancer for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 255
+          },
+          "name": "loadBalancer",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationLoadBalancer"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 265
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationTargetGroup"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Certificate Manager certificate to associate with the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 270
+          },
+          "name": "certificate",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-certificatemanager.ICertificate"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base ApplicationLoadBalancedEc2Service or ApplicationLoadBalancedFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedServiceBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-load-balanced-service-base.ts",
+        "line": 13
+      },
+      "name": "ApplicationLoadBalancedServiceBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No certificate associated with the load balancer, if using\nthe HTTP protocol. For HTTPS, a DNS-validated certificate will be\ncreated for the load balancer's specified domain name.",
+            "remarks": "Setting this option will set the load balancer protocol to HTTPS.",
+            "stability": "stable",
+            "summary": "Certificate Manager certificate to associate with the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 60
+          },
+          "name": "certificate",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-certificatemanager.ICertificate"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AWS Cloud Map service discovery is not enabled.",
+            "stability": "stable",
+            "summary": "The options for configuring an Amazon ECS service to use service discovery."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 158
+          },
+          "name": "cloudMapOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.CloudMapOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 20
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "remarks": "The minimum value is 1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 50
+          },
+          "name": "desiredCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No domain name.",
+            "stability": "stable",
+            "summary": "The domain name for the service, e.g. \"api.example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 78
+          },
+          "name": "domainName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No Route53 hosted domain zone.",
+            "stability": "stable",
+            "summary": "The Route53 hosted zone for the domain, e.g. \"example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 85
+          },
+          "name": "domainZone",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-route53.IHostedZone"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "remarks": "For more information, see\n[Tagging Your Amazon ECS Resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)",
+            "stability": "stable",
+            "summary": "Specifies whether to enable Amazon ECS managed tags for the tasks within the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 151
+          },
+          "name": "enableECSManagedTags",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- defaults to 60 seconds if at least one load balancer is in-use and it is not already set",
+            "stability": "stable",
+            "summary": "The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 100
+          },
+          "name": "healthCheckGracePeriod",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/core.Duration"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- The default listener port is determined from the protocol (port 80 for HTTP,\nport 443 for HTTPS). A domain name and zone must be also be specified if using HTTPS.",
+            "stability": "stable",
+            "summary": "Listener port of the application load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 135
+          },
+          "name": "listenerPort",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- a new load balancer will be created.",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The application load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 127
+          },
+          "name": "loadBalancer",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationLoadBalancer"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- 100 if daemon, otherwise 200",
+            "stability": "stable",
+            "summary": "The maximum number of tasks, specified as a percentage of the Amazon ECS service's DesiredCount value, that can run in a service during a deployment."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 109
+          },
+          "name": "maxHealthyPercent",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- 0 if daemon, otherwise 50",
+            "stability": "stable",
+            "summary": "The minimum number of tasks, specified as a percentage of the Amazon ECS service's DesiredCount value, that must continue to run and remain healthy during a deployment."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 118
+          },
+          "name": "minHealthyPercent",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Tags can only be propagated to the tasks within the service during service creation.",
+            "stability": "stable",
+            "summary": "Specifies whether to propagate the tags from the task definition or the service to the tasks in the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 143
+          },
+          "name": "propagateTags",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.PropagatedTagSource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "HTTP. If a certificate is specified, the protocol will be\nset by default to HTTPS.",
+            "remarks": "The load balancer port is determined from the protocol (port 80 for\nHTTP, port 443 for HTTPS).  A domain name and zone must be also be\nspecified if using HTTPS.",
+            "stability": "stable",
+            "summary": "The protocol for connections from clients to the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 71
+          },
+          "name": "protocol",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationProtocol"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Determines whether the Load Balancer will be internet-facing."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 42
+          },
+          "name": "publicLoadBalancer",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CloudFormation-generated name.",
+            "stability": "stable",
+            "summary": "The name of the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 92
+          },
+          "name": "serviceName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "TaskDefinition or TaskImageOptions must be specified, but not both.",
+            "stability": "stable",
+            "summary": "The properties required to create a new task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 35
+          },
+          "name": "taskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 28
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageOptions",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-load-balanced-service-base.ts",
+        "line": 161
+      },
+      "name": "ApplicationLoadBalancedTaskImageOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Image or taskDefinition must be specified, not both.",
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 167
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "stability": "stable",
+            "summary": "The container name value to be specified in the task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 216
+          },
+          "name": "containerName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "80",
+            "remarks": "If you are using containers in a task with the awsvpc or host network mode, exposed ports should be specified using containerPort.\nIf you are using containers in a task with the bridge network mode and you specify a container port and not a host port,\nyour container automatically receives a host port in the ephemeral port range.\n\nPort mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance.\n\nFor more information, see\n[hostPort](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html#ECS-Type-PortMapping-hostPort).",
+            "stability": "stable",
+            "summary": "The port number on the container that is bound to the user-specified or automatically assigned host port."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 232
+          },
+          "name": "containerPort",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Flag to indicate whether to enable logging."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 188
+          },
+          "name": "enableLogging",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No environment variables.",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 174
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No value",
+            "stability": "stable",
+            "summary": "The name of the task execution IAM role that grants the Amazon ECS container agent permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 202
+          },
+          "name": "executionRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Automatically generated name.",
+            "remarks": "A family groups multiple versions of a task definition.",
+            "stability": "stable",
+            "summary": "The name of a family that this task definition is registered to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 239
+          },
+          "name": "family",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 195
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secret to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 181
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- A task role is automatically created for you.",
+            "stability": "stable",
+            "summary": "The name of the task IAM role that grants containers in the task permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-load-balanced-service-base.ts",
+            "line": 209
+          },
+          "name": "taskRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Options for configuring a new container."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 103
+      },
+      "name": "ApplicationLoadBalancedTaskImageProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Image or taskDefinition must be specified, not both.",
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 109
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- web",
+            "stability": "stable",
+            "summary": "The container name value to be specified in the task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 158
+          },
+          "name": "containerName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- [80]",
+            "remarks": "If you are using containers in a task with the awsvpc or host network mode, exposed ports should be specified using containerPort.\nIf you are using containers in a task with the bridge network mode and you specify a container port and not a host port,\nyour container automatically receives a host port in the ephemeral port range.\n\nPort mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance.\n\nFor more information, see\n[hostPort](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html#ECS-Type-PortMapping-hostPort).",
+            "stability": "stable",
+            "summary": "A list of port numbers on the container that is bound to the user-specified or automatically assigned host port."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 174
+          },
+          "name": "containerPorts",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "number"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Flag to indicate whether to enable logging."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 130
+          },
+          "name": "enableLogging",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No environment variables.",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 116
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No value",
+            "stability": "stable",
+            "summary": "The name of the task execution IAM role that grants the Amazon ECS container agent permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 144
+          },
+          "name": "executionRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Automatically generated name.",
+            "remarks": "A family groups multiple versions of a task definition.",
+            "stability": "stable",
+            "summary": "The name of a family that this task definition is registered to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 181
+          },
+          "name": "family",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 137
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secrets to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 123
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- A task role is automatically created for you.",
+            "stability": "stable",
+            "summary": "The name of the task IAM role that grants containers in the task permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 151
+          },
+          "name": "taskRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancerProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define an application load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 250
+      },
+      "name": "ApplicationLoadBalancerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Listeners (at least one listener) attached to this load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 259
+          },
+          "name": "listeners",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationListenerProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Name of the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 254
+          },
+          "name": "name",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No domain name.",
+            "stability": "stable",
+            "summary": "The domain name for the service, e.g. \"api.example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 273
+          },
+          "name": "domainName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No Route53 hosted domain zone.",
+            "stability": "stable",
+            "summary": "The Route53 hosted zone for the domain, e.g. \"example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 280
+          },
+          "name": "domainZone",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-route53.IHostedZone"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Determines whether the Load Balancer will be internet-facing."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 266
+          },
+          "name": "publicLoadBalancer",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsEc2Service": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "An EC2 service running on an ECS cluster fronted by an application load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsEc2Service",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationMultipleTargetGroupsEc2Service class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsEc2ServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+        "line": 63
+      },
+      "name": "ApplicationMultipleTargetGroupsEc2Service",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 68
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2Service"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 76
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationTargetGroup"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 Task Definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 72
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsEc2ServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ApplicationMultipleTargetGroupsEc2Service service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsEc2ServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+        "line": 10
+      },
+      "name": "ApplicationMultipleTargetGroupsEc2ServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No minimum CPU units reserved.",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:",
+            "stability": "stable",
+            "summary": "The minimum number of CPU units to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 28
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 40
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under heavy contention, Docker attempts to keep the\ncontainer memory to this soft limit. However, your container can consume more\nmemory when it needs to, up to either the hard limit specified with the memory\nparameter (if applicable), or all of the available memory on the container\ninstance, whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.\n\nNote that this setting will be ignored if TaskImagesOptions is specified",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 57
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. Only one of TaskDefinition or TaskImageOptions must be specified."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/application-multiple-target-groups-ecs-service.ts",
+            "line": 19
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsFargateService": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A Fargate service running on an ECS cluster fronted by an application load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsFargateService",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationMultipleTargetGroupsFargateService class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsFargateServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+        "line": 75
+      },
+      "name": "ApplicationMultipleTargetGroupsFargateService",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 80
+          },
+          "name": "assignPublicIp",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 85
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateService"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 95
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationTargetGroup"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 90
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsFargateServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ApplicationMultipleTargetGroupsFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsFargateServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+        "line": 10
+      },
+      "name": "ApplicationMultipleTargetGroupsFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 69
+          },
+          "name": "assignPublicIp",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 40
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25 vCPU)\n\n1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values: 512 (.5 vCPU)\n\n2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)\n\nBetween 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) - Available cpu values: 2048 (2 vCPU)\n\nBetween 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 62
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. Only one of TaskDefinition or TaskImageOptions must be specified."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/application-multiple-target-groups-fargate-service.ts",
+            "line": 19
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for ApplicationMultipleTargetGroupsEc2Service and ApplicationMultipleTargetGroupsFargateService classes."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ApplicationMultipleTargetGroupsServiceBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 324
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 459
+          },
+          "name": "addPortMappingForTargets",
+          "parameters": [
+            {
+              "name": "container",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.ContainerDefinition"
+              }
+            },
+            {
+              "name": "targets",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationTargetProps"
+                  },
+                  "kind": "array"
+                }
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 420
+          },
+          "name": "createAWSLogDriver",
+          "parameters": [
+            {
+              "name": "prefix",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.AwsLogDriver"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 424
+          },
+          "name": "findListener",
+          "parameters": [
+            {
+              "name": "name",
+              "optional": true,
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationListener"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 413
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 436
+          },
+          "name": "registerECSTargets",
+          "parameters": [
+            {
+              "name": "service",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.BaseService"
+              }
+            },
+            {
+              "name": "container",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.ContainerDefinition"
+              }
+            },
+            {
+              "name": "targets",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationTargetProps"
+                  },
+                  "kind": "array"
+                }
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationTargetGroup"
+            }
+          }
+        }
+      ],
+      "name": "ApplicationMultipleTargetGroupsServiceBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 344
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 329
+          },
+          "name": "desiredCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default listener for the service (first added listener)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 339
+          },
+          "name": "listener",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationListener"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default Application Load Balancer for the service (first added load balancer)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 334
+          },
+          "name": "loadBalancer",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationLoadBalancer"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 347
+          },
+          "name": "listeners",
+          "protected": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationListener"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 348
+          },
+          "name": "targetGroups",
+          "protected": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-elasticloadbalancingv2.ApplicationTargetGroup"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 346
+          },
+          "name": "logDriver",
+          "optional": true,
+          "protected": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base ApplicationMultipleTargetGroupsEc2Service or ApplicationMultipleTargetGroupsFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationMultipleTargetGroupsServiceBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 14
+      },
+      "name": "ApplicationMultipleTargetGroupsServiceBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AWS Cloud Map service discovery is not enabled.",
+            "stability": "stable",
+            "summary": "The options for configuring an Amazon ECS service to use service discovery."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 90
+          },
+          "name": "cloudMapOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.CloudMapOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 22
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 45
+          },
+          "name": "desiredCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "remarks": "For more information, see\n[Tagging Your Amazon ECS Resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)",
+            "stability": "stable",
+            "summary": "Specifies whether to enable Amazon ECS managed tags for the tasks within the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 83
+          },
+          "name": "enableECSManagedTags",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- defaults to 60 seconds if at least one load balancer is in-use and it is not already set",
+            "stability": "stable",
+            "summary": "The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 53
+          },
+          "name": "healthCheckGracePeriod",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/core.Duration"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- a new load balancer with a listener will be created.",
+            "stability": "stable",
+            "summary": "The application load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 67
+          },
+          "name": "loadBalancers",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancerProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Tags can only be propagated to the tasks within the service during service creation.",
+            "stability": "stable",
+            "summary": "Specifies whether to propagate the tags from the task definition or the service to the tasks in the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 75
+          },
+          "name": "propagateTags",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.PropagatedTagSource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CloudFormation-generated name.",
+            "stability": "stable",
+            "summary": "The name of the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 60
+          },
+          "name": "serviceName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- default portMapping registered as target group and attached to the first defined listener",
+            "stability": "stable",
+            "summary": "Properties to specify ALB target groups."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 97
+          },
+          "name": "targetGroups",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationTargetProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "Only one of TaskDefinition or TaskImageOptions must be specified.",
+            "stability": "stable",
+            "summary": "The properties required to create a new task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 38
+          },
+          "name": "taskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationLoadBalancedTaskImageProps"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 31
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ApplicationTargetProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define an application target group."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ApplicationTargetProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+        "line": 187
+      },
+      "name": "ApplicationTargetProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "remarks": "Only applicable when using application/network load balancers.",
+            "stability": "stable",
+            "summary": "The port number of the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 191
+          },
+          "name": "containerPort",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "No host condition",
+            "remarks": "May contain up to three '*' wildcards.\n\nRequires that priority is set.",
+            "see": "https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#host-conditions",
+            "stability": "stable",
+            "summary": "Rule applies if the requested host matches the indicated host."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 231
+          },
+          "name": "hostHeader",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- default listener (first added listener)",
+            "stability": "stable",
+            "summary": "Name of the listener the target group attached to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 205
+          },
+          "name": "listener",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "No path condition",
+            "remarks": "May contain up to three '*' wildcards.\n\nRequires that priority is set.",
+            "see": "https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#path-conditions",
+            "stability": "stable",
+            "summary": "Rule applies if the requested path matches the given path pattern."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 244
+          },
+          "name": "pathPattern",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "Target groups are used as defaults",
+            "remarks": "The rule with the lowest priority will be used for every request.\nIf priority is not given, these target groups will be added as\ndefaults, and must not have conditions.\n\nPriorities must be unique.",
+            "stability": "stable",
+            "summary": "Priority of this target group."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 218
+          },
+          "name": "priority",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "ecs.Protocol.TCP",
+            "remarks": "Only applicable when using application load balancers.",
+            "stability": "stable",
+            "summary": "The protocol used for the port mapping."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/application-multiple-target-groups-service-base.ts",
+            "line": 198
+          },
+          "name": "protocol",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Protocol"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkListenerProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define an network listener."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkListenerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 223
+      },
+      "name": "NetworkListenerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Name of the listener."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 227
+          },
+          "name": "name",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "80",
+            "stability": "stable",
+            "summary": "The port on which the listener listens for requests."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 234
+          },
+          "name": "port",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedEc2Service": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "An EC2 service running on an ECS cluster fronted by a network load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedEc2Service",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkLoadBalancedEc2Service class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedEc2ServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+        "line": 68
+      },
+      "name": "NetworkLoadBalancedEc2Service",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The ECS service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 73
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2Service"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 Task Definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 77
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedEc2ServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the NetworkLoadBalancedEc2Service service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedEc2ServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+        "line": 8
+      },
+      "name": "NetworkLoadBalancedEc2ServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 37
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The hard limit (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 48
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under contention, Docker attempts to keep the\ncontainer memory within the limit. If the container requires more memory,\nit can consume up to the value specified by the Memory property or all of\nthe available memory on the container instance—whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 62
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. TaskDefinition or TaskImageOptions must be specified, but not both.."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-load-balanced-ecs-service.ts",
+            "line": 16
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedFargateService": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A Fargate service running on an ECS cluster fronted by a network load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedFargateService",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkLoadBalancedFargateService class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedFargateServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+        "line": 72
+      },
+      "name": "NetworkLoadBalancedFargateService",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 74
+          },
+          "name": "assignPublicIp",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 78
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateService"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 82
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedFargateServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the NetworkLoadBalancedFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedFargateServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+        "line": 8
+      },
+      "name": "NetworkLoadBalancedFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 66
+          },
+          "name": "assignPublicIp",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 37
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25 vCPU)\n\n1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values: 512 (.5 vCPU)\n\n2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)\n\nBetween 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) - Available cpu values: 2048 (2 vCPU)\n\nBetween 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 59
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. TaskDefinition or TaskImageOptions must be specified, but not both."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-load-balanced-fargate-service.ts",
+            "line": 16
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for NetworkLoadBalancedEc2Service and NetworkLoadBalancedFargateService services."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkLoadBalancedServiceBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/network-load-balanced-service-base.ts",
+        "line": 222
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Adds service as a target of the target group."
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 310
+          },
+          "name": "addServiceAsTarget",
+          "parameters": [
+            {
+              "name": "service",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.BaseService"
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 314
+          },
+          "name": "createAWSLogDriver",
+          "parameters": [
+            {
+              "name": "prefix",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.AwsLogDriver"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 300
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        }
+      ],
+      "name": "NetworkLoadBalancedServiceBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 246
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 226
+          },
+          "name": "desiredCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The listener for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 236
+          },
+          "name": "listener",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkListener"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Network Load Balancer for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 231
+          },
+          "name": "loadBalancer",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkLoadBalancer"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 241
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkTargetGroup"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base NetworkLoadBalancedEc2Service or NetworkLoadBalancedFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedServiceBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-load-balanced-service-base.ts",
+        "line": 12
+      },
+      "name": "NetworkLoadBalancedServiceBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AWS Cloud Map service discovery is not enabled.",
+            "stability": "stable",
+            "summary": "The options for configuring an Amazon ECS service to use service discovery."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 135
+          },
+          "name": "cloudMapOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.CloudMapOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 19
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "remarks": "The minimum value is 1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 49
+          },
+          "name": "desiredCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No domain name.",
+            "stability": "stable",
+            "summary": "The domain name for the service, e.g. \"api.example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 56
+          },
+          "name": "domainName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No Route53 hosted domain zone.",
+            "stability": "stable",
+            "summary": "The Route53 hosted zone for the domain, e.g. \"example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 63
+          },
+          "name": "domainZone",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-route53.IHostedZone"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "remarks": "For more information, see\n[Tagging Your Amazon ECS Resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)",
+            "stability": "stable",
+            "summary": "Specifies whether to enable Amazon ECS managed tags for the tasks within the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 128
+          },
+          "name": "enableECSManagedTags",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- defaults to 60 seconds if at least one load balancer is in-use and it is not already set",
+            "stability": "stable",
+            "summary": "The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 78
+          },
+          "name": "healthCheckGracePeriod",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/core.Duration"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "80",
+            "stability": "stable",
+            "summary": "Listener port of the network load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 112
+          },
+          "name": "listenerPort",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- a new load balancer will be created.",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The network load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 105
+          },
+          "name": "loadBalancer",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkLoadBalancer"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- 100 if daemon, otherwise 200",
+            "stability": "stable",
+            "summary": "The maximum number of tasks, specified as a percentage of the Amazon ECS service's DesiredCount value, that can run in a service during a deployment."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 87
+          },
+          "name": "maxHealthyPercent",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- 0 if daemon, otherwise 50",
+            "stability": "stable",
+            "summary": "The minimum number of tasks, specified as a percentage of the Amazon ECS service's DesiredCount value, that must continue to run and remain healthy during a deployment."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 96
+          },
+          "name": "minHealthyPercent",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Tags can only be propagated to the tasks within the service during service creation.",
+            "stability": "stable",
+            "summary": "Specifies whether to propagate the tags from the task definition or the service to the tasks in the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 120
+          },
+          "name": "propagateTags",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.PropagatedTagSource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Determines whether the Load Balancer will be internet-facing."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 41
+          },
+          "name": "publicLoadBalancer",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CloudFormation-generated name.",
+            "stability": "stable",
+            "summary": "The name of the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 70
+          },
+          "name": "serviceName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "One of taskImageOptions or taskDefinition must be specified.",
+            "stability": "stable",
+            "summary": "The properties required to create a new task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 34
+          },
+          "name": "taskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 27
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageOptions",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-load-balanced-service-base.ts",
+        "line": 138
+      },
+      "name": "NetworkLoadBalancedTaskImageOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Image or taskDefinition must be specified, but not both.",
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 144
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "stability": "stable",
+            "summary": "The container name value to be specified in the task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 193
+          },
+          "name": "containerName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "80",
+            "remarks": "If you are using containers in a task with the awsvpc or host network mode, exposed ports should be specified using containerPort.\nIf you are using containers in a task with the bridge network mode and you specify a container port and not a host port,\nyour container automatically receives a host port in the ephemeral port range.\n\nPort mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance.\n\nFor more information, see\n[hostPort](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html#ECS-Type-PortMapping-hostPort).",
+            "stability": "stable",
+            "summary": "The port number on the container that is bound to the user-specified or automatically assigned host port."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 209
+          },
+          "name": "containerPort",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Flag to indicate whether to enable logging."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 165
+          },
+          "name": "enableLogging",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No environment variables.",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 151
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No value",
+            "stability": "stable",
+            "summary": "The name of the task execution IAM role that grants the Amazon ECS container agent permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 179
+          },
+          "name": "executionRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Automatically generated name.",
+            "remarks": "A family groups multiple versions of a task definition.",
+            "stability": "stable",
+            "summary": "The name of a family that this task definition is registered to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 216
+          },
+          "name": "family",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 172
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secret to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 158
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- A task role is automatically created for you.",
+            "stability": "stable",
+            "summary": "The name of the task IAM role that grants containers in the task permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-load-balanced-service-base.ts",
+            "line": 186
+          },
+          "name": "taskRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Options for configuring a new container."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 101
+      },
+      "name": "NetworkLoadBalancedTaskImageProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Image or taskDefinition must be specified, but not both.",
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 107
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "stability": "stable",
+            "summary": "The container name value to be specified in the task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 156
+          },
+          "name": "containerName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- [80]",
+            "remarks": "If you are using containers in a task with the awsvpc or host network mode, exposed ports should be specified using containerPort.\nIf you are using containers in a task with the bridge network mode and you specify a container port and not a host port,\nyour container automatically receives a host port in the ephemeral port range.\n\nPort mappings that are automatically assigned in this way do not count toward the 100 reserved ports limit of a container instance.\n\nFor more information, see\n[hostPort](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html#ECS-Type-PortMapping-hostPort).",
+            "stability": "stable",
+            "summary": "A list of port numbers on the container that is bound to the user-specified or automatically assigned host port."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 172
+          },
+          "name": "containerPorts",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "number"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Flag to indicate whether to enable logging."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 128
+          },
+          "name": "enableLogging",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No environment variables.",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 114
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No value",
+            "stability": "stable",
+            "summary": "The name of the task execution IAM role that grants the Amazon ECS container agent permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 142
+          },
+          "name": "executionRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Automatically generated name.",
+            "remarks": "A family groups multiple versions of a task definition.",
+            "stability": "stable",
+            "summary": "The name of a family that this task definition is registered to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 179
+          },
+          "name": "family",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 135
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secrets to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 121
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- A task role is automatically created for you.",
+            "stability": "stable",
+            "summary": "The name of the task IAM role that grants containers in the task permission to call AWS APIs on your behalf."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 149
+          },
+          "name": "taskRole",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-iam.IRole"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancerProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define an network load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 185
+      },
+      "name": "NetworkLoadBalancerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "stability": "stable",
+            "summary": "Listeners (at least one listener) attached to this load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 196
+          },
+          "name": "listeners",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.NetworkListenerProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Name of the load balancer."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 189
+          },
+          "name": "name",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No domain name.",
+            "stability": "stable",
+            "summary": "The domain name for the service, e.g. \"api.example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 210
+          },
+          "name": "domainName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No Route53 hosted domain zone.",
+            "stability": "stable",
+            "summary": "The Route53 hosted zone for the domain, e.g. \"example.com.\"."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 217
+          },
+          "name": "domainZone",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-route53.IHostedZone"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Determines whether the Load Balancer will be internet-facing."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 203
+          },
+          "name": "publicLoadBalancer",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsEc2Service": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "An EC2 service running on an ECS cluster fronted by a network load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsEc2Service",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkMultipleTargetGroupsEc2Service class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsEc2ServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+        "line": 62
+      },
+      "name": "NetworkMultipleTargetGroupsEc2Service",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 67
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2Service"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 75
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkTargetGroup"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 Task Definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 71
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsEc2ServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the NetworkMultipleTargetGroupsEc2Service service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsEc2ServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+        "line": 10
+      },
+      "name": "NetworkMultipleTargetGroupsEc2ServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No minimum CPU units reserved.",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:",
+            "stability": "stable",
+            "summary": "The minimum number of CPU units to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 27
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 39
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under heavy contention, Docker attempts to keep the\ncontainer memory to this soft limit. However, your container can consume more\nmemory when it needs to, up to either the hard limit specified with the memory\nparameter (if applicable), or all of the available memory on the container\ninstance, whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required.\n\nNote that this setting will be ignored if TaskImagesOptions is specified.",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 56
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. Only one of TaskDefinition or TaskImageOptions must be specified."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/network-multiple-target-groups-ecs-service.ts",
+            "line": 18
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsFargateService": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A Fargate service running on an ECS cluster fronted by a network load balancer."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsFargateService",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkMultipleTargetGroupsFargateService class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsFargateServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+        "line": 75
+      },
+      "name": "NetworkMultipleTargetGroupsFargateService",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 80
+          },
+          "name": "assignPublicIp",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 85
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateService"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The default target group for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 95
+          },
+          "name": "targetGroup",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkTargetGroup"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 90
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsFargateServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the NetworkMultipleTargetGroupsFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsFargateServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+        "line": 10
+      },
+      "name": "NetworkMultipleTargetGroupsFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "stability": "stable",
+            "summary": "Determines whether the service will be assigned a public IP address."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 69
+          },
+          "name": "assignPublicIp",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 40
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25 vCPU)\n\n1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values: 512 (.5 vCPU)\n\n2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)\n\nBetween 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) - Available cpu values: 2048 (2 vCPU)\n\nBetween 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 62
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. Only one of TaskDefinition or TaskImageOptions must be specified."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/network-multiple-target-groups-fargate-service.ts",
+            "line": 19
+          },
+          "name": "taskDefinition",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for NetworkMultipleTargetGroupsEc2Service and NetworkMultipleTargetGroupsFargateService classes."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the NetworkMultipleTargetGroupsServiceBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 257
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 366
+          },
+          "name": "addPortMappingForTargets",
+          "parameters": [
+            {
+              "name": "container",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.ContainerDefinition"
+              }
+            },
+            {
+              "name": "targets",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "@aws-cdk/aws-ecs-patterns.NetworkTargetProps"
+                  },
+                  "kind": "array"
+                }
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 331
+          },
+          "name": "createAWSLogDriver",
+          "parameters": [
+            {
+              "name": "prefix",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.AwsLogDriver"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 335
+          },
+          "name": "findListener",
+          "parameters": [
+            {
+              "name": "name",
+              "optional": true,
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkListener"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 324
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 347
+          },
+          "name": "registerECSTargets",
+          "parameters": [
+            {
+              "name": "service",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.BaseService"
+              }
+            },
+            {
+              "name": "container",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.ContainerDefinition"
+              }
+            },
+            {
+              "name": "targets",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "@aws-cdk/aws-ecs-patterns.NetworkTargetProps"
+                  },
+                  "kind": "array"
+                }
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkTargetGroup"
+            }
+          }
+        }
+      ],
+      "name": "NetworkMultipleTargetGroupsServiceBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 276
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 261
+          },
+          "name": "desiredCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The listener for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 271
+          },
+          "name": "listener",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkListener"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Network Load Balancer for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 266
+          },
+          "name": "loadBalancer",
+          "type": {
+            "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkLoadBalancer"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 279
+          },
+          "name": "listeners",
+          "protected": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkListener"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 280
+          },
+          "name": "targetGroups",
+          "protected": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-elasticloadbalancingv2.NetworkTargetGroup"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 278
+          },
+          "name": "logDriver",
+          "optional": true,
+          "protected": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base NetworkMultipleTargetGroupsEc2Service or NetworkMultipleTargetGroupsFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkMultipleTargetGroupsServiceBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 13
+      },
+      "name": "NetworkMultipleTargetGroupsServiceBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AWS Cloud Map service discovery is not enabled.",
+            "stability": "stable",
+            "summary": "The options for configuring an Amazon ECS service to use service discovery."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 88
+          },
+          "name": "cloudMapOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.CloudMapOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 20
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "remarks": "The minimum value is 1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 43
+          },
+          "name": "desiredCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "remarks": "For more information, see\n[Tagging Your Amazon ECS Resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)",
+            "stability": "stable",
+            "summary": "Specifies whether to enable Amazon ECS managed tags for the tasks within the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 81
+          },
+          "name": "enableECSManagedTags",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- defaults to 60 seconds if at least one load balancer is in-use and it is not already set",
+            "stability": "stable",
+            "summary": "The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy Elastic Load Balancing target health checks after a task has first started."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 58
+          },
+          "name": "healthCheckGracePeriod",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/core.Duration"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- a new load balancer with a listener will be created.",
+            "stability": "stable",
+            "summary": "The network load balancer that will serve traffic to the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 65
+          },
+          "name": "loadBalancers",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancerProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Tags can only be propagated to the tasks within the service during service creation.",
+            "stability": "stable",
+            "summary": "Specifies whether to propagate the tags from the task definition or the service to the tasks in the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 73
+          },
+          "name": "propagateTags",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.PropagatedTagSource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CloudFormation-generated name.",
+            "stability": "stable",
+            "summary": "Name of the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 50
+          },
+          "name": "serviceName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- default portMapping registered as target group and attached to the first defined listener",
+            "stability": "stable",
+            "summary": "Properties to specify NLB target groups."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 95
+          },
+          "name": "targetGroups",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs-patterns.NetworkTargetProps"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Only one of TaskDefinition or TaskImageOptions must be specified.",
+            "stability": "stable",
+            "summary": "The properties required to create a new task definition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 35
+          },
+          "name": "taskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.NetworkLoadBalancedTaskImageProps"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 28
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.NetworkTargetProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Properties to define a network load balancer target group."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.NetworkTargetProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+        "line": 240
+      },
+      "name": "NetworkTargetProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "remarks": "Only applicable when using application/network load balancers.",
+            "stability": "stable",
+            "summary": "The port number of the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 244
+          },
+          "name": "containerPort",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- default listener (first added listener)",
+            "stability": "stable",
+            "summary": "Name of the listener the target group attached to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/network-multiple-target-groups-service-base.ts",
+            "line": 251
+          },
+          "name": "listener",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingEc2Service": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "Class to create a queue processing EC2 service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingEc2Service",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the QueueProcessingEc2Service class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingEc2ServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/queue-processing-ecs-service.ts",
+        "line": 60
+      },
+      "name": "QueueProcessingEc2Service",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/queue-processing-ecs-service.ts",
+            "line": 65
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2Service"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/queue-processing-ecs-service.ts",
+            "line": 69
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingEc2ServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the QueueProcessingEc2Service service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingEc2ServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/queue-processing-ecs-service.ts",
+        "line": 8
+      },
+      "name": "QueueProcessingEc2ServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/queue-processing-ecs-service.ts",
+            "line": 28
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required for non-Fargate services.",
+            "stability": "stable",
+            "summary": "The hard limit (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/queue-processing-ecs-service.ts",
+            "line": 40
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under contention, Docker attempts to keep the\ncontainer memory within the limit. If the container requires more memory,\nit can consume up to the value specified by the Memory property or all of\nthe available memory on the container instance—whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required for non-Fargate services.",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/queue-processing-ecs-service.ts",
+            "line": 54
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingFargateService": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "Class to create a queue processing Fargate service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingFargateService",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the QueueProcessingFargateService class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingFargateServiceProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/queue-processing-fargate-service.ts",
+        "line": 56
+      },
+      "name": "QueueProcessingFargateService",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate service in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/queue-processing-fargate-service.ts",
+            "line": 60
+          },
+          "name": "service",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateService"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/queue-processing-fargate-service.ts",
+            "line": 64
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingFargateServiceProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the QueueProcessingFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingFargateServiceProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/queue-processing-fargate-service.ts",
+        "line": 8
+      },
+      "name": "QueueProcessingFargateServiceProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/queue-processing-fargate-service.ts",
+            "line": 28
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "This field is required and you must use one of the following values, which determines your range of valid values\nfor the cpu parameter:\n\n0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)\n\n1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)\n\n2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)\n\nBetween 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)\n\nBetween 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The amount (in MiB) of memory used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/queue-processing-fargate-service.ts",
+            "line": 50
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for QueueProcessingEc2Service and QueueProcessingFargateService services."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the QueueProcessingServiceBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/queue-processing-service-base.ts",
+        "line": 140
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Configure autoscaling based off of CPU utilization as well as the number of messages visible in the SQS queue."
+          },
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 230
+          },
+          "name": "configureAutoscalingForService",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the ECS/Fargate service for which to apply the autoscaling rules to."
+              },
+              "name": "service",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.BaseService"
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 244
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        }
+      ],
+      "name": "QueueProcessingServiceBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The cluster where your service will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 149
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The minimum number of tasks to run."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 167
+          },
+          "name": "desiredCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Environment variables that will include the queue name."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 157
+          },
+          "name": "environment",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The maximum number of instances for autoscaling to scale up to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 172
+          },
+          "name": "maxCapacity",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The scaling interval for autoscaling based off an SQS Queue size."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 177
+          },
+          "name": "scalingSteps",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-applicationautoscaling.ScalingInterval"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The SQS queue that the service will process from."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 144
+          },
+          "name": "sqsQueue",
+          "type": {
+            "fqn": "@aws-cdk/aws-sqs.IQueue"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The AwsLogDriver to use for logging if logging is enabled."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 181
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The secret environment variables."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 162
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base QueueProcessingEc2Service or QueueProcessingFargateService service."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.QueueProcessingServiceBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/queue-processing-service-base.ts",
+        "line": 10
+      },
+      "name": "QueueProcessingServiceBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 37
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 24
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CMD value built into container image.",
+            "remarks": "If you provide a shell command as a single string, you have to quote command-line arguments.",
+            "stability": "stable",
+            "summary": "The command that is passed to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 46
+          },
+          "name": "command",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 53
+          },
+          "name": "desiredTaskCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "false",
+            "remarks": "For more information, see\n[Tagging Your Amazon ECS Resources](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)",
+            "stability": "stable",
+            "summary": "Specifies whether to enable Amazon ECS managed tags for the tasks within the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 127
+          },
+          "name": "enableECSManagedTags",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "true",
+            "stability": "stable",
+            "summary": "Flag to indicate whether to enable logging."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 60
+          },
+          "name": "enableLogging",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "'QUEUE_NAME: queue.queueName'",
+            "remarks": "The variable `QUEUE_NAME` with value `queue.queueName` will\nalways be passed.",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 70
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- Automatically generated name.",
+            "remarks": "A family groups multiple versions of a task definition.",
+            "stability": "stable",
+            "summary": "The name of a family that the task definition is registered to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 134
+          },
+          "name": "family",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 111
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "(desiredTaskCount * 2)",
+            "stability": "stable",
+            "summary": "Maximum capacity to scale to."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 94
+          },
+          "name": "maxScalingCapacity",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Tags can only be propagated to the tasks within the service during service creation.",
+            "stability": "stable",
+            "summary": "Specifies whether to propagate the tags from the task definition or the service to the tasks in the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 119
+          },
+          "name": "propagateTags",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.PropagatedTagSource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "'SQSQueue with CloudFormation-generated name'",
+            "remarks": "If specified and this is a FIFO queue, the queue name must end in the string '.fifo'. See\n[CreateQueue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html)",
+            "stability": "stable",
+            "summary": "A queue for which to process items from."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 87
+          },
+          "name": "queue",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-sqs.IQueue"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "[{ upper: 0, change: -1 },{ lower: 100, change: +1 },{ lower: 500, change: +5 }]",
+            "remarks": "Maps a range of metric values to a particular scaling behavior. See\n[Simple and Step Scaling Policies for Amazon EC2 Auto Scaling](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html)",
+            "stability": "stable",
+            "summary": "The intervals for scaling based on the SQS queue's ApproximateNumberOfMessagesVisible metric."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 104
+          },
+          "name": "scalingSteps",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-applicationautoscaling.ScalingInterval"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secret to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 77
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CloudFormation-generated name.",
+            "stability": "stable",
+            "summary": "The name of the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 16
+          },
+          "name": "serviceName",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/queue-processing-service-base.ts",
+            "line": 32
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledEc2Task": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ScheduledTaskBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A scheduled EC2 task that will be initiated off of CloudWatch Events."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2Task",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ScheduledEc2Task class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/ecs/scheduled-ecs-task.ts",
+        "line": 81
+      },
+      "name": "ScheduledEc2Task",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The EC2 task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 86
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskDefinitionOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledEc2Task using a task definition."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskDefinitionOptions",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/scheduled-ecs-task.ts",
+        "line": 67
+      },
+      "name": "ScheduledEc2TaskDefinitionOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. One of image or taskDefinition must be specified."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 75
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.Ec2TaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskImageOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledEc2Task using an image."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskImageOptions",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskImageProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/scheduled-ecs-task.ts",
+        "line": 29
+      },
+      "name": "ScheduledEc2TaskImageOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "stability": "stable",
+            "summary": "The minimum number of CPU units to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 35
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory limit.",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required for non-Fargate services.",
+            "stability": "stable",
+            "summary": "The hard limit (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 47
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No memory reserved.",
+            "remarks": "When system memory is under contention, Docker attempts to keep the\ncontainer memory within the limit. If the container requires more memory,\nit can consume up to the value specified by the Memory property or all of\nthe available memory on the container instance—whichever comes first.\n\nAt least one of memoryLimitMiB and memoryReservationMiB is required for non-Fargate services.",
+            "stability": "stable",
+            "summary": "The soft limit (in MiB) of memory to reserve for the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 61
+          },
+          "name": "memoryReservationMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledEc2Task task."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/ecs/scheduled-ecs-task.ts",
+        "line": 8
+      },
+      "name": "ScheduledEc2TaskProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "ScheduledEc2TaskDefinitionOptions or ScheduledEc2TaskImageOptions must be defined, but not both.",
+            "stability": "stable",
+            "summary": "The properties to define if using an existing TaskDefinition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 15
+          },
+          "name": "scheduledEc2TaskDefinitionOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskDefinitionOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "ScheduledEc2TaskDefinitionOptions or ScheduledEc2TaskImageOptions must be defined, but not both.",
+            "stability": "stable",
+            "summary": "The properties to define if the construct is to create a TaskDefinition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/ecs/scheduled-ecs-task.ts",
+            "line": 23
+          },
+          "name": "scheduledEc2TaskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledEc2TaskImageOptions"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledFargateTask": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/aws-ecs-patterns.ScheduledTaskBase",
+      "docs": {
+        "stability": "stable",
+        "summary": "A scheduled Fargate task that will be initiated off of CloudWatch Events."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTask",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ScheduledFargateTask class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/fargate/scheduled-fargate-task.ts",
+        "line": 79
+      },
+      "name": "ScheduledFargateTask",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The Fargate task definition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 83
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskDefinitionOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledFargateTask using a task definition."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskDefinitionOptions",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/scheduled-fargate-task.ts",
+        "line": 65
+      },
+      "name": "ScheduledFargateTaskDefinitionOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "[disable-awslint:ref-via-interface]",
+            "stability": "stable",
+            "summary": "The task definition to use for tasks in the service. Image or taskDefinition must be specified, but not both."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 73
+          },
+          "name": "taskDefinition",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.FargateTaskDefinition"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskImageOptions": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledFargateTask using an image."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskImageOptions",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskImageProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/scheduled-fargate-task.ts",
+        "line": 29
+      },
+      "name": "ScheduledFargateTaskImageOptions",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "256",
+            "remarks": "Valid values, which determines your range of valid values for the memory parameter:\n\n256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB\n\n512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB\n\n1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB\n\n2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments\n\n4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments\n\nThis default is set in the underlying FargateTaskDefinition construct.",
+            "stability": "stable",
+            "summary": "The number of cpu units used by the task."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 49
+          },
+          "name": "cpu",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "512",
+            "remarks": "If your container attempts to exceed the allocated memory, the container\nis terminated.",
+            "stability": "stable",
+            "summary": "The hard limit (in MiB) of memory to present to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 59
+          },
+          "name": "memoryLimitMiB",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the ScheduledFargateTask task."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskProps",
+      "interfaces": [
+        "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/fargate/scheduled-fargate-task.ts",
+        "line": 8
+      },
+      "name": "ScheduledFargateTaskProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "ScheduledFargateTaskDefinitionOptions or ScheduledFargateTaskImageOptions must be defined, but not both.",
+            "stability": "stable",
+            "summary": "The properties to define if using an existing TaskDefinition in this construct."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 15
+          },
+          "name": "scheduledFargateTaskDefinitionOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskDefinitionOptions"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "remarks": "ScheduledFargateTaskDefinitionOptions or ScheduledFargateTaskImageOptions must be defined, but not both.",
+            "stability": "stable",
+            "summary": "The properties to define if the construct is to create a TaskDefinition."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/fargate/scheduled-fargate-task.ts",
+            "line": 23
+          },
+          "name": "scheduledFargateTaskImageOptions",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledFargateTaskImageOptions"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledTaskBase": {
+      "abstract": true,
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "base": "@aws-cdk/core.Construct",
+      "docs": {
+        "stability": "stable",
+        "summary": "The base class for ScheduledEc2Task and ScheduledFargateTask tasks."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledTaskBase",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Constructs a new instance of the ScheduledTaskBase class."
+        },
+        "parameters": [
+          {
+            "name": "scope",
+            "type": {
+              "fqn": "@aws-cdk/core.Construct"
+            }
+          },
+          {
+            "name": "id",
+            "type": {
+              "primitive": "string"
+            }
+          },
+          {
+            "name": "props",
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/base/scheduled-task-base.ts",
+        "line": 86
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Create an ECS task using the task definition provided and add it to the scheduled event rule."
+          },
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 126
+          },
+          "name": "addTaskDefinitionToEventTarget",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the TaskDefinition to add to the event rule."
+              },
+              "name": "taskDefinition",
+              "type": {
+                "fqn": "@aws-cdk/aws-ecs.TaskDefinition"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-events-targets.EcsTask"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Create an AWS Log Driver with the provided streamPrefix."
+          },
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 154
+          },
+          "name": "createAWSLogDriver",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the Cloudwatch logging prefix."
+              },
+              "name": "prefix",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.AwsLogDriver"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the default cluster."
+          },
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 142
+          },
+          "name": "getDefaultCluster",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@aws-cdk/core.Construct"
+              }
+            },
+            {
+              "name": "vpc",
+              "optional": true,
+              "type": {
+                "fqn": "@aws-cdk/aws-ec2.IVpc"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "fqn": "@aws-cdk/aws-ecs.Cluster"
+            }
+          }
+        }
+      ],
+      "name": "ScheduledTaskBase",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 90
+          },
+          "name": "cluster",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "docs": {
+            "remarks": "The minimum value is 1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 96
+          },
+          "name": "desiredTaskCount",
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "The CloudWatch Events rule for the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 101
+          },
+          "name": "eventRule",
+          "type": {
+            "fqn": "@aws-cdk/aws-events.Rule"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "The properties for the base ScheduledEc2Task or ScheduledFargateTask task."
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledTaskBaseProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/scheduled-task-base.ts",
+        "line": 11
+      },
+      "name": "ScheduledTaskBaseProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "remarks": "For more information, see\n[Schedule Expression Syntax for Rules](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html)\nin the Amazon CloudWatch User Guide.",
+            "stability": "stable",
+            "summary": "The schedule or rate (frequency) that determines when CloudWatch Events runs the rule."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 34
+          },
+          "name": "schedule",
+          "type": {
+            "fqn": "@aws-cdk/aws-applicationautoscaling.Schedule"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- create a new cluster; if both cluster and vpc are omitted, a new VPC will be created for you.",
+            "remarks": "If a cluster is specified, the vpc construct should be omitted. Alternatively, you can omit both cluster and vpc.",
+            "stability": "stable",
+            "summary": "The name of the cluster that hosts the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 18
+          },
+          "name": "cluster",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ICluster"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "1",
+            "stability": "stable",
+            "summary": "The desired number of instantiations of the task definition to keep running on the service."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 41
+          },
+          "name": "desiredTaskCount",
+          "optional": true,
+          "type": {
+            "primitive": "number"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- uses the VPC defined in the cluster or creates a new VPC.",
+            "remarks": "If a vpc is specified, the cluster construct should be omitted. Alternatively, you can omit both vpc and cluster.",
+            "stability": "stable",
+            "summary": "The VPC where the container instances will be launched or the elastic network interfaces (ENIs) will be deployed."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 26
+          },
+          "name": "vpc",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ec2.IVpc"
+          }
+        }
+      ]
+    },
+    "@aws-cdk/aws-ecs-patterns.ScheduledTaskImageProps": {
+      "assembly": "@aws-cdk/aws-ecs-patterns",
+      "datatype": true,
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "@aws-cdk/aws-ecs-patterns.ScheduledTaskImageProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/base/scheduled-task-base.ts",
+        "line": 44
+      },
+      "name": "ScheduledTaskImageProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- none",
+            "remarks": "Image or taskDefinition must be specified, but not both.",
+            "stability": "stable",
+            "summary": "The image used to start a container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 50
+          },
+          "name": "image",
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.ContainerImage"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- CMD value built into container image.",
+            "remarks": "If you provide a shell command as a single string, you have to quote command-line arguments.",
+            "stability": "stable",
+            "summary": "The command that is passed to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 59
+          },
+          "name": "command",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "none",
+            "stability": "stable",
+            "summary": "The environment variables to pass to the container."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 66
+          },
+          "name": "environment",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "primitive": "string"
+              },
+              "kind": "map"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- AwsLogDriver if enableLogging is true",
+            "stability": "stable",
+            "summary": "The log driver to use."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 80
+          },
+          "name": "logDriver",
+          "optional": true,
+          "type": {
+            "fqn": "@aws-cdk/aws-ecs.LogDriver"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "default": "- No secret environment variables.",
+            "stability": "stable",
+            "summary": "The secret to expose to the container as an environment variable."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/base/scheduled-task-base.ts",
+            "line": 73
+          },
+          "name": "secrets",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "@aws-cdk/aws-ecs.Secret"
+              },
+              "kind": "map"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "version": "1.22.0",
+  "fingerprint": "/uV+V7EmvZ86dhBizVIx9ArVdwypxXC0BmVoZP/mzRI="
+}

--- a/packages/@jsii/spec/test/validate-assembly.test.ts
+++ b/packages/@jsii/spec/test/validate-assembly.test.ts
@@ -1,6 +1,16 @@
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
 import { validateAssembly } from '../lib/validate-assembly';
 
-describe('validateAssembly', () => {
-  test('rejects invalid assembly', () =>
-    expect(() => validateAssembly({})).toThrow(/Invalid assembly:/));
+test('rejects invalid assembly', () =>
+  expect(() => validateAssembly({})).toThrow(/Invalid assembly:/));
+
+describe('can load older assemblies', () => {
+  const samplesDir = resolve(__dirname, 'previous-assemblies');
+  for (const sample of readdirSync(samplesDir)) {
+    test(sample, () => {
+      const data = JSON.parse(readFileSync(resolve(samplesDir, sample), { encoding: 'utf-8' }));
+      expect(validateAssembly(data)).toBe(data);
+    });
+  }
 });


### PR DESCRIPTION
In order to ensure backwards-compatibility against previously generated
assemblies, add a test that validates a random assembly generated by
some semi-arbitrary version of `jsii` (in this case,
`@aws-cdk/aws-ecs-patterns` about version `1.22.0`).

Fixes #1190

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
