### PR TITLE
chore: use new mergify commit_message option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,4 @@
-<!--
-Explain what changed and why.
 
-Please read the [Contribution guidelines][1] and follow the pull-request
-checklist.
-
-[1]: https://github.com/aws/jsii/blob/master/CONTRIBUTING.md
--->
 
 ---
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -43,6 +43,7 @@ pull_request_rules:
         strict_method: merge
       comment:
         message: Merging (with squash)...
+      commit_message: title+body
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
@@ -60,7 +61,7 @@ pull_request_rules:
       - status-success~=AWS CodeBuild us-east-1
       - status-success=continuous-integration/travis-ci/pr
       - status-success=Semantic Pull Request
-      
+
   - name: Synchronize that PR to upstream and merge it (no-squash)
     actions:
       dismiss_reviews:
@@ -72,6 +73,7 @@ pull_request_rules:
         strict_method: merge
       comment:
         message: Merging (no-squash)...
+      commit_message: title+body
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
@@ -88,7 +90,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - status-success~=AWS CodeBuild us-east-1
       - status-success=continuous-integration/travis-ci/pr
-      - status-success=Semantic Pull Request      
+      - status-success=Semantic Pull Request
 
   - name: Clean branch up
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,9 +41,9 @@ pull_request_rules:
         strict: smart
         method: squash
         strict_method: merge
+        commit_message: title+body
       comment:
         message: Merging (with squash)...
-      commit_message: title+body
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]
@@ -71,9 +71,9 @@ pull_request_rules:
         strict: smart
         method: merge
         strict_method: merge
+        commit_message: title+body
       comment:
         message: Merging (no-squash)...
-      commit_message: title+body
     conditions:
       - author!=dependabot[bot]
       - author!=dependabot-preview[bot]


### PR DESCRIPTION
Use the PR title and body as the commit message instead of using the
GitHUb-provided commit message or the one specified in a markdown
section titled "Commit Message".

This streamlines the contribution workflow while ensuring a consistent
style in commit messages.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
