### PR TITLE
fix(dotnet): missing ? on nullable interface members

### DIFF
--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -2458,3 +2458,10 @@ export class InterfaceCollections {
 
   private constructor(){ }
 }
+
+/**
+ * Checks that optional result from interface method code generates correctly
+ */
+export interface IOptionalMethod {
+    optional(): string | undefined;
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -5507,6 +5507,39 @@
         }
       ]
     },
+    "jsii-calc.IOptionalMethod": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "Checks that optional result from interface method code generates correctly."
+      },
+      "fqn": "jsii-calc.IOptionalMethod",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2465
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2466
+          },
+          "name": "optional",
+          "returns": {
+            "optional": true,
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IOptionalMethod"
+    },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
       "docs": {
@@ -12123,5 +12156,5 @@
     }
   },
   "version": "1.0.0",
-  "fingerprint": "rtlqfLVk+YuqJRqeFCR5A3mesEPpfJgo5m1gRM323+U="
+  "fingerprint": "oTbIPjVGH+NSJCWHMqRYC7fJ3XjjZSr8TvvRkANEonA="
 }

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -154,7 +154,8 @@ export class DotNetGenerator extends Generator {
     this.dotnetDocGenerator.emitDocs(method);
     this.dotnetRuntimeGenerator.emitAttributesForMethod(ifc, method);
     const returnType = method.returns ? this.typeresolver.toDotNetType(method.returns.type) : 'void';
-    this.code.line(`${returnType} ${this.nameutils.convertMethodName(method.name)}(${this.renderMethodParameters(method)});`);
+    const nullable = method.returns?.optional ? '?' : '';
+    this.code.line(`${returnType}${nullable} ${this.nameutils.convertMethodName(method.name)}(${this.renderMethodParameters(method)});`);
   }
 
   protected onInterfaceMethodOverload(ifc: spec.InterfaceType, overload: spec.Method, _originalMethod: spec.Method) {

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -605,7 +605,7 @@ class JavaGenerator extends Generator {
 
   protected onInterfaceMethod(_ifc: spec.InterfaceType, method: spec.Method) {
     this.code.line();
-    const returnType = method.returns ? this.toJavaType(method.returns.type) : 'void';
+    const returnType = method.returns ? this.toDecoratedJavaType(method.returns) : 'void';
     this.addJavaDocs(method);
     this.emitStabilityAnnotations(method);
     this.code.line(`${returnType} ${method.name}(${this.renderMethodParameters(method)});`);
@@ -616,8 +616,8 @@ class JavaGenerator extends Generator {
   }
 
   protected onInterfaceProperty(_ifc: spec.InterfaceType, prop: spec.Property) {
-    const getterType = this.toJavaType(prop.type);
-    const setterTypes = this.toJavaTypes(prop.type);
+    const getterType = this.toDecoratedJavaType(prop);
+    const setterTypes = this.toDecoratedJavaTypes(prop);
     const propName = this.code.toPascalCase(JavaGenerator.safeJavaPropertyName(prop.name));
 
     // for unions we only generate overloads for setters, not getters.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
@@ -5,7 +5,7 @@ package software.amazon.jsii.tests.calculator.baseofbase;
 @software.amazon.jsii.Jsii.Proxy(VeryBaseProps.Jsii$Proxy.class)
 public interface VeryBaseProps extends software.amazon.jsii.JsiiSerializable {
 
-    software.amazon.jsii.tests.calculator.baseofbase.Very getFoo();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.baseofbase.Very getFoo();
 
     /**
      * @return a {@link Builder} of {@link VeryBaseProps}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -5,7 +5,7 @@ package software.amazon.jsii.tests.calculator.base;
 @software.amazon.jsii.Jsii.Proxy(BaseProps.Jsii$Proxy.class)
 public interface BaseProps extends software.amazon.jsii.JsiiSerializable, software.amazon.jsii.tests.calculator.baseofbase.VeryBaseProps {
 
-    java.lang.String getBar();
+    @org.jetbrains.annotations.NotNull java.lang.String getBar();
 
     /**
      * @return a {@link Builder} of {@link BaseProps}

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IDoublable.java
@@ -14,7 +14,7 @@ public interface IDoublable extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    java.lang.Number getDoubleValue();
+    @org.jetbrains.annotations.NotNull java.lang.Number getDoubleValue();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/IFriendly.java
@@ -18,7 +18,7 @@ public interface IFriendly extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    java.lang.String hello();
+    @org.jetbrains.annotations.NotNull java.lang.String hello();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -15,20 +15,20 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    java.lang.Number getAnumber();
+    @org.jetbrains.annotations.NotNull java.lang.Number getAnumber();
 
     /**
      * A string value.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    java.lang.String getAstring();
+    @org.jetbrains.annotations.NotNull java.lang.String getAstring();
 
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    default java.util.List<java.lang.String> getFirstOptional() {
+    default @org.jetbrains.annotations.Nullable java.util.List<java.lang.String> getFirstOptional() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -15,7 +15,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    default java.lang.String getOptional1() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getOptional1() {
         return null;
     }
 
@@ -23,7 +23,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    default java.lang.Number getOptional2() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getOptional2() {
         return null;
     }
 
@@ -31,7 +31,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    default java.lang.Boolean getOptional3() {
+    default @org.jetbrains.annotations.Nullable java.lang.Boolean getOptional3() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -5507,6 +5507,39 @@
         }
       ]
     },
+    "jsii-calc.IOptionalMethod": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "experimental",
+        "summary": "Checks that optional result from interface method code generates correctly."
+      },
+      "fqn": "jsii-calc.IOptionalMethod",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2465
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2466
+          },
+          "name": "optional",
+          "returns": {
+            "optional": true,
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IOptionalMethod"
+    },
     "jsii-calc.IPrivatelyImplemented": {
       "assembly": "jsii-calc",
       "docs": {
@@ -12123,5 +12156,5 @@
     }
   },
   "version": "1.0.0",
-  "fingerprint": "rtlqfLVk+YuqJRqeFCR5A3mesEPpfJgo5m1gRM323+U="
+  "fingerprint": "oTbIPjVGH+NSJCWHMqRYC7fJ3XjjZSr8TvvRkANEonA="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalMethod.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalMethod.cs
@@ -1,0 +1,20 @@
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Checks that optional result from interface method code generates correctly.</summary>
+    /// <remarks>
+    /// <strong>Stability</strong>: Experimental
+    /// </remarks>
+    [JsiiInterface(nativeType: typeof(IOptionalMethod), fullyQualifiedName: "jsii-calc.IOptionalMethod")]
+    public interface IOptionalMethod
+    {
+        /// <remarks>
+        /// <strong>Stability</strong>: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "optional", returnsJson: "{\"optional\":true,\"type\":{\"primitive\":\"string\"}}")]
+        string? Optional();
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalMethodProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IOptionalMethodProxy.cs
@@ -1,0 +1,27 @@
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Checks that optional result from interface method code generates correctly.</summary>
+    /// <remarks>
+    /// <strong>Stability</strong>: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(IOptionalMethod), fullyQualifiedName: "jsii-calc.IOptionalMethod")]
+    internal sealed class IOptionalMethodProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IOptionalMethod
+    {
+        private IOptionalMethodProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <remarks>
+        /// <strong>Stability</strong>: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "optional", returnsJson: "{\"optional\":true,\"type\":{\"primitive\":\"string\"}}")]
+        public string? Optional()
+        {
+            return InvokeInstanceMethod<string?>(new System.Type[]{}, new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/$Module.java
@@ -106,6 +106,7 @@ public final class $Module extends JsiiModule {
             case "jsii-calc.IMutableObjectLiteral": return software.amazon.jsii.tests.calculator.IMutableObjectLiteral.class;
             case "jsii-calc.INonInternalInterface": return software.amazon.jsii.tests.calculator.INonInternalInterface.class;
             case "jsii-calc.IObjectWithProperty": return software.amazon.jsii.tests.calculator.IObjectWithProperty.class;
+            case "jsii-calc.IOptionalMethod": return software.amazon.jsii.tests.calculator.IOptionalMethod.class;
             case "jsii-calc.IPrivatelyImplemented": return software.amazon.jsii.tests.calculator.IPrivatelyImplemented.class;
             case "jsii-calc.IPublicInterface": return software.amazon.jsii.tests.calculator.IPublicInterface.class;
             case "jsii-calc.IPublicInterface2": return software.amazon.jsii.tests.calculator.IPublicInterface2.class;

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -21,7 +21,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Number getInitialValue() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getInitialValue() {
         return null;
     }
 
@@ -33,7 +33,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Number getMaximumValue() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getMaximumValue() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
@@ -13,7 +13,7 @@ public interface ChildStruct982 extends software.amazon.jsii.JsiiSerializable, s
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getBar();
+    @org.jetbrains.annotations.NotNull java.lang.Number getBar();
 
     /**
      * @return a {@link Builder} of {@link ChildStruct982}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
@@ -13,7 +13,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Object getUnionProperty() {
+    default @org.jetbrains.annotations.Nullable java.lang.Object getUnionProperty() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -15,7 +15,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    java.lang.String getReadonlyProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty();
 
     /**
      * @return a {@link Builder} of {@link DeprecatedStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -15,13 +15,13 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.time.Instant getAnotherRequired();
+    @org.jetbrains.annotations.NotNull java.time.Instant getAnotherRequired();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean getBool();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean getBool();
 
     /**
      * An example of a non primitive property.
@@ -29,7 +29,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.DoubleTrouble getNonPrimitive();
 
     /**
      * This is optional.
@@ -37,7 +37,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
+    default @org.jetbrains.annotations.Nullable java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> getAnotherOptional() {
         return null;
     }
 
@@ -45,7 +45,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Object getOptionalAny() {
+    default @org.jetbrains.annotations.Nullable java.lang.Object getOptionalAny() {
         return null;
     }
 
@@ -53,7 +53,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.util.List<java.lang.String> getOptionalArray() {
+    default @org.jetbrains.annotations.Nullable java.util.List<java.lang.String> getOptionalArray() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -13,7 +13,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getBaseLevelProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getBaseLevelProperty();
 
     /**
      * @return a {@link Builder} of {@link DiamondInheritanceBaseLevelStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -13,7 +13,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getFirstMidLevelProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getFirstMidLevelProperty();
 
     /**
      * @return a {@link Builder} of {@link DiamondInheritanceFirstMidLevelStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -13,7 +13,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getSecondMidLevelProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getSecondMidLevelProperty();
 
     /**
      * @return a {@link Builder} of {@link DiamondInheritanceSecondMidLevelStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -13,7 +13,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getTopLevelProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getTopLevelProperty();
 
     /**
      * @return a {@link Builder} of {@link DiamondInheritanceTopLevelStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -13,7 +13,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getOption1() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getOption1() {
         return null;
     }
 
@@ -21,7 +21,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getOption2() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getOption2() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -13,7 +13,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getReadonlyProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty();
 
     /**
      * @return a {@link Builder} of {@link ExperimentalStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -13,13 +13,13 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean getBoom();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean getBoom();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getProp();
+    @org.jetbrains.annotations.NotNull java.lang.String getProp();
 
     /**
      * @return a {@link Builder} of {@link ExtendsInternalInterface}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -19,7 +19,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getName() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getName() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymousImplementationProvider.java
@@ -15,13 +15,13 @@ public interface IAnonymousImplementationProvider extends software.amazon.jsii.J
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.Implementation provideAsClass();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Implementation provideAsClass();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnonymouslyImplementMe.java
@@ -13,13 +13,13 @@ public interface IAnonymouslyImplementMe extends software.amazon.jsii.JsiiSerial
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getValue();
+    @org.jetbrains.annotations.NotNull java.lang.Number getValue();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String verb();
+    @org.jetbrains.annotations.NotNull java.lang.String verb();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IAnotherPublicInterface.java
@@ -13,12 +13,12 @@ public interface IAnotherPublicInterface extends software.amazon.jsii.JsiiSerial
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getA();
+    @org.jetbrains.annotations.NotNull java.lang.String getA();
 
     /**
      * EXPERIMENTAL
      */
-    void setA(final java.lang.String value);
+    void setA(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IDeprecatedInterface.java
@@ -15,7 +15,7 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    default java.lang.Number getMutableProperty() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return null;
     }
 
@@ -23,8 +23,8 @@ public interface IDeprecatedInterface extends software.amazon.jsii.JsiiSerializa
      * @deprecated could be better
      */
     @software.amazon.jsii.Optional
-    default void setMutableProperty(final java.lang.Number value) {
-        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(java.lang.Number)' is not implemented!");
+    default void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
+        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(@org.jetbrains.annotations.Nullable java.lang.Number)' is not implemented!");
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExperimentalInterface.java
@@ -13,7 +13,7 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Number getMutableProperty() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return null;
     }
 
@@ -21,8 +21,8 @@ public interface IExperimentalInterface extends software.amazon.jsii.JsiiSeriali
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Optional
-    default void setMutableProperty(final java.lang.Number value) {
-        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(java.lang.Number)' is not implemented!");
+    default void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
+        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(@org.jetbrains.annotations.Nullable java.lang.Number)' is not implemented!");
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IExtendsPrivateInterface.java
@@ -13,18 +13,18 @@ public interface IExtendsPrivateInterface extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.util.List<java.lang.String> getMoreThings();
+    @org.jetbrains.annotations.NotNull java.util.List<java.lang.String> getMoreThings();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getPrivateValue();
+    @org.jetbrains.annotations.NotNull java.lang.String getPrivateValue();
 
     /**
      * EXPERIMENTAL
      */
-    void setPrivateValue(final java.lang.String value);
+    void setPrivateValue(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IFriendlier.java
@@ -17,7 +17,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String farewell();
+    @org.jetbrains.annotations.NotNull java.lang.String farewell();
 
     /**
      * Say goodbye.
@@ -27,7 +27,7 @@ public interface IFriendlier extends software.amazon.jsii.JsiiSerializable, soft
      * @return A goodbye blessing.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String goodbye();
+    @org.jetbrains.annotations.NotNull java.lang.String goodbye();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceImplementedByAbstractClass.java
@@ -15,7 +15,7 @@ public interface IInterfaceImplementedByAbstractClass extends software.amazon.js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getPropFromInterface();
+    @org.jetbrains.annotations.NotNull java.lang.String getPropFromInterface();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceThatShouldNotBeADataType.java
@@ -15,7 +15,7 @@ public interface IInterfaceThatShouldNotBeADataType extends software.amazon.jsii
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getOtherValue();
+    @org.jetbrains.annotations.NotNull java.lang.String getOtherValue();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithMethods.java
@@ -13,7 +13,7 @@ public interface IInterfaceWithMethods extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getValue();
+    @org.jetbrains.annotations.NotNull java.lang.String getValue();
 
     /**
      * EXPERIMENTAL

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithProperties.java
@@ -13,18 +13,18 @@ public interface IInterfaceWithProperties extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getReadOnlyString();
+    @org.jetbrains.annotations.NotNull java.lang.String getReadOnlyString();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getReadWriteString();
+    @org.jetbrains.annotations.NotNull java.lang.String getReadWriteString();
 
     /**
      * EXPERIMENTAL
      */
-    void setReadWriteString(final java.lang.String value);
+    void setReadWriteString(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IInterfaceWithPropertiesExtension.java
@@ -13,12 +13,12 @@ public interface IInterfaceWithPropertiesExtension extends software.amazon.jsii.
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getFoo();
+    @org.jetbrains.annotations.NotNull java.lang.Number getFoo();
 
     /**
      * EXPERIMENTAL
      */
-    void setFoo(final java.lang.Number value);
+    void setFoo(final @org.jetbrains.annotations.NotNull java.lang.Number value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417Derived.java
@@ -13,7 +13,7 @@ public interface IJSII417Derived extends software.amazon.jsii.JsiiSerializable, 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getProperty();
 
     /**
      * EXPERIMENTAL

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IJSII417PublicBaseOfBase.java
@@ -13,7 +13,7 @@ public interface IJSII417PublicBaseOfBase extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean getHasRoot();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean getHasRoot();
 
     /**
      * EXPERIMENTAL

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IMutableObjectLiteral.java
@@ -13,12 +13,12 @@ public interface IMutableObjectLiteral extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getValue();
+    @org.jetbrains.annotations.NotNull java.lang.String getValue();
 
     /**
      * EXPERIMENTAL
      */
-    void setValue(final java.lang.String value);
+    void setValue(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/INonInternalInterface.java
@@ -13,23 +13,23 @@ public interface INonInternalInterface extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getB();
+    @org.jetbrains.annotations.NotNull java.lang.String getB();
 
     /**
      * EXPERIMENTAL
      */
-    void setB(final java.lang.String value);
+    void setB(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getC();
+    @org.jetbrains.annotations.NotNull java.lang.String getC();
 
     /**
      * EXPERIMENTAL
      */
-    void setC(final java.lang.String value);
+    void setC(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IObjectWithProperty.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IObjectWithProperty.java
@@ -15,18 +15,18 @@ public interface IObjectWithProperty extends software.amazon.jsii.JsiiSerializab
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getProperty();
 
     /**
      * EXPERIMENTAL
      */
-    void setProperty(final java.lang.String value);
+    void setProperty(final @org.jetbrains.annotations.NotNull java.lang.String value);
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean wasSet();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean wasSet();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IOptionalMethod.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IOptionalMethod.java
@@ -1,24 +1,26 @@
 package software.amazon.jsii.tests.calculator;
 
 /**
+ * Checks that optional result from interface method code generates correctly.
+ * <p>
  * EXPERIMENTAL
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
-@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.IPublicInterface2")
-@software.amazon.jsii.Jsii.Proxy(IPublicInterface2.Jsii$Proxy.class)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.IOptionalMethod")
+@software.amazon.jsii.Jsii.Proxy(IOptionalMethod.Jsii$Proxy.class)
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable {
+public interface IOptionalMethod extends software.amazon.jsii.JsiiSerializable {
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    @org.jetbrains.annotations.NotNull java.lang.String ciao();
+    @org.jetbrains.annotations.Nullable java.lang.String optional();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.
      */
-    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IPublicInterface2 {
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IOptionalMethod {
         protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
             super(objRef);
         }
@@ -28,8 +30,8 @@ public interface IPublicInterface2 extends software.amazon.jsii.JsiiSerializable
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
         @Override
-        public @org.jetbrains.annotations.NotNull java.lang.String ciao() {
-            return this.jsiiCall("ciao", java.lang.String.class);
+        public @org.jetbrains.annotations.Nullable java.lang.String optional() {
+            return this.jsiiCall("optional", java.lang.String.class);
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPrivatelyImplemented.java
@@ -13,7 +13,7 @@ public interface IPrivatelyImplemented extends software.amazon.jsii.JsiiSerializ
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean getSuccess();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean getSuccess();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IPublicInterface.java
@@ -13,7 +13,7 @@ public interface IPublicInterface extends software.amazon.jsii.JsiiSerializable 
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String bye();
+    @org.jetbrains.annotations.NotNull java.lang.String bye();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IRandomNumberGenerator.java
@@ -19,7 +19,7 @@ public interface IRandomNumberGenerator extends software.amazon.jsii.JsiiSeriali
      * @return A random number.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number next();
+    @org.jetbrains.annotations.NotNull java.lang.Number next();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnJsii976.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnJsii976.java
@@ -15,7 +15,7 @@ public interface IReturnJsii976 extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getFoo();
+    @org.jetbrains.annotations.NotNull java.lang.Number getFoo();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IReturnsNumber.java
@@ -13,13 +13,13 @@ public interface IReturnsNumber extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.lib.Number getNumberProp();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Number getNumberProp();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.IDoublable obtainNumber();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStableInterface.java
@@ -11,15 +11,15 @@ public interface IStableInterface extends software.amazon.jsii.JsiiSerializable 
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    default java.lang.Number getMutableProperty() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getMutableProperty() {
         return null;
     }
 
     /**
      */
     @software.amazon.jsii.Optional
-    default void setMutableProperty(final java.lang.Number value) {
-        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(java.lang.Number)' is not implemented!");
+    default void setMutableProperty(final @org.jetbrains.annotations.Nullable java.lang.Number value) {
+        throw new UnsupportedOperationException("'void " + getClass().getCanonicalName() + "#setMutableProperty(@org.jetbrains.annotations.Nullable java.lang.Number)' is not implemented!");
     }
 
     /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStructReturningDelegate.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/IStructReturningDelegate.java
@@ -15,7 +15,7 @@ public interface IStructReturningDelegate extends software.amazon.jsii.JsiiSeria
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    software.amazon.jsii.tests.calculator.StructB returnStruct();
+    @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructB returnStruct();
 
     /**
      * A proxy class which represents a concrete javascript instance of this type.

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -13,7 +13,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.time.Instant getGoo();
+    @org.jetbrains.annotations.NotNull java.time.Instant getGoo();
 
     /**
      * @return a {@link Builder} of {@link ImplictBaseOfBase}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceIncludesClasses/Hello.java
@@ -13,7 +13,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getFoo();
+    @org.jetbrains.annotations.NotNull java.lang.Number getFoo();
 
     /**
      * @return a {@link Builder} of {@link Hello}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/InterfaceInNamespaceOnlyInterface/Hello.java
@@ -13,7 +13,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getFoo();
+    @org.jetbrains.annotations.NotNull java.lang.Number getFoo();
 
     /**
      * @return a {@link Builder} of {@link Hello}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -21,7 +21,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Number getContainerPort() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getContainerPort() {
         return null;
     }
 
@@ -42,7 +42,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getCpu() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getCpu() {
         return null;
     }
 
@@ -69,7 +69,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getMemoryMiB() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getMemoryMiB() {
         return null;
     }
 
@@ -81,7 +81,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Boolean getPublicLoadBalancer() {
+    default @org.jetbrains.annotations.Nullable java.lang.Boolean getPublicLoadBalancer() {
         return null;
     }
 
@@ -93,7 +93,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Boolean getPublicTasks() {
+    default @org.jetbrains.annotations.Nullable java.lang.Boolean getPublicTasks() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
@@ -15,7 +15,7 @@ public interface NestedStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getNumberProp();
+    @org.jetbrains.annotations.NotNull java.lang.Number getNumberProp();
 
     /**
      * @return a {@link Builder} of {@link NestedStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -13,13 +13,13 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument();
+    @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> getArrayWithThreeElementsAndUndefinedAsSecondArgument();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Object getThisShouldBeUndefined() {
+    default @org.jetbrains.annotations.Nullable java.lang.Object getThisShouldBeUndefined() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -13,7 +13,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getField() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getField() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
@@ -15,7 +15,7 @@ public interface ParentStruct982 extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getFoo();
+    @org.jetbrains.annotations.NotNull java.lang.String getFoo();
 
     /**
      * @return a {@link Builder} of {@link ParentStruct982}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
@@ -20,13 +20,13 @@ public interface RootStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getStringProp();
+    @org.jetbrains.annotations.NotNull java.lang.String getStringProp();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default software.amazon.jsii.tests.calculator.NestedStruct getNestedStruct() {
+    default @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.NestedStruct getNestedStruct() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -15,7 +15,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getDeeperRequiredProp();
+    @org.jetbrains.annotations.NotNull java.lang.String getDeeperRequiredProp();
 
     /**
      * It's long, but you'll almost never pass it.
@@ -23,7 +23,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getDeeperOptionalProp() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getDeeperOptionalProp() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SmellyStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SmellyStruct.java
@@ -13,13 +13,13 @@ public interface SmellyStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getProperty();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Boolean getYetAnoterOne();
+    @org.jetbrains.annotations.NotNull java.lang.Boolean getYetAnoterOne();
 
     /**
      * @return a {@link Builder} of {@link SmellyStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -11,7 +11,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
     /**
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    java.lang.String getReadonlyProperty();
+    @org.jetbrains.annotations.NotNull java.lang.String getReadonlyProperty();
 
     /**
      * @return a {@link Builder} of {@link StableStruct}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
@@ -15,13 +15,13 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getRequiredString();
+    @org.jetbrains.annotations.NotNull java.lang.String getRequiredString();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Number getOptionalNumber() {
+    default @org.jetbrains.annotations.Nullable java.lang.Number getOptionalNumber() {
         return null;
     }
 
@@ -29,7 +29,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getOptionalString() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getOptionalString() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
@@ -15,13 +15,13 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getRequiredString();
+    @org.jetbrains.annotations.NotNull java.lang.String getRequiredString();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Boolean getOptionalBoolean() {
+    default @org.jetbrains.annotations.Nullable java.lang.Boolean getOptionalBoolean() {
         return null;
     }
 
@@ -29,7 +29,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default software.amazon.jsii.tests.calculator.StructA getOptionalStructA() {
+    default @org.jetbrains.annotations.Nullable software.amazon.jsii.tests.calculator.StructA getOptionalStructA() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructParameterType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructParameterType.java
@@ -17,13 +17,13 @@ public interface StructParameterType extends software.amazon.jsii.JsiiSerializab
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getScope();
+    @org.jetbrains.annotations.NotNull java.lang.String getScope();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Boolean getProps() {
+    default @org.jetbrains.annotations.Nullable java.lang.Boolean getProps() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -13,13 +13,13 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getDefaultValue();
+    @org.jetbrains.annotations.NotNull java.lang.String getDefaultValue();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getAssertValue() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getAssertValue() {
         return null;
     }
 
@@ -27,7 +27,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getResult() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getResult() {
         return null;
     }
 
@@ -35,7 +35,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getThat() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getThat() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
@@ -15,7 +15,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Number getBar();
+    @org.jetbrains.annotations.NotNull java.lang.Number getBar();
 
     /**
      * An `id` field here is terrible API design, because the constructor of `SupportsNiceJavaBuilder` already has a parameter named `id`.
@@ -25,7 +25,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getId() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getId() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -15,7 +15,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.String getRequired();
+    @org.jetbrains.annotations.NotNull java.lang.String getRequired();
 
     /**
      * A union to really stress test our serialization.
@@ -23,7 +23,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Object getSecondLevel();
+    @org.jetbrains.annotations.NotNull java.lang.Object getSecondLevel();
 
     /**
      * You don't have to pass this.
@@ -31,7 +31,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.String getOptional() {
+    default @org.jetbrains.annotations.Nullable java.lang.String getOptional() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -13,13 +13,13 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    java.lang.Object getBar();
+    @org.jetbrains.annotations.NotNull java.lang.Object getBar();
 
     /**
      * EXPERIMENTAL
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    default java.lang.Object getFoo() {
+    default @org.jetbrains.annotations.Nullable java.lang.Object getFoo() {
         return null;
     }
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -3911,6 +3911,42 @@ class _IObjectWithPropertyProxy():
         return jsii.invoke(self, "wasSet", [])
 
 
+@jsii.interface(jsii_type="jsii-calc.IOptionalMethod")
+class IOptionalMethod(jsii.compat.Protocol):
+    """Checks that optional result from interface method code generates correctly.
+
+    stability
+    :stability: experimental
+    """
+    @builtins.staticmethod
+    def __jsii_proxy_class__():
+        return _IOptionalMethodProxy
+
+    @jsii.member(jsii_name="optional")
+    def optional(self) -> typing.Optional[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        ...
+
+
+class _IOptionalMethodProxy():
+    """Checks that optional result from interface method code generates correctly.
+
+    stability
+    :stability: experimental
+    """
+    __jsii_type__ = "jsii-calc.IOptionalMethod"
+    @jsii.member(jsii_name="optional")
+    def optional(self) -> typing.Optional[str]:
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.invoke(self, "optional", [])
+
+
 @jsii.interface(jsii_type="jsii-calc.IPrivatelyImplemented")
 class IPrivatelyImplemented(jsii.compat.Protocol):
     """
@@ -8562,6 +8598,6 @@ class Sum(composition.CompositeOperation, metaclass=jsii.JSIIMeta, jsii_type="js
         jsii.set(self, "parts", value)
 
 
-__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "AbstractSuite", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AmbiguousParameters", "AnonymousImplementationProvider", "AsyncVirtualMethods", "AugmentableClass", "BaseJsii976", "Bell", "BinaryOperation", "Calculator", "CalculatorProps", "ChildStruct982", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConfusingToJackson", "ConfusingToJacksonStruct", "ConstructorPassesThisOut", "Constructors", "ConsumePureInterface", "ConsumerCanRingBell", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "Demonstrate982", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DisappointingCollectionSource", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnonymousImplementationProvider", "IAnonymouslyImplementMe", "IAnotherPublicInterface", "IBell", "IBellRinger", "IConcreteBellRinger", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IObjectWithProperty", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnJsii976", "IReturnsNumber", "IStableInterface", "IStructReturningDelegate", "ImplementInternalInterface", "Implementation", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceCollections", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "JsonFormatter", "LoadBalancedFargateServiceProps", "MethodNamedProperty", "Multiply", "Negate", "NestedStruct", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "ObjectWithPropertyProvider", "Old", "OptionalArgumentInvoker", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverridableProtectedMember", "OverrideReturnsObject", "ParentStruct982", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PropertyNamedProperty", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RootStruct", "RootStructValidator", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "SmellyStruct", "SomeTypeJsii976", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructA", "StructB", "StructParameterType", "StructPassing", "StructUnionConsumer", "StructWithJavaReservedWords", "Sum", "SupportsNiceJavaBuilder", "SupportsNiceJavaBuilderProps", "SupportsNiceJavaBuilderWithRequiredProps", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicInvoker", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
+__all__ = ["AbstractClass", "AbstractClassBase", "AbstractClassReturner", "AbstractSuite", "Add", "AllTypes", "AllTypesEnum", "AllowedMethodNames", "AmbiguousParameters", "AnonymousImplementationProvider", "AsyncVirtualMethods", "AugmentableClass", "BaseJsii976", "Bell", "BinaryOperation", "Calculator", "CalculatorProps", "ChildStruct982", "ClassThatImplementsTheInternalInterface", "ClassThatImplementsThePrivateInterface", "ClassWithCollections", "ClassWithDocs", "ClassWithJavaReservedWords", "ClassWithMutableObjectLiteralProperty", "ClassWithPrivateConstructorAndAutomaticProperties", "ConfusingToJackson", "ConfusingToJacksonStruct", "ConstructorPassesThisOut", "Constructors", "ConsumePureInterface", "ConsumerCanRingBell", "ConsumersOfThisCrazyTypeSystem", "DataRenderer", "DefaultedConstructorArgument", "Demonstrate982", "DeprecatedClass", "DeprecatedEnum", "DeprecatedStruct", "DerivedClassHasNoProperties", "DerivedStruct", "DiamondInheritanceBaseLevelStruct", "DiamondInheritanceFirstMidLevelStruct", "DiamondInheritanceSecondMidLevelStruct", "DiamondInheritanceTopLevelStruct", "DisappointingCollectionSource", "DoNotOverridePrivates", "DoNotRecognizeAnyAsOptional", "DocumentedClass", "DontComplainAboutVariadicAfterOptional", "DoubleTrouble", "EnumDispenser", "EraseUndefinedHashValues", "EraseUndefinedHashValuesOptions", "ExperimentalClass", "ExperimentalEnum", "ExperimentalStruct", "ExportedBaseClass", "ExtendsInternalInterface", "GiveMeStructs", "Greetee", "GreetingAugmenter", "IAnonymousImplementationProvider", "IAnonymouslyImplementMe", "IAnotherPublicInterface", "IBell", "IBellRinger", "IConcreteBellRinger", "IDeprecatedInterface", "IExperimentalInterface", "IExtendsPrivateInterface", "IFriendlier", "IFriendlyRandomGenerator", "IInterfaceImplementedByAbstractClass", "IInterfaceThatShouldNotBeADataType", "IInterfaceWithInternal", "IInterfaceWithMethods", "IInterfaceWithOptionalMethodArguments", "IInterfaceWithProperties", "IInterfaceWithPropertiesExtension", "IJSII417Derived", "IJSII417PublicBaseOfBase", "IJsii487External", "IJsii487External2", "IJsii496", "IMutableObjectLiteral", "INonInternalInterface", "IObjectWithProperty", "IOptionalMethod", "IPrivatelyImplemented", "IPublicInterface", "IPublicInterface2", "IRandomNumberGenerator", "IReturnJsii976", "IReturnsNumber", "IStableInterface", "IStructReturningDelegate", "ImplementInternalInterface", "Implementation", "ImplementsInterfaceWithInternal", "ImplementsInterfaceWithInternalSubclass", "ImplementsPrivateInterface", "ImplictBaseOfBase", "InbetweenClass", "InterfaceCollections", "InterfaceInNamespaceIncludesClasses", "InterfaceInNamespaceOnlyInterface", "InterfacesMaker", "JSII417Derived", "JSII417PublicBaseOfBase", "JSObjectLiteralForInterface", "JSObjectLiteralToNative", "JSObjectLiteralToNativeClass", "JavaReservedWords", "Jsii487Derived", "Jsii496Derived", "JsiiAgent", "JsonFormatter", "LoadBalancedFargateServiceProps", "MethodNamedProperty", "Multiply", "Negate", "NestedStruct", "NodeStandardLibrary", "NullShouldBeTreatedAsUndefined", "NullShouldBeTreatedAsUndefinedData", "NumberGenerator", "ObjectRefsInCollections", "ObjectWithPropertyProvider", "Old", "OptionalArgumentInvoker", "OptionalConstructorArgument", "OptionalStruct", "OptionalStructConsumer", "OverridableProtectedMember", "OverrideReturnsObject", "ParentStruct982", "PartiallyInitializedThisConsumer", "Polymorphism", "Power", "PropertyNamedProperty", "PublicClass", "PythonReservedWords", "ReferenceEnumFromScopedPackage", "ReturnsPrivateImplementationOfInterface", "RootStruct", "RootStructValidator", "RuntimeTypeChecking", "SecondLevelStruct", "SingleInstanceTwoTypes", "SingletonInt", "SingletonIntEnum", "SingletonString", "SingletonStringEnum", "SmellyStruct", "SomeTypeJsii976", "StableClass", "StableEnum", "StableStruct", "StaticContext", "Statics", "StringEnum", "StripInternal", "StructA", "StructB", "StructParameterType", "StructPassing", "StructUnionConsumer", "StructWithJavaReservedWords", "Sum", "SupportsNiceJavaBuilder", "SupportsNiceJavaBuilderProps", "SupportsNiceJavaBuilderWithRequiredProps", "SyncVirtualMethods", "Thrower", "TopLevelStruct", "UnaryOperation", "UnionProperties", "UseBundledDependency", "UseCalcBase", "UsesInterfaceWithProperties", "VariadicInvoker", "VariadicMethod", "VirtualMethodPlayground", "VoidCallback", "WithPrivatePropertyInConstructor", "__jsii_assembly__", "composition"]
 
 publication.publish()

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -2003,6 +2003,11 @@ exports[`jsii-tree --all 1`] = `
  │   │   └─┬ property property (experimental)
  │   │     ├── abstract
  │   │     └── type: string
+ │   ├─┬ interface IOptionalMethod (experimental)
+ │   │ └─┬ members
+ │   │   └─┬ optional() method (experimental)
+ │   │     ├── abstract
+ │   │     └── returns: Optional<string>
  │   ├─┬ interface IPrivatelyImplemented (experimental)
  │   │ └─┬ members
  │   │   └─┬ success property (experimental)
@@ -2611,6 +2616,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   │ └─┬ interfaces
  │   │   └── IAnotherPublicInterface
  │   ├── interface IObjectWithProperty
+ │   ├── interface IOptionalMethod
  │   ├── interface IPrivatelyImplemented
  │   ├── interface IPublicInterface
  │   ├── interface IPublicInterface2
@@ -3544,6 +3550,9 @@ exports[`jsii-tree --members 1`] = `
  │   │ └─┬ members
  │   │   ├── wasSet() method
  │   │   └── property property
+ │   ├─┬ interface IOptionalMethod
+ │   │ └─┬ members
+ │   │   └── optional() method
  │   ├─┬ interface IPrivatelyImplemented
  │   │ └─┬ members
  │   │   └── success property
@@ -3902,6 +3911,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── interface IMutableObjectLiteral
  │   ├── interface INonInternalInterface
  │   ├── interface IObjectWithProperty
+ │   ├── interface IOptionalMethod
  │   ├── interface IPrivatelyImplemented
  │   ├── interface IPublicInterface
  │   ├── interface IPublicInterface2


### PR DESCRIPTION
When interfaces declare nullable members, the code generator erroneously omitted the `?` that denotes it, while generated implementations of the interface would have it, causing compilation failures.

Fixes #1285

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
