### PR TITLE
chore(dotnet): standardize generation of jsii runtime dependency

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as xmlbuilder from 'xmlbuilder';
 import { DotNetNameUtils } from './nameutils';
 import * as logging from '../../logging';
-import { nextMajorVersion } from '../../util';
 import { TARGET_FRAMEWORK } from '../dotnet';
 import { toNuGetVersionRange } from '../version-utils';
 
@@ -104,12 +103,11 @@ export class FileGenerator {
 
     // Strip " (build abcdef)" from the jsii version
     const jsiiVersion = assembly.jsiiVersion.replace(/ .*$/, '');
-    const jsiiVersionNextMajor = nextMajorVersion(jsiiVersion);
 
     const itemGroup2 = rootNode.ele('ItemGroup');
     const packageReference = itemGroup2.ele('PackageReference');
     packageReference.att('Include', 'Amazon.JSII.Runtime');
-    packageReference.att('Version', `[${jsiiVersion},${jsiiVersionNextMajor})`);
+    packageReference.att('Version', toNuGetVersionRange(`^${jsiiVersion}`));
 
     dependencies.forEach((value: DotNetDependency) => {
       if (value.partOfCompilation) {

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
 import * as os from 'os';
 import * as path from 'path';
-import * as semver from 'semver';
 import * as logging from './logging';
 
 export interface ShellOptions extends SpawnOptions {
@@ -132,29 +131,6 @@ export class Scratch<A> {
     }
   }
 }
-
-/**
- * Determines the next major version from a given current version. This honors
- * the specificities of pre-1.0.0 releases, too.
- *
- * @param version the current version from which to bump.
- *
- * @returns the next Major Version string.
- */
-export function nextMajorVersion(version: string): string {
-  const v = semver.parse(version);
-  if (!v) {
-    throw new Error(`Invalid semantic version identifier: ${version}`);
-  }
-  if (v.major !== 0) {
-    return v.inc('major').version;
-  }
-  if (v.minor !== 0) {
-    return v.inc('minor').version;
-  }
-  return v.inc('patch').version;
-}
-
 
 export function setExtend<A>(xs: Set<A>, els: Iterable<A>) {
   for (const el of els) {


### PR DESCRIPTION
Instead of having it's own range generation, use the standard
translation used to represent dependencies' ranges for the jsii runtime
version, too.

This removes an exception path, and simplifies the overall code.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
