### PR TITLE
chore: align versions in build test

### DIFF
--- a/packages/@jsii/integ-test/test/build-cdk.test.ts
+++ b/packages/@jsii/integ-test/test/build-cdk.test.ts
@@ -52,6 +52,11 @@ describe('Build CDK', () => {
       cwd: srcDir
     });
 
+    // align versions for packaging
+    await processes.spawn('./scripts/align-version.sh', [], {
+      cwd: srcDir
+    });
+
     // build cdk modules
     await processes.spawn('npx', ['lerna', 'run', 'build'], {
       cwd: srcDir


### PR DESCRIPTION
Update integ test to include new step for aligning versions. This was
breaking packaging in other languages because it was trying to build
against v0.0.0.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
