### PR TITLE
feat(java): add a Builder<T> interface implemented by all builders

### DIFF
--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/Builder.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/Builder.java
@@ -3,7 +3,7 @@ package software.amazon.jsii;
 /**
  * A superinterface common to instance builders.
  */
- @FunctionalInterface
+@FunctionalInterface
 public interface Builder<T> {
   /**
    * Builds the instance given the current builder configuration.

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/Builder.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/Builder.java
@@ -1,0 +1,14 @@
+package software.amazon.jsii;
+
+/**
+ * A superinterface common to instance builders.
+ */
+ @FunctionalInterface
+public interface Builder<T> {
+  /**
+   * Builds the instance given the current builder configuration.
+   *
+   * @return the built instance.
+   */
+  T build();
+}

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1177,7 +1177,7 @@ class JavaGenerator extends Generator {
     this.code.line(` * A fluent builder for {@link ${builtType}}.`);
     this.code.line(' */');
     this.emitStabilityAnnotations(cls.initializer);
-    this.code.openBlock(`public static final class ${BUILDER_CLASS_NAME}`);
+    this.code.openBlock(`public static final class ${BUILDER_CLASS_NAME} implements software.amazon.jsii.Builder<${builtType}>`);
 
     // Static factory method(s)
     for (const params of computeOverrides(positionalParams)) {
@@ -1247,6 +1247,7 @@ class JavaGenerator extends Generator {
     this.code.line(` * @returns a newly built instance of {@link ${builtType}}.`);
     this.code.line(' */');
     this.emitStabilityAnnotations(cls.initializer);
+    this.code.line('@Override');
     this.code.openBlock(`public ${builtType} build()`);
     const params = cls.initializer.parameters.map(param => {
       if (param === firstStruct) {
@@ -1322,7 +1323,7 @@ class JavaGenerator extends Generator {
     this.code.line(` * A builder for {@link ${classSpec.name}}`);
     this.code.line(' */');
     this.emitStabilityAnnotations(classSpec);
-    this.code.openBlock(`public static final class ${BUILDER_CLASS_NAME}`);
+    this.code.openBlock(`public static final class ${BUILDER_CLASS_NAME} implements software.amazon.jsii.Builder<${classSpec.name}>`);
 
     props.forEach(prop => this.code.line(`private ${prop.fieldJavaType} ${prop.fieldName};`));
     props.forEach(prop => this.emitBuilderSetter(prop, BUILDER_CLASS_NAME, classSpec.name));
@@ -1335,6 +1336,7 @@ class JavaGenerator extends Generator {
     this.code.line(' * @throws NullPointerException if any required attribute was not provided');
     this.code.line(' */');
     this.emitStabilityAnnotations(classSpec);
+    this.code.line('@Override');
     this.code.openBlock(`public ${classSpec.name} build()`);
 
     const propFields = props.map(prop => prop.fieldName).join(', ');

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base-of-base/java/src/main/java/software/amazon/jsii/tests/calculator/baseofbase/VeryBaseProps.java
@@ -16,7 +16,7 @@ public interface VeryBaseProps extends software.amazon.jsii.JsiiSerializable {
     /**
      * A builder for {@link VeryBaseProps}
      */
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<VeryBaseProps> {
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
         /**
@@ -34,6 +34,7 @@ public interface VeryBaseProps extends software.amazon.jsii.JsiiSerializable {
          * @return a new instance of {@link VeryBaseProps}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @Override
         public VeryBaseProps build() {
             return new Jsii$Proxy(foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-base/java/src/main/java/software/amazon/jsii/tests/calculator/base/BaseProps.java
@@ -16,7 +16,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
     /**
      * A builder for {@link BaseProps}
      */
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<BaseProps> {
         private java.lang.String bar;
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
 
@@ -45,6 +45,7 @@ public interface BaseProps extends software.amazon.jsii.JsiiSerializable, softwa
          * @return a new instance of {@link BaseProps}
          * @throws NullPointerException if any required attribute was not provided
          */
+        @Override
         public BaseProps build() {
             return new Jsii$Proxy(bar, foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/MyFirstStruct.java
@@ -45,7 +45,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<MyFirstStruct> {
         private java.lang.Number anumber;
         private java.lang.String astring;
         private java.util.List<java.lang.String> firstOptional;
@@ -93,6 +93,7 @@ public interface MyFirstStruct extends software.amazon.jsii.JsiiSerializable {
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
+        @Override
         public MyFirstStruct build() {
             return new Jsii$Proxy(anumber, astring, firstOptional);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/StructWithOnlyOptionals.java
@@ -48,7 +48,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StructWithOnlyOptionals> {
         private java.lang.String optional1;
         private java.lang.Number optional2;
         private java.lang.Boolean optional3;
@@ -96,6 +96,7 @@ public interface StructWithOnlyOptionals extends software.amazon.jsii.JsiiSerial
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
+        @Override
         public StructWithOnlyOptionals build() {
             return new Jsii$Proxy(optional1, optional2, optional3);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/submodule/ReflectableEntry.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc-lib/java/src/main/java/software/amazon/jsii/tests/calculator/lib/submodule/ReflectableEntry.java
@@ -34,7 +34,7 @@ public interface ReflectableEntry extends software.amazon.jsii.JsiiSerializable 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ReflectableEntry> {
         private java.lang.String key;
         private java.lang.Object value;
 
@@ -69,6 +69,7 @@ public interface ReflectableEntry extends software.amazon.jsii.JsiiSerializable 
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
+        @Override
         public ReflectableEntry build() {
             return new Jsii$Proxy(key, value);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AmbiguousParameters.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/AmbiguousParameters.java
@@ -48,7 +48,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
      * A fluent builder for {@link software.amazon.jsii.tests.calculator.AmbiguousParameters}.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.AmbiguousParameters> {
         /**
          * EXPERIMENTAL
          * <p>
@@ -96,6 +96,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
          * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.AmbiguousParameters}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public software.amazon.jsii.tests.calculator.AmbiguousParameters build() {
             return new software.amazon.jsii.tests.calculator.AmbiguousParameters(
                 this.scope,

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Calculator.java
@@ -234,7 +234,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
      * A fluent builder for {@link software.amazon.jsii.tests.calculator.Calculator}.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.Calculator> {
         /**
          * EXPERIMENTAL
          * <p>
@@ -288,6 +288,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
          * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.Calculator}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public software.amazon.jsii.tests.calculator.Calculator build() {
             return new software.amazon.jsii.tests.calculator.Calculator(
                 this.props != null ? this.props.build() : null

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/CalculatorProps.java
@@ -48,7 +48,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link CalculatorProps}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<CalculatorProps> {
         private java.lang.Number initialValue;
         private java.lang.Number maximumValue;
 
@@ -81,6 +81,7 @@ public interface CalculatorProps extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public CalculatorProps build() {
             return new Jsii$Proxy(initialValue, maximumValue);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ChildStruct982.java
@@ -26,7 +26,7 @@ public interface ChildStruct982 extends software.amazon.jsii.JsiiSerializable, s
      * A builder for {@link ChildStruct982}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ChildStruct982> {
         private java.lang.Number bar;
         private java.lang.String foo;
 
@@ -58,6 +58,7 @@ public interface ChildStruct982 extends software.amazon.jsii.JsiiSerializable, s
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ChildStruct982 build() {
             return new Jsii$Proxy(bar, foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJacksonStruct.java
@@ -28,7 +28,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
      * A builder for {@link ConfusingToJacksonStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ConfusingToJacksonStruct> {
         private java.lang.Object unionProperty;
 
         /**
@@ -59,6 +59,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ConfusingToJacksonStruct build() {
             return new Jsii$Proxy(unionProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DeprecatedStruct.java
@@ -30,7 +30,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
     @Deprecated
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DeprecatedStruct> {
         private java.lang.String readonlyProperty;
 
         /**
@@ -53,6 +53,7 @@ public interface DeprecatedStruct extends software.amazon.jsii.JsiiSerializable 
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Deprecated)
         @Deprecated
+        @Override
         public DeprecatedStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DerivedStruct.java
@@ -68,7 +68,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
      * A builder for {@link DerivedStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DerivedStruct> {
         private java.time.Instant anotherRequired;
         private java.lang.Boolean bool;
         private software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive;
@@ -187,6 +187,7 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public DerivedStruct build() {
             return new Jsii$Proxy(anotherRequired, bool, nonPrimitive, anotherOptional, optionalAny, optionalArray, anumber, astring, firstOptional);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceBaseLevelStruct.java
@@ -26,7 +26,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
      * A builder for {@link DiamondInheritanceBaseLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DiamondInheritanceBaseLevelStruct> {
         private java.lang.String baseLevelProperty;
 
         /**
@@ -46,6 +46,7 @@ public interface DiamondInheritanceBaseLevelStruct extends software.amazon.jsii.
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public DiamondInheritanceBaseLevelStruct build() {
             return new Jsii$Proxy(baseLevelProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceFirstMidLevelStruct.java
@@ -26,7 +26,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
      * A builder for {@link DiamondInheritanceFirstMidLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DiamondInheritanceFirstMidLevelStruct> {
         private java.lang.String firstMidLevelProperty;
         private java.lang.String baseLevelProperty;
 
@@ -58,6 +58,7 @@ public interface DiamondInheritanceFirstMidLevelStruct extends software.amazon.j
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public DiamondInheritanceFirstMidLevelStruct build() {
             return new Jsii$Proxy(firstMidLevelProperty, baseLevelProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceSecondMidLevelStruct.java
@@ -26,7 +26,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
      * A builder for {@link DiamondInheritanceSecondMidLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DiamondInheritanceSecondMidLevelStruct> {
         private java.lang.String secondMidLevelProperty;
         private java.lang.String baseLevelProperty;
 
@@ -58,6 +58,7 @@ public interface DiamondInheritanceSecondMidLevelStruct extends software.amazon.
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public DiamondInheritanceSecondMidLevelStruct build() {
             return new Jsii$Proxy(secondMidLevelProperty, baseLevelProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/DiamondInheritanceTopLevelStruct.java
@@ -26,7 +26,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
      * A builder for {@link DiamondInheritanceTopLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<DiamondInheritanceTopLevelStruct> {
         private java.lang.String topLevelProperty;
         private java.lang.String firstMidLevelProperty;
         private java.lang.String baseLevelProperty;
@@ -82,6 +82,7 @@ public interface DiamondInheritanceTopLevelStruct extends software.amazon.jsii.J
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public DiamondInheritanceTopLevelStruct build() {
             return new Jsii$Proxy(topLevelProperty, firstMidLevelProperty, baseLevelProperty, secondMidLevelProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/EraseUndefinedHashValuesOptions.java
@@ -36,7 +36,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
      * A builder for {@link EraseUndefinedHashValuesOptions}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<EraseUndefinedHashValuesOptions> {
         private java.lang.String option1;
         private java.lang.String option2;
 
@@ -68,6 +68,7 @@ public interface EraseUndefinedHashValuesOptions extends software.amazon.jsii.Js
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public EraseUndefinedHashValuesOptions build() {
             return new Jsii$Proxy(option1, option2);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExperimentalStruct.java
@@ -26,7 +26,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
      * A builder for {@link ExperimentalStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ExperimentalStruct> {
         private java.lang.String readonlyProperty;
 
         /**
@@ -46,6 +46,7 @@ public interface ExperimentalStruct extends software.amazon.jsii.JsiiSerializabl
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ExperimentalStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExtendsInternalInterface.java
@@ -32,7 +32,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
      * A builder for {@link ExtendsInternalInterface}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ExtendsInternalInterface> {
         private java.lang.Boolean boom;
         private java.lang.String prop;
 
@@ -64,6 +64,7 @@ public interface ExtendsInternalInterface extends software.amazon.jsii.JsiiSeria
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ExtendsInternalInterface build() {
             return new Jsii$Proxy(boom, prop);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExternalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ExternalStruct.java
@@ -26,7 +26,7 @@ public interface ExternalStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link ExternalStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ExternalStruct> {
         private java.lang.String readonlyProperty;
 
         /**
@@ -46,6 +46,7 @@ public interface ExternalStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ExternalStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Greetee.java
@@ -34,7 +34,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link Greetee}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<Greetee> {
         private java.lang.String name;
 
         /**
@@ -54,6 +54,7 @@ public interface Greetee extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public Greetee build() {
             return new Jsii$Proxy(name);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ImplictBaseOfBase.java
@@ -26,7 +26,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
      * A builder for {@link ImplictBaseOfBase}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ImplictBaseOfBase> {
         private java.time.Instant goo;
         private java.lang.String bar;
         private software.amazon.jsii.tests.calculator.baseofbase.Very foo;
@@ -68,6 +68,7 @@ public interface ImplictBaseOfBase extends software.amazon.jsii.JsiiSerializable
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ImplictBaseOfBase build() {
             return new Jsii$Proxy(goo, bar, foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/LoadBalancedFargateServiceProps.java
@@ -108,7 +108,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
      * A builder for {@link LoadBalancedFargateServiceProps}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<LoadBalancedFargateServiceProps> {
         private java.lang.Number containerPort;
         private java.lang.String cpu;
         private java.lang.String memoryMiB;
@@ -199,6 +199,7 @@ public interface LoadBalancedFargateServiceProps extends software.amazon.jsii.Js
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public LoadBalancedFargateServiceProps build() {
             return new Jsii$Proxy(containerPort, cpu, memoryMiB, publicLoadBalancer, publicTasks);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NestedStruct.java
@@ -28,7 +28,7 @@ public interface NestedStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link NestedStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<NestedStruct> {
         private java.lang.Number numberProp;
 
         /**
@@ -48,6 +48,7 @@ public interface NestedStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public NestedStruct build() {
             return new Jsii$Proxy(numberProp);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/NullShouldBeTreatedAsUndefinedData.java
@@ -34,7 +34,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
      * A builder for {@link NullShouldBeTreatedAsUndefinedData}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<NullShouldBeTreatedAsUndefinedData> {
         private java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument;
         private java.lang.Object thisShouldBeUndefined;
 
@@ -66,6 +66,7 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public NullShouldBeTreatedAsUndefinedData build() {
             return new Jsii$Proxy(arrayWithThreeElementsAndUndefinedAsSecondArgument, thisShouldBeUndefined);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStruct.java
@@ -28,7 +28,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link OptionalStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<OptionalStruct> {
         private java.lang.String field;
 
         /**
@@ -48,6 +48,7 @@ public interface OptionalStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public OptionalStruct build() {
             return new Jsii$Proxy(field);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/OptionalStructConsumer.java
@@ -56,7 +56,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
      * A fluent builder for {@link software.amazon.jsii.tests.calculator.OptionalStructConsumer}.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.OptionalStructConsumer> {
         /**
          * EXPERIMENTAL
          * <p>
@@ -88,6 +88,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
          * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.OptionalStructConsumer}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public software.amazon.jsii.tests.calculator.OptionalStructConsumer build() {
             return new software.amazon.jsii.tests.calculator.OptionalStructConsumer(
                 this.optionalStruct != null ? this.optionalStruct.build() : null

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java
@@ -28,7 +28,7 @@ public interface ParentStruct982 extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link ParentStruct982}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<ParentStruct982> {
         private java.lang.String foo;
 
         /**
@@ -48,6 +48,7 @@ public interface ParentStruct982 extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public ParentStruct982 build() {
             return new Jsii$Proxy(foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/RootStruct.java
@@ -41,7 +41,7 @@ public interface RootStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link RootStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<RootStruct> {
         private java.lang.String stringProp;
         private software.amazon.jsii.tests.calculator.NestedStruct nestedStruct;
 
@@ -73,6 +73,7 @@ public interface RootStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public RootStruct build() {
             return new Jsii$Proxy(stringProp, nestedStruct);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SecondLevelStruct.java
@@ -38,7 +38,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
      * A builder for {@link SecondLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<SecondLevelStruct> {
         private java.lang.String deeperRequiredProp;
         private java.lang.String deeperOptionalProp;
 
@@ -70,6 +70,7 @@ public interface SecondLevelStruct extends software.amazon.jsii.JsiiSerializable
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public SecondLevelStruct build() {
             return new Jsii$Proxy(deeperRequiredProp, deeperOptionalProp);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SmellyStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SmellyStruct.java
@@ -32,7 +32,7 @@ public interface SmellyStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link SmellyStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<SmellyStruct> {
         private java.lang.String property;
         private java.lang.Boolean yetAnoterOne;
 
@@ -64,6 +64,7 @@ public interface SmellyStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public SmellyStruct build() {
             return new Jsii$Proxy(property, yetAnoterOne);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StableStruct.java
@@ -24,7 +24,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link StableStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StableStruct> {
         private java.lang.String readonlyProperty;
 
         /**
@@ -44,6 +44,7 @@ public interface StableStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
         public StableStruct build() {
             return new Jsii$Proxy(readonlyProperty);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructA.java
@@ -44,7 +44,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link StructA}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StructA> {
         private java.lang.String requiredString;
         private java.lang.Number optionalNumber;
         private java.lang.String optionalString;
@@ -88,6 +88,7 @@ public interface StructA extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public StructA build() {
             return new Jsii$Proxy(requiredString, optionalNumber, optionalString);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructB.java
@@ -44,7 +44,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link StructB}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StructB> {
         private java.lang.String requiredString;
         private java.lang.Boolean optionalBoolean;
         private software.amazon.jsii.tests.calculator.StructA optionalStructA;
@@ -88,6 +88,7 @@ public interface StructB extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public StructB build() {
             return new Jsii$Proxy(requiredString, optionalBoolean, optionalStructA);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructParameterType.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructParameterType.java
@@ -38,7 +38,7 @@ public interface StructParameterType extends software.amazon.jsii.JsiiSerializab
      * A builder for {@link StructParameterType}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StructParameterType> {
         private java.lang.String scope;
         private java.lang.Boolean props;
 
@@ -70,6 +70,7 @@ public interface StructParameterType extends software.amazon.jsii.JsiiSerializab
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public StructParameterType build() {
             return new Jsii$Proxy(scope, props);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/StructWithJavaReservedWords.java
@@ -50,7 +50,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
      * A builder for {@link StructWithJavaReservedWords}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<StructWithJavaReservedWords> {
         private java.lang.String defaultValue;
         private java.lang.String assertValue;
         private java.lang.String result;
@@ -106,6 +106,7 @@ public interface StructWithJavaReservedWords extends software.amazon.jsii.JsiiSe
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public StructWithJavaReservedWords build() {
             return new Jsii$Proxy(defaultValue, assertValue, result, that);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilder.java
@@ -53,7 +53,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
      * A fluent builder for {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder}.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder> {
         /**
          * EXPERIMENTAL
          * <p>
@@ -122,6 +122,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
          * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder build() {
             return new software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder(
                 this.id,

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderProps.java
@@ -40,7 +40,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
      * A builder for {@link SupportsNiceJavaBuilderProps}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<SupportsNiceJavaBuilderProps> {
         private java.lang.Number bar;
         private java.lang.String id;
 
@@ -73,6 +73,7 @@ public interface SupportsNiceJavaBuilderProps extends software.amazon.jsii.JsiiS
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public SupportsNiceJavaBuilderProps build() {
             return new Jsii$Proxy(bar, id);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/SupportsNiceJavaBuilderWithRequiredProps.java
@@ -60,7 +60,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
      * A fluent builder for {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps}.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps> {
         /**
          * EXPERIMENTAL
          * <p>
@@ -114,6 +114,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
          * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps build() {
             return new software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps(
                 this.id,

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/TopLevelStruct.java
@@ -46,7 +46,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link TopLevelStruct}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<TopLevelStruct> {
         private java.lang.String required;
         private java.lang.Object secondLevel;
         private java.lang.String optional;
@@ -101,6 +101,7 @@ public interface TopLevelStruct extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public TopLevelStruct build() {
             return new Jsii$Proxy(required, secondLevel, optional);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UnionProperties.java
@@ -34,7 +34,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link UnionProperties}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<UnionProperties> {
         private java.lang.Object bar;
         private java.lang.Object foo;
 
@@ -99,6 +99,7 @@ public interface UnionProperties extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public UnionProperties build() {
             return new Jsii$Proxy(bar, foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/interface_in_namespace_includes_classes/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/interface_in_namespace_includes_classes/Hello.java
@@ -26,7 +26,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link Hello}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<Hello> {
         private java.lang.Number foo;
 
         /**
@@ -46,6 +46,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public Hello build() {
             return new Jsii$Proxy(foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/interface_in_namespace_only_interface/Hello.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/interface_in_namespace_only_interface/Hello.java
@@ -26,7 +26,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link Hello}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<Hello> {
         private java.lang.Number foo;
 
         /**
@@ -46,6 +46,7 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public Hello build() {
             return new Jsii$Proxy(foo);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/submodule/back_references/MyClassReference.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/submodule/back_references/MyClassReference.java
@@ -26,7 +26,7 @@ public interface MyClassReference extends software.amazon.jsii.JsiiSerializable 
      * A builder for {@link MyClassReference}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<MyClassReference> {
         private software.amazon.jsii.tests.calculator.submodule.MyClass reference;
 
         /**
@@ -46,6 +46,7 @@ public interface MyClassReference extends software.amazon.jsii.JsiiSerializable 
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public MyClassReference build() {
             return new Jsii$Proxy(reference);
         }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/submodule/child/Structure.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/submodule/child/Structure.java
@@ -26,7 +26,7 @@ public interface Structure extends software.amazon.jsii.JsiiSerializable {
      * A builder for {@link Structure}
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-    public static final class Builder {
+    public static final class Builder implements software.amazon.jsii.Builder<Structure> {
         private java.lang.Boolean bool;
 
         /**
@@ -46,6 +46,7 @@ public interface Structure extends software.amazon.jsii.JsiiSerializable {
          * @throws NullPointerException if any required attribute was not provided
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+        @Override
         public Structure build() {
             return new Jsii$Proxy(bool);
         }


### PR DESCRIPTION
## Commit Message 
feat(java): add a Builder<T> interface implemented by all builders (#1654)

The common super-interface for all `Builder` classes creates a nice and
clean extension point that can be leveraged to improve the experience of
developers using Kotlin extensions, or doing fancy AOP things. For example,
this enables introduction of Kotlin extensions to improve/simplify the syntax
needed to initialize types that provide a `Builder` further from what the
Java implementation natively allows (see the related issue for more info).

The new interface does not change the current `Builder` layout, merely
adding the new super-interface to pre-declare an already-existing method.

Fixes #1652
## End Commit Message

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
