### PR TITLE
fix(python): reference isomorphism is broken within __init__

### DIFF
--- a/packages/@jsii/python-runtime/bin/generate-calc
+++ b/packages/@jsii/python-runtime/bin/generate-calc
@@ -34,7 +34,6 @@ subprocess.run(
         "-m",
         "pip",
         "install",
-        "--force-reinstall",
         "--upgrade",
     ]
     +

--- a/packages/@jsii/python-runtime/package.json
+++ b/packages/@jsii/python-runtime/package.json
@@ -27,8 +27,10 @@
     "dist-clean": "rm -rf dist",
     "build": "cp ../../../README.md . && rm -f jsii-*.whl && npm run generate && npm run deps",
     "package": "package-python && package-private",
-    "test": ".env/bin/python bin/generate-calc && .env/bin/py.test -v --mypy",
-    "test:update": "UPDATE_DIFF=1 .env/bin/python bin/generate-calc && .env/bin/py.test -v --mypy"
+    "test": "npm run test:gen && npm run test:run",
+    "test:gen": ".env/bin/python bin/generate-calc",
+    "test:run": ".env/bin/py.test -v --mypy",
+    "test:update": "UPDATE_DIFF=1 npm run test"
   },
   "dependencies": {
     "@jsii/runtime": "^0.0.0"

--- a/packages/@jsii/python-runtime/requirements.txt
+++ b/packages/@jsii/python-runtime/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-mypy
+.

--- a/packages/@jsii/python-runtime/src/jsii/_kernel/__init__.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/__init__.py
@@ -233,6 +233,10 @@ class Kernel(metaclass=Singleton):
             obj.__jsii_ref__ =  _callback_till_result(self, response, CreateResponse)
         else:
             obj.__jsii_ref__ = response
+
+        # Register this to the reference map already (so it's available within the rest of the __init__)
+        _reference_map.register_reference(obj)
+
         return obj.__jsii_ref__
 
     def delete(self, ref: ObjRef) -> None:

--- a/packages/@jsii/python-runtime/tests/test_compliance.py
+++ b/packages/@jsii/python-runtime/tests/test_compliance.py
@@ -37,6 +37,7 @@ from jsii_calc import (
     InterfaceCollections,
     IInterfaceWithProperties,
     IStructReturningDelegate,
+    Isomorphism,
     JsiiAgent,
     JSObjectLiteralForInterface,
     JSObjectLiteralToNative,
@@ -1196,3 +1197,12 @@ def test_parameter_named_self_ClassWithSelf():
 def test_parameter_named_self_ClassWithSelfKwarg():
     subject = ClassWithSelfKwarg(self='Howdy!')
     assert subject.props.self == 'Howdy!'
+
+
+def test_isomorphism_within_constructor():
+    class Subject(Isomorphism):
+        def __init__(self):
+            super().__init__()
+            assert self == self.myself()
+
+    Subject()

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -2490,3 +2490,15 @@ export class InterfaceCollections {
 export interface IOptionalMethod {
     optional(): string | undefined;
 }
+
+/**
+ * Checks the "same instance" isomorphism is preserved within the constructor.
+ *
+ * Create a subclass of this, and assert that `this.myself()` actually returns
+ * `this` from within the constructor.
+ */
+export abstract class Isomorphism {
+    public myself(): Isomorphism {
+        return this;
+    }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -6566,6 +6566,40 @@
       ],
       "name": "InterfacesMaker"
     },
+    "jsii-calc.Isomorphism": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "Create a subclass of this, and assert that `this.myself()` actually returns\n`this` from within the constructor.",
+        "stability": "experimental",
+        "summary": "Checks the \"same instance\" isomorphism is preserved within the constructor."
+      },
+      "fqn": "jsii-calc.Isomorphism",
+      "initializer": {},
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2500
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2501
+          },
+          "name": "myself",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.Isomorphism"
+            }
+          }
+        }
+      ],
+      "name": "Isomorphism"
+    },
     "jsii-calc.JSII417Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.JSII417PublicBaseOfBase",
@@ -13128,5 +13162,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "5SbCJfv1kDW24DUhPcwzoQ1k7Moq+rKOB+Q4TSZlKPE="
+  "fingerprint": "miVjqwWxNOLMY7fR23c/SVvfiGqkgqLgG+18qp4f8MM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -6566,6 +6566,40 @@
       ],
       "name": "InterfacesMaker"
     },
+    "jsii-calc.Isomorphism": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "Create a subclass of this, and assert that `this.myself()` actually returns\n`this` from within the constructor.",
+        "stability": "experimental",
+        "summary": "Checks the \"same instance\" isomorphism is preserved within the constructor."
+      },
+      "fqn": "jsii-calc.Isomorphism",
+      "initializer": {},
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2500
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2501
+          },
+          "name": "myself",
+          "returns": {
+            "type": {
+              "fqn": "jsii-calc.Isomorphism"
+            }
+          }
+        }
+      ],
+      "name": "Isomorphism"
+    },
     "jsii-calc.JSII417Derived": {
       "assembly": "jsii-calc",
       "base": "jsii-calc.JSII417PublicBaseOfBase",
@@ -13128,5 +13162,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "5SbCJfv1kDW24DUhPcwzoQ1k7Moq+rKOB+Q4TSZlKPE="
+  "fingerprint": "miVjqwWxNOLMY7fR23c/SVvfiGqkgqLgG+18qp4f8MM="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Isomorphism.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Isomorphism.cs
@@ -1,0 +1,44 @@
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Checks the "same instance" isomorphism is preserved within the constructor.</summary>
+    /// <remarks>
+    /// Create a subclass of this, and assert that <c>this.myself()</c> actually returns
+    /// <c>this</c> from within the constructor.
+    /// 
+    /// <strong>Stability</strong>: Experimental
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Isomorphism), fullyQualifiedName: "jsii-calc.Isomorphism")]
+    public abstract class Isomorphism : DeputyBase
+    {
+        protected Isomorphism(): base(new DeputyProps(new object[]{}))
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Isomorphism(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Isomorphism(DeputyProps props): base(props)
+        {
+        }
+
+        /// <remarks>
+        /// <strong>Stability</strong>: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "myself", returnsJson: "{\"type\":{\"fqn\":\"jsii-calc.Isomorphism\"}}")]
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.Isomorphism Myself()
+        {
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Isomorphism>(new System.Type[]{}, new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IsomorphismProxy.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IsomorphismProxy.cs
@@ -1,0 +1,21 @@
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Checks the "same instance" isomorphism is preserved within the constructor.</summary>
+    /// <remarks>
+    /// Create a subclass of this, and assert that <c>this.myself()</c> actually returns
+    /// <c>this</c> from within the constructor.
+    /// 
+    /// <strong>Stability</strong>: Experimental
+    /// </remarks>
+    [JsiiTypeProxy(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Isomorphism), fullyQualifiedName: "jsii-calc.Isomorphism")]
+    internal sealed class IsomorphismProxy : Amazon.JSII.Tests.CalculatorNamespace.Isomorphism
+    {
+        private IsomorphismProxy(ByRefValue reference): base(reference)
+        {
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Isomorphism.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/Isomorphism.java
@@ -1,0 +1,45 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Checks the "same instance" isomorphism is preserved within the constructor.
+ * <p>
+ * Create a subclass of this, and assert that <code>this.myself()</code> actually returns
+ * <code>this</code> from within the constructor.
+ * <p>
+ * EXPERIMENTAL
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Isomorphism")
+public abstract class Isomorphism extends software.amazon.jsii.JsiiObject {
+
+    protected Isomorphism(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Isomorphism(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    protected Isomorphism() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    /**
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.Isomorphism myself() {
+        return this.jsiiCall("myself", software.amazon.jsii.tests.calculator.Isomorphism.class);
+    }
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.Isomorphism {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/resources/software/amazon/jsii/tests/calculator/$Module.txt
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/resources/software/amazon/jsii/tests/calculator/$Module.txt
@@ -111,6 +111,7 @@ jsii-calc.InterfaceInNamespaceIncludesClasses.Foo=software.amazon.jsii.tests.cal
 jsii-calc.InterfaceInNamespaceIncludesClasses.Hello=software.amazon.jsii.tests.calculator.interface_in_namespace_includes_classes.Hello
 jsii-calc.InterfaceInNamespaceOnlyInterface.Hello=software.amazon.jsii.tests.calculator.interface_in_namespace_only_interface.Hello
 jsii-calc.InterfacesMaker=software.amazon.jsii.tests.calculator.InterfacesMaker
+jsii-calc.Isomorphism=software.amazon.jsii.tests.calculator.Isomorphism
 jsii-calc.JSII417Derived=software.amazon.jsii.tests.calculator.JSII417Derived
 jsii-calc.JSII417PublicBaseOfBase=software.amazon.jsii.tests.calculator.JSII417PublicBaseOfBase
 jsii-calc.JSObjectLiteralForInterface=software.amazon.jsii.tests.calculator.JSObjectLiteralForInterface

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -4348,6 +4348,34 @@ class InterfacesMaker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InterfacesMa
         return jsii.sinvoke(cls, "makeInterfaces", [count])
 
 
+class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
+    """Checks the "same instance" isomorphism is preserved within the constructor.
+
+    Create a subclass of this, and assert that ``this.myself()`` actually returns
+    ``this`` from within the constructor.
+
+    stability
+    :stability: experimental
+    """
+    @builtins.staticmethod
+    def __jsii_proxy_class__():
+        return _IsomorphismProxy
+
+    def __init__(self) -> None:
+        jsii.create(Isomorphism, self, [])
+
+    @jsii.member(jsii_name="myself")
+    def myself(self) -> "Isomorphism":
+        """
+        stability
+        :stability: experimental
+        """
+        return jsii.invoke(self, "myself", [])
+
+
+class _IsomorphismProxy(Isomorphism):
+    pass
+
 class JSII417PublicBaseOfBase(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JSII417PublicBaseOfBase"):
     """
     stability
@@ -8685,6 +8713,7 @@ __all__ = [
     "InbetweenClass",
     "InterfaceCollections",
     "InterfacesMaker",
+    "Isomorphism",
     "JSII417Derived",
     "JSII417PublicBaseOfBase",
     "JSObjectLiteralForInterface",

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -924,6 +924,11 @@ exports[`jsii-tree --all 1`] = `
  │   │     │ └─┬ count
  │   │     │   └── type: number
  │   │     └── returns: Array<@scope/jsii-calc-lib.IDoublable>
+ │   ├─┬ class Isomorphism (experimental)
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer (experimental)
+ │   │   └─┬ myself() method (experimental)
+ │   │     └── returns: jsii-calc.Isomorphism
  │   ├─┬ class JSII417Derived (experimental)
  │   │ ├── base: JSII417PublicBaseOfBase
  │   │ └─┬ members
@@ -2734,6 +2739,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   │ └── interfaces: IPublicInterface2
  │   ├── class InterfaceCollections
  │   ├── class InterfacesMaker
+ │   ├── class Isomorphism
  │   ├─┬ class JSII417Derived
  │   │ └── base: JSII417PublicBaseOfBase
  │   ├── class JSII417PublicBaseOfBase
@@ -3365,6 +3371,10 @@ exports[`jsii-tree --members 1`] = `
  │   ├─┬ class InterfacesMaker
  │   │ └─┬ members
  │   │   └── static makeInterfaces(count) method
+ │   ├─┬ class Isomorphism
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   └── myself() method
  │   ├─┬ class JSII417Derived
  │   │ └─┬ members
  │   │   ├── <initializer>(property) initializer
@@ -4241,6 +4251,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class InbetweenClass
  │   ├── class InterfaceCollections
  │   ├── class InterfacesMaker
+ │   ├── class Isomorphism
  │   ├── class JSII417Derived
  │   ├── class JSII417PublicBaseOfBase
  │   ├── class JSObjectLiteralForInterface

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -73,6 +73,7 @@ Array [
   "jsii-calc.InterfaceCollections",
   "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
   "jsii-calc.InterfacesMaker",
+  "jsii-calc.Isomorphism",
   "jsii-calc.JSII417Derived",
   "jsii-calc.JSII417PublicBaseOfBase",
   "jsii-calc.JSObjectLiteralForInterface",


### PR DESCRIPTION
Within the `__init__` of a class, reading `self` back from the JS
process would result in a proxy object created for the parent type,
instead of returning `self`. This is because the `JSIIMeta` metaclass
only registered the instance in the rerefence map **after** the
constructor had returned.

This adds an additional registration point right after the `create` API
returned from the kernel, making the reference available as early as it
can possibly be known.

Fixes aws/aws-cdk#8262



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
