### PR TITLE
chore: Fix integ test module install strategy

### DIFF
--- a/packages/@jsii/integ-test/utils/index.ts
+++ b/packages/@jsii/integ-test/utils/index.ts
@@ -55,14 +55,17 @@ export class ProcessManager {
    */
   public async spawn(cmd: string, args: string[], opts: any = {}): Promise<void> {
     const proc = cp.spawn(cmd, args, { stdio: 'inherit', ...opts });
+    const cmdString = `${cmd} ${args.join(' ')}`;
+    process.stdout.write(`Running command: ${cmdString}\n`);
 
     const promise = new Promise<void>((ok, ko) => {
       proc.once('exit', code => {
-        const message = `child process exited with code: ${code}`;
+        const message = `child process exited with code: ${code}\n`;
         if (code === 0) {
           process.stdout.write(message);
           ok();
         } else {
+          process.stderr.write(`Command failed: ${cmdString}\n`);
           process.stderr.write(message);
           ko(new Error(message));
         }
@@ -71,6 +74,7 @@ export class ProcessManager {
       });
 
       proc.once('error', error => {
+        process.stderr.write(`Command failed: ${cmdString}\n`);
         process.stderr.write(`Process ${proc.pid} error: ${error}`);
         ko();
       });


### PR DESCRIPTION
Change the way we are installing local versions of jsii modules to
ensure that they are present where they are needed during cdk build. A
conflict of versions was causing packaging to stall out during dotnet
build.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
