### PR TITLE
fix(dotnet): F# dictionaries cause NullReferenceException

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        
+        <IsPackable>false</IsPackable>
+        <VSTestLogger>xunit</VSTestLogger>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Tests.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId" Version="[$(JsiiVersion)]" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
+        <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\dotnet-runtime\src\Amazon.JSII.Runtime\Amazon.JSII.Runtime.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Tests.fs
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Tests.fs
@@ -1,0 +1,15 @@
+namespace Amazon.JSII.Runtime.IntegrationTests.FSharp
+#nowarn "44" // Usage of Obsolete entity 
+
+open Amazon.JSII.Tests.CalculatorNamespace
+open Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
+open System
+open Xunit
+
+type [<Sealed>] Tests () =
+
+    [<Fact>]
+    member this.FSharpDictCanBePassedDown () =
+        let allTypes = new AllTypes()
+        let number = new Number(1337.0)
+        allTypes.MapProperty = dict[("number", number)]

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.sln
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.sln
@@ -5,7 +5,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Runtime.Integra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Runtime", "..\..\dotnet-runtime\src\Amazon.JSII.Runtime\Amazon.JSII.Runtime.csproj", "{CA2CBE1C-5435-416B-B4E6-22D1FABA8AFF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.JsonModel", "..\..\dotnet-jsonmodel\src\Amazon.JSII.JsonModel\Amazon.JSII.JsonModel.csproj", "{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.JsonModel", "..\..\dotnet-runtime\src\Amazon.JSII.JsonModel\Amazon.JSII.JsonModel.csproj", "{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Amazon.JSII.Runtime.IntegrationTests.FSharp", "Amazon.JSII.Runtime.IntegrationTests.FSharp\Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj", "{224406B0-12D5-408C-91E9-7420F72C2855}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,5 +27,9 @@ Global
 		{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{224406B0-12D5-408C-91E9-7420F72C2855}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{224406B0-12D5-408C-91E9-7420F72C2855}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{224406B0-12D5-408C-91E9-7420F72C2855}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{224406B0-12D5-408C-91E9-7420F72C2855}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/Converters/FrameworkToJsiiConverter.cs
@@ -74,10 +74,10 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 var structInfo = new JObject();
                 structInfo.Add(new JProperty("fqn", byValueAttribute.FullyQualifiedName));
                 structInfo.Add(new JProperty("data", data));
-                
+
                 var resultObject = new JObject();
                 resultObject.Add(new JProperty("$jsii.struct", structInfo));
-                
+
                 result = resultObject;
                 return true;
             }
@@ -253,8 +253,8 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return true;
             }
 
-            Type valueType = value.GetType()!;
-            Type dictionaryInterface = valueType.GetInterfaces()
+            Type dictionaryInterface = value.GetType()!
+                .GetInterfaces()
                 .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
 
             if (dictionaryInterface == null ||
@@ -264,8 +264,8 @@ namespace Amazon.JSII.Runtime.Services.Converters
                 return false;
             }
 
-            IEnumerable<string> keys = (IEnumerable<string>) valueType.GetProperty("Keys")!.GetValue(value)!;
-            PropertyInfo indexer = ReflectionUtils.GetIndexer(valueType);
+            IEnumerable<string> keys = (IEnumerable<string>)dictionaryInterface.GetProperty("Keys")!.GetValue(value)!;
+            PropertyInfo indexer = ReflectionUtils.GetIndexer(dictionaryInterface);
 
             JObject resultObject = new JObject();
             foreach (string key in keys)
@@ -408,7 +408,7 @@ namespace Amazon.JSII.Runtime.Services.Converters
                     (
                         kind: CollectionKind.Map,
                         elementType: typeof(Object) == elementType
-                            ? new TypeReference(primitive: PrimitiveType.Any) 
+                            ? new TypeReference(primitive: PrimitiveType.Any)
                             : InferType(referenceMap, elementType)
                     )
                 );


### PR DESCRIPTION
## Commit Message
fix(dotnet): F# dictionaries cause NullReferenceException (#1655)

Perform reflection calls against the resolved `IDictionary` interface
instead of on the raw value type, guaranteeing the expected accessors
are returned.

Fixes #1322

## End Commit Message

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
