### PR TITLE
chore: clean up all dist folders before building release packages

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -12,7 +12,7 @@ phases:
   build:
     commands:
       - yarn build && yarn test
-      - rm -rf dist/*
+      - yarn dist-clean
       - /bin/bash ./scripts/align-version.sh
       - yarn build
   post_build:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "lerna run build --stream --sort --concurrency=1",
     "bump": "bash scripts/bump.sh",
+    "dist-clean": "lerna run dist-clean --stream && rm -rf dist",
     "fetch-dotnet-snk": "bash scripts/fetch-dotnet-snk.sh",
     "package": "bash scripts/package.sh",
     "test": "lerna run test --stream",

--- a/packages/@jsii/dotnet-analyzers/build.sh
+++ b/packages/@jsii/dotnet-analyzers/build.sh
@@ -2,5 +2,3 @@
 set -euo pipefail
 
 dotnet build --force -c Release ./src/Amazon.JSII.Analyzers
-
-cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/@jsii/dotnet-analyzers/package.json
+++ b/packages/@jsii/dotnet-analyzers/package.json
@@ -32,9 +32,10 @@
   "scripts": {
     "gen": "/bin/bash ./generate.sh",
     "build": "npm run gen && tsc --build && /bin/bash ./build.sh",
+    "dist-clean": "rm -rf dist && dotnet clean -c Release ./src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj",
     "test": "/bin/bash ./test.sh",
     "test:update": "UPDATE_DIFF=1 npm run test",
-    "package": "package-dotnet"
+    "package": "package-dotnet ./src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj"
   },
   "devDependencies": {
     "@types/node": "^10.17.19",

--- a/packages/@jsii/dotnet-jsonmodel/build.sh
+++ b/packages/@jsii/dotnet-jsonmodel/build.sh
@@ -4,5 +4,3 @@ set -euo pipefail
 npm run gen
 
 dotnet build --force -c Release ./src/Amazon.JSII.JsonModel.sln
-
-cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/@jsii/dotnet-jsonmodel/package.json
+++ b/packages/@jsii/dotnet-jsonmodel/package.json
@@ -30,9 +30,10 @@
   "scripts": {
     "gen": "/bin/bash ./generate.sh",
     "build": "tsc --build && /bin/bash ./build.sh",
+    "dist-clean": "rm -rf dist && dotnet clean -c Release ./src/Amazon.JSII.JsonModel/Amazon.JSII.JsonModel.csproj",
     "test": "/bin/bash ./test.sh",
     "test:update": "UPDATE_DIFF=1 npm run test",
-    "package": "package-dotnet"
+    "package": "package-dotnet ./src/Amazon.JSII.JsonModel/Amazon.JSII.JsonModel.csproj"
   },
   "devDependencies": {
     "@types/node": "^10.17.19",

--- a/packages/@jsii/dotnet-runtime/build.sh
+++ b/packages/@jsii/dotnet-runtime/build.sh
@@ -10,5 +10,3 @@ rsync -av $(node -p 'require("path").dirname(require.resolve("@jsii/runtime/pack
 # solution to avoid integration tests from trying to be
 # built before the calc packages are generated.
 dotnet build --force -c Release ./src/Amazon.JSII.Runtime
-
-cp -f ./bin/Release/NuGet/*.nupkg ./bin/Release/NuGet/*.snupkg .

--- a/packages/@jsii/dotnet-runtime/package.json
+++ b/packages/@jsii/dotnet-runtime/package.json
@@ -32,9 +32,10 @@
   "scripts": {
     "gen": "/bin/bash ./generate.sh",
     "build": "npm run gen && tsc --build && /bin/bash ./build.sh",
+    "dist-clean": "rm -rf dist && dotnet clean -c Release ./src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj",
     "test": "/bin/bash ./test.sh",
     "test:update": "UPDATE_DIFF=1 npm run test",
-    "package": "package-dotnet"
+    "package": "package-dotnet ./src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj"
   },
   "devDependencies": {
     "@jsii/dotnet-jsonmodel": "^0.0.0",

--- a/packages/@jsii/java-runtime/package.json
+++ b/packages/@jsii/java-runtime/package.json
@@ -25,7 +25,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "gen": "/bin/bash ./generate.sh",
-    "build": "tsc --build && npm run gen && cd project && mvn package",
+    "build": "tsc --build && npm run gen && cd project && mvn -B deploy -D altDeploymentRepository=local::default::file://${PWD}/../maven-repo",
     "dist-clean": "rm -rf dist maven-repo && cd project && mvn -B clean",
     "test": "echo 'Tests are run as part of the build target'",
     "test:update": "UPDATE_DIFF=1 npm run test",

--- a/packages/@jsii/java-runtime/package.json
+++ b/packages/@jsii/java-runtime/package.json
@@ -25,7 +25,8 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "gen": "/bin/bash ./generate.sh",
-    "build": "tsc --build && npm run gen && cd project && mvn -B deploy -D altDeploymentRepository=local::default::file://${PWD}/../maven-repo",
+    "build": "tsc --build && npm run gen && cd project && mvn package",
+    "dist-clean": "rm -rf dist maven-repo && cd project && mvn -B clean",
     "test": "echo 'Tests are run as part of the build target'",
     "test:update": "UPDATE_DIFF=1 npm run test",
     "package": "package-java"

--- a/packages/@jsii/python-runtime/.gitignore
+++ b/packages/@jsii/python-runtime/.gitignore
@@ -12,4 +12,6 @@ __pycache__
 .mypy_cache
 .pytest_cache
 
+build
+
 README.md

--- a/packages/@jsii/python-runtime/package.json
+++ b/packages/@jsii/python-runtime/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "generate": "python3 bin/generate",
     "deps": "python3 -m venv .env && .env/bin/pip install pip~=20.0.2 setuptools~=46.1.3 wheel~=0.34.2 && .env/bin/pip install -r requirements.txt",
-    "build": "cp ../../../README.md . && rm -f jsii-*.whl && npm run generate && npm run deps && .env/bin/python setup.py sdist -d . bdist_wheel -d . && rm -rf build",
+    "dist-clean": "rm -rf dist",
+    "build": "cp ../../../README.md . && rm -f jsii-*.whl && npm run generate && npm run deps",
     "package": "package-python",
     "test": ".env/bin/python bin/generate-calc && .env/bin/py.test -v --mypy",
     "test:update": "UPDATE_DIFF=1 .env/bin/python bin/generate-calc && .env/bin/py.test -v --mypy"

--- a/packages/@jsii/ruby-runtime/package.json
+++ b/packages/@jsii/ruby-runtime/package.json
@@ -26,8 +26,9 @@
   "scripts": {
     "gen": "/bin/bash generate.sh",
     "deps": "cd project && bundle install --path vendor/bundle --binstubs vendor/bin",
+    "dist-clean": "rm -rf dist",
     "lint": "cd project && vendor/bin/rubocop",
-    "build": "npm run gen && npm run deps && npm run lint && gem build project/*.gemspec",
+    "build": "npm run gen && npm run deps && npm run lint",
     "test": "cd project && ruby test/suite.rb",
     "test:update": "UPDATE_DIFF=1 npm run test",
     "package": "package-ruby"

--- a/tools/jsii-build-tools/bin/package-dotnet
+++ b/tools/jsii-build-tools/bin/package-dotnet
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-rm -fr dist/dotnet
+
 mkdir -p dist/dotnet
-cp *.nupkg *.snupkg dist/dotnet
+
+dotnet build --force -c Release $1
+dotnet pack --include-symbols --include-source --output dist/dotnet -c Release $1

--- a/tools/jsii-build-tools/bin/package-java
+++ b/tools/jsii-build-tools/bin/package-java
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -euo pipefail
-rm -fr dist/java
+
 mkdir -p dist/java
+mkdir -p maven-repo
+
+(
+  cd project
+  mvn -B deploy -D altDeploymentRepository=local::default::file://${PWD}/../maven-repo
+)
+
 rsync -av maven-repo/ dist/java/
 

--- a/tools/jsii-build-tools/bin/package-java
+++ b/tools/jsii-build-tools/bin/package-java
@@ -2,12 +2,6 @@
 set -euo pipefail
 
 mkdir -p dist/java
-mkdir -p maven-repo
-
-(
-  cd project
-  mvn -B deploy -D altDeploymentRepository=local::default::file://${PWD}/../maven-repo
-)
 
 rsync -av maven-repo/ dist/java/
 

--- a/tools/jsii-build-tools/bin/package-python
+++ b/tools/jsii-build-tools/bin/package-python
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-rm -rf dist/python
 mkdir -p dist/python
-cp *.whl dist/python
-cp *.tar.gz dist/python
+
+.env/bin/python setup.py sdist -d dist/python bdist_wheel -d dist/python

--- a/tools/jsii-build-tools/bin/package-ruby
+++ b/tools/jsii-build-tools/bin/package-ruby
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-rm -fr dist/ruby
+
 mkdir -p dist/ruby
-cp *.gem dist/ruby
+
+gem build project/*.gemspec
+mv *.gem dist/ruby


### PR DESCRIPTION
Makes sure no outstanding files containing version `0.0.0` are left to be
copied into the top-level `dist` folder during the packaging phase.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
