### PR TITLE
fix(dotnet-analyzers): unit test null reference

### DIFF
--- a/packages/@jsii/dotnet-analyzers/src/Amazon.JSII.Analyzers.UnitTests/Verifiers/DiagnosticVerifier.cs
+++ b/packages/@jsii/dotnet-analyzers/src/Amazon.JSII.Analyzers.UnitTests/Verifiers/DiagnosticVerifier.cs
@@ -245,7 +245,8 @@ namespace TestHelper
                             Assert.True(location.IsInSource,
                                 $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
-                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+                            bool fileIsCSharp = diagnostics[i].Location.SourceTree?.FilePath.EndsWith(".cs") ?? false;
+                            string resultMethodName = fileIsCSharp ? "GetCSharpResultAt" : "GetBasicResultAt";
                             var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
                             builder.AppendFormat("{0}({1}, {2}, {3}.{4})",


### PR DESCRIPTION
Fixes dereference of possible null value in dotnet-analyzers unit test.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
