### PR TITLE
chore: run travis on release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: minimal
 branches:
   only:
     - master
+    - release
     - /^v\d+\.\d+.\d+$/
 
 cache:


### PR DESCRIPTION
Change travis CI config to run on release branch in addition to master.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
