### PR TITLE
feat(java): annotate nullability

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1584,8 +1584,11 @@ class JavaGenerator extends Generator {
   }
 
   private toDecoratedJavaType(optionalValue: spec.OptionalValue): string {
-    const nakedType = this.toJavaType(optionalValue.type);
-    return `${optionalValue.optional ? ANN_NULLABLE : ANN_NOT_NULL} ${nakedType}`;
+    const result = this.toDecoratedJavaTypes(optionalValue);
+    if (result.length > 1) {
+      return `${optionalValue.optional ? ANN_NULLABLE : ANN_NOT_NULL} java.lang.Object`;
+    }
+    return result[0];
   }
 
   private toDecoratedJavaTypes(optionalValue: spec.OptionalValue): string[] {

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/pom.xml
@@ -39,10 +39,9 @@
       <version>[0.21.2,0.22.0)</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>[1.3.2,)</version>
-      <scope>provided</scope>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>[18.0.0,19.0.0)</version>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/Very.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/Very.java
@@ -17,7 +17,7 @@ public class Very extends software.amazon.jsii.JsiiObject {
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
     }
 
-    public java.lang.Number hey() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number hey() {
         return this.jsiiCall("hey", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/pom.xml
@@ -44,10 +44,9 @@
       <version>[0.21.2,0.22.0)</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>[1.3.2,)</version>
-      <scope>provided</scope>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>[18.0.0,19.0.0)</version>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/Base.java
@@ -23,7 +23,7 @@ public abstract class Base extends software.amazon.jsii.JsiiObject {
     /**
      * @return the name of the class (to verify native type names are created for derived classes).
      */
-    public java.lang.Object typeName() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object typeName() {
         return this.jsiiCall("typeName", java.lang.Object.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
@@ -44,10 +44,9 @@
       <version>[0.21.2,0.22.0)</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>[1.3.2,)</version>
-      <scope>provided</scope>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>[18.0.0,19.0.0)</version>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -29,7 +29,7 @@ public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getDoubleValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getDoubleValue() {
             return this.jsiiGet("doubleValue", java.lang.Number.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -34,7 +34,7 @@ public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String hello() {
+        public @org.jetbrains.annotations.NotNull java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Number.java
@@ -24,7 +24,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public Number(final java.lang.Number value) {
+    public Number(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
@@ -35,7 +35,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public java.lang.Number getDoubleValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getDoubleValue() {
         return this.jsiiGet("doubleValue", java.lang.Number.class);
     }
 
@@ -45,7 +45,7 @@ public class Number extends software.amazon.jsii.tests.calculator.lib.Value impl
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Operation.java
@@ -28,7 +28,7 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
     @Override
-    public abstract java.lang.String toString();
+    public abstract @org.jetbrains.annotations.NotNull java.lang.String toString();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -44,7 +44,7 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
 
@@ -54,7 +54,7 @@ public abstract class Operation extends software.amazon.jsii.tests.calculator.li
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String toString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/Value.java
@@ -27,7 +27,7 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public java.lang.String toString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
 
@@ -36,7 +36,7 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public abstract java.lang.Number getValue();
+    public abstract @org.jetbrains.annotations.NotNull java.lang.Number getValue();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -52,7 +52,7 @@ public abstract class Value extends software.amazon.jsii.tests.calculator.base.B
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/pom.xml
@@ -75,10 +75,9 @@
       <version>[0.21.2,0.22.0)</version>
     </dependency>
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>[1.3.2,)</version>
-      <scope>provided</scope>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>[18.0.0,19.0.0)</version>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClass.java
@@ -27,13 +27,13 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
      * @param name This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public abstract java.lang.String abstractMethod(final java.lang.String name);
+    public abstract @org.jetbrains.annotations.NotNull java.lang.String abstractMethod(final @org.jetbrains.annotations.NotNull java.lang.String name);
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number nonAbstractMethod() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number nonAbstractMethod() {
         return this.jsiiCall("nonAbstractMethod", java.lang.Number.class);
     }
 
@@ -42,7 +42,7 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getPropFromInterface() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getPropFromInterface() {
         return this.jsiiGet("propFromInterface", java.lang.String.class);
     }
 
@@ -59,7 +59,7 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getPropFromInterface() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getPropFromInterface() {
             return this.jsiiGet("propFromInterface", java.lang.String.class);
         }
 
@@ -68,7 +68,7 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getAbstractProperty() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getAbstractProperty() {
             return this.jsiiGet("abstractProperty", java.lang.String.class);
         }
 
@@ -79,7 +79,7 @@ public abstract class AbstractClass extends software.amazon.jsii.tests.calculato
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String abstractMethod(final java.lang.String name) {
+        public @org.jetbrains.annotations.NotNull java.lang.String abstractMethod(final @org.jetbrains.annotations.NotNull java.lang.String name) {
             return this.jsiiCall("abstractMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassBase.java
@@ -25,7 +25,7 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public abstract java.lang.String getAbstractProperty();
+    public abstract @org.jetbrains.annotations.NotNull java.lang.String getAbstractProperty();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -40,7 +40,7 @@ public abstract class AbstractClassBase extends software.amazon.jsii.JsiiObject 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getAbstractProperty() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getAbstractProperty() {
             return this.jsiiGet("abstractProperty", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractClassReturner.java
@@ -25,7 +25,7 @@ public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.AbstractClass giveMeAbstract() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AbstractClass giveMeAbstract() {
         return this.jsiiCall("giveMeAbstract", software.amazon.jsii.tests.calculator.AbstractClass.class);
     }
 
@@ -33,7 +33,7 @@ public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass giveMeInterface() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass giveMeInterface() {
         return this.jsiiCall("giveMeInterface", software.amazon.jsii.tests.calculator.IInterfaceImplementedByAbstractClass.class);
     }
 
@@ -41,7 +41,7 @@ public class AbstractClassReturner extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.AbstractClassBase getReturnAbstractFromProperty() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AbstractClassBase getReturnAbstractFromProperty() {
         return this.jsiiGet("returnAbstractFromProperty", software.amazon.jsii.tests.calculator.AbstractClassBase.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractSuite.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AbstractSuite.java
@@ -29,7 +29,7 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
      * @param str This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected abstract java.lang.String someMethod(final java.lang.String str);
+    protected abstract @org.jetbrains.annotations.NotNull java.lang.String someMethod(final @org.jetbrains.annotations.NotNull java.lang.String str);
 
     /**
      * Sets `seed` to `this.property`, then calls `someMethod` with `this.property` and returns the result.
@@ -39,7 +39,7 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
      * @param seed a `string`. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String workItAll(final java.lang.String seed) {
+    public @org.jetbrains.annotations.NotNull java.lang.String workItAll(final @org.jetbrains.annotations.NotNull java.lang.String seed) {
         return this.jsiiCall("workItAll", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(seed, "seed is required") });
     }
 
@@ -47,13 +47,13 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected abstract java.lang.String getProperty();
+    protected abstract @org.jetbrains.annotations.NotNull java.lang.String getProperty();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected abstract void setProperty(final java.lang.String value);
+    protected abstract void setProperty(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -68,7 +68,7 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        protected java.lang.String getProperty() {
+        protected @org.jetbrains.annotations.NotNull java.lang.String getProperty() {
             return this.jsiiGet("property", java.lang.String.class);
         }
 
@@ -77,7 +77,7 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        protected void setProperty(final java.lang.String value) {
+        protected void setProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("property", java.util.Objects.requireNonNull(value, "property is required"));
         }
 
@@ -88,7 +88,7 @@ public abstract class AbstractSuite extends software.amazon.jsii.JsiiObject {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        protected java.lang.String someMethod(final java.lang.String str) {
+        protected @org.jetbrains.annotations.NotNull java.lang.String someMethod(final @org.jetbrains.annotations.NotNull java.lang.String str) {
             return this.jsiiCall("someMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(str, "str is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Add.java
@@ -27,7 +27,7 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Add(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
+    public Add(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value lhs, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
@@ -39,7 +39,7 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String toString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
 
@@ -50,7 +50,7 @@ public class Add extends software.amazon.jsii.tests.calculator.BinaryOperation {
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java
@@ -32,7 +32,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * @param inp This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void anyIn(final java.lang.Object inp) {
+    public void anyIn(final @org.jetbrains.annotations.NotNull java.lang.Object inp) {
         this.jsiiCall("anyIn", software.amazon.jsii.NativeType.VOID, new Object[] { inp });
     }
 
@@ -40,7 +40,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object anyOut() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object anyOut() {
         return this.jsiiCall("anyOut", java.lang.Object.class);
     }
 
@@ -50,7 +50,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.StringEnum enumMethod(final software.amazon.jsii.tests.calculator.StringEnum value) {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StringEnum enumMethod(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StringEnum value) {
         return this.jsiiCall("enumMethod", software.amazon.jsii.tests.calculator.StringEnum.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -58,7 +58,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getEnumPropertyValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getEnumPropertyValue() {
         return this.jsiiGet("enumPropertyValue", java.lang.Number.class);
     }
 
@@ -66,7 +66,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.Object> getAnyArrayProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> getAnyArrayProperty() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("anyArrayProperty", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -74,7 +74,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setAnyArrayProperty(final java.util.List<java.lang.Object> value) {
+    public void setAnyArrayProperty(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> value) {
         this.jsiiSet("anyArrayProperty", java.util.Objects.requireNonNull(value, "anyArrayProperty is required"));
     }
 
@@ -82,7 +82,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, java.lang.Object> getAnyMapProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> getAnyMapProperty() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("anyMapProperty", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -90,7 +90,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setAnyMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
+    public void setAnyMapProperty(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("anyMapProperty", java.util.Objects.requireNonNull(value, "anyMapProperty is required"));
     }
 
@@ -98,7 +98,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object getAnyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object getAnyProperty() {
         return this.jsiiGet("anyProperty", java.lang.Object.class);
     }
 
@@ -106,7 +106,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setAnyProperty(final java.lang.Object value) {
+    public void setAnyProperty(final @org.jetbrains.annotations.NotNull java.lang.Object value) {
         this.jsiiSet("anyProperty", java.util.Objects.requireNonNull(value, "anyProperty is required"));
     }
 
@@ -114,7 +114,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.String> getArrayProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getArrayProperty() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("arrayProperty", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -122,7 +122,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setArrayProperty(final java.util.List<java.lang.String> value) {
+    public void setArrayProperty(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> value) {
         this.jsiiSet("arrayProperty", java.util.Objects.requireNonNull(value, "arrayProperty is required"));
     }
 
@@ -130,7 +130,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getBooleanProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getBooleanProperty() {
         return this.jsiiGet("booleanProperty", java.lang.Boolean.class);
     }
 
@@ -138,7 +138,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setBooleanProperty(final java.lang.Boolean value) {
+    public void setBooleanProperty(final @org.jetbrains.annotations.NotNull java.lang.Boolean value) {
         this.jsiiSet("booleanProperty", java.util.Objects.requireNonNull(value, "booleanProperty is required"));
     }
 
@@ -146,7 +146,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.time.Instant getDateProperty() {
+    public @org.jetbrains.annotations.NotNull java.time.Instant getDateProperty() {
         return this.jsiiGet("dateProperty", java.time.Instant.class);
     }
 
@@ -154,7 +154,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setDateProperty(final java.time.Instant value) {
+    public void setDateProperty(final @org.jetbrains.annotations.NotNull java.time.Instant value) {
         this.jsiiSet("dateProperty", java.util.Objects.requireNonNull(value, "dateProperty is required"));
     }
 
@@ -162,7 +162,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.AllTypesEnum getEnumProperty() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AllTypesEnum getEnumProperty() {
         return this.jsiiGet("enumProperty", software.amazon.jsii.tests.calculator.AllTypesEnum.class);
     }
 
@@ -170,7 +170,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setEnumProperty(final software.amazon.jsii.tests.calculator.AllTypesEnum value) {
+    public void setEnumProperty(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AllTypesEnum value) {
         this.jsiiSet("enumProperty", java.util.Objects.requireNonNull(value, "enumProperty is required"));
     }
 
@@ -178,7 +178,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public com.fasterxml.jackson.databind.node.ObjectNode getJsonProperty() {
+    public @org.jetbrains.annotations.NotNull com.fasterxml.jackson.databind.node.ObjectNode getJsonProperty() {
         return this.jsiiGet("jsonProperty", com.fasterxml.jackson.databind.node.ObjectNode.class);
     }
 
@@ -186,7 +186,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setJsonProperty(final com.fasterxml.jackson.databind.node.ObjectNode value) {
+    public void setJsonProperty(final @org.jetbrains.annotations.NotNull com.fasterxml.jackson.databind.node.ObjectNode value) {
         this.jsiiSet("jsonProperty", java.util.Objects.requireNonNull(value, "jsonProperty is required"));
     }
 
@@ -194,7 +194,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> getMapProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> getMapProperty() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("mapProperty", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.Number.class))));
     }
 
@@ -202,7 +202,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMapProperty(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> value) {
+    public void setMapProperty(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Number> value) {
         this.jsiiSet("mapProperty", java.util.Objects.requireNonNull(value, "mapProperty is required"));
     }
 
@@ -210,7 +210,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getNumberProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getNumberProperty() {
         return this.jsiiGet("numberProperty", java.lang.Number.class);
     }
 
@@ -218,7 +218,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setNumberProperty(final java.lang.Number value) {
+    public void setNumberProperty(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiSet("numberProperty", java.util.Objects.requireNonNull(value, "numberProperty is required"));
     }
 
@@ -226,7 +226,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getStringProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getStringProperty() {
         return this.jsiiGet("stringProperty", java.lang.String.class);
     }
 
@@ -234,7 +234,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setStringProperty(final java.lang.String value) {
+    public void setStringProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("stringProperty", java.util.Objects.requireNonNull(value, "stringProperty is required"));
     }
 
@@ -242,7 +242,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.Object> getUnionArrayProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> getUnionArrayProperty() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("unionArrayProperty", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -250,7 +250,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionArrayProperty(final java.util.List<java.lang.Object> value) {
+    public void setUnionArrayProperty(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> value) {
         this.jsiiSet("unionArrayProperty", java.util.Objects.requireNonNull(value, "unionArrayProperty is required"));
     }
 
@@ -258,7 +258,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, java.lang.Object> getUnionMapProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> getUnionMapProperty() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("unionMapProperty", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -266,7 +266,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
+    public void setUnionMapProperty(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unionMapProperty", java.util.Objects.requireNonNull(value, "unionMapProperty is required"));
     }
 
@@ -274,7 +274,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object getUnionProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
 
@@ -282,7 +282,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final java.lang.String value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
@@ -290,7 +290,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final java.lang.Number value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
@@ -298,7 +298,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
@@ -306,7 +306,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.lib.Number value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Number value) {
         this.jsiiSet("unionProperty", java.util.Objects.requireNonNull(value, "unionProperty is required"));
     }
 
@@ -314,7 +314,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.Object> getUnknownArrayProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> getUnknownArrayProperty() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("unknownArrayProperty", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -322,7 +322,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnknownArrayProperty(final java.util.List<java.lang.Object> value) {
+    public void setUnknownArrayProperty(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> value) {
         this.jsiiSet("unknownArrayProperty", java.util.Objects.requireNonNull(value, "unknownArrayProperty is required"));
     }
 
@@ -330,7 +330,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, java.lang.Object> getUnknownMapProperty() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> getUnknownMapProperty() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("unknownMapProperty", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -338,7 +338,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnknownMapProperty(final java.util.Map<java.lang.String, java.lang.Object> value) {
+    public void setUnknownMapProperty(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> value) {
         this.jsiiSet("unknownMapProperty", java.util.Objects.requireNonNull(value, "unknownMapProperty is required"));
     }
 
@@ -346,7 +346,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object getUnknownProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object getUnknownProperty() {
         return this.jsiiGet("unknownProperty", java.lang.Object.class);
     }
 
@@ -354,7 +354,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnknownProperty(final java.lang.Object value) {
+    public void setUnknownProperty(final @org.jetbrains.annotations.NotNull java.lang.Object value) {
         this.jsiiSet("unknownProperty", java.util.Objects.requireNonNull(value, "unknownProperty is required"));
     }
 
@@ -362,7 +362,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.StringEnum getOptionalEnumValue() {
+    public @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.StringEnum getOptionalEnumValue() {
         return this.jsiiGet("optionalEnumValue", software.amazon.jsii.tests.calculator.StringEnum.class);
     }
 
@@ -370,7 +370,7 @@ public class AllTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setOptionalEnumValue(final software.amazon.jsii.tests.calculator.StringEnum value) {
+    public void setOptionalEnumValue(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.StringEnum value) {
         this.jsiiSet("optionalEnumValue", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AllowedMethodNames.java
@@ -28,7 +28,7 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * @param _p2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void getBar(final java.lang.String _p1, final java.lang.Number _p2) {
+    public void getBar(final @org.jetbrains.annotations.NotNull java.lang.String _p1, final @org.jetbrains.annotations.NotNull java.lang.Number _p2) {
         this.jsiiCall("getBar", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(_p1, "_p1 is required"), java.util.Objects.requireNonNull(_p2, "_p2 is required") });
     }
 
@@ -40,7 +40,7 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * @param withParam This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getFoo(final java.lang.String withParam) {
+    public @org.jetbrains.annotations.NotNull java.lang.String getFoo(final @org.jetbrains.annotations.NotNull java.lang.String withParam) {
         return this.jsiiCall("getFoo", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(withParam, "withParam is required") });
     }
 
@@ -52,7 +52,7 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * @param _z This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setBar(final java.lang.String _x, final java.lang.Number _y, final java.lang.Boolean _z) {
+    public void setBar(final @org.jetbrains.annotations.NotNull java.lang.String _x, final @org.jetbrains.annotations.NotNull java.lang.Number _y, final @org.jetbrains.annotations.NotNull java.lang.Boolean _z) {
         this.jsiiCall("setBar", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required"), java.util.Objects.requireNonNull(_z, "_z is required") });
     }
 
@@ -65,7 +65,7 @@ public class AllowedMethodNames extends software.amazon.jsii.JsiiObject {
      * @param _y This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setFoo(final java.lang.String _x, final java.lang.Number _y) {
+    public void setFoo(final @org.jetbrains.annotations.NotNull java.lang.String _x, final @org.jetbrains.annotations.NotNull java.lang.Number _y) {
         this.jsiiCall("setFoo", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(_x, "_x is required"), java.util.Objects.requireNonNull(_y, "_y is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AmbiguousParameters.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AmbiguousParameters.java
@@ -23,7 +23,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
      * @param props This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public AmbiguousParameters(final software.amazon.jsii.tests.calculator.Bell scope, final software.amazon.jsii.tests.calculator.StructParameterType props) {
+    public AmbiguousParameters(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Bell scope, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructParameterType props) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(scope, "scope is required"), java.util.Objects.requireNonNull(props, "props is required") });
     }
@@ -32,7 +32,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.StructParameterType getProps() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructParameterType getProps() {
         return this.jsiiGet("props", software.amazon.jsii.tests.calculator.StructParameterType.class);
     }
 
@@ -40,7 +40,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.Bell getScope() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Bell getScope() {
         return this.jsiiGet("scope", software.amazon.jsii.tests.calculator.Bell.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AnonymousImplementationProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AnonymousImplementationProvider.java
@@ -26,7 +26,7 @@ public class AnonymousImplementationProvider extends software.amazon.jsii.JsiiOb
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public software.amazon.jsii.tests.calculator.Implementation provideAsClass() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Implementation provideAsClass() {
         return this.jsiiCall("provideAsClass", software.amazon.jsii.tests.calculator.Implementation.class);
     }
 
@@ -35,7 +35,7 @@ public class AnonymousImplementationProvider extends software.amazon.jsii.JsiiOb
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface() {
         return this.jsiiCall("provideAsInterface", software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AsyncVirtualMethods.java
@@ -25,7 +25,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number callMe() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number callMe() {
         return this.jsiiAsyncCall("callMe", java.lang.Number.class);
     }
 
@@ -35,7 +35,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number callMe2() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number callMe2() {
         return this.jsiiAsyncCall("callMe2", java.lang.Number.class);
     }
 
@@ -49,7 +49,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number callMeDoublePromise() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number callMeDoublePromise() {
         return this.jsiiAsyncCall("callMeDoublePromise", java.lang.Number.class);
     }
 
@@ -57,7 +57,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number dontOverrideMe() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number dontOverrideMe() {
         return this.jsiiCall("dontOverrideMe", java.lang.Number.class);
     }
 
@@ -67,7 +67,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * @param mult This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number overrideMe(final java.lang.Number mult) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number overrideMe(final @org.jetbrains.annotations.NotNull java.lang.Number mult) {
         return this.jsiiAsyncCall("overrideMe", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(mult, "mult is required") });
     }
 
@@ -75,7 +75,7 @@ public class AsyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number overrideMeToo() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number overrideMeToo() {
         return this.jsiiAsyncCall("overrideMeToo", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Bell.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Bell.java
@@ -34,7 +34,7 @@ public class Bell extends software.amazon.jsii.JsiiObject implements software.am
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getRung() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getRung() {
         return this.jsiiGet("rung", java.lang.Boolean.class);
     }
 
@@ -42,7 +42,7 @@ public class Bell extends software.amazon.jsii.JsiiObject implements software.am
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setRung(final java.lang.Boolean value) {
+    public void setRung(final @org.jetbrains.annotations.NotNull java.lang.Boolean value) {
         this.jsiiSet("rung", java.util.Objects.requireNonNull(value, "rung is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/BinaryOperation.java
@@ -27,7 +27,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected BinaryOperation(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
+    protected BinaryOperation(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value lhs, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
@@ -39,7 +39,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String hello() {
+    public @org.jetbrains.annotations.NotNull java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
 
@@ -49,7 +49,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getLhs() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getLhs() {
         return this.jsiiGet("lhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -59,7 +59,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getRhs() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getRhs() {
         return this.jsiiGet("rhs", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -77,7 +77,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
 
@@ -87,7 +87,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String hello() {
+        public @org.jetbrains.annotations.NotNull java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);
         }
 
@@ -97,7 +97,7 @@ public abstract class BinaryOperation extends software.amazon.jsii.tests.calcula
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String toString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -47,7 +47,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * @param props Initialization properties.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Calculator(final software.amazon.jsii.tests.calculator.CalculatorProps props) {
+    public Calculator(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.CalculatorProps props) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { props });
     }
@@ -71,7 +71,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void add(final java.lang.Number value) {
+    public void add(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiCall("add", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -83,7 +83,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void mul(final java.lang.Number value) {
+    public void mul(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiCall("mul", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -105,7 +105,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void pow(final java.lang.Number value) {
+    public void pow(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiCall("pow", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -115,7 +115,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number readUnionValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number readUnionValue() {
         return this.jsiiCall("readUnionValue", java.lang.Number.class);
     }
 
@@ -126,7 +126,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -136,7 +136,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getOperationsLog() {
+    public @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getOperationsLog() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("operationsLog", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.Value.class))));
     }
 
@@ -146,7 +146,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, java.util.List<software.amazon.jsii.tests.calculator.lib.Value>> getOperationsMap() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.util.List<software.amazon.jsii.tests.calculator.lib.Value>> getOperationsMap() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("operationsMap", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.Value.class)))));
     }
 
@@ -156,7 +156,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getCurr() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getCurr() {
         return this.jsiiGet("curr", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -166,7 +166,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setCurr(final software.amazon.jsii.tests.calculator.lib.Value value) {
+    public void setCurr(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value value) {
         this.jsiiSet("curr", java.util.Objects.requireNonNull(value, "curr is required"));
     }
 
@@ -176,7 +176,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getMaxValue() {
+    public @org.jetbrains.annotations.Nullable java.lang.Number getMaxValue() {
         return this.jsiiGet("maxValue", java.lang.Number.class);
     }
 
@@ -186,7 +186,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMaxValue(final java.lang.Number value) {
+    public void setMaxValue(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
         this.jsiiSet("maxValue", value);
     }
 
@@ -196,7 +196,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object getUnionProperty() {
+    public @org.jetbrains.annotations.Nullable java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
 
@@ -206,7 +206,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Add value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.Add value) {
         this.jsiiSet("unionProperty", value);
     }
 
@@ -216,7 +216,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Multiply value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.Multiply value) {
         this.jsiiSet("unionProperty", value);
     }
 
@@ -226,7 +226,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.Power value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.Power value) {
         this.jsiiSet("unionProperty", value);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsTheInternalInterface.java
@@ -26,7 +26,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getA() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getA() {
         return this.jsiiGet("a", java.lang.String.class);
     }
 
@@ -35,7 +35,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setA(final java.lang.String value) {
+    public void setA(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
@@ -44,7 +44,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getB() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getB() {
         return this.jsiiGet("b", java.lang.String.class);
     }
 
@@ -53,7 +53,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setB(final java.lang.String value) {
+    public void setB(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
     }
 
@@ -62,7 +62,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getC() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getC() {
         return this.jsiiGet("c", java.lang.String.class);
     }
 
@@ -71,7 +71,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setC(final java.lang.String value) {
+    public void setC(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
     }
 
@@ -79,7 +79,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getD() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getD() {
         return this.jsiiGet("d", java.lang.String.class);
     }
 
@@ -87,7 +87,7 @@ public class ClassThatImplementsTheInternalInterface extends software.amazon.jsi
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setD(final java.lang.String value) {
+    public void setD(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("d", java.util.Objects.requireNonNull(value, "d is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassThatImplementsThePrivateInterface.java
@@ -26,7 +26,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getA() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getA() {
         return this.jsiiGet("a", java.lang.String.class);
     }
 
@@ -35,7 +35,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setA(final java.lang.String value) {
+    public void setA(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
@@ -44,7 +44,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getB() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getB() {
         return this.jsiiGet("b", java.lang.String.class);
     }
 
@@ -53,7 +53,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setB(final java.lang.String value) {
+    public void setB(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
     }
 
@@ -62,7 +62,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getC() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getC() {
         return this.jsiiGet("c", java.lang.String.class);
     }
 
@@ -71,7 +71,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setC(final java.lang.String value) {
+    public void setC(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
     }
 
@@ -79,7 +79,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getE() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getE() {
         return this.jsiiGet("e", java.lang.String.class);
     }
 
@@ -87,7 +87,7 @@ public class ClassThatImplementsThePrivateInterface extends software.amazon.jsii
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setE(final java.lang.String value) {
+    public void setE(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("e", java.util.Objects.requireNonNull(value, "e is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollections.java
@@ -23,7 +23,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * @param array This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ClassWithCollections(final java.util.Map<java.lang.String, java.lang.String> map, final java.util.List<java.lang.String> array) {
+    public ClassWithCollections(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> map, final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> array) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(map, "map is required"), java.util.Objects.requireNonNull(array, "array is required") });
     }
@@ -32,7 +32,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<java.lang.String> createAList() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> createAList() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "createAList", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -40,7 +40,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, java.lang.String> createAMap() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> createAMap() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "createAMap", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -48,7 +48,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<java.lang.String> getStaticArray() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getStaticArray() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticArray", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -56,7 +56,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void setStaticArray(final java.util.List<java.lang.String> value) {
+    public static void setStaticArray(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticArray", java.util.Objects.requireNonNull(value, "staticArray is required"));
     }
 
@@ -64,7 +64,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, java.lang.String> getStaticMap() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> getStaticMap() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticMap", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -72,7 +72,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void setStaticMap(final java.util.Map<java.lang.String, java.lang.String> value) {
+    public static void setStaticMap(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.ClassWithCollections.class, "staticMap", java.util.Objects.requireNonNull(value, "staticMap is required"));
     }
 
@@ -80,7 +80,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.String> getArray() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getArray() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("array", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -88,7 +88,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setArray(final java.util.List<java.lang.String> value) {
+    public void setArray(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> value) {
         this.jsiiSet("array", java.util.Objects.requireNonNull(value, "array is required"));
     }
 
@@ -96,7 +96,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.Map<java.lang.String, java.lang.String> getMap() {
+    public @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> getMap() {
         return java.util.Collections.unmodifiableMap(this.jsiiGet("map", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -104,7 +104,7 @@ public class ClassWithCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMap(final java.util.Map<java.lang.String, java.lang.String> value) {
+    public void setMap(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.String> value) {
         this.jsiiSet("map", java.util.Objects.requireNonNull(value, "map is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithJavaReservedWords.java
@@ -22,7 +22,7 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
      * @param int This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ClassWithJavaReservedWords(final java.lang.String intValue) {
+    public ClassWithJavaReservedWords(final @org.jetbrains.annotations.NotNull java.lang.String intValue) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(intValue, "intValue is required") });
     }
@@ -33,7 +33,7 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
      * @param assert This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String doImport(final java.lang.String assertValue) {
+    public @org.jetbrains.annotations.NotNull java.lang.String doImport(final @org.jetbrains.annotations.NotNull java.lang.String assertValue) {
         return this.jsiiCall("import", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(assertValue, "assertValue is required") });
     }
 
@@ -41,7 +41,7 @@ public class ClassWithJavaReservedWords extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getIntValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getIntValue() {
         return this.jsiiGet("int", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithMutableObjectLiteralProperty.java
@@ -25,7 +25,7 @@ public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IMutableObjectLiteral getMutableObject() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IMutableObjectLiteral getMutableObject() {
         return this.jsiiGet("mutableObject", software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class);
     }
 
@@ -33,7 +33,7 @@ public class ClassWithMutableObjectLiteralProperty extends software.amazon.jsii.
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMutableObject(final software.amazon.jsii.tests.calculator.IMutableObjectLiteral value) {
+    public void setMutableObject(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IMutableObjectLiteral value) {
         this.jsiiSet("mutableObject", java.util.Objects.requireNonNull(value, "mutableObject is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithPrivateConstructorAndAutomaticProperties.java
@@ -25,7 +25,7 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
      * @param readWriteString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties create(final java.lang.String readOnlyString, final java.lang.String readWriteString) {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties create(final @org.jetbrains.annotations.NotNull java.lang.String readOnlyString, final @org.jetbrains.annotations.NotNull java.lang.String readWriteString) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, "create", software.amazon.jsii.tests.calculator.ClassWithPrivateConstructorAndAutomaticProperties.class, new Object[] { java.util.Objects.requireNonNull(readOnlyString, "readOnlyString is required"), java.util.Objects.requireNonNull(readWriteString, "readWriteString is required") });
     }
 
@@ -34,7 +34,7 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getReadOnlyString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadOnlyString() {
         return this.jsiiGet("readOnlyString", java.lang.String.class);
     }
 
@@ -43,7 +43,7 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getReadWriteString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadWriteString() {
         return this.jsiiGet("readWriteString", java.lang.String.class);
     }
 
@@ -52,7 +52,7 @@ public class ClassWithPrivateConstructorAndAutomaticProperties extends software.
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setReadWriteString(final java.lang.String value) {
+    public void setReadWriteString(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJackson.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJackson.java
@@ -24,7 +24,7 @@ public class ConfusingToJackson extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.ConfusingToJackson makeInstance() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ConfusingToJackson makeInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConfusingToJackson.class, "makeInstance", software.amazon.jsii.tests.calculator.ConfusingToJackson.class);
     }
 
@@ -32,7 +32,7 @@ public class ConfusingToJackson extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.ConfusingToJacksonStruct makeStructInstance() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ConfusingToJacksonStruct makeStructInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConfusingToJackson.class, "makeStructInstance", software.amazon.jsii.tests.calculator.ConfusingToJacksonStruct.class);
     }
 
@@ -40,7 +40,7 @@ public class ConfusingToJackson extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object getUnionProperty() {
+    public @org.jetbrains.annotations.Nullable java.lang.Object getUnionProperty() {
         return this.jsiiGet("unionProperty", java.lang.Object.class);
     }
 
@@ -48,7 +48,7 @@ public class ConfusingToJackson extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final software.amazon.jsii.tests.calculator.lib.IFriendly value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.lib.IFriendly value) {
         this.jsiiSet("unionProperty", value);
     }
 
@@ -56,7 +56,7 @@ public class ConfusingToJackson extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setUnionProperty(final java.util.List<java.lang.Object> value) {
+    public void setUnionProperty(final @org.jetbrains.annotations.Nullable java.util.List<java.lang.Object> value) {
         this.jsiiSet("unionProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConstructorPassesThisOut.java
@@ -22,7 +22,7 @@ public class ConstructorPassesThisOut extends software.amazon.jsii.JsiiObject {
      * @param consumer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ConstructorPassesThisOut(final software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {
+    public ConstructorPassesThisOut(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer consumer) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(consumer, "consumer is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Constructors.java
@@ -25,7 +25,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.IPublicInterface hiddenInterface() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IPublicInterface hiddenInterface() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterface", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }
 
@@ -33,7 +33,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenInterfaces() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenInterfaces() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenInterfaces", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IPublicInterface.class))));
     }
 
@@ -41,7 +41,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenSubInterfaces() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> hiddenSubInterfaces() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "hiddenSubInterfaces", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IPublicInterface.class))));
     }
 
@@ -49,7 +49,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.PublicClass makeClass() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.PublicClass makeClass() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeClass", software.amazon.jsii.tests.calculator.PublicClass.class);
     }
 
@@ -57,7 +57,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.IPublicInterface makeInterface() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IPublicInterface makeInterface() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterface", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }
 
@@ -65,7 +65,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.IPublicInterface2 makeInterface2() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IPublicInterface2 makeInterface2() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterface2", software.amazon.jsii.tests.calculator.IPublicInterface2.class);
     }
 
@@ -73,7 +73,7 @@ public class Constructors extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> makeInterfaces() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.IPublicInterface> makeInterfaces() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Constructors.class, "makeInterfaces", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IPublicInterface.class))));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumePureInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumePureInterface.java
@@ -22,7 +22,7 @@ public class ConsumePureInterface extends software.amazon.jsii.JsiiObject {
      * @param delegate This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ConsumePureInterface(final software.amazon.jsii.tests.calculator.IStructReturningDelegate delegate) {
+    public ConsumePureInterface(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IStructReturningDelegate delegate) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(delegate, "delegate is required") });
     }
@@ -31,7 +31,7 @@ public class ConsumePureInterface extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.StructB workItBaby() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructB workItBaby() {
         return this.jsiiCall("workItBaby", software.amazon.jsii.tests.calculator.StructB.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumerCanRingBell.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumerCanRingBell.java
@@ -36,7 +36,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean staticImplementedByObjectLiteral(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean staticImplementedByObjectLiteral(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConsumerCanRingBell.class, "staticImplementedByObjectLiteral", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -50,7 +50,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean staticImplementedByPrivateClass(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean staticImplementedByPrivateClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConsumerCanRingBell.class, "staticImplementedByPrivateClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -64,7 +64,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean staticImplementedByPublicClass(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean staticImplementedByPublicClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConsumerCanRingBell.class, "staticImplementedByPublicClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -78,7 +78,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean staticWhenTypedAsClass(final software.amazon.jsii.tests.calculator.IConcreteBellRinger ringer) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean staticWhenTypedAsClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IConcreteBellRinger ringer) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ConsumerCanRingBell.class, "staticWhenTypedAsClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -92,7 +92,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean implementedByObjectLiteral(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean implementedByObjectLiteral(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return this.jsiiCall("implementedByObjectLiteral", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -106,7 +106,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean implementedByPrivateClass(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean implementedByPrivateClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return this.jsiiCall("implementedByPrivateClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -120,7 +120,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean implementedByPublicClass(final software.amazon.jsii.tests.calculator.IBellRinger ringer) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean implementedByPublicClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBellRinger ringer) {
         return this.jsiiCall("implementedByPublicClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 
@@ -134,7 +134,7 @@ public class ConsumerCanRingBell extends software.amazon.jsii.JsiiObject {
      * @param ringer This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean whenTypedAsClass(final software.amazon.jsii.tests.calculator.IConcreteBellRinger ringer) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean whenTypedAsClass(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IConcreteBellRinger ringer) {
         return this.jsiiCall("whenTypedAsClass", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(ringer, "ringer is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConsumersOfThisCrazyTypeSystem.java
@@ -27,7 +27,7 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
      * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String consumeAnotherPublicInterface(final software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
+    public @org.jetbrains.annotations.NotNull java.lang.String consumeAnotherPublicInterface(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IAnotherPublicInterface obj) {
         return this.jsiiCall("consumeAnotherPublicInterface", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 
@@ -37,7 +37,7 @@ public class ConsumersOfThisCrazyTypeSystem extends software.amazon.jsii.JsiiObj
      * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object consumeNonInternalInterface(final software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
+    public @org.jetbrains.annotations.NotNull java.lang.Object consumeNonInternalInterface(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.INonInternalInterface obj) {
         return this.jsiiCall("consumeNonInternalInterface", java.lang.Object.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DataRenderer.java
@@ -33,7 +33,7 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
      * @param data
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String render(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct data) {
+    public @org.jetbrains.annotations.NotNull java.lang.String render(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.lib.MyFirstStruct data) {
         return this.jsiiCall("render", java.lang.String.class, new Object[] { data });
     }
 
@@ -41,7 +41,7 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String render() {
+    public @org.jetbrains.annotations.NotNull java.lang.String render() {
         return this.jsiiCall("render", java.lang.String.class);
     }
 
@@ -51,7 +51,7 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
      * @param data This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String renderArbitrary(final java.util.Map<java.lang.String, java.lang.Object> data) {
+    public @org.jetbrains.annotations.NotNull java.lang.String renderArbitrary(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> data) {
         return this.jsiiCall("renderArbitrary", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(data, "data is required") });
     }
 
@@ -61,7 +61,7 @@ public class DataRenderer extends software.amazon.jsii.JsiiObject {
      * @param map This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String renderMap(final java.util.Map<java.lang.String, java.lang.Object> map) {
+    public @org.jetbrains.annotations.NotNull java.lang.String renderMap(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> map) {
         return this.jsiiCall("renderMap", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(map, "map is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DefaultedConstructorArgument.java
@@ -24,7 +24,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+    public DefaultedConstructorArgument(final @org.jetbrains.annotations.Nullable java.lang.Number arg1, final @org.jetbrains.annotations.Nullable java.lang.String arg2, final @org.jetbrains.annotations.Nullable java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2, arg3 });
     }
@@ -36,7 +36,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
+    public DefaultedConstructorArgument(final @org.jetbrains.annotations.Nullable java.lang.Number arg1, final @org.jetbrains.annotations.Nullable java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1, arg2 });
     }
@@ -47,7 +47,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * @param arg1
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public DefaultedConstructorArgument(final java.lang.Number arg1) {
+    public DefaultedConstructorArgument(final @org.jetbrains.annotations.Nullable java.lang.Number arg1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { arg1 });
     }
@@ -65,7 +65,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getArg1() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getArg1() {
         return this.jsiiGet("arg1", java.lang.Number.class);
     }
 
@@ -73,7 +73,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.time.Instant getArg3() {
+    public @org.jetbrains.annotations.NotNull java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);
     }
 
@@ -81,7 +81,7 @@ public class DefaultedConstructorArgument extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getArg2() {
+    public @org.jetbrains.annotations.Nullable java.lang.String getArg2() {
         return this.jsiiGet("arg2", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Demonstrate982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Demonstrate982.java
@@ -36,7 +36,7 @@ public class Demonstrate982 extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.ChildStruct982 takeThis() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ChildStruct982 takeThis() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Demonstrate982.class, "takeThis", software.amazon.jsii.tests.calculator.ChildStruct982.class);
     }
 
@@ -46,7 +46,7 @@ public class Demonstrate982 extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.ParentStruct982 takeThisToo() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ParentStruct982 takeThisToo() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Demonstrate982.class, "takeThisToo", software.amazon.jsii.tests.calculator.ParentStruct982.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedClass.java
@@ -24,7 +24,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public DeprecatedClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+    public DeprecatedClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString, final @org.jetbrains.annotations.Nullable java.lang.Number mutableNumber) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
     }
@@ -35,7 +35,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public DeprecatedClass(final java.lang.String readonlyString) {
+    public DeprecatedClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
     }
@@ -54,7 +54,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public java.lang.String getReadonlyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
 
@@ -63,7 +63,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public java.lang.Number getMutableProperty() {
+    public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
 
@@ -72,7 +72,7 @@ public class DeprecatedClass extends software.amazon.jsii.JsiiObject {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public void setMutableProperty(final java.lang.Number value) {
+    public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedClassHasNoProperties/Base.java
@@ -25,7 +25,7 @@ public class Base extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getProp() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getProp() {
         return this.jsiiGet("prop", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class Base extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setProp(final java.lang.String value) {
+    public void setProp(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("prop", java.util.Objects.requireNonNull(value, "prop is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotOverridePrivates.java
@@ -27,7 +27,7 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
      * @param newValue This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void changePrivatePropertyValue(final java.lang.String newValue) {
+    public void changePrivatePropertyValue(final @org.jetbrains.annotations.NotNull java.lang.String newValue) {
         this.jsiiCall("changePrivatePropertyValue", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(newValue, "newValue is required") });
     }
 
@@ -35,7 +35,7 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String privateMethodValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String privateMethodValue() {
         return this.jsiiCall("privateMethodValue", java.lang.String.class);
     }
 
@@ -43,7 +43,7 @@ public class DoNotOverridePrivates extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String privatePropertyValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String privatePropertyValue() {
         return this.jsiiCall("privatePropertyValue", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoNotRecognizeAnyAsOptional.java
@@ -31,7 +31,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
      * @param _optionalString
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny, final java.lang.String _optionalString) {
+    public void method(final @org.jetbrains.annotations.NotNull java.lang.Object _requiredAny, final @org.jetbrains.annotations.Nullable java.lang.Object _optionalAny, final @org.jetbrains.annotations.Nullable java.lang.String _optionalString) {
         this.jsiiCall("method", software.amazon.jsii.NativeType.VOID, new Object[] { _requiredAny, _optionalAny, _optionalString });
     }
 
@@ -42,7 +42,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
      * @param _optionalAny
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(final java.lang.Object _requiredAny, final java.lang.Object _optionalAny) {
+    public void method(final @org.jetbrains.annotations.NotNull java.lang.Object _requiredAny, final @org.jetbrains.annotations.Nullable java.lang.Object _optionalAny) {
         this.jsiiCall("method", software.amazon.jsii.NativeType.VOID, new Object[] { _requiredAny, _optionalAny });
     }
 
@@ -52,7 +52,7 @@ public class DoNotRecognizeAnyAsOptional extends software.amazon.jsii.JsiiObject
      * @param _requiredAny This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void method(final java.lang.Object _requiredAny) {
+    public void method(final @org.jetbrains.annotations.NotNull java.lang.Object _requiredAny) {
         this.jsiiCall("method", software.amazon.jsii.NativeType.VOID, new Object[] { _requiredAny });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DocumentedClass.java
@@ -36,7 +36,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * @param greetee The person to be greeted.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public java.lang.Number greet(final software.amazon.jsii.tests.calculator.Greetee greetee) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number greet(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.Greetee greetee) {
         return this.jsiiCall("greet", java.lang.Number.class, new Object[] { greetee });
     }
 
@@ -49,7 +49,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
      * @return A number that everyone knows very well
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public java.lang.Number greet() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number greet() {
         return this.jsiiCall("greet", java.lang.Number.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DontComplainAboutVariadicAfterOptional.java
@@ -28,7 +28,7 @@ public class DontComplainAboutVariadicAfterOptional extends software.amazon.jsii
      * @param things This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String optionalAndVariadic(final java.lang.String optional, final java.lang.String... things) {
+    public @org.jetbrains.annotations.NotNull java.lang.String optionalAndVariadic(final @org.jetbrains.annotations.Nullable java.lang.String optional, final @org.jetbrains.annotations.NotNull java.lang.String... things) {
         return this.jsiiCall("optionalAndVariadic", java.lang.String.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { optional }), java.util.Arrays.<Object>stream(things)).toArray(Object[]::new));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DoubleTrouble.java
@@ -28,7 +28,7 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String hello() {
+    public @org.jetbrains.annotations.NotNull java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
 
@@ -39,7 +39,7 @@ public class DoubleTrouble extends software.amazon.jsii.JsiiObject implements so
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.Number next() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EnumDispenser.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EnumDispenser.java
@@ -20,7 +20,7 @@ public class EnumDispenser extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.AllTypesEnum randomIntegerLikeEnum() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AllTypesEnum randomIntegerLikeEnum() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EnumDispenser.class, "randomIntegerLikeEnum", software.amazon.jsii.tests.calculator.AllTypesEnum.class);
     }
 
@@ -28,7 +28,7 @@ public class EnumDispenser extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.StringEnum randomStringLikeEnum() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StringEnum randomStringLikeEnum() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EnumDispenser.class, "randomStringLikeEnum", software.amazon.jsii.tests.calculator.StringEnum.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValues.java
@@ -33,7 +33,7 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * @param key This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean doesKeyExist(final software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions opts, final java.lang.String key) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean doesKeyExist(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions opts, final @org.jetbrains.annotations.NotNull java.lang.String key) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "doesKeyExist", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(opts, "opts is required"), java.util.Objects.requireNonNull(key, "key is required") });
     }
 
@@ -43,7 +43,7 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, java.lang.Object> prop1IsNull() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> prop1IsNull() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop1IsNull", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 
@@ -53,7 +53,7 @@ public class EraseUndefinedHashValues extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, java.lang.Object> prop2IsUndefined() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, java.lang.Object> prop2IsUndefined() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.EraseUndefinedHashValues.class, "prop2IsUndefined", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalClass.java
@@ -23,7 +23,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * @param mutableNumber
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ExperimentalClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+    public ExperimentalClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString, final @org.jetbrains.annotations.Nullable java.lang.Number mutableNumber) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
     }
@@ -34,7 +34,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * @param readonlyString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ExperimentalClass(final java.lang.String readonlyString) {
+    public ExperimentalClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
     }
@@ -51,7 +51,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getReadonlyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
 
@@ -59,7 +59,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getMutableProperty() {
+    public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
 
@@ -67,7 +67,7 @@ public class ExperimentalClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setMutableProperty(final java.lang.Number value) {
+    public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExportedBaseClass.java
@@ -22,7 +22,7 @@ public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
      * @param success This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public ExportedBaseClass(final java.lang.Boolean success) {
+    public ExportedBaseClass(final @org.jetbrains.annotations.NotNull java.lang.Boolean success) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(success, "success is required") });
     }
@@ -31,7 +31,7 @@ public class ExportedBaseClass extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getSuccess() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getSuccess() {
         return this.jsiiGet("success", java.lang.Boolean.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GiveMeStructs.java
@@ -29,7 +29,7 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * @param derived This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.MyFirstStruct derivedToFirst(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("derivedToFirst", software.amazon.jsii.tests.calculator.lib.MyFirstStruct.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
@@ -41,7 +41,7 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * @param derived This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final software.amazon.jsii.tests.calculator.DerivedStruct derived) {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.DoubleTrouble readDerivedNonPrimitive(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.DerivedStruct derived) {
         return this.jsiiCall("readDerivedNonPrimitive", software.amazon.jsii.tests.calculator.DoubleTrouble.class, new Object[] { java.util.Objects.requireNonNull(derived, "derived is required") });
     }
 
@@ -53,7 +53,7 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * @param first This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number readFirstNumber(final software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number readFirstNumber(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.MyFirstStruct first) {
         return this.jsiiCall("readFirstNumber", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(first, "first is required") });
     }
 
@@ -61,7 +61,7 @@ public class GiveMeStructs extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals getStructLiteral() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals getStructLiteral() {
         return this.jsiiGet("structLiteral", software.amazon.jsii.tests.calculator.lib.StructWithOnlyOptionals.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/GreetingAugmenter.java
@@ -27,7 +27,7 @@ public class GreetingAugmenter extends software.amazon.jsii.JsiiObject {
      * @param friendly This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String betterGreeting(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
+    public @org.jetbrains.annotations.NotNull java.lang.String betterGreeting(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
         return this.jsiiCall("betterGreeting", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
@@ -36,7 +36,7 @@ public interface IAnonymousImplementationProvider extends software.amazon.jsii.J
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public software.amazon.jsii.tests.calculator.Implementation provideAsClass() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Implementation provideAsClass() {
             return this.jsiiCall("provideAsClass", software.amazon.jsii.tests.calculator.Implementation.class);
         }
 
@@ -45,7 +45,7 @@ public interface IAnonymousImplementationProvider extends software.amazon.jsii.J
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface() {
             return this.jsiiCall("provideAsInterface", software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
@@ -34,7 +34,7 @@ public interface IAnonymouslyImplementMe extends software.amazon.jsii.JsiiSerial
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
 
@@ -43,7 +43,7 @@ public interface IAnonymouslyImplementMe extends software.amazon.jsii.JsiiSerial
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String verb() {
+        public @org.jetbrains.annotations.NotNull java.lang.String verb() {
             return this.jsiiCall("verb", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -33,7 +33,7 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getA() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getA() {
             return this.jsiiGet("a", java.lang.String.class);
         }
 
@@ -42,7 +42,7 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setA(final java.lang.String value) {
+        public void setA(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IBellRinger.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IBellRinger.java
@@ -17,7 +17,7 @@ public interface IBellRinger extends software.amazon.jsii.JsiiSerializable {
      * @param bell This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    void yourTurn(final software.amazon.jsii.tests.calculator.IBell bell);
+    void yourTurn(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBell bell);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -34,7 +34,7 @@ public interface IBellRinger extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public void yourTurn(final software.amazon.jsii.tests.calculator.IBell bell) {
+        public void yourTurn(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IBell bell) {
             this.jsiiCall("yourTurn", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(bell, "bell is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IConcreteBellRinger.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IConcreteBellRinger.java
@@ -17,7 +17,7 @@ public interface IConcreteBellRinger extends software.amazon.jsii.JsiiSerializab
      * @param bell This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    void yourTurn(final software.amazon.jsii.tests.calculator.Bell bell);
+    void yourTurn(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Bell bell);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -34,7 +34,7 @@ public interface IConcreteBellRinger extends software.amazon.jsii.JsiiSerializab
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public void yourTurn(final software.amazon.jsii.tests.calculator.Bell bell) {
+        public void yourTurn(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Bell bell) {
             this.jsiiCall("yourTurn", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(bell, "bell is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
@@ -48,7 +48,7 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getMutableProperty() {
+        public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
 
@@ -58,7 +58,7 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public void setMutableProperty(final java.lang.Number value) {
+        public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
@@ -44,7 +44,7 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getMutableProperty() {
+        public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
 
@@ -53,7 +53,7 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setMutableProperty(final java.lang.Number value) {
+        public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
@@ -39,7 +39,7 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.util.List<java.lang.String> getMoreThings() {
+        public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getMoreThings() {
             return java.util.Collections.unmodifiableList(this.jsiiGet("moreThings", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
         }
 
@@ -48,7 +48,7 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getPrivateValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getPrivateValue() {
             return this.jsiiGet("private", java.lang.String.class);
         }
 
@@ -57,7 +57,7 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setPrivateValue(final java.lang.String value) {
+        public void setPrivateValue(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("private", java.util.Objects.requireNonNull(value, "private is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -44,7 +44,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String farewell() {
+        public @org.jetbrains.annotations.NotNull java.lang.String farewell() {
             return this.jsiiCall("farewell", java.lang.String.class);
         }
 
@@ -57,7 +57,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String goodbye() {
+        public @org.jetbrains.annotations.NotNull java.lang.String goodbye() {
             return this.jsiiCall("goodbye", java.lang.String.class);
         }
 
@@ -67,7 +67,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String hello() {
+        public @org.jetbrains.annotations.NotNull java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlyRandomGenerator.java
@@ -26,7 +26,7 @@ public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSeria
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.Number next() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number next() {
             return this.jsiiCall("next", java.lang.Number.class);
         }
 
@@ -36,7 +36,7 @@ public interface IFriendlyRandomGenerator extends software.amazon.jsii.JsiiSeria
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String hello() {
+        public @org.jetbrains.annotations.NotNull java.lang.String hello() {
             return this.jsiiCall("hello", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
@@ -30,7 +30,7 @@ public interface IInterfaceImplementedByAbstractClass extends software.amazon.js
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getPropFromInterface() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getPropFromInterface() {
             return this.jsiiGet("propFromInterface", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -30,7 +30,7 @@ public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getOtherValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getOtherValue() {
             return this.jsiiGet("otherValue", java.lang.String.class);
         }
 
@@ -39,7 +39,7 @@ public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -34,7 +34,7 @@ public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithOptionalMethodArguments.java
@@ -18,7 +18,7 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
      * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    void hello(final java.lang.String arg1, final java.lang.Number arg2);
+    void hello(final @org.jetbrains.annotations.NotNull java.lang.String arg1, final @org.jetbrains.annotations.Nullable java.lang.Number arg2);
 
     /**
      * EXPERIMENTAL
@@ -26,7 +26,7 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
      * @param arg1 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    void hello(final java.lang.String arg1);
+    void hello(final @org.jetbrains.annotations.NotNull java.lang.String arg1);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -44,7 +44,7 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public void hello(final java.lang.String arg1, final java.lang.Number arg2) {
+        public void hello(final @org.jetbrains.annotations.NotNull java.lang.String arg1, final @org.jetbrains.annotations.Nullable java.lang.Number arg2) {
             this.jsiiCall("hello", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), arg2 });
         }
 
@@ -55,7 +55,7 @@ public interface IInterfaceWithOptionalMethodArguments extends software.amazon.j
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public void hello(final java.lang.String arg1) {
+        public void hello(final @org.jetbrains.annotations.NotNull java.lang.String arg1) {
             this.jsiiCall("hello", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -39,7 +39,7 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getReadOnlyString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getReadOnlyString() {
             return this.jsiiGet("readOnlyString", java.lang.String.class);
         }
 
@@ -48,7 +48,7 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getReadWriteString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
 
@@ -57,7 +57,7 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setReadWriteString(final java.lang.String value) {
+        public void setReadWriteString(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -33,7 +33,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getFoo() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }
 
@@ -42,7 +42,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setFoo(final java.lang.Number value) {
+        public void setFoo(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
             this.jsiiSet("foo", java.util.Objects.requireNonNull(value, "foo is required"));
         }
 
@@ -51,7 +51,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getReadOnlyString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getReadOnlyString() {
             return this.jsiiGet("readOnlyString", java.lang.String.class);
         }
 
@@ -60,7 +60,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getReadWriteString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getReadWriteString() {
             return this.jsiiGet("readWriteString", java.lang.String.class);
         }
 
@@ -69,7 +69,7 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setReadWriteString(final java.lang.String value) {
+        public void setReadWriteString(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("readWriteString", java.util.Objects.requireNonNull(value, "readWriteString is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
@@ -40,7 +40,7 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getProperty() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getProperty() {
             return this.jsiiGet("property", java.lang.String.class);
         }
 
@@ -49,7 +49,7 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Boolean getHasRoot() {
+        public @org.jetbrains.annotations.NotNull java.lang.Boolean getHasRoot() {
             return this.jsiiGet("hasRoot", java.lang.Boolean.class);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
@@ -34,7 +34,7 @@ public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSeria
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Boolean getHasRoot() {
+        public @org.jetbrains.annotations.NotNull java.lang.Boolean getHasRoot() {
             return this.jsiiGet("hasRoot", java.lang.Boolean.class);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
@@ -33,7 +33,7 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getValue() {
             return this.jsiiGet("value", java.lang.String.class);
         }
 
@@ -42,7 +42,7 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setValue(final java.lang.String value) {
+        public void setValue(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("value", java.util.Objects.requireNonNull(value, "value is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -44,7 +44,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getB() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getB() {
             return this.jsiiGet("b", java.lang.String.class);
         }
 
@@ -53,7 +53,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setB(final java.lang.String value) {
+        public void setB(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("b", java.util.Objects.requireNonNull(value, "b is required"));
         }
 
@@ -62,7 +62,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getC() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getC() {
             return this.jsiiGet("c", java.lang.String.class);
         }
 
@@ -71,7 +71,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setC(final java.lang.String value) {
+        public void setC(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("c", java.util.Objects.requireNonNull(value, "c is required"));
         }
 
@@ -80,7 +80,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getA() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getA() {
             return this.jsiiGet("a", java.lang.String.class);
         }
 
@@ -89,7 +89,7 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setA(final java.lang.String value) {
+        public void setA(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IObjectWithProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IObjectWithProperty.java
@@ -41,7 +41,7 @@ public interface IObjectWithProperty extends software.amazon.jsii.JsiiSerializab
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.String getProperty() {
+        public @org.jetbrains.annotations.NotNull java.lang.String getProperty() {
             return this.jsiiGet("property", java.lang.String.class);
         }
 
@@ -50,7 +50,7 @@ public interface IObjectWithProperty extends software.amazon.jsii.JsiiSerializab
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public void setProperty(final java.lang.String value) {
+        public void setProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
             this.jsiiSet("property", java.util.Objects.requireNonNull(value, "property is required"));
         }
 
@@ -59,7 +59,7 @@ public interface IObjectWithProperty extends software.amazon.jsii.JsiiSerializab
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.Boolean wasSet() {
+        public @org.jetbrains.annotations.NotNull java.lang.Boolean wasSet() {
             return this.jsiiCall("wasSet", java.lang.Boolean.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
@@ -28,7 +28,7 @@ public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializ
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Boolean getSuccess() {
+        public @org.jetbrains.annotations.NotNull java.lang.Boolean getSuccess() {
             return this.jsiiGet("success", java.lang.Boolean.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
@@ -28,7 +28,7 @@ public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable 
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String bye() {
+        public @org.jetbrains.annotations.NotNull java.lang.String bye() {
             return this.jsiiCall("bye", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface2.java
@@ -28,7 +28,7 @@ public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String ciao() {
+        public @org.jetbrains.annotations.NotNull java.lang.String ciao() {
             return this.jsiiCall("ciao", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -38,7 +38,7 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.Number next() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number next() {
             return this.jsiiCall("next", java.lang.Number.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnJsii976.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnJsii976.java
@@ -30,7 +30,7 @@ public interface IReturnJsii976 extends software.amazon.jsii.JsiiSerializable {
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public java.lang.Number getFoo() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getFoo() {
             return this.jsiiGet("foo", java.lang.Number.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -34,7 +34,7 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public software.amazon.jsii.tests.calculator.lib.Number getNumberProp() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Number getNumberProp() {
             return this.jsiiGet("numberProp", software.amazon.jsii.tests.calculator.lib.Number.class);
         }
 
@@ -43,7 +43,7 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber() {
             return this.jsiiCall("obtainNumber", software.amazon.jsii.tests.calculator.lib.IDoublable.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
@@ -39,7 +39,7 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        public java.lang.Number getMutableProperty() {
+        public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
             return this.jsiiGet("mutableProperty", java.lang.Number.class);
         }
 
@@ -47,7 +47,7 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-        public void setMutableProperty(final java.lang.Number value) {
+        public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
             this.jsiiSet("mutableProperty", value);
         }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStructReturningDelegate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStructReturningDelegate.java
@@ -30,7 +30,7 @@ public interface IStructReturningDelegate extends software.amazon.jsii.JsiiSeria
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public software.amazon.jsii.tests.calculator.StructB returnStruct() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructB returnStruct() {
             return this.jsiiCall("returnStruct", software.amazon.jsii.tests.calculator.StructB.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementInternalInterface.java
@@ -25,7 +25,7 @@ public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getProp() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getProp() {
         return this.jsiiGet("prop", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class ImplementInternalInterface extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setProp(final java.lang.String value) {
+    public void setProp(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("prop", java.util.Objects.requireNonNull(value, "prop is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Implementation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Implementation.java
@@ -25,7 +25,7 @@ public class Implementation extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplementsPrivateInterface.java
@@ -25,7 +25,7 @@ public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getPrivateValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getPrivateValue() {
         return this.jsiiGet("private", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class ImplementsPrivateInterface extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setPrivateValue(final java.lang.String value) {
+    public void setPrivateValue(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("private", java.util.Objects.requireNonNull(value, "private is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InbetweenClass.java
@@ -26,7 +26,7 @@ public class InbetweenClass extends software.amazon.jsii.tests.calculator.Public
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String ciao() {
+    public @org.jetbrains.annotations.NotNull java.lang.String ciao() {
         return this.jsiiCall("ciao", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceCollections.java
@@ -24,7 +24,7 @@ public class InterfaceCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.IBell> listOfInterfaces() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.IBell> listOfInterfaces() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfaceCollections.class, "listOfInterfaces", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IBell.class))));
     }
 
@@ -32,7 +32,7 @@ public class InterfaceCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.StructA> listOfStructs() {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.StructA> listOfStructs() {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfaceCollections.class, "listOfStructs", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.StructA.class))));
     }
 
@@ -40,7 +40,7 @@ public class InterfaceCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.IBell> mapOfInterfaces() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.IBell> mapOfInterfaces() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfaceCollections.class, "mapOfInterfaces", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IBell.class))));
     }
 
@@ -48,7 +48,7 @@ public class InterfaceCollections extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.StructA> mapOfStructs() {
+    public static @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.StructA> mapOfStructs() {
         return java.util.Collections.unmodifiableMap(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfaceCollections.class, "mapOfStructs", software.amazon.jsii.NativeType.mapOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.StructA.class))));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Foo.java
@@ -25,7 +25,7 @@ public class Foo extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getBar() {
+    public @org.jetbrains.annotations.Nullable java.lang.String getBar() {
         return this.jsiiGet("bar", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class Foo extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setBar(final java.lang.String value) {
+    public void setBar(final @org.jetbrains.annotations.Nullable java.lang.String value) {
         this.jsiiSet("bar", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfacesMaker.java
@@ -24,7 +24,7 @@ public class InterfacesMaker extends software.amazon.jsii.JsiiObject {
      * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.util.List<software.amazon.jsii.tests.calculator.lib.IDoublable> makeInterfaces(final java.lang.Number count) {
+    public static @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.lib.IDoublable> makeInterfaces(final @org.jetbrains.annotations.NotNull java.lang.Number count) {
         return java.util.Collections.unmodifiableList(software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.InterfacesMaker.class, "makeInterfaces", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.IDoublable.class)), new Object[] { java.util.Objects.requireNonNull(count, "count is required") }));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417Derived.java
@@ -22,7 +22,7 @@ public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII41
      * @param property This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public JSII417Derived(final java.lang.String property) {
+    public JSII417Derived(final @org.jetbrains.annotations.NotNull java.lang.String property) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(property, "property is required") });
     }
@@ -47,7 +47,7 @@ public class JSII417Derived extends software.amazon.jsii.tests.calculator.JSII41
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected java.lang.String getProperty() {
+    protected @org.jetbrains.annotations.NotNull java.lang.String getProperty() {
         return this.jsiiGet("property", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSII417PublicBaseOfBase.java
@@ -25,7 +25,7 @@ public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase makeInstance() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase makeInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase.class, "makeInstance", software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase.class);
     }
 
@@ -41,7 +41,7 @@ public class JSII417PublicBaseOfBase extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getHasRoot() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getHasRoot() {
         return this.jsiiGet("hasRoot", java.lang.Boolean.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralForInterface.java
@@ -25,7 +25,7 @@ public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.IFriendly giveMeFriendly() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.IFriendly giveMeFriendly() {
         return this.jsiiCall("giveMeFriendly", software.amazon.jsii.tests.calculator.lib.IFriendly.class);
     }
 
@@ -33,7 +33,7 @@ public class JSObjectLiteralForInterface extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator giveMeFriendlyGenerator() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator giveMeFriendlyGenerator() {
         return this.jsiiCall("giveMeFriendlyGenerator", software.amazon.jsii.tests.calculator.IFriendlyRandomGenerator.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNative.java
@@ -25,7 +25,7 @@ public class JSObjectLiteralToNative extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass returnLiteral() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass returnLiteral() {
         return this.jsiiCall("returnLiteral", software.amazon.jsii.tests.calculator.JSObjectLiteralToNativeClass.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JSObjectLiteralToNativeClass.java
@@ -25,7 +25,7 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getPropA() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getPropA() {
         return this.jsiiGet("propA", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setPropA(final java.lang.String value) {
+    public void setPropA(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("propA", java.util.Objects.requireNonNull(value, "propA is required"));
     }
 
@@ -41,7 +41,7 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getPropB() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getPropB() {
         return this.jsiiGet("propB", java.lang.Number.class);
     }
 
@@ -49,7 +49,7 @@ public class JSObjectLiteralToNativeClass extends software.amazon.jsii.JsiiObjec
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setPropB(final java.lang.Number value) {
+    public void setPropB(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiSet("propB", java.util.Objects.requireNonNull(value, "propB is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JavaReservedWords.java
@@ -441,7 +441,7 @@ public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getWhileValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getWhileValue() {
         return this.jsiiGet("while", java.lang.String.class);
     }
 
@@ -449,7 +449,7 @@ public class JavaReservedWords extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setWhileValue(final java.lang.String value) {
+    public void setWhileValue(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("while", java.util.Objects.requireNonNull(value, "while is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsiiAgent.java
@@ -29,7 +29,7 @@ public class JsiiAgent extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.String getJsiiAgent() {
+    public static @org.jetbrains.annotations.Nullable java.lang.String getJsiiAgent() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.JsiiAgent.class, "jsiiAgent", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsonFormatter.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/JsonFormatter.java
@@ -24,7 +24,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyArray() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyArray() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyArray", java.lang.Object.class);
     }
 
@@ -32,7 +32,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyBooleanFalse() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyBooleanFalse() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyBooleanFalse", java.lang.Object.class);
     }
 
@@ -40,7 +40,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyBooleanTrue() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyBooleanTrue() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyBooleanTrue", java.lang.Object.class);
     }
 
@@ -48,7 +48,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyDate() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyDate() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyDate", java.lang.Object.class);
     }
 
@@ -56,7 +56,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyEmptyString() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyEmptyString() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyEmptyString", java.lang.Object.class);
     }
 
@@ -64,7 +64,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyFunction() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyFunction() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyFunction", java.lang.Object.class);
     }
 
@@ -72,7 +72,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyHash() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyHash() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyHash", java.lang.Object.class);
     }
 
@@ -80,7 +80,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyNull() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyNull() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyNull", java.lang.Object.class);
     }
 
@@ -88,7 +88,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyNumber() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyNumber() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyNumber", java.lang.Object.class);
     }
 
@@ -96,7 +96,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyRef() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyRef() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyRef", java.lang.Object.class);
     }
 
@@ -104,7 +104,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyString() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyString() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyString", java.lang.Object.class);
     }
 
@@ -112,7 +112,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyUndefined() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyUndefined() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyUndefined", java.lang.Object.class);
     }
 
@@ -120,7 +120,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object anyZero() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object anyZero() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "anyZero", java.lang.Object.class);
     }
 
@@ -130,7 +130,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * @param value
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.String stringify(final java.lang.Object value) {
+    public static @org.jetbrains.annotations.Nullable java.lang.String stringify(final @org.jetbrains.annotations.Nullable java.lang.Object value) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "stringify", java.lang.String.class, new Object[] { value });
     }
 
@@ -138,7 +138,7 @@ public class JsonFormatter extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.String stringify() {
+    public static @org.jetbrains.annotations.Nullable java.lang.String stringify() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.JsonFormatter.class, "stringify", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/MethodNamedProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/MethodNamedProperty.java
@@ -25,7 +25,7 @@ public class MethodNamedProperty extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String property() {
+    public @org.jetbrains.annotations.NotNull java.lang.String property() {
         return this.jsiiCall("property", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class MethodNamedProperty extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getElite() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getElite() {
         return this.jsiiGet("elite", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Multiply.java
@@ -27,7 +27,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      * @param rhs Right-hand side operand. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Multiply(final software.amazon.jsii.tests.calculator.lib.Value lhs, final software.amazon.jsii.tests.calculator.lib.Value rhs) {
+    public Multiply(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value lhs, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value rhs) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(lhs, "lhs is required"), java.util.Objects.requireNonNull(rhs, "rhs is required") });
     }
@@ -39,7 +39,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String farewell() {
+    public @org.jetbrains.annotations.NotNull java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
     }
 
@@ -50,7 +50,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String goodbye() {
+    public @org.jetbrains.annotations.NotNull java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
     }
 
@@ -61,7 +61,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.Number next() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number next() {
         return this.jsiiCall("next", java.lang.Number.class);
     }
 
@@ -72,7 +72,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String toString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
 
@@ -83,7 +83,7 @@ public class Multiply extends software.amazon.jsii.tests.calculator.BinaryOperat
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Negate.java
@@ -24,7 +24,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      * @param operand This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Negate(final software.amazon.jsii.tests.calculator.lib.Value operand) {
+    public Negate(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
     }
@@ -36,7 +36,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String farewell() {
+    public @org.jetbrains.annotations.NotNull java.lang.String farewell() {
         return this.jsiiCall("farewell", java.lang.String.class);
     }
 
@@ -47,7 +47,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String goodbye() {
+    public @org.jetbrains.annotations.NotNull java.lang.String goodbye() {
         return this.jsiiCall("goodbye", java.lang.String.class);
     }
 
@@ -58,7 +58,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String hello() {
+    public @org.jetbrains.annotations.NotNull java.lang.String hello() {
         return this.jsiiCall("hello", java.lang.String.class);
     }
 
@@ -69,7 +69,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String toString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
 
@@ -80,7 +80,7 @@ public class Negate extends software.amazon.jsii.tests.calculator.UnaryOperation
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NodeStandardLibrary.java
@@ -31,7 +31,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
      * @return "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String cryptoSha256() {
+    public @org.jetbrains.annotations.NotNull java.lang.String cryptoSha256() {
         return this.jsiiCall("cryptoSha256", java.lang.String.class);
     }
 
@@ -43,7 +43,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
      * @return "Hello, resource!"
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String fsReadFile() {
+    public @org.jetbrains.annotations.NotNull java.lang.String fsReadFile() {
         return this.jsiiAsyncCall("fsReadFile", java.lang.String.class);
     }
 
@@ -55,7 +55,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
      * @return "Hello, resource! SYNC!"
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String fsReadFileSync() {
+    public @org.jetbrains.annotations.NotNull java.lang.String fsReadFileSync() {
         return this.jsiiCall("fsReadFileSync", java.lang.String.class);
     }
 
@@ -65,7 +65,7 @@ public class NodeStandardLibrary extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getOsPlatform() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getOsPlatform() {
         return this.jsiiGet("osPlatform", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefined.java
@@ -25,7 +25,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * @param optional
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public NullShouldBeTreatedAsUndefined(final java.lang.String _param1, final java.lang.Object optional) {
+    public NullShouldBeTreatedAsUndefined(final @org.jetbrains.annotations.NotNull java.lang.String _param1, final @org.jetbrains.annotations.Nullable java.lang.Object optional) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required"), optional });
     }
@@ -36,7 +36,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * @param _param1 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public NullShouldBeTreatedAsUndefined(final java.lang.String _param1) {
+    public NullShouldBeTreatedAsUndefined(final @org.jetbrains.annotations.NotNull java.lang.String _param1) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_param1, "_param1 is required") });
     }
@@ -47,7 +47,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * @param value
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void giveMeUndefined(final java.lang.Object value) {
+    public void giveMeUndefined(final @org.jetbrains.annotations.Nullable java.lang.Object value) {
         this.jsiiCall("giveMeUndefined", software.amazon.jsii.NativeType.VOID, new Object[] { value });
     }
 
@@ -65,7 +65,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * @param input This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void giveMeUndefinedInsideAnObject(final software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData input) {
+    public void giveMeUndefinedInsideAnObject(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.NullShouldBeTreatedAsUndefinedData input) {
         this.jsiiCall("giveMeUndefinedInsideAnObject", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(input, "input is required") });
     }
 
@@ -81,7 +81,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getChangeMeToUndefined() {
+    public @org.jetbrains.annotations.Nullable java.lang.String getChangeMeToUndefined() {
         return this.jsiiGet("changeMeToUndefined", java.lang.String.class);
     }
 
@@ -89,7 +89,7 @@ public class NullShouldBeTreatedAsUndefined extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setChangeMeToUndefined(final java.lang.String value) {
+    public void setChangeMeToUndefined(final @org.jetbrains.annotations.Nullable java.lang.String value) {
         this.jsiiSet("changeMeToUndefined", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NumberGenerator.java
@@ -24,7 +24,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
      * @param generator This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public NumberGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
+    public NumberGenerator(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IRandomNumberGenerator generator) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(generator, "generator is required") });
     }
@@ -35,7 +35,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
      * @param gen This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean isSameGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean isSameGenerator(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IRandomNumberGenerator gen) {
         return this.jsiiCall("isSameGenerator", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(gen, "gen is required") });
     }
 
@@ -43,7 +43,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number nextTimes100() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number nextTimes100() {
         return this.jsiiCall("nextTimes100", java.lang.Number.class);
     }
 
@@ -51,7 +51,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IRandomNumberGenerator getGenerator() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IRandomNumberGenerator getGenerator() {
         return this.jsiiGet("generator", software.amazon.jsii.tests.calculator.IRandomNumberGenerator.class);
     }
 
@@ -59,7 +59,7 @@ public class NumberGenerator extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setGenerator(final software.amazon.jsii.tests.calculator.IRandomNumberGenerator value) {
+    public void setGenerator(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IRandomNumberGenerator value) {
         this.jsiiSet("generator", java.util.Objects.requireNonNull(value, "generator is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectRefsInCollections.java
@@ -31,7 +31,7 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
      * @param values This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number sumFromArray(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number sumFromArray(final @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.lib.Value> values) {
         return this.jsiiCall("sumFromArray", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }
 
@@ -43,7 +43,7 @@ public class ObjectRefsInCollections extends software.amazon.jsii.JsiiObject {
      * @param values This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number sumFromMap(final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> values) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number sumFromMap(final @org.jetbrains.annotations.NotNull java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> values) {
         return this.jsiiCall("sumFromMap", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(values, "values is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectWithPropertyProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ObjectWithPropertyProvider.java
@@ -20,7 +20,7 @@ public class ObjectWithPropertyProvider extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.IObjectWithProperty provide() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IObjectWithProperty provide() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.ObjectWithPropertyProvider.class, "provide", software.amazon.jsii.tests.calculator.IObjectWithProperty.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalArgumentInvoker.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalArgumentInvoker.java
@@ -22,7 +22,7 @@ public class OptionalArgumentInvoker extends software.amazon.jsii.JsiiObject {
      * @param delegate This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalArgumentInvoker(final software.amazon.jsii.tests.calculator.IInterfaceWithOptionalMethodArguments delegate) {
+    public OptionalArgumentInvoker(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IInterfaceWithOptionalMethodArguments delegate) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(delegate, "delegate is required") });
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalConstructorArgument.java
@@ -24,7 +24,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+    public OptionalConstructorArgument(final @org.jetbrains.annotations.NotNull java.lang.Number arg1, final @org.jetbrains.annotations.NotNull java.lang.String arg2, final @org.jetbrains.annotations.Nullable java.time.Instant arg3) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
@@ -36,7 +36,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * @param arg2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalConstructorArgument(final java.lang.Number arg1, final java.lang.String arg2) {
+    public OptionalConstructorArgument(final @org.jetbrains.annotations.NotNull java.lang.Number arg1, final @org.jetbrains.annotations.NotNull java.lang.String arg2) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }
@@ -45,7 +45,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getArg1() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getArg1() {
         return this.jsiiGet("arg1", java.lang.Number.class);
     }
 
@@ -53,7 +53,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getArg2() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getArg2() {
         return this.jsiiGet("arg2", java.lang.String.class);
     }
 
@@ -61,7 +61,7 @@ public class OptionalConstructorArgument extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.time.Instant getArg3() {
+    public @org.jetbrains.annotations.Nullable java.time.Instant getArg3() {
         return this.jsiiGet("arg3", java.time.Instant.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -22,7 +22,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
      * @param optionalStruct
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public OptionalStructConsumer(final software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
+    public OptionalStructConsumer(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.OptionalStruct optionalStruct) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { optionalStruct });
     }
@@ -40,7 +40,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getParameterWasUndefined() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getParameterWasUndefined() {
         return this.jsiiGet("parameterWasUndefined", java.lang.Boolean.class);
     }
 
@@ -48,7 +48,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getFieldValue() {
+    public @org.jetbrains.annotations.Nullable java.lang.String getFieldValue() {
         return this.jsiiGet("fieldValue", java.lang.String.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverridableProtectedMember.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverridableProtectedMember.java
@@ -27,7 +27,7 @@ public class OverridableProtectedMember extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected java.lang.String overrideMe() {
+    protected @org.jetbrains.annotations.NotNull java.lang.String overrideMe() {
         return this.jsiiCall("overrideMe", java.lang.String.class);
     }
 
@@ -43,7 +43,7 @@ public class OverridableProtectedMember extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String valueFromProtected() {
+    public @org.jetbrains.annotations.NotNull java.lang.String valueFromProtected() {
         return this.jsiiCall("valueFromProtected", java.lang.String.class);
     }
 
@@ -51,7 +51,7 @@ public class OverridableProtectedMember extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected java.lang.String getOverrideReadOnly() {
+    protected @org.jetbrains.annotations.NotNull java.lang.String getOverrideReadOnly() {
         return this.jsiiGet("overrideReadOnly", java.lang.String.class);
     }
 
@@ -59,7 +59,7 @@ public class OverridableProtectedMember extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected java.lang.String getOverrideReadWrite() {
+    protected @org.jetbrains.annotations.NotNull java.lang.String getOverrideReadWrite() {
         return this.jsiiGet("overrideReadWrite", java.lang.String.class);
     }
 
@@ -67,7 +67,7 @@ public class OverridableProtectedMember extends software.amazon.jsii.JsiiObject 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected void setOverrideReadWrite(final java.lang.String value) {
+    protected void setOverrideReadWrite(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("overrideReadWrite", java.util.Objects.requireNonNull(value, "overrideReadWrite is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OverrideReturnsObject.java
@@ -27,7 +27,7 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
      * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number test(final software.amazon.jsii.tests.calculator.IReturnsNumber obj) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number test(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IReturnsNumber obj) {
         return this.jsiiCall("test", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PartiallyInitializedThisConsumer.java
@@ -29,7 +29,7 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
      * @param ev This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public abstract java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev);
+    public abstract @org.jetbrains.annotations.NotNull java.lang.String consumePartiallyInitializedThis(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final @org.jetbrains.annotations.NotNull java.time.Instant dt, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AllTypesEnum ev);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
@@ -48,7 +48,7 @@ public abstract class PartiallyInitializedThisConsumer extends software.amazon.j
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public java.lang.String consumePartiallyInitializedThis(final software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final java.time.Instant dt, final software.amazon.jsii.tests.calculator.AllTypesEnum ev) {
+        public @org.jetbrains.annotations.NotNull java.lang.String consumePartiallyInitializedThis(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.ConstructorPassesThisOut obj, final @org.jetbrains.annotations.NotNull java.time.Instant dt, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.AllTypesEnum ev) {
             return this.jsiiCall("consumePartiallyInitializedThis", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required"), java.util.Objects.requireNonNull(dt, "dt is required"), java.util.Objects.requireNonNull(ev, "ev is required") });
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Polymorphism.java
@@ -27,7 +27,7 @@ public class Polymorphism extends software.amazon.jsii.JsiiObject {
      * @param friendly This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String sayHello(final software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
+    public @org.jetbrains.annotations.NotNull java.lang.String sayHello(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.IFriendly friendly) {
         return this.jsiiCall("sayHello", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(friendly, "friendly is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Power.java
@@ -27,7 +27,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      * @param pow The number of times to multiply. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Power(final software.amazon.jsii.tests.calculator.lib.Value base, final software.amazon.jsii.tests.calculator.lib.Value pow) {
+    public Power(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value base, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value pow) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(base, "base is required"), java.util.Objects.requireNonNull(pow, "pow is required") });
     }
@@ -38,7 +38,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getBase() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getBase() {
         return this.jsiiGet("base", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -51,7 +51,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -61,7 +61,7 @@ public class Power extends software.amazon.jsii.tests.calculator.composition.Com
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getPow() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getPow() {
         return this.jsiiGet("pow", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PropertyNamedProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/PropertyNamedProperty.java
@@ -27,7 +27,7 @@ public class PropertyNamedProperty extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getProperty() {
         return this.jsiiGet("property", java.lang.String.class);
     }
 
@@ -35,7 +35,7 @@ public class PropertyNamedProperty extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getYetAnoterOne() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getYetAnoterOne() {
         return this.jsiiGet("yetAnoterOne", java.lang.Boolean.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReferenceEnumFromScopedPackage.java
@@ -27,7 +27,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule loadFoo() {
+    public @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule loadFoo() {
         return this.jsiiCall("loadFoo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
 
@@ -37,7 +37,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void saveFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
+    public void saveFoo(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiCall("saveFoo", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -45,7 +45,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule getFoo() {
+    public @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule getFoo() {
         return this.jsiiGet("foo", software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule.class);
     }
 
@@ -53,7 +53,7 @@ public class ReferenceEnumFromScopedPackage extends software.amazon.jsii.JsiiObj
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setFoo(final software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
+    public void setFoo(final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.lib.EnumFromScopedModule value) {
         this.jsiiSet("foo", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ReturnsPrivateImplementationOfInterface.java
@@ -30,7 +30,7 @@ public class ReturnsPrivateImplementationOfInterface extends software.amazon.jsi
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IPrivatelyImplemented getPrivateImplementation() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IPrivatelyImplemented getPrivateImplementation() {
         return this.jsiiGet("privateImplementation", software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStructValidator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStructValidator.java
@@ -22,7 +22,7 @@ public class RootStructValidator extends software.amazon.jsii.JsiiObject {
      * @param struct This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void validate(final software.amazon.jsii.tests.calculator.RootStruct struct) {
+    public static void validate(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.RootStruct struct) {
         software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.RootStructValidator.class, "validate", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(struct, "struct is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RuntimeTypeChecking.java
@@ -29,7 +29,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+    public void methodWithDefaultedArguments(final @org.jetbrains.annotations.Nullable java.lang.Number arg1, final @org.jetbrains.annotations.Nullable java.lang.String arg2, final @org.jetbrains.annotations.Nullable java.time.Instant arg3) {
         this.jsiiCall("methodWithDefaultedArguments", software.amazon.jsii.NativeType.VOID, new Object[] { arg1, arg2, arg3 });
     }
 
@@ -40,7 +40,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg2
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(final java.lang.Number arg1, final java.lang.String arg2) {
+    public void methodWithDefaultedArguments(final @org.jetbrains.annotations.Nullable java.lang.Number arg1, final @org.jetbrains.annotations.Nullable java.lang.String arg2) {
         this.jsiiCall("methodWithDefaultedArguments", software.amazon.jsii.NativeType.VOID, new Object[] { arg1, arg2 });
     }
 
@@ -50,7 +50,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg1
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithDefaultedArguments(final java.lang.Number arg1) {
+    public void methodWithDefaultedArguments(final @org.jetbrains.annotations.Nullable java.lang.Number arg1) {
         this.jsiiCall("methodWithDefaultedArguments", software.amazon.jsii.NativeType.VOID, new Object[] { arg1 });
     }
 
@@ -68,7 +68,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithOptionalAnyArgument(final java.lang.Object arg) {
+    public void methodWithOptionalAnyArgument(final @org.jetbrains.annotations.Nullable java.lang.Object arg) {
         this.jsiiCall("methodWithOptionalAnyArgument", software.amazon.jsii.NativeType.VOID, new Object[] { arg });
     }
 
@@ -90,7 +90,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg3
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2, final java.time.Instant arg3) {
+    public void methodWithOptionalArguments(final @org.jetbrains.annotations.NotNull java.lang.Number arg1, final @org.jetbrains.annotations.NotNull java.lang.String arg2, final @org.jetbrains.annotations.Nullable java.time.Instant arg3) {
         this.jsiiCall("methodWithOptionalArguments", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required"), arg3 });
     }
 
@@ -103,7 +103,7 @@ public class RuntimeTypeChecking extends software.amazon.jsii.JsiiObject {
      * @param arg2 This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void methodWithOptionalArguments(final java.lang.Number arg1, final java.lang.String arg2) {
+    public void methodWithOptionalArguments(final @org.jetbrains.annotations.NotNull java.lang.Number arg1, final @org.jetbrains.annotations.NotNull java.lang.String arg2) {
         this.jsiiCall("methodWithOptionalArguments", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(arg1, "arg1 is required"), java.util.Objects.requireNonNull(arg2, "arg2 is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingleInstanceTwoTypes.java
@@ -31,7 +31,7 @@ public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.InbetweenClass interface1() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.InbetweenClass interface1() {
         return this.jsiiCall("interface1", software.amazon.jsii.tests.calculator.InbetweenClass.class);
     }
 
@@ -39,7 +39,7 @@ public class SingleInstanceTwoTypes extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IPublicInterface interface2() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IPublicInterface interface2() {
         return this.jsiiCall("interface2", software.amazon.jsii.tests.calculator.IPublicInterface.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonInt.java
@@ -26,7 +26,7 @@ public class SingletonInt extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean isSingletonInt(final java.lang.Number value) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean isSingletonInt(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         return this.jsiiCall("isSingletonInt", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SingletonString.java
@@ -26,7 +26,7 @@ public class SingletonString extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean isSingletonString(final java.lang.String value) {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean isSingletonString(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         return this.jsiiCall("isSingletonString", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SomeTypeJsii976.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SomeTypeJsii976.java
@@ -25,7 +25,7 @@ public class SomeTypeJsii976 extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Object returnAnonymous() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Object returnAnonymous() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.SomeTypeJsii976.class, "returnAnonymous", java.lang.Object.class);
     }
 
@@ -33,7 +33,7 @@ public class SomeTypeJsii976 extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.IReturnJsii976 returnReturn() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IReturnJsii976 returnReturn() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.SomeTypeJsii976.class, "returnReturn", software.amazon.jsii.tests.calculator.IReturnJsii976.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableClass.java
@@ -20,7 +20,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
      * @param mutableNumber
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public StableClass(final java.lang.String readonlyString, final java.lang.Number mutableNumber) {
+    public StableClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString, final @org.jetbrains.annotations.Nullable java.lang.Number mutableNumber) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required"), mutableNumber });
     }
@@ -29,7 +29,7 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
      * @param readonlyString This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public StableClass(final java.lang.String readonlyString) {
+    public StableClass(final @org.jetbrains.annotations.NotNull java.lang.String readonlyString) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(readonlyString, "readonlyString is required") });
     }
@@ -44,21 +44,21 @@ public class StableClass extends software.amazon.jsii.JsiiObject {
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public java.lang.String getReadonlyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
 
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public java.lang.Number getMutableProperty() {
+    public @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return this.jsiiGet("mutableProperty", java.lang.Number.class);
     }
 
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public void setMutableProperty(final java.lang.Number value) {
+    public void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
         this.jsiiSet("mutableProperty", value);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StaticContext.java
@@ -24,7 +24,7 @@ public class StaticContext extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean canAccessStaticContext() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean canAccessStaticContext() {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StaticContext.class, "canAccessStaticContext", java.lang.Boolean.class);
     }
 
@@ -32,7 +32,7 @@ public class StaticContext extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean getStaticVariable() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean getStaticVariable() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.StaticContext.class, "staticVariable", java.lang.Boolean.class);
     }
 
@@ -40,7 +40,7 @@ public class StaticContext extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void setStaticVariable(final java.lang.Boolean value) {
+    public static void setStaticVariable(final @org.jetbrains.annotations.NotNull java.lang.Boolean value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.StaticContext.class, "staticVariable", java.util.Objects.requireNonNull(value, "staticVariable is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Statics.java
@@ -29,7 +29,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public Statics(final java.lang.String value) {
+    public Statics(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
@@ -42,7 +42,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * @param name The name of the person to say hello to. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.String staticMethod(final java.lang.String name) {
+    public static @org.jetbrains.annotations.NotNull java.lang.String staticMethod(final @org.jetbrains.annotations.NotNull java.lang.String name) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.Statics.class, "staticMethod", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(name, "name is required") });
     }
 
@@ -50,7 +50,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String justMethod() {
+    public @org.jetbrains.annotations.NotNull java.lang.String justMethod() {
         return this.jsiiCall("justMethod", java.lang.String.class);
     }
 
@@ -92,7 +92,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static software.amazon.jsii.tests.calculator.Statics getInstance() {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Statics getInstance() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "instance", software.amazon.jsii.tests.calculator.Statics.class);
     }
 
@@ -104,7 +104,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void setInstance(final software.amazon.jsii.tests.calculator.Statics value) {
+    public static void setInstance(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Statics value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "instance", java.util.Objects.requireNonNull(value, "instance is required"));
     }
 
@@ -112,7 +112,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Number getNonConstStatic() {
+    public static @org.jetbrains.annotations.NotNull java.lang.Number getNonConstStatic() {
         return software.amazon.jsii.JsiiObject.jsiiStaticGet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.lang.Number.class);
     }
 
@@ -120,7 +120,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static void setNonConstStatic(final java.lang.Number value) {
+    public static void setNonConstStatic(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         software.amazon.jsii.JsiiObject.jsiiStaticSet(software.amazon.jsii.tests.calculator.Statics.class, "nonConstStatic", java.util.Objects.requireNonNull(value, "nonConstStatic is required"));
     }
 
@@ -128,7 +128,7 @@ public class Statics extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getValue() {
         return this.jsiiGet("value", java.lang.String.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StripInternal.java
@@ -25,7 +25,7 @@ public class StripInternal extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getYouSeeMe() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getYouSeeMe() {
         return this.jsiiGet("youSeeMe", java.lang.String.class);
     }
 
@@ -33,7 +33,7 @@ public class StripInternal extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setYouSeeMe(final java.lang.String value) {
+    public void setYouSeeMe(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("youSeeMe", java.util.Objects.requireNonNull(value, "youSeeMe is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructPassing.java
@@ -26,7 +26,7 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
      * @param inputs This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
-    public static java.lang.Number howManyVarArgsDidIPass(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct... inputs) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Number howManyVarArgsDidIPass(final @org.jetbrains.annotations.NotNull java.lang.Number _positional, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.TopLevelStruct... inputs) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "howManyVarArgsDidIPass", java.lang.Number.class, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required") }), java.util.Arrays.<Object>stream(inputs)).toArray(Object[]::new));
     }
 
@@ -35,7 +35,7 @@ public class StructPassing extends software.amazon.jsii.JsiiObject {
      * @param input This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.External)
-    public static software.amazon.jsii.tests.calculator.TopLevelStruct roundTrip(final java.lang.Number _positional, final software.amazon.jsii.tests.calculator.TopLevelStruct input) {
+    public static @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.TopLevelStruct roundTrip(final @org.jetbrains.annotations.NotNull java.lang.Number _positional, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.TopLevelStruct input) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructPassing.class, "roundTrip", software.amazon.jsii.tests.calculator.TopLevelStruct.class, new Object[] { java.util.Objects.requireNonNull(_positional, "_positional is required"), java.util.Objects.requireNonNull(input, "input is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java
@@ -22,7 +22,7 @@ public class StructUnionConsumer extends software.amazon.jsii.JsiiObject {
      * @param struct This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean isStructA(final java.lang.Object struct) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean isStructA(final @org.jetbrains.annotations.NotNull java.lang.Object struct) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructUnionConsumer.class, "isStructA", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(struct, "struct is required") });
     }
 
@@ -32,7 +32,7 @@ public class StructUnionConsumer extends software.amazon.jsii.JsiiObject {
      * @param struct This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static java.lang.Boolean isStructB(final java.lang.Object struct) {
+    public static @org.jetbrains.annotations.NotNull java.lang.Boolean isStructB(final @org.jetbrains.annotations.NotNull java.lang.Object struct) {
         return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.StructUnionConsumer.class, "isStructB", java.lang.Boolean.class, new Object[] { java.util.Objects.requireNonNull(struct, "struct is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Sum.java
@@ -36,7 +36,7 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getExpression() {
         return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -46,7 +46,7 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getParts() {
+    public @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.lib.Value> getParts() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("parts", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.Value.class))));
     }
 
@@ -56,7 +56,7 @@ public class Sum extends software.amazon.jsii.tests.calculator.composition.Compo
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setParts(final java.util.List<software.amazon.jsii.tests.calculator.lib.Value> value) {
+    public void setParts(final @org.jetbrains.annotations.NotNull java.util.List<software.amazon.jsii.tests.calculator.lib.Value> value) {
         this.jsiiSet("parts", java.util.Objects.requireNonNull(value, "parts is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
@@ -25,7 +25,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
      * @param rest a variadic continuation. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public SupportsNiceJavaBuilder(final java.lang.Number id, final java.lang.Number defaultBar, final software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderProps props, final java.lang.String... rest) {
+    public SupportsNiceJavaBuilder(final @org.jetbrains.annotations.NotNull java.lang.Number id, final @org.jetbrains.annotations.Nullable java.lang.Number defaultBar, final @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderProps props, final @org.jetbrains.annotations.NotNull java.lang.String... rest) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(id, "id is required"), defaultBar, props }), java.util.Arrays.<Object>stream(rest)).toArray(Object[]::new));
     }
@@ -37,7 +37,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getId() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getId() {
         return this.jsiiGet("id", java.lang.Number.class);
     }
 
@@ -45,7 +45,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.String> getRest() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getRest() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("rest", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
@@ -25,7 +25,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
      * @param props some properties. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public SupportsNiceJavaBuilderWithRequiredProps(final java.lang.Number id, final software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderProps props) {
+    public SupportsNiceJavaBuilderWithRequiredProps(final @org.jetbrains.annotations.NotNull java.lang.Number id, final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderProps props) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(id, "id is required"), java.util.Objects.requireNonNull(props, "props is required") });
     }
@@ -34,7 +34,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getBar() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getBar() {
         return this.jsiiGet("bar", java.lang.Number.class);
     }
 
@@ -44,7 +44,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getId() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getId() {
         return this.jsiiGet("id", java.lang.Number.class);
     }
 
@@ -52,7 +52,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getPropId() {
+    public @org.jetbrains.annotations.Nullable java.lang.String getPropId() {
         return this.jsiiGet("propId", java.lang.String.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SyncVirtualMethods.java
@@ -25,7 +25,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number callerIsAsync() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number callerIsAsync() {
         return this.jsiiAsyncCall("callerIsAsync", java.lang.Number.class);
     }
 
@@ -33,7 +33,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number callerIsMethod() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number callerIsMethod() {
         return this.jsiiCall("callerIsMethod", java.lang.Number.class);
     }
 
@@ -43,7 +43,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void modifyOtherProperty(final java.lang.String value) {
+    public void modifyOtherProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiCall("modifyOtherProperty", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -53,7 +53,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void modifyValueOfTheProperty(final java.lang.String value) {
+    public void modifyValueOfTheProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiCall("modifyValueOfTheProperty", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -61,7 +61,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number readA() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number readA() {
         return this.jsiiCall("readA", java.lang.Number.class);
     }
 
@@ -69,7 +69,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String retrieveOtherProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String retrieveOtherProperty() {
         return this.jsiiCall("retrieveOtherProperty", java.lang.String.class);
     }
 
@@ -77,7 +77,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String retrieveReadOnlyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String retrieveReadOnlyProperty() {
         return this.jsiiCall("retrieveReadOnlyProperty", java.lang.String.class);
     }
 
@@ -85,7 +85,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String retrieveValueOfTheProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String retrieveValueOfTheProperty() {
         return this.jsiiCall("retrieveValueOfTheProperty", java.lang.String.class);
     }
 
@@ -95,7 +95,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * @param n This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number virtualMethod(final java.lang.Number n) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number virtualMethod(final @org.jetbrains.annotations.NotNull java.lang.Number n) {
         return this.jsiiCall("virtualMethod", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(n, "n is required") });
     }
 
@@ -105,7 +105,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void writeA(final java.lang.Number value) {
+    public void writeA(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiCall("writeA", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -113,7 +113,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getReadonlyProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty() {
         return this.jsiiGet("readonlyProperty", java.lang.String.class);
     }
 
@@ -121,7 +121,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getA() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getA() {
         return this.jsiiGet("a", java.lang.Number.class);
     }
 
@@ -129,7 +129,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setA(final java.lang.Number value) {
+    public void setA(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiSet("a", java.util.Objects.requireNonNull(value, "a is required"));
     }
 
@@ -137,7 +137,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getCallerIsProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getCallerIsProperty() {
         return this.jsiiGet("callerIsProperty", java.lang.Number.class);
     }
 
@@ -145,7 +145,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setCallerIsProperty(final java.lang.Number value) {
+    public void setCallerIsProperty(final @org.jetbrains.annotations.NotNull java.lang.Number value) {
         this.jsiiSet("callerIsProperty", java.util.Objects.requireNonNull(value, "callerIsProperty is required"));
     }
 
@@ -153,7 +153,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getOtherProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getOtherProperty() {
         return this.jsiiGet("otherProperty", java.lang.String.class);
     }
 
@@ -161,7 +161,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setOtherProperty(final java.lang.String value) {
+    public void setOtherProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("otherProperty", java.util.Objects.requireNonNull(value, "otherProperty is required"));
     }
 
@@ -169,7 +169,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getTheProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getTheProperty() {
         return this.jsiiGet("theProperty", java.lang.String.class);
     }
 
@@ -177,7 +177,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setTheProperty(final java.lang.String value) {
+    public void setTheProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("theProperty", java.util.Objects.requireNonNull(value, "theProperty is required"));
     }
 
@@ -185,7 +185,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String getValueOfOtherProperty() {
+    public @org.jetbrains.annotations.NotNull java.lang.String getValueOfOtherProperty() {
         return this.jsiiGet("valueOfOtherProperty", java.lang.String.class);
     }
 
@@ -193,7 +193,7 @@ public class SyncVirtualMethods extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setValueOfOtherProperty(final java.lang.String value) {
+    public void setValueOfOtherProperty(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         this.jsiiSet("valueOfOtherProperty", java.util.Objects.requireNonNull(value, "valueOfOtherProperty is required"));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnaryOperation.java
@@ -24,7 +24,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
      * @param operand This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    protected UnaryOperation(final software.amazon.jsii.tests.calculator.lib.Value operand) {
+    protected UnaryOperation(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value operand) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(operand, "operand is required") });
     }
@@ -33,7 +33,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.lib.Value getOperand() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getOperand() {
         return this.jsiiGet("operand", software.amazon.jsii.tests.calculator.lib.Value.class);
     }
 
@@ -51,7 +51,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
 
@@ -61,7 +61,7 @@ public abstract class UnaryOperation extends software.amazon.jsii.tests.calculat
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String toString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);
         }
     }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseBundledDependency.java
@@ -25,7 +25,7 @@ public class UseBundledDependency extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Object value() {
+    public @org.jetbrains.annotations.NotNull java.lang.Object value() {
         return this.jsiiCall("value", java.lang.Object.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UseCalcBase.java
@@ -27,7 +27,7 @@ public class UseCalcBase extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.base.Base hello() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.base.Base hello() {
         return this.jsiiCall("hello", software.amazon.jsii.tests.calculator.base.Base.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UsesInterfaceWithProperties.java
@@ -22,7 +22,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
      * @param obj This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public UsesInterfaceWithProperties(final software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
+    public UsesInterfaceWithProperties(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IInterfaceWithProperties obj) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(obj, "obj is required") });
     }
@@ -31,7 +31,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String justRead() {
+    public @org.jetbrains.annotations.NotNull java.lang.String justRead() {
         return this.jsiiCall("justRead", java.lang.String.class);
     }
 
@@ -41,7 +41,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
      * @param ext This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String readStringAndNumber(final software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
+    public @org.jetbrains.annotations.NotNull java.lang.String readStringAndNumber(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IInterfaceWithPropertiesExtension ext) {
         return this.jsiiCall("readStringAndNumber", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(ext, "ext is required") });
     }
 
@@ -51,7 +51,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
      * @param value This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.String writeAndRead(final java.lang.String value) {
+    public @org.jetbrains.annotations.NotNull java.lang.String writeAndRead(final @org.jetbrains.annotations.NotNull java.lang.String value) {
         return this.jsiiCall("writeAndRead", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(value, "value is required") });
     }
 
@@ -59,7 +59,7 @@ public class UsesInterfaceWithProperties extends software.amazon.jsii.JsiiObject
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.IInterfaceWithProperties getObj() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IInterfaceWithProperties getObj() {
         return this.jsiiGet("obj", software.amazon.jsii.tests.calculator.IInterfaceWithProperties.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicInvoker.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicInvoker.java
@@ -22,7 +22,7 @@ public class VariadicInvoker extends software.amazon.jsii.JsiiObject {
      * @param method This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public VariadicInvoker(final software.amazon.jsii.tests.calculator.VariadicMethod method) {
+    public VariadicInvoker(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.VariadicMethod method) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(method, "method is required") });
     }
@@ -33,7 +33,7 @@ public class VariadicInvoker extends software.amazon.jsii.JsiiObject {
      * @param values This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.Number> asArray(final java.lang.Number... values) {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Number> asArray(final @org.jetbrains.annotations.NotNull java.lang.Number... values) {
         return java.util.Collections.unmodifiableList(this.jsiiCall("asArray", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Number.class)), java.util.Arrays.<Object>stream(values).toArray(Object[]::new)));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicMethod.java
@@ -22,7 +22,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      * @param prefix a prefix that will be use for all values returned by `#asArray`. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public VariadicMethod(final java.lang.Number... prefix) {
+    public VariadicMethod(final @org.jetbrains.annotations.NotNull java.lang.Number... prefix) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(prefix).toArray(Object[]::new));
     }
@@ -34,7 +34,7 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
      * @param others other elements to be included in the array. This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.Number> asArray(final java.lang.Number first, final java.lang.Number... others) {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Number> asArray(final @org.jetbrains.annotations.NotNull java.lang.Number first, final @org.jetbrains.annotations.NotNull java.lang.Number... others) {
         return java.util.Collections.unmodifiableList(this.jsiiCall("asArray", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Number.class)), java.util.stream.Stream.concat(java.util.Arrays.<Object>stream(new Object[] { java.util.Objects.requireNonNull(first, "first is required") }), java.util.Arrays.<Object>stream(others)).toArray(Object[]::new)));
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java
@@ -27,7 +27,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
      * @param index This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number overrideMeAsync(final java.lang.Number index) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number overrideMeAsync(final @org.jetbrains.annotations.NotNull java.lang.Number index) {
         return this.jsiiAsyncCall("overrideMeAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
@@ -37,7 +37,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
      * @param index This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number overrideMeSync(final java.lang.Number index) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number overrideMeSync(final @org.jetbrains.annotations.NotNull java.lang.Number index) {
         return this.jsiiCall("overrideMeSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(index, "index is required") });
     }
 
@@ -47,7 +47,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
      * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number parallelSumAsync(final java.lang.Number count) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number parallelSumAsync(final @org.jetbrains.annotations.NotNull java.lang.Number count) {
         return this.jsiiAsyncCall("parallelSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
@@ -57,7 +57,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
      * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number serialSumAsync(final java.lang.Number count) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number serialSumAsync(final @org.jetbrains.annotations.NotNull java.lang.Number count) {
         return this.jsiiAsyncCall("serialSumAsync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 
@@ -67,7 +67,7 @@ public class VirtualMethodPlayground extends software.amazon.jsii.JsiiObject {
      * @param count This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number sumSync(final java.lang.Number count) {
+    public @org.jetbrains.annotations.NotNull java.lang.Number sumSync(final @org.jetbrains.annotations.NotNull java.lang.Number count) {
         return this.jsiiCall("sumSync", java.lang.Number.class, new Object[] { java.util.Objects.requireNonNull(count, "count is required") });
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/VoidCallback.java
@@ -47,7 +47,7 @@ public abstract class VoidCallback extends software.amazon.jsii.JsiiObject {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getMethodWasCalled() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getMethodWasCalled() {
         return this.jsiiGet("methodWasCalled", java.lang.Boolean.class);
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/WithPrivatePropertyInConstructor.java
@@ -24,7 +24,7 @@ public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiO
      * @param privateField
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public WithPrivatePropertyInConstructor(final java.lang.String privateField) {
+    public WithPrivatePropertyInConstructor(final @org.jetbrains.annotations.Nullable java.lang.String privateField) {
         super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
         software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { privateField });
     }
@@ -42,7 +42,7 @@ public class WithPrivatePropertyInConstructor extends software.amazon.jsii.JsiiO
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Boolean getSuccess() {
+    public @org.jetbrains.annotations.NotNull java.lang.Boolean getSuccess() {
         return this.jsiiGet("success", java.lang.Boolean.class);
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/composition/CompositeOperation.java
@@ -30,7 +30,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
     @Override
-    public java.lang.String toString() {
+    public @org.jetbrains.annotations.NotNull java.lang.String toString() {
         return this.jsiiCall("toString", java.lang.String.class);
     }
 
@@ -42,7 +42,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public abstract software.amazon.jsii.tests.calculator.lib.Value getExpression();
+    public abstract @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getExpression();
 
     /**
      * The value.
@@ -51,7 +51,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      */
     @Override
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.lang.Number getValue() {
+    public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
         return this.jsiiGet("value", java.lang.Number.class);
     }
 
@@ -61,7 +61,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.String> getDecorationPostfixes() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getDecorationPostfixes() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("decorationPostfixes", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -71,7 +71,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setDecorationPostfixes(final java.util.List<java.lang.String> value) {
+    public void setDecorationPostfixes(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPostfixes", java.util.Objects.requireNonNull(value, "decorationPostfixes is required"));
     }
 
@@ -81,7 +81,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public java.util.List<java.lang.String> getDecorationPrefixes() {
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getDecorationPrefixes() {
         return java.util.Collections.unmodifiableList(this.jsiiGet("decorationPrefixes", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.String.class))));
     }
 
@@ -91,7 +91,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setDecorationPrefixes(final java.util.List<java.lang.String> value) {
+    public void setDecorationPrefixes(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> value) {
         this.jsiiSet("decorationPrefixes", java.util.Objects.requireNonNull(value, "decorationPrefixes is required"));
     }
 
@@ -101,7 +101,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle getStringStyle() {
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle getStringStyle() {
         return this.jsiiGet("stringStyle", software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle.class);
     }
 
@@ -111,7 +111,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public void setStringStyle(final software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle value) {
+    public void setStringStyle(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.composition.CompositeOperation.CompositionStringStyle value) {
         this.jsiiSet("stringStyle", java.util.Objects.requireNonNull(value, "stringStyle is required"));
     }
     /**
@@ -155,7 +155,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
          */
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public software.amazon.jsii.tests.calculator.lib.Value getExpression() {
+        public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Value getExpression() {
             return this.jsiiGet("expression", software.amazon.jsii.tests.calculator.lib.Value.class);
         }
 
@@ -165,7 +165,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
         @Override
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
-        public java.lang.Number getValue() {
+        public @org.jetbrains.annotations.NotNull java.lang.Number getValue() {
             return this.jsiiGet("value", java.lang.Number.class);
         }
 
@@ -175,7 +175,7 @@ public abstract class CompositeOperation extends software.amazon.jsii.tests.calc
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
         @Override
-        public java.lang.String toString() {
+        public @org.jetbrains.annotations.NotNull java.lang.String toString() {
             return this.jsiiCall("toString", java.lang.String.class);
         }
     }


### PR DESCRIPTION
This commit annotates values (parameters, properties, and method return
values) with the JetBrains annotations associated to the use-case:
- `@org.jetbrains.annotations.NotNull`
- `@org.jetbrains.annotations.Nullable`

While there is no standard nullability annotation in the Java Language Specification,
several alternatives exist - including [JSR-305](https://jcp.org/en/jsr/detail?id=305)
and [FindBugs](https://mvnrepository.com/artifact/com.google.code.findbugs/annotations).
The decision to use JetBrains' is based on the following reasoning:
- JSR-305 has been dormant, and may incur licensing issues (see google/guava#2960)
- JetBrains' annotations are licensed as Apache-2.0 (same as jsii itself), while FindBugs is LGPL
- One of the values of annotating is to improve Kotlin interoperability, so JetBrains annotations make the most sense in this context.

This can help IDEs provide static analysis of the code for discovery
of possible bugs; and will make usage from Kotlin nicer as it enables
use of the correct platform types.

Implements aws/aws-cdk#6026

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
