### PR TITLE
fix(python-runtime): KernelResponse missing types

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_kernel/types.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/types.py
@@ -232,11 +232,13 @@ KernelRequest = Union[
 ]
 
 KernelResponse = Union[
+    BeginResponse,
     LoadResponse,
     CreateResponse,
     DeleteResponse,
     GetResponse,
     InvokeResponse,
+    SetResponse,
     StatsResponse,
     Callback,
 ]


### PR DESCRIPTION
Adds `BeginResponse` and `SetResponse` to `KernelResponse` union type in
python-runtime. This fixes python-runtime test failures.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
