### PR TITLE
chore(pacmak): fix local runtime detection

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,6 @@
+---
+bracketSpacing: true
+semi: true
 singleQuote: true
+tabWidth: 2
 trailingComma: all

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -174,7 +174,7 @@ export class DotnetBuilder implements TargetBuilder {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
       const jsiiDotNetRuntime = require('@jsii/dotnet-runtime');
-      logging.info(`Uning local version of the DotNet jsii runtime package at: ${jsiiDotNetRuntime.repository}`);
+      logging.info(`Using local version of the DotNet jsii runtime package at: ${jsiiDotNetRuntime.repository}`);
       localRepos.push(jsiiDotNetRuntime.repository);
     } catch {
       // Couldn't locate @jsii/dotnet-runtime, which is owkay!

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -174,6 +174,7 @@ export class DotnetBuilder implements TargetBuilder {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
       const jsiiDotNetRuntime = require('@jsii/dotnet-runtime');
+      logging.info(`Uning local version of the DotNet jsii runtime package at: ${jsiiDotNetRuntime.repository}`);
       localRepos.push(jsiiDotNetRuntime.repository);
     } catch {
       // Couldn't locate @jsii/dotnet-runtime, which is owkay!

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -174,7 +174,9 @@ export class DotnetBuilder implements TargetBuilder {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
       const jsiiDotNetRuntime = require('@jsii/dotnet-runtime');
-      logging.info(`Using local version of the DotNet jsii runtime package at: ${jsiiDotNetRuntime.repository}`);
+      logging.info(
+        `Using local version of the DotNet jsii runtime package at: ${jsiiDotNetRuntime.repository}`,
+      );
       localRepos.push(jsiiDotNetRuntime.repository);
     } catch {
       // Couldn't locate @jsii/dotnet-runtime, which is owkay!

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2733,7 +2733,9 @@ function findJavaRuntimeLocalRepository() {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
     const javaRuntime = require('@jsii/java-runtime');
-    logging.info(`Using local version of the Java jsii runtime package at: ${javaRuntime.repository}`);
+    logging.info(
+      `Using local version of the Java jsii runtime package at: ${javaRuntime.repository}`,
+    );
     return javaRuntime.repository;
   } catch {
     return undefined;

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2733,7 +2733,7 @@ function findJavaRuntimeLocalRepository() {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
     const javaRuntime = require('@jsii/java-runtime');
-    logging.info(`Uning local version of the Java jsii runtime package at: ${javaRuntime.repository}`);
+    logging.info(`Using local version of the Java jsii runtime package at: ${javaRuntime.repository}`);
     return javaRuntime.repository;
   } catch {
     return undefined;

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2724,7 +2724,7 @@ interface MavenDependency {
 }
 
 /**
- * Looks up the `jsii-java-runtime` package from the local repository.
+ * Looks up the `@jsii/java-runtime` package from the local repository.
  * If it contains a "maven-repo" directory, it will be added as a local maven repo
  * so when we build locally, we build against it and not against the one published
  * to Maven Central.
@@ -2732,7 +2732,8 @@ interface MavenDependency {
 function findJavaRuntimeLocalRepository() {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports,import/no-extraneous-dependencies
-    const javaRuntime = require('jsii-java-runtime');
+    const javaRuntime = require('@jsii/java-runtime');
+    logging.info(`Uning local version of the Java jsii runtime package at: ${javaRuntime.repository}`);
     return javaRuntime.repository;
   } catch {
     return undefined;


### PR DESCRIPTION
## Commit Message
chore(pacmak): fix local runtime detection (#1679)

Local installs of the java runtime were not properly discovered because
the opportunistic resolution used the incorrect package name (it was
using the older `jsii-java-runtime` name instead of the new
`@jsii/java-runtime` name).

This commit fixes that problem, and also adds an `info` log entry that
indicates a locally built runtime is being used instead of the standard
one from the registry.

Co-Authored-By: rix0rrr@gmail.com

## End Commit Message

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
