### PR TITLE
fix(jsii-diff): detect interfaces inherited via interfaces

### DIFF
--- a/packages/jsii-diff/test/classes.test.ts
+++ b/packages/jsii-diff/test/classes.test.ts
@@ -285,6 +285,58 @@ describe('implement base types need to be present in updated type system', () =>
     `)
   );
 
+  test('change direct implementation to inherited implementation via interface', () =>
+    expectNoError(
+      `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export class Bebe implements IPapa {
+        readonly pipe: string = 'pff';
+        readonly pacifier: string = 'mmm';
+      }
+    `, `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export interface IInbetween extends IPapa {
+      }
+
+      export class Bebe implements IInbetween {
+        readonly pipe: string = 'pff';
+        readonly pacifier: string = 'mmm';
+      }
+    `)
+  );
+
+  test('change direct implementation to inherited implementation via base class', () =>
+    expectNoError(
+      `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export class Bebe implements IPapa {
+        readonly pipe: string = 'pff';
+        readonly pacifier: string = 'mmm';
+      }
+    `, `
+      export interface IPapa {
+        readonly pipe: string;
+      }
+
+      export class Inbetween implements IPapa {
+        readonly pipe: string = 'pff';
+      }
+
+      export class Bebe extends Inbetween {
+        readonly pacifier: string = 'mmm';
+      }
+    `)
+  );
+
 });
 
 // ----------------------------------------------------------------------

--- a/packages/jsii-reflect/lib/class.ts
+++ b/packages/jsii-reflect/lib/class.ts
@@ -88,11 +88,10 @@ export class ClassType extends ReferenceType {
       out.push(...this.base.getInterfaces(inherited));
     }
     if (this.spec.interfaces) {
-      out.push(...flatten(
-        this.spec.interfaces
+      out.push(...flatten(this.spec.interfaces
         .map(fqn => this.system.findInterface(fqn))
         .map(iface => [iface, ...inherited ? iface.getInterfaces(true) : []]),
-        ));
+      ));
     }
     return out;
   }

--- a/packages/jsii-reflect/lib/class.ts
+++ b/packages/jsii-reflect/lib/class.ts
@@ -88,7 +88,11 @@ export class ClassType extends ReferenceType {
       out.push(...this.base.getInterfaces(inherited));
     }
     if (this.spec.interfaces) {
-      out.push(...this.spec.interfaces.map(iface => this.system.findInterface(iface)));
+      out.push(...flatten(
+        this.spec.interfaces
+        .map(fqn => this.system.findInterface(fqn))
+        .map(iface => [iface, ...inherited ? iface.getInterfaces(true) : []]),
+        ));
     }
     return out;
   }
@@ -110,4 +114,8 @@ export class ClassType extends ReferenceType {
       (this.spec.methods ?? []).map(m => new Method(this.system, this.assembly, parentType, this, m)),
       m => m.name));
   }
+}
+
+function flatten<A>(xs: A[][]): A[] {
+  return Array.prototype.concat([], ...xs);
 }


### PR DESCRIPTION
`jsii-diff` is currently throwing on CDK because it thinks interfaces
are being removed from the inheritance chain, even if they've actually
been moved to base classes.

This is because the `ClassType.getInterfaces()` method of `jsii-reflect`
was only returning its direct interfaces, even when run with
`inherited=true` (as opposed to recursively returning the interfaces
all the way up the tree).

Q: Why did you not add a unit test in `jsii-reflect`?

A: The set suite of `jsii-reflect` is quite anemic, and basically only
tests that we can mostly deduce the types that are present in an
assembly. It doesn't have good testing infrastructure for actually
asserting things about arbitrary small pieces of typescript, instead it
mostly works on the generated assemblies from the `jsii-calc` etc.
examples. `jsii-diff` *does* have that testing infrastructure, and so
`jsii-diff` serves as the test suite for `jsii-reflect` at the moment...

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
