### PR TITLE
feat(jsii): exclude files in tsconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .vscode
 *.tsbuildinfo
 *.tabl.json
+yarn-error.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ $ cd jsii # go to the root of the jsii repo
 $ docker run --rm --net=host -it -v $PWD:$PWD -w $PWD ${IMAGE}
 ```
 
-In the shell that pops up, the `npm run` commands in the following sections must
+In the shell that pops up, the `yarn` commands in the following sections must
 be executed.
 
 ### Alternative: Manually install the toolchain

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -202,7 +202,7 @@ export class Compiler implements Emitter {
         jsx: COMPILER_OPTIONS.jsx && Case.snake(ts.JsxEmit[COMPILER_OPTIONS.jsx]),
       },
       include: [pi.tsc && pi.tsc.rootDir ? `${pi.tsc.rootDir}/**/*.ts` : '**/*.ts'],
-      exclude: ['node_modules'].concat(pi.excludeTypescript),
+      exclude: ['node_modules'].concat(pi.exclude).concat(pi.excludeTypescript || []),
       // Change the references a little. We write 'originalpath' to the
       // file under the 'path' key, which is the same as what the
       // TypeScript compiler does. Make it relative so that the files are

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -45,7 +45,9 @@ export interface ProjectInfo {
   readonly description?: string;
   readonly homepage?: string;
   readonly contributors?: readonly spec.Person[];
-  readonly excludeTypescript: string[];
+  /** @deprecated - use excludes */
+  readonly excludeTypescript?: string[];
+  readonly exclude: string[];
   readonly projectReferences?: boolean;
   readonly tsc?: TSCompilerOptions;
 }
@@ -142,6 +144,7 @@ export async function loadProjectInfo(projectRoot: string, { fixPeerDependencies
             && (pkg.contributors as any[]).map((contrib, index) => _toPerson(contrib, `contributors[${index}]`, 'contributor')),
 
     excludeTypescript: (pkg.jsii && pkg.jsii.excludeTypescript) || [],
+    exclude: (pkg.jsii && pkg.jsii.exclude) || [],
     projectReferences: pkg.jsii && pkg.jsii.projectReferences,
     tsc: {
       outDir: pkg.jsii && pkg.jsii.tsc && pkg.jsii.tsc.outDir,

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -1,0 +1,45 @@
+import fs = require('fs-extra');
+import os = require('os');
+import path = require('path');
+import { Compiler } from '../lib/compiler';
+import { loadProjectInfo } from '../lib/project-info';
+
+let tmpdir: string | undefined;
+
+beforeEach(async () => {
+  tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), path.basename(__filename)));
+});
+
+afterEach(async () => {
+  if (tmpdir !== undefined) { 
+    await fs.remove(tmpdir);
+  }
+});
+
+test('compiled output contains jsii excludes', async () => {
+  const packageInfo = {
+    types: 'index.ts',
+    main: 'index.js',
+    name: 'testpkg', // That's what package.json would tell if we look up...
+    version: '0.0.1',
+    license: 'Apache-2.0',
+    author: { name: 'John Doe', roles: ['author'] },
+    repository: { type: 'git', url: 'https://github.com/aws/jsii.git' },
+    jsii: {
+      exclude: ['exclude-dir/exclude-file'],
+      excludeTypescript: ['exclude-ts'],
+    },
+  };
+
+  await fs.writeFile(path.resolve(tmpdir!, 'index.ts'), 'export class Foo { public foo() {} }', { encoding: 'utf-8' });
+  await fs.writeJson(path.resolve(tmpdir!, 'package.json'), packageInfo, { encoding: 'utf-8' });
+  
+  const compiler = new Compiler({
+    projectInfo: await loadProjectInfo(tmpdir!, { fixPeerDependencies: false }),
+  });
+  await compiler.emit();
+  const tsConfigPath = path.resolve(tmpdir!, 'tsconfig.json');
+  expect(await fs.pathExists(tsConfigPath)).toBeTruthy();
+  const tsConfigJson = await fs.readJSON(tsConfigPath);
+  console.log(`nijaaa ${JSON.stringify(tsConfigJson)}`);
+});

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -79,6 +79,6 @@ function _makeProjectInfo(types: string): ProjectInfo {
     transitiveDependencies: [],
     bundleDependencies: {},
     targets: {},
-    excludeTypescript: [],
+    exclude: [],
   };
 }


### PR DESCRIPTION
## Commit Message

This change lets package.json of a jsii package to specify additional
'exclude' paths. They are encoded into tsconfig.json.

Motivation
jsconfig is a common way to configure tools like eslint and jest. These
files have the 'js' extension but should not be compiled into the
package. This flag lets the jsii compiled packages to configure this.
## End Commit Message
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
