### PR TITLE
fix(jsii): missing context on "Message" diagnostics

### DIFF
--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -43,11 +43,9 @@ export function logDiagnostic(diagnostic: ts.Diagnostic, projectRoot: string) {
     getNewLine: () => ts.sys.newLine,
   };
 
-  const message = diagnostic.category === ts.DiagnosticCategory.Message && typeof diagnostic.messageText === 'string'
-    ? diagnostic.messageText
-    : diagnostic.file
-      ? ts.formatDiagnosticsWithColorAndContext([diagnostic], formatDiagnosticsHost)
-      : ts.formatDiagnostics([diagnostic], formatDiagnosticsHost);
+  const message = diagnostic.file != null
+    ? ts.formatDiagnosticsWithColorAndContext([diagnostic], formatDiagnosticsHost)
+    : ts.formatDiagnostics([diagnostic], formatDiagnosticsHost);
 
   const logFunc = diagnosticsLogger(log4js.getLogger(DIAGNOSTICS), diagnostic);
   if (!logFunc) { return; }


### PR DESCRIPTION
The context (source file with wiggly lines) was not shown for
diagnostics using the `Message` category. This removes the special
case so that context is always rendered, which ensures a better
experience overall.

Fixes #1174

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
