### PR TITLE
fix(diff): check base types

### DIFF
--- a/packages/jsii-diff/lib/type-analysis.ts
+++ b/packages/jsii-diff/lib/type-analysis.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import * as reflect from 'jsii-reflect';
 import { flatMap } from './util';
 
@@ -93,7 +94,7 @@ export function isSuperType(a: reflect.TypeReference, b: reflect.TypeReference, 
 /**
  * Find types A and B in the updated type system, and check whether they have a supertype relationship in the type system
  */
-function isNominalSuperType(a: reflect.TypeReference, b: reflect.TypeReference, updatedSystem: reflect.TypeSystem): Analysis {
+export function isNominalSuperType(a: reflect.TypeReference, b: reflect.TypeReference, updatedSystem: reflect.TypeSystem): Analysis {
   if (a.fqn === undefined) {
     throw new Error(`I was expecting a named type, got '${a}'`);
   }

--- a/packages/jsii-diff/test/classes.test.ts
+++ b/packages/jsii-diff/test/classes.test.ts
@@ -169,6 +169,126 @@ test('cannot make a member less visible', () =>
 
 // ----------------------------------------------------------------------
 
+describe('implement base types need to be present in updated type system', () => {
+
+  test('for interfaces', () =>
+    expectError(
+      /not assignable to all base types anymore/,
+      `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export interface IBebe extends IPapa {
+        readonly pacifier: string;
+      }
+    `, `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export interface IBebe {
+        readonly pacifier: string;
+      }
+    `)
+  );
+
+  test('for structs', () =>
+    expectError(
+      /not assignable to all base types anymore/,
+      `
+      export interface Papa {
+        readonly pipe: string;
+      }
+
+      export interface Bebe extends Papa {
+        readonly pacifier: string;
+      }
+    `, `
+      export interface Papa {
+        readonly pipe: string;
+      }
+
+      export interface Bebe {
+        readonly pacifier: string;
+      }
+    `)
+  );
+
+  test('for classes', () =>
+    expectError(
+      /not assignable to all base types anymore/,
+      `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export class Bebe implements IPapa {
+        readonly pipe: string = 'pff';
+        readonly pacifier: string = 'mmm';
+      }
+    `, `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export class Bebe {
+        readonly pipe: string = 'pff';
+        readonly pacifier: string = 'mmm';
+      }
+    `)
+  );
+
+  test('for base classes', () =>
+    expectError(
+      /not assignable to all base types anymore/,
+      `
+      export class Papa {
+        readonly pipe: string = 'pff';
+      }
+
+      export class Bebe extends Papa {
+        readonly pacifier: string = 'mmm';
+      }
+    `, `
+      export class Papa {
+        readonly pipe: string = 'pff';
+      }
+
+      export class Bebe {
+        readonly pacifier: string = 'mmm';
+      }
+    `)
+  );
+
+  test('new levels of inheritance are allowed', () =>
+    expectNoError(
+      `
+      export class Papa {
+        readonly pipe: string = 'pff';
+      }
+
+      export class Bebe extends Papa {
+        readonly pacifier: string = 'mmm';
+      }
+    `, `
+      export class Papa {
+        readonly pipe: string = 'pff';
+      }
+
+      export class Inbetween extends Papa {
+      }
+
+      export class Bebe extends Inbetween {
+        readonly pacifier: string = 'mmm';
+      }
+    `)
+  );
+
+});
+
+// ----------------------------------------------------------------------
+
 test('cannot make a class property optional', () =>
   expectError(
     /prop.*henk.*type Optional<string> \(formerly string\): output type is now optional/i,

--- a/packages/jsii-reflect/lib/type.ts
+++ b/packages/jsii-reflect/lib/type.ts
@@ -6,6 +6,7 @@ import { EnumType } from './enum';
 import { InterfaceType } from './interface';
 import { locationInRepository, SourceLocatable, SourceLocation } from './source';
 import { TypeSystem } from './type-system';
+import { TypeReference } from './type-ref';
 
 export abstract class Type implements Documentable, SourceLocatable {
   public constructor(
@@ -49,6 +50,15 @@ export abstract class Type implements Documentable, SourceLocatable {
 
   public get docs(): Docs {
     return new Docs(this.system, this, this.spec.docs ?? {});
+  }
+
+  /**
+   * A type reference to this type
+   */
+  public get reference(): TypeReference {
+    return new TypeReference(this.system, {
+      fqn: this.fqn,
+    });
   }
 
   /**


### PR DESCRIPTION
Check that an updated type still extends all of its previous base types,
so that objects of the updated type can still be assigned to variables
or passed into parameters of the declared supertype.

This check would have prevented a deployment failure during a big
refactoring of the CDK.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
