### PR TITLE
fix(python): no overload variant of "Factory" matches argument type "object"

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_kernel/types.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/types.py
@@ -54,7 +54,7 @@ class CreateRequest:
     fqn: str
     args: List[Any] = attr.Factory(list)
     overrides: List[Override] = attr.Factory(list)
-    interfaces: Optional[List[str]] = attr.Factory(Optional[list])
+    interfaces: Optional[List[str]] = None
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)


### PR DESCRIPTION
Remove attempt to use a `attr.Factory` for an optional field that should
anyway have defaulted to a plain `None` value.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
