### PR TITLE
fix(python): incorrect dependency on jsii

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1320,7 +1320,7 @@ class Package {
       packages: modules.map(m => m.pythonName),
       package_data: packageData,
       python_requires: '>=3.6',
-      install_requires: [`jsii~=${jsiiVersionSimple}`, 'publication>=0.0.3'].concat(dependencies),
+      install_requires: [`jsii${toPythonVersionRange(`^${jsiiVersionSimple}`)}`, 'publication>=0.0.3'].concat(dependencies),
       classifiers: [
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/python/setup.py
@@ -30,7 +30,7 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.0.0",
+        "jsii>=0.0.0, <0.0.1",
         "publication>=0.0.3"
     ],
     "classifiers": [

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/python/setup.py
@@ -30,7 +30,7 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.0.0",
+        "jsii>=0.0.0, <0.0.1",
         "publication>=0.0.3",
         "scope.jsii-calc-base-of-base>=0.0.0, <0.0.1"
     ],

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/python/setup.py
@@ -30,7 +30,7 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.0.0",
+        "jsii>=0.0.0, <0.0.1",
         "publication>=0.0.3",
         "scope.jsii-calc-base>=0.0.0, <0.0.1",
         "scope.jsii-calc-base-of-base>=0.0.0, <0.0.1"

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/setup.py
@@ -39,7 +39,7 @@ kwargs = json.loads("""
     },
     "python_requires": ">=3.6",
     "install_requires": [
-        "jsii~=0.0.0",
+        "jsii>=0.0.0, <0.0.1",
         "publication>=0.0.3",
         "scope.jsii-calc-base>=0.0.0, <0.0.1",
         "scope.jsii-calc-base-of-base>=0.0.0, <0.0.1",


### PR DESCRIPTION
The Python runtime dependency of generated Python code was incorrectly pinning on the minor, instead of allowing the necessary semver range. Changed the dependency statement from `~=<version>` to the correctly translated caret range.

Fixes #1573
