### PR TITLE
chore: improve error message when a non-jsii dependency is not bundled

### DIFF
--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -253,7 +253,7 @@ function _tryResolveAssembly(mod: string, localPackage: string | undefined, sear
     const paths = [searchPath, path.join(searchPath, 'node_modules')];
     return require.resolve(path.join(mod, '.jsii'), { paths });
   } catch {
-    throw new Error(`Unable to locate module: ${mod}`);
+    throw new Error(`Unable to locate jsii assembly for "${mod}". If this module is not jsii-enabled, it must be bundled.`);
   }
 }
 

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -253,7 +253,7 @@ function _tryResolveAssembly(mod: string, localPackage: string | undefined, sear
     const paths = [searchPath, path.join(searchPath, 'node_modules')];
     return require.resolve(path.join(mod, '.jsii'), { paths });
   } catch {
-    throw new Error(`Unable to locate jsii assembly for "${mod}". If this module is not jsii-enabled, it must be bundled.`);
+    throw new Error(`Unable to locate jsii assembly for "${mod}". If this module is not jsii-enabled, it must also be declared under bundledDependencies.`);
   }
 }
 


### PR DESCRIPTION
## Commit Message
chore: improve error message when a non-jsii dependency is not bundled (#1651)

Instead of outputting a very terse 'Unable to locate module', which misleads users into believing
the module cannot be resolved by the compiler, use a longer error message that clearly states the
jsii Assembly could not be located, and that non-jsii dependencies must be bundled.

Fixes #1636

## End Commit Message
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
