### PR TITLE
fix(jsii): out-of-source builds are broken

### DIFF
--- a/packages/@scope/jsii-calc-lib/.gitignore
+++ b/packages/@scope/jsii-calc-lib/.gitignore
@@ -1,5 +1,6 @@
 tsconfig.json
-dist
+build/
+dist/
 .jsii
 *.tgz
 

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -23,8 +23,8 @@
   "engines": {
     "node": ">= 10.3.0"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "build": "jsii && jsii-rosetta",
     "test": "diff-test test/assembly.jsii .jsii",
@@ -34,7 +34,8 @@
     "@scope/jsii-calc-base": "^1.1.0"
   },
   "peerDependencies": {
-    "@scope/jsii-calc-base": "^1.1.0"
+    "@scope/jsii-calc-base": "^1.1.0",
+    "@scope/jsii-calc-base-of-base": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^10.17.17",
@@ -62,6 +63,9 @@
         "distName": "scope.jsii-calc-lib",
         "module": "scope.jsii_calc_lib"
       }
+    },
+    "tsc": {
+      "outDir": "build"
     },
     "versionFormat": "short"
   }

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -8,7 +8,8 @@
     "url": "https://aws.amazon.com"
   },
   "dependencies": {
-    "@scope/jsii-calc-base": "^1.1.0"
+    "@scope/jsii-calc-base": "^1.1.0",
+    "@scope/jsii-calc-base-of-base": "^1.1.0"
   },
   "dependencyClosure": {
     "@scope/jsii-calc-base": {
@@ -516,5 +517,5 @@
     }
   },
   "version": "1.1.0",
-  "fingerprint": "dr9yoUHBpy7DOzkDtuWMW6EBGlCIarZPtTIdtJe3Y4o="
+  "fingerprint": "ewx+U4o9Eq6THqw75uddLD5Yhaciw+s/tLVVeGeMKTg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/.jsii
@@ -8,7 +8,8 @@
     "url": "https://aws.amazon.com"
   },
   "dependencies": {
-    "@scope/jsii-calc-base": "^1.1.0"
+    "@scope/jsii-calc-base": "^1.1.0",
+    "@scope/jsii-calc-base-of-base": "^1.1.0"
   },
   "dependencyClosure": {
     "@scope/jsii-calc-base": {
@@ -516,5 +517,5 @@
     }
   },
   "version": "1.1.0",
-  "fingerprint": "dr9yoUHBpy7DOzkDtuWMW6EBGlCIarZPtTIdtJe3Y4o="
+  "fingerprint": "ewx+U4o9Eq6THqw75uddLD5Yhaciw+s/tLVVeGeMKTg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="[1.1.0,2.0.0)" />
     <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[1.1.0,2.0.0)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[1.1.0,2.0.0)" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>0612,0618</NoWarn>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Internal/DependencyResolution/Anchor.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon/JSII/Tests/CalculatorNamespace/LibNamespace/Internal/DependencyResolution/Anchor.cs
@@ -7,6 +7,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Internal.Dependency
         public Anchor()
         {
             new Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Internal.DependencyResolution.Anchor();
+            new Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Internal.DependencyResolution.Anchor();
         }
     }
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/pom.xml
@@ -39,6 +39,11 @@
       <version>[1.1.0,2.0.0)</version>
     </dependency>
     <dependency>
+      <groupId>software.amazon.jsii.tests</groupId>
+      <artifactId>calculator-base-of-base</artifactId>
+      <version>[1.1.0,2.0.0)</version>
+    </dependency>
+    <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
       <version>[1.1.0,2.0.0)</version>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/$Module.java
@@ -12,7 +12,7 @@ public final class $Module extends JsiiModule {
 
     @Override
     public List<Class<? extends JsiiModule>> getDependencies() {
-        return asList(software.amazon.jsii.tests.calculator.base.$Module.class);
+        return asList(software.amazon.jsii.tests.calculator.base.$Module.class, software.amazon.jsii.tests.calculator.baseofbase.$Module.class);
     }
 
     @Override

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
@@ -32,7 +32,8 @@ kwargs = json.loads("""
     "install_requires": [
         "jsii~=1.1.0",
         "publication>=0.0.3",
-        "scope.jsii-calc-base>=1.1.0, <2.0.0"
+        "scope.jsii-calc-base>=1.1.0, <2.0.0",
+        "scope.jsii-calc-base-of-base>=1.1.0, <2.0.0"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/__init__.py
@@ -9,6 +9,7 @@ import jsii.compat
 import publication
 
 import scope.jsii_calc_base
+import scope.jsii_calc_base_of_base
 
 __jsii_assembly__ = jsii.JSIIAssembly.load("@scope/jsii-calc-lib", "1.1.0", __name__, "jsii-calc-lib@1.1.0.jsii.tgz")
 

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/_jsii/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/src/scope/jsii_calc_lib/_jsii/__init__.py
@@ -9,6 +9,7 @@ import jsii.compat
 import publication
 
 import scope.jsii_calc_base
+import scope.jsii_calc_base_of_base
 __all__ = []
 
 publication.publish()

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -2321,7 +2321,8 @@ exports[`jsii-tree --all 1`] = `
  │         └── type: @scope/jsii-calc-base-of-base.Very
  └─┬ @scope/jsii-calc-lib
    ├─┬ dependencies
-   │ └── @scope/jsii-calc-base
+   │ ├── @scope/jsii-calc-base
+   │ └── @scope/jsii-calc-base-of-base
    └─┬ types
      ├─┬ class Number (deprecated)
      │ ├── base: Value

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -44,10 +44,14 @@ export class Assembler implements Emitter {
     const dts = projectInfo.types;
     let mainFile = dts.replace(/\.d\.ts(x?)$/, '.ts$1');
 
+    // If out-of-source build was configured (tsc's outDir and rootDir), the
+    // main file's path needs to be re-rooted from the outDir into the rootDir.
     const tscOutDir = program.getCompilerOptions().outDir;
     if (tscOutDir != null) {
       mainFile = path.relative(tscOutDir, mainFile);
 
+      // rootDir may be set explicitly or not. If not, inferRootDir replicates
+      // tsc's behavior of using the longest prefix of all built source files.
       const tscRootDir = program.getCompilerOptions().rootDir ?? inferRootDir(program);
       if (tscRootDir != null) {
         mainFile = path.join(tscRootDir, mainFile);

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -26,6 +26,8 @@ const LOG = log4js.getLogger('jsii/assembler');
  * The JSII Assembler consumes a ``ts.Program`` instance and emits a JSII assembly.
  */
 export class Assembler implements Emitter {
+  private readonly mainFile: string;
+
   private _diagnostics = new Array<Diagnostic>();
   private _deferred = new Array<DeferredRecord>();
   private _types: { [fqn: string]: spec.Type } = {};
@@ -38,7 +40,22 @@ export class Assembler implements Emitter {
   public constructor(
     public readonly projectInfo: ProjectInfo,
     public readonly program: ts.Program,
-    public readonly stdlib: string) { }
+    public readonly stdlib: string) {
+    const dts = projectInfo.types;
+    let mainFile = dts.replace(/\.d\.ts(x?)$/, '.ts$1');
+
+    const tscOutDir = program.getCompilerOptions().outDir;
+    if (tscOutDir != null) {
+      mainFile = path.relative(tscOutDir, mainFile);
+
+      const tscRootDir = program.getCompilerOptions().rootDir ?? inferRootDir(program);
+      if (tscRootDir != null) {
+        mainFile = path.join(tscRootDir, mainFile);
+      }
+    }
+
+    this.mainFile = path.resolve(projectInfo.projectRoot, mainFile);
+  }
 
   private get _typeChecker(): ts.TypeChecker {
     return this.program.getTypeChecker();
@@ -71,19 +88,24 @@ export class Assembler implements Emitter {
 
     this._types = {};
     this._deferred = [];
-    const mainFile = path.resolve(this.projectInfo.projectRoot, this.projectInfo.types.replace(/\.d\.ts(x?)$/, '.ts$1'));
     const visitPromises = new Array<Promise<any>>();
-    for (const sourceFile of this.program.getSourceFiles().filter(f => !f.isDeclarationFile)) {
-      if (sourceFile.fileName !== mainFile) { continue; }
+
+    const sourceFile = this.program.getSourceFile(this.mainFile);
+
+    if (sourceFile == null) {
+      this._diagnostic(null, ts.DiagnosticCategory.Error, `Could not find "main" file: ${this.mainFile}`);
+    } else {
       if (LOG.isTraceEnabled()) {
         LOG.trace(`Processing source file: ${colors.blue(path.relative(this.projectInfo.projectRoot, sourceFile.fileName))}`);
       }
       const symbol = this._typeChecker.getSymbolAtLocation(sourceFile);
-      if (!symbol) { continue; }
-      for (const node of this._typeChecker.getExportsOfModule(symbol)) {
-        visitPromises.push(this._visitNode(node.declarations[0], new EmitContext([], this.projectInfo.stability)));
+      if (symbol) {
+        for (const node of this._typeChecker.getExportsOfModule(symbol)) {
+          visitPromises.push(this._visitNode(node.declarations[0], new EmitContext([], this.projectInfo.stability)));
+        }
       }
     }
+
     await Promise.all(visitPromises);
 
     this.callDeferredsInOrder();
@@ -1635,4 +1657,36 @@ async function flattenPromises<T>(promises: Array<Promise<T[]>>): Promise<T[]> {
     result.push(...subset);
   }
   return result;
+}
+
+function inferRootDir(program: ts.Program): string | undefined {
+  const directories = program.getRootFileNames()
+    .filter(fileName => {
+      const sourceFile = program.getSourceFile(fileName);
+      return sourceFile != null
+        && !program.isSourceFileFromExternalLibrary(sourceFile)
+        && !program.isSourceFileDefaultLibrary(sourceFile);
+    })
+    .map(fileName => path.relative(program.getCurrentDirectory(), path.dirname(fileName)))
+    .map(segmentPath);
+
+  const maxPrefix = Math.min(...directories.map(segments => segments.length - 1));
+  let commonIndex = -1;
+  while (commonIndex < maxPrefix && new Set(directories.map(segments => segments[commonIndex + 1])).size === 1) {
+    commonIndex++;
+  }
+
+  if (commonIndex < 0) {
+    return undefined;
+  }
+
+  return directories[0][commonIndex];
+
+  function segmentPath(fileName: string): string[] {
+    const result = new Array<string>();
+    for (let parent = fileName; parent !== path.dirname(parent); parent = path.dirname(parent)) {
+      result.unshift(parent);
+    }
+    return result;
+  }
 }

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -223,8 +223,18 @@ export class Compiler implements Emitter {
         target: COMPILER_OPTIONS.target && ts.ScriptTarget[COMPILER_OPTIONS.target],
         jsx: COMPILER_OPTIONS.jsx && Case.snake(ts.JsxEmit[COMPILER_OPTIONS.jsx]),
       },
-      include: [pi.tsc?.rootDir ? `${pi.tsc.rootDir}/**/*.ts` : '**/*.ts'],
-      exclude: ['node_modules'].concat(pi.excludeTypescript),
+      include: [
+        pi.tsc?.rootDir
+          ? path.join(pi.tsc.rootDir, '**', '*.ts')
+          : path.join('**', '*.ts')
+      ],
+      exclude: [
+        'node_modules',
+        ...pi.excludeTypescript,
+        ...pi.tsc?.outDir != null
+          ? [path.join(pi.tsc.outDir, '**', '*.ts')]
+          : [],
+      ],
       // Change the references a little. We write 'originalpath' to the
       // file under the 'path' key, which is the same as what the
       // TypeScript compiler does. Make it relative so that the files are
@@ -236,7 +246,7 @@ export class Compiler implements Emitter {
   /**
    * Creates a `tsconfig.json` file to improve the IDE experience.
    *
-   * @return the fully qualified path to the ``tsconfig.json`` file
+   * @return the fully qualified path to the `tsconfig.json` file
    */
   private async writeTypeScriptConfig(): Promise<void> {
     const commentKey = '_generated_by_jsii_';

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -224,7 +224,7 @@ export class Compiler implements Emitter {
         jsx: COMPILER_OPTIONS.jsx && Case.snake(ts.JsxEmit[COMPILER_OPTIONS.jsx]),
       },
       include: [
-        pi.tsc?.rootDir
+        pi.tsc?.rootDir != null
           ? path.join(pi.tsc.rootDir, '**', '*.ts')
           : path.join('**', '*.ts')
       ],


### PR DESCRIPTION
When configuring tsc.outDir, the jsii compiler would not look for the
correct source file and captured no types from the module. This
commit fixes this problem by reversing the types attribute in order
to resolve back to the corresponding source file.

Fixes #1273

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
