### PR TITLE
fix(kernel): "any" serialization breaks private type instances

### DIFF
--- a/docs/specifications/2-type-system.md
+++ b/docs/specifications/2-type-system.md
@@ -201,8 +201,11 @@ term *primitive* encompasses `boolean`, `string`, and `number`.
 `interface` | `undefined` | :x:         | :x:         | :x:         | [Reference] | [Reference]
 `struct`    | `undefined` | :x:         | :x:         | :x:         | :x:         | [Value]
 `class`     | `undefined` | :x:         | :x:         | :x:         | [Reference] | [Reference]
-`any`       | `undefined` | [Date]      | [Identity]  | [Array]     | [Reference] | [Mapping]
+`any`       | `undefined` | [Date]      | [Identity]  | [Array]     | [Reference] | [Value] or [Reference]
 
+In the case of `object` being passed though `any`, the value may be serialized
+by [Value] only if the value being passed does not have any method or dynamic
+accessor. Otherwise, it must be passed by [Reference] instead.
 
 > :warning: The serialization behavior around `undefined` values is affected by
 > the `optional` attribute of the declared type. As discussed earlier, the `any`

--- a/packages/@jsii/kernel/lib/objects.ts
+++ b/packages/@jsii/kernel/lib/objects.ts
@@ -26,8 +26,7 @@ const JSII_SYMBOL = Symbol.for('__jsii__');
  * information.
  */
 export function jsiiTypeFqn(obj: any): string | undefined {
-  const jsii = obj.constructor[JSII_SYMBOL];
-  return jsii?.fqn;
+  return obj.constructor[JSII_SYMBOL]?.fqn;
 }
 
 /**

--- a/packages/@jsii/kernel/lib/serialization.ts
+++ b/packages/@jsii/kernel/lib/serialization.ts
@@ -474,7 +474,7 @@ export const SERIALIZERS: {[k: string]: Serializer} = {
 
       // If this is or should be a reference type, pass or make the reference
       // (Like regular reftype serialization, but without the type derivation to an interface)
-      const jsiiType = jsiiTypeFqn(value) ?? isByReferenceOnly(value) ? EMPTY_OBJECT_FQN : undefined;
+      const jsiiType = jsiiTypeFqn(value) ?? (isByReferenceOnly(value) ? EMPTY_OBJECT_FQN : undefined);
       if (jsiiType) { return host.objects.registerObject(value, jsiiType); }
 
       // At this point we have an object that is not of an exported type. Either an object

--- a/packages/@jsii/kernel/lib/serialization.ts
+++ b/packages/@jsii/kernel/lib/serialization.ts
@@ -757,11 +757,12 @@ function isByReferenceOnly(obj: any): boolean {
     for (const prop of Object.getOwnPropertyNames(curr)) {
       const descr = Object.getOwnPropertyDescriptor(curr, prop);
       if (descr?.get != null || descr?.set != null || typeof descr?.value === 'function') {
-        // Property has a dynamic getter, setter or is a method/constructor, so by-ref required!
+        // Property has a dynamic getter, setter or is a constructor/method, so by-ref required!
         return true;
       }
     }
-  } while (Object.prototype !== (curr = Object.getPrototypeOf(curr)));
+    // End when the parent proto is `Object`, which has no parent proto itself.
+  } while (Object.getPrototypeOf(curr = Object.getPrototypeOf(curr)) != null);
 
   return false;
 }

--- a/packages/@jsii/python-runtime/src/jsii/_reference_map.py
+++ b/packages/@jsii/python-runtime/src/jsii/_reference_map.py
@@ -95,9 +95,9 @@ class _ReferenceMap:
             return data_type(**python_props)
         elif class_fqn in _enums:
             return _enums[class_fqn]
-        elif class_fqn == "Object" and ref.interfaces is not None:
+        elif class_fqn == "Object":
             # If any one interface is a struct, all of them are guaranteed to be (Kernel invariant)
-            if any(fqn in _data_types for fqn in ref.interfaces):
+            if ref.interfaces is not None and any(fqn in _data_types for fqn in ref.interfaces):
                 # Ugly delayed import here because I can't solve the cyclic
                 # package dependency right now :(.
                 from ._runtime import python_jsii_mapping
@@ -117,9 +117,7 @@ class _ReferenceMap:
         return self._refs[id]
 
     def build_interface_proxies_for_ref(self, ref):
-        if ref.interfaces is None:
-            raise AssertionError("Attempted to create interface proxies for ObjectRef without interfaces!")
-        ifaces = [_interfaces[fqn] for fqn in ref.interfaces]
+        ifaces = [_interfaces[fqn] for fqn in ref.interfaces or []]
         classes = [iface.__jsii_proxy_class__() for iface in ifaces]
         insts = [klass.__new__(klass) for klass in classes]
         for inst in insts:

--- a/packages/@jsii/python-runtime/tests/README.md
+++ b/packages/@jsii/python-runtime/tests/README.md
@@ -1,0 +1,10 @@
+# Python jsii runtime tests
+## Development Iteration
+
+When iterating on the jsii runtime for Python, the develomer must run
+`yarn build` before making a subsequent attempt at running `pytest` (e.g: via
+`yarn test`). This is because the tests run on the code installed in `.env` and
+this is updated only by `yarn build`.
+
+Note also that stack traces from test failures will point to the `.env` tree,
+so be careful when using IDE linkage to navigate to points of that trace.


### PR DESCRIPTION
When a "private" type (aka a class that is not visible in the `.jsii`
assembly) is passed from JS to Host through an `any`-typed entity, the
value was serialized by-value, passing only the instance's properties,
and omitting any methods.

This changes the behavior of the `SerializationClass.Any` serializer,
so that when an anonymous object is encountered, if it has a dynamic
getter, setter or any method (including a constructor), it is passed
by-reference instead of by-value.

Fixes aws/aws-cdk#6746

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
