### PR TITLE
chore: remove artifacts between builds in CI

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -12,6 +12,7 @@ phases:
   build:
     commands:
       - yarn build && yarn test
+      - rm -rf dist/*
       - /bin/bash ./scripts/align-version.sh
       - yarn build
   post_build:


### PR DESCRIPTION
Clears the contents of the `dist` directory between builds in
buildspec.yaml. This prevents modules with `v0.0.0` from being
published.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
