### PR TITLE
fix(jsii-pacmak): invalid dotnet version suffixes

### DIFF
--- a/packages/jsii-pacmak/lib/targets/version-utils.ts
+++ b/packages/jsii-pacmak/lib/targets/version-utils.ts
@@ -20,7 +20,7 @@ export function toMavenVersionRange(semverRange: string, suffix?: string): strin
  * @see https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-ranges-and-wildcards
  */
 export function toNuGetVersionRange(semverRange: string): string {
-  return toBracketNotation(semverRange);
+  return toBracketNotation(semverRange, undefined, { semver: false });
 }
 
 /**

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1-0)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1)" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>0612,0618</NoWarn>

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/dotnet/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId/Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,0.0.1-0)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1-0)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1)" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>0612,0618</NoWarn>

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,0.0.1-0)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1-0)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="[0.0.0-devpreview,0.0.1-0)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[0.0.0,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="[0.0.0-devpreview,0.0.1)" />
   </ItemGroup>
   <PropertyGroup>
     <NoWarn>0612,0618</NoWarn>

--- a/packages/jsii-pacmak/test/targets/version-utils.test.ts
+++ b/packages/jsii-pacmak/test/targets/version-utils.test.ts
@@ -9,12 +9,12 @@ const examples: Record<string, { maven: string, nuget: string, python: string }>
   },
   '~1.2.3': {
     maven: '[1.2.3,1.3.0)',
-    nuget: '[1.2.3,1.3.0-0)',
+    nuget: '[1.2.3,1.3.0)',
     python: '>=1.2.3, <1.3.0',
   },
   '^1.2.3': {
     maven: '[1.2.3,2.0.0)',
-    nuget: '[1.2.3,2.0.0-0)',
+    nuget: '[1.2.3,2.0.0)',
     python: '>=1.2.3, <2.0.0',
   },
 
@@ -26,12 +26,12 @@ const examples: Record<string, { maven: string, nuget: string, python: string }>
   },
   '~0.1.2': {
     maven: '[0.1.2,0.2.0)',
-    nuget: '[0.1.2,0.2.0-0)',
+    nuget: '[0.1.2,0.2.0)',
     python: '>=0.1.2, <0.2.0',
   },
   '^0.1.2': {
     maven: '[0.1.2,0.2.0)',
-    nuget: '[0.1.2,0.2.0-0)',
+    nuget: '[0.1.2,0.2.0)',
     python: '>=0.1.2, <0.2.0',
   },
 


### PR DESCRIPTION
Removes version suffix from version ranges in `.csproj` files generated
by jsii-pacmak.

Dotnet doesn't allow version suffixes that start with a number. Version
ranges by default don't include prereleases so the resolved version is
as intended without the suffix in this case.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
