### PR TITLE
feat(jsii): allow users to set TSC config via CLI

### DIFF
--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -64,8 +64,8 @@ const warningTypes = Object.keys(enabledWarnings);
     projectInfo = {
       ...projectInfo, 
       tsc: {
-        outDir: argv['tsc-outdir'] || projectInfo.tsc.outDir,
-        rootDir: argv['tsc-rootdir'] || projectInfo.tsc.rootDir,
+        outDir: argv['tsc-outdir'] || projectInfo.tsc?.outDir,
+        rootDir: argv['tsc-rootdir'] || projectInfo.tsc?.rootDir,
       }
     };
   }

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -58,14 +58,16 @@ const warningTypes = Object.keys(enabledWarnings);
 
   const projectRoot = path.normalize(path.resolve(process.cwd(), argv._[0] ?? '.'));
 
-  const projectInfo = await loadProjectInfo(projectRoot, { fixPeerDependencies: argv['fix-peer-dependencies'] });
+  let projectInfo = await loadProjectInfo(projectRoot, { fixPeerDependencies: argv['fix-peer-dependencies'] });
 
-  if (argv['tsc-outdir']) {
-    projectInfo.tsc.outDir = argv['tsc-outdir'];
-  }
-
-  if (argv['tsc-rootdir']) {
-    projectInfo.tsc.rootDir = argv['tsc-rootdir'];
+  if (argv['tsc-outdir'] || argv['tsc-rootdir']) {
+    projectInfo = {
+      ...projectInfo, 
+      tsc: {
+        outDir: argv['tsc-outdir'] || projectInfo.tsc.outDir,
+        rootDir: argv['tsc-rootdir'] || projectInfo.tsc.rootDir,
+      }
+    };
   }
 
   // disable all silenced warnings

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -35,6 +35,20 @@ const warningTypes = Object.keys(enabledWarnings);
       default: [],
       desc: `List of warnings to silence (warnings: ${warningTypes.join(',')})`,
     })
+    .option('tsc-outdir', {
+      alias: 'o',
+      type: 'string',
+      desc: 'directory where TS artifacts will be generated',
+      defaultDescription: 'based on `jsii.tsc.outDir` in `package.json`',
+      required: false
+    })
+    .option('tsc-rootdir', {
+      alias: 'rd',
+      type: 'string',
+      desc: 'root directory where TS artifacts will be generated',
+      defaultDescription: 'based on `jsii.tsc.rootDir` in `package.json`',
+      required: false
+    })
     .help()
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     .version(`${VERSION}, typescript ${require('typescript/package.json').version}`)
@@ -45,6 +59,14 @@ const warningTypes = Object.keys(enabledWarnings);
   const projectRoot = path.normalize(path.resolve(process.cwd(), argv._[0] ?? '.'));
 
   const projectInfo = await loadProjectInfo(projectRoot, { fixPeerDependencies: argv['fix-peer-dependencies'] });
+
+  if (argv['tsc-outdir']) {
+    projectInfo.tsc.outDir = argv['tsc-outdir];
+  }
+
+  if (argv['tsc-rootdir') {
+    projectInfo.tsc.rootDir = argv['tsc-rootdir'];
+  }
 
   // disable all silenced warnings
   for (const key of argv['silence-warnings']) {

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -61,10 +61,10 @@ const warningTypes = Object.keys(enabledWarnings);
   const projectInfo = await loadProjectInfo(projectRoot, { fixPeerDependencies: argv['fix-peer-dependencies'] });
 
   if (argv['tsc-outdir']) {
-    projectInfo.tsc.outDir = argv['tsc-outdir];
+    projectInfo.tsc.outDir = argv['tsc-outdir'];
   }
 
-  if (argv['tsc-rootdir') {
+  if (argv['tsc-rootdir']) {
     projectInfo.tsc.rootDir = argv['tsc-rootdir'];
   }
 


### PR DESCRIPTION
Allow setting supported TSC properties `outDir` and `rootDir`
via the CLI

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
