### PR TITLE
feat(jsii): use incremental builders

### DIFF
--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.JsonModel/JsonDictionaryBase.cs
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.JsonModel/JsonDictionaryBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Amazon.JSII.JsonModel
 {
@@ -69,7 +70,7 @@ namespace Amazon.JSII.JsonModel
             return _members.Remove(item);
         }
 
-        public bool TryGetValue(TKey key, out TValue value)
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             return _members.TryGetValue(key, out value);
         }

--- a/packages/@scope/jsii-calc-base-of-base/package.json
+++ b/packages/@scope/jsii-calc-base-of-base/package.json
@@ -24,7 +24,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "jsii && jsii-rosetta",
+    "build": "jsii --project-references && jsii-rosetta",
     "test": "diff-test test/assembly.jsii .jsii",
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -24,7 +24,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "jsii && jsii-rosetta",
+    "build": "jsii --project-references && jsii-rosetta",
     "test": "diff-test test/assembly.jsii .jsii",
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -26,7 +26,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "jsii && jsii-rosetta",
+    "build": "jsii --project-references && jsii-rosetta",
     "test": "diff-test test/assembly.jsii .jsii",
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -30,8 +30,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "jsii --silence-warnings reserved-word && jsii-rosetta --compile",
-    "watch": "jsii -w",
+    "build": "jsii --project-references --silence-warnings reserved-word && jsii-rosetta --compile",
+    "watch": "jsii --project-references -w",
     "test": "node test/test.calc.js && diff-test test/assembly.jsii .jsii",
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -63,10 +63,13 @@ export class Compiler implements Emitter {
   private readonly projectReferences: boolean;
 
   public constructor(private readonly options: CompilerOptions) {
-    this.compilerHost = ts.createIncrementalCompilerHost(BASE_COMPILER_OPTIONS, {
-      ...ts.sys,
-      getCurrentDirectory: () => this.options.projectInfo.projectRoot,
-    });
+    this.compilerHost = ts.createIncrementalCompilerHost(
+      BASE_COMPILER_OPTIONS,
+      {
+        ...ts.sys,
+        getCurrentDirectory: () => this.options.projectInfo.projectRoot,
+      },
+    );
 
     this.configPath = path.join(
       this.options.projectInfo.projectRoot,

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -266,7 +266,8 @@ export class Compiler implements Emitter {
     let incremental: boolean | undefined;
     if (this.projectReferences) {
       references = await this.findProjectReferences();
-      composite = incremental = true;
+      composite = true;
+      incremental = true;
     }
 
     const pi = this.options.projectInfo;


### PR DESCRIPTION
Using the `IncrementalBuilder` to compiler code instead of a regular
`Builder` allows saving time when certain files are aloready up-to-date.

The incremental support is only enabled when `--project-references` is
passed to the compiler, as it relies on project references and the
composite model to work it's magic (as far as `tsc` is concerned, the
`incremental` option implies the `composite` option).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
