### PR TITLE
chore(jsii): improved diagnostics for package.json

### DIFF
--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as process from 'process';
 import * as yargs from 'yargs';
 import { Compiler } from '../lib/compiler';
-import { loadProjectInfo } from '../lib/project-info';
+import { ProjectInfo } from '../lib/project-info';
 import * as utils from '../lib/utils';
 import { VERSION } from '../lib/version';
 import { enabledWarnings } from '../lib/warnings';
@@ -58,7 +58,7 @@ const warningTypes = Object.keys(enabledWarnings);
     path.resolve(process.cwd(), argv._[0] ?? '.'),
   );
 
-  const projectInfo = await loadProjectInfo(projectRoot, {
+  const projectInfo = await ProjectInfo.load(projectRoot, {
     fixPeerDependencies: argv['fix-peer-dependencies'],
   });
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -82,14 +82,14 @@ export class Assembler implements Emitter {
     if (!this.projectInfo.description) {
       this._diagnostic(
         null,
-        ts.DiagnosticCategory.Suggestion,
+        ts.DiagnosticCategory.Message,
         'A "description" field should be specified in "package.json"',
       );
     }
     if (!this.projectInfo.homepage) {
       this._diagnostic(
         null,
-        ts.DiagnosticCategory.Suggestion,
+        ts.DiagnosticCategory.Message,
         'A "homepage" field should be specified in "package.json"',
       );
     }
@@ -97,7 +97,7 @@ export class Assembler implements Emitter {
     if (readme == null) {
       this._diagnostic(
         null,
-        ts.DiagnosticCategory.Suggestion,
+        ts.DiagnosticCategory.Message,
         'There is no "README.md" file. It is recommended to have one.',
       );
     }
@@ -174,7 +174,7 @@ export class Assembler implements Emitter {
       version: this.projectInfo.version,
       description: this.projectInfo.description || this.projectInfo.name,
       license: this.projectInfo.license,
-      keywords: this.projectInfo.keywords,
+      keywords: this.projectInfo.keywords && [...this.projectInfo.keywords],
       homepage: this.projectInfo.homepage || this.projectInfo.repository.url,
       author: this.projectInfo.author,
       contributors: this.projectInfo.contributors && [
@@ -188,7 +188,7 @@ export class Assembler implements Emitter {
       dependencyClosure: noEmptyDict(
         toDependencyClosure(this.projectInfo.dependencyClosure),
       ),
-      bundled: this.projectInfo.bundleDependencies,
+      bundled: noEmptyDict(this.projectInfo.bundleDependencies),
       types: this._types,
       submodules: noEmptyDict(
         toSubmoduleDeclarations(this._submodules.values()),

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -12,7 +12,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { DiagnosticCategory } from 'typescript';
 import { Compiler } from './compiler';
-import { loadProjectInfo, ProjectInfo } from './project-info';
+import { ProjectInfo } from './project-info';
 
 /**
  * Compile a piece of source and return the JSII assembly for it
@@ -90,7 +90,7 @@ async function makeProjectInfo(
     spaces: 2,
   });
 
-  return loadProjectInfo(path.resolve(process.cwd(), '.'), {
+  return ProjectInfo.load(path.resolve(process.cwd(), '.'), {
     fixPeerDependencies: true,
   });
 }

--- a/packages/jsii/lib/private/json.ts
+++ b/packages/jsii/lib/private/json.ts
@@ -1,0 +1,408 @@
+import { promises as fs } from 'fs';
+import * as ts from 'typescript';
+import { inspect } from 'util';
+import { JSII_DIAGNOSTICS_CODE } from '../utils';
+
+/**
+ * Shared attributes of a JSON file.
+ */
+export abstract class JsonNode<T extends ts.Node = ts.Node, R = any> {
+  /** Diagnostic messages generated while parsing this JSON node. */
+  public abstract readonly diagnostics: readonly ts.Diagnostic[];
+
+  private _raw?: R;
+
+  /** @internal */
+  protected constructor(
+    private readonly sourceFile: ts.SourceFile,
+    private readonly node: T,
+  ) {}
+
+  /** @internal */
+  public diagnostic(
+    messageText: string,
+    category: ts.DiagnosticCategory = ts.DiagnosticCategory.Error,
+    ...context: ts.DiagnosticRelatedInformation[]
+  ): ts.Diagnostic {
+    const start = this.node.getStart(this.sourceFile);
+    const length = this.node.getEnd() - start;
+    return {
+      category,
+      code: JSII_DIAGNOSTICS_CODE,
+      file: this.sourceFile,
+      length,
+      messageText,
+      start,
+      relatedInformation: context,
+    };
+  }
+
+  /**
+   * @returns the "raw" value represented by this JSON node.
+   */
+  public get raw(): R {
+    return (
+      this._raw ??
+      (this._raw = JSON.parse(
+        // Stipping trailing commas and semis to ensure validity
+        this.node.getText(this.sourceFile).replace(/[,;]$/, ''),
+      ))
+    );
+  }
+
+  public map<V>(cb: (value: this) => V): V {
+    return cb(this);
+  }
+
+  /**
+   * Create a custom representation of this value for inspection in a Node
+   * debugger or interactive shell. While not strictly necessary, this makes the
+   * debugging experience a lot nicer than when using the default rendering.
+   *
+   * @internal
+   */
+  public abstract [inspect.custom](depth: number, options: any): string;
+}
+
+/**
+ * A JSON file that can contain one or more documents.
+ */
+export class JsonFile extends JsonNode<ts.JsonSourceFile> {
+  /**
+   * Loads the JSON file at the designated path.
+   *
+   * @param filePath the path to load a JSON file from.
+   *
+   * @return the loaded JSON file.
+   */
+  public static async load(filePath: string): Promise<JsonFile> {
+    const data = await fs.readFile(filePath, { encoding: 'utf8' });
+    const file = ts.parseJsonText(filePath, data);
+    return new JsonFile(filePath, file);
+  }
+
+  /** The documents included in this JSON file */
+  public readonly documents: readonly JsonNode[];
+
+  private constructor(
+    public readonly filePath: string,
+    file: ts.JsonSourceFile,
+  ) {
+    super(file, file);
+    this.documents = file.statements.map((stmt) => parseValue(file, stmt));
+  }
+
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return new Array<ts.Diagnostic>().concat(
+      ...this.documents.map((doc) => doc.diagnostics),
+    );
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    const inner = inspect(this.documents, {
+      ...options,
+      depth: options.depth && options.depth - 1,
+    });
+    return `${options.stylize('JsonFile', 'special')} documents = ${inner}`;
+  }
+}
+
+/**
+ * A JSON object is a collection of named properties.
+ */
+export class JsonObject extends JsonNode<ts.ObjectLiteralExpression> {
+  /** The properties included in this JSON object. */
+  public readonly properties: readonly JsonObjectProperty[];
+  private readonly _diagnostics = new Array<ts.Diagnostic>();
+
+  /** @internal */
+  public constructor(
+    sourceFile: ts.SourceFile,
+    node: ts.ObjectLiteralExpression,
+  ) {
+    super(sourceFile, node);
+    this.properties = node.properties
+      .map((prop) => {
+        if (!ts.isPropertyAssignment(prop)) {
+          this._diagnostics.push(
+            new UnsupportedNode(sourceFile, node).diagnostic(
+              'Unsupported node for a JsonObject property',
+              ts.DiagnosticCategory.Warning,
+            ),
+          );
+          // Cheating the invalid sutff out
+          return (undefined as any) as JsonObjectProperty;
+        }
+        return new JsonObjectProperty(sourceFile, prop);
+      })
+      .filter((val) => val != null);
+  }
+
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return new Array<ts.Diagnostic>().concat(
+      this._diagnostics,
+      ...this.properties.map((prop) => prop.diagnostics),
+    );
+  }
+
+  /**
+   * Access on of this object's properties by its name.
+   *
+   * @param name the name of the property being looked up.
+   *
+   * @returns the property named `name`, if there is one.
+   */
+  public get(name: string): JsonObjectProperty | undefined {
+    return this.properties.find((prop) => prop.name?.text === name);
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    const inner = this.properties
+      .map((prop) =>
+        inspect(prop, {
+          ...options,
+          depth: options.depth && options.depth - 1,
+        }),
+      )
+      .join(',\n')
+      .replace(/\n/g, '\n  ');
+    return `${options.stylize('JsonObject', 'special')} {\n  ${inner}\n}`;
+  }
+}
+
+/**
+ * A property of a JSON object.
+ */
+export class JsonObjectProperty extends JsonNode<ts.ObjectLiteralElement> {
+  /** The name of the property. */
+  public readonly name: JsonPropertyName;
+  /** The value of the property. */
+  public readonly value: JsonNode;
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.PropertyAssignment) {
+    super(sourceFile, node);
+    this.name = new JsonPropertyName(sourceFile, node.name);
+    this.value = parseValue(sourceFile, node.initializer);
+  }
+
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return [...this.name.diagnostics, ...this.value.diagnostics];
+  }
+
+  public get raw() {
+    return { [this.name.text]: this.value.raw };
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    const newOpts = {
+      ...options,
+      depth: options.depth && options.depth - 1,
+    };
+    return `${inspect(this.name, newOpts)}: ${inspect(this.value, newOpts)}`;
+  }
+}
+
+/**
+ * The name of a JSON property.
+ */
+export class JsonPropertyName extends JsonNode<ts.PropertyName> {
+  /** The string representation of a property's name. */
+  public readonly text: string;
+
+  private readonly _diagnostics = new Array<ts.Diagnostic>();
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.PropertyName) {
+    super(sourceFile, node);
+
+    if (ts.isIdentifier(node)) {
+      this.text = node.text;
+    } else if (ts.isStringLiteral(node)) {
+      this.text = node.text;
+    } else if (ts.isNumericLiteral(node)) {
+      this.text = node.text;
+    } else if (ts.isComputedPropertyName(node)) {
+      this.text = node.getText();
+    } else if (ts.isPrivateIdentifier(node)) {
+      this.text = node.text;
+    } else {
+      // Explicit casts here because we've tested all known members of the ts.PropertyName union, so it's "never" now.
+      this._diagnostics.push(
+        this.diagnostic(
+          `Unexpected node kind for a JSON property name: ${
+            ts.SyntaxKind[(node as ts.PropertyName).kind]
+          }`,
+          ts.DiagnosticCategory.Warning,
+        ),
+      );
+      this.text = (node as ts.PropertyName).getText();
+    }
+  }
+
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return this._diagnostics;
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return inspect(this.text, {
+      ...options,
+      depths: options.depth && options.depth - 1,
+    });
+  }
+}
+
+/**
+ * A JSON array is a collection of JSON elements.
+ */
+export class JsonArray extends JsonNode<ts.ArrayLiteralExpression> {
+  /** The elements contained in this array. */
+  public readonly elements: readonly JsonNode[];
+
+  /** @internal */
+  public constructor(
+    sourceFile: ts.SourceFile,
+    node: ts.ArrayLiteralExpression,
+  ) {
+    super(sourceFile, node);
+    this.elements = node.elements.map((elt) => parseValue(sourceFile, elt));
+  }
+
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return new Array<ts.Diagnostic>().concat(
+      ...this.elements.map((elt) => elt.diagnostics),
+    );
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return `${options.stylize('JsonArray', 'special')} ${inspect(
+      this.elements,
+      { ...options, depth: options.depth && options.depth - 1 },
+    )}`;
+  }
+}
+
+/**
+ * The JSON representation of a boolean.
+ */
+export class JsonBoolean extends JsonNode<ts.BooleanLiteral, boolean> {
+  public readonly diagnostics: readonly ts.Diagnostic[] = [];
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.BooleanLiteral) {
+    super(sourceFile, node);
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return inspect(this.raw, {
+      ...options,
+      depths: options.depth && options.depth - 1,
+    });
+  }
+}
+
+/**
+ * The JSON representation of a number.
+ */
+export class JsonNumber extends JsonNode<ts.NumericLiteral, number> {
+  public readonly diagnostics: readonly ts.Diagnostic[] = [];
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.NumericLiteral) {
+    super(sourceFile, node);
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return inspect(this.raw, {
+      ...options,
+      depths: options.depth && options.depth - 1,
+    });
+  }
+}
+
+/**
+ * The JSON representation of a String.
+ */
+export class JsonString extends JsonNode<ts.StringLiteral, string> {
+  public readonly diagnostics: readonly ts.Diagnostic[] = [];
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.StringLiteral) {
+    super(sourceFile, node);
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return inspect(this.raw, {
+      ...options,
+      depths: options.depth && options.depth - 1,
+    });
+  }
+}
+
+/**
+ * a JSON node that we do not yet support.
+ */
+export class UnsupportedNode extends JsonNode {
+  /** The TypeScript SyntaxKind for this unsupported node. */
+  public readonly kind: ts.SyntaxKind;
+  /** The source code corresponding to this unsupported node. */
+  public readonly code: string;
+  public readonly diagnostics: readonly ts.Diagnostic[] = [];
+
+  /** @internal */
+  public constructor(sourceFile: ts.SourceFile, node: ts.Node) {
+    super(sourceFile, node);
+    this.kind = node.kind;
+    this.code = node.getText(sourceFile);
+  }
+
+  /** @internal */
+  /* istanbul ignore next */
+  public [inspect.custom](_depth: number, options: any) {
+    return `${options.stylize('Unsupported', 'special')}<${options.stylize(
+      ts.SyntaxKind[this.kind],
+      'undefined',
+    )} = \n${this.code}\n>`;
+  }
+}
+
+function parseValue(sourceFile: ts.SourceFile, node: ts.Node): JsonNode {
+  if (ts.isExpressionStatement(node)) {
+    return parseValue(sourceFile, node.expression);
+  }
+  if (ts.isStringLiteral(node)) {
+    return new JsonString(sourceFile, node);
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    return new JsonArray(sourceFile, node);
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    return new JsonObject(sourceFile, node);
+  }
+  if (ts.isNumericLiteral(node)) {
+    return new JsonNumber(sourceFile, node);
+  }
+  if (
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword
+  ) {
+    return new JsonBoolean(sourceFile, node as ts.BooleanLiteral);
+  }
+  return new UnsupportedNode(sourceFile, node);
+}

--- a/packages/jsii/lib/private/validators.ts
+++ b/packages/jsii/lib/private/validators.ts
@@ -1,0 +1,30 @@
+import * as spec from '@jsii/spec';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
+const spdx: Set<string> = require('spdx-license-list/simple');
+
+export function validateLicense(text: string): string | never {
+  if (text === 'UNLICENSED') {
+    return text;
+  }
+  if (!spdx.has(text)) {
+    throw new Error(
+      `Invalid license identifier: "${text}", see valid license identifiers at https://spdx.org/licenses`,
+    );
+  }
+  return text;
+}
+
+export function validateStability(text: string): spec.Stability | never {
+  const validValues = Object.values(spec.Stability);
+  for (const value of validValues) {
+    if (value === text) {
+      return value;
+    }
+  }
+  throw new Error(
+    `Invalid stability rating: "${text}", valid values are ${validValues
+      .map((val) => `"${val}"`)
+      .join(', ')}`,
+  );
+}

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -1,408 +1,909 @@
-import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
-import * as log4js from 'log4js';
-import * as path from 'path';
-import * as semver from 'semver';
+import { pathExistsSync, readJsonSync } from 'fs-extra';
+import { join, resolve, dirname } from 'path';
+import { Range } from 'semver';
 import { intersect } from 'semver-intersect';
+import * as ts from 'typescript';
+import {
+  JsonArray,
+  JsonBoolean,
+  JsonFile,
+  JsonNode,
+  JsonObject,
+  JsonObjectProperty,
+  JsonString,
+} from './private/json';
+import { validateLicense, validateStability } from './private/validators';
 import { parsePerson, parseRepository } from './utils';
+import { VERSION } from './version';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const spdx: Set<string> = require('spdx-license-list/simple');
-
-const LOG = log4js.getLogger('jsii/package-info');
-
-export interface TSCompilerOptions {
-  readonly outDir?: string;
-  readonly rootDir?: string;
+export interface ProjectInfoLoadOptions {
+  readonly fixPeerDependencies?: boolean;
 }
 
-export interface ProjectInfo {
-  readonly projectRoot: string;
-  readonly packageJson: any;
+export class ProjectInfo {
+  public static async load(
+    projectRoot: string,
+    _options: ProjectInfoLoadOptions = {},
+  ): Promise<ProjectInfo> {
+    const packageJson = await JsonFile.load(join(projectRoot, 'package.json'));
+    if (packageJson.documents.length !== 1) {
+      throw new Error(
+        `Found ${packageJson.documents.length} documents in ${packageJson.filePath}, expected exactly 1.`,
+      );
+    }
+    const metadata = packageJson.documents[0];
+    if (!(metadata instanceof JsonObject)) {
+      throw new Error(
+        `Expected ${packageJson.filePath} to contain a JSON object, but found ${metadata.constructor.name}`,
+      );
+    }
 
-  readonly name: string;
-  readonly version: string;
-  readonly author: spec.Person;
-  readonly deprecated?: string;
-  readonly stability?: spec.Stability;
-  readonly license: string;
-  readonly repository: {
+    return new ProjectInfo(projectRoot, metadata);
+  }
+
+  private readonly _diagnostics: ts.Diagnostic[];
+
+  public readonly deprecated?: string;
+  public readonly description?: string;
+  public readonly homepage?: string;
+  public readonly license: string;
+  public readonly main: string;
+  public readonly name: string;
+  public readonly stability?: spec.Stability;
+  public readonly types: string;
+  public readonly version: string;
+
+  public readonly keywords?: readonly string[];
+
+  public readonly repository: {
     readonly type: string;
     readonly url: string;
     readonly directory?: string;
   };
-  readonly keywords?: string[];
 
-  readonly main: string;
-  readonly types: string;
+  public readonly author: spec.Person;
+  public readonly contributors?: readonly spec.Person[];
 
-  readonly dependencies: { readonly [name: string]: string };
-  readonly peerDependencies: { readonly [name: string]: string };
-  readonly dependencyClosure: readonly spec.Assembly[];
-  readonly bundleDependencies?: { readonly [name: string]: string };
-  readonly targets: spec.AssemblyTargets;
-  readonly metadata?: { [key: string]: any };
-  readonly jsiiVersionFormat: 'short' | 'full';
-  readonly description?: string;
-  readonly homepage?: string;
-  readonly contributors?: readonly spec.Person[];
-  readonly excludeTypescript: string[];
-  readonly projectReferences?: boolean;
-  readonly tsc?: TSCompilerOptions;
-}
+  public readonly dependencies: { readonly [name: string]: string };
+  public readonly devDependencies: { readonly [name: string]: string };
+  public readonly peerDependencies: { readonly [name: string]: string };
+  public readonly dependencyClosure: readonly spec.Assembly[];
+  public readonly bundleDependencies: { readonly [name: string]: string };
 
-export async function loadProjectInfo(
-  projectRoot: string,
-  { fixPeerDependencies }: { fixPeerDependencies: boolean },
-): Promise<ProjectInfo> {
-  const packageJsonPath = path.join(projectRoot, 'package.json');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
-  const pkg = require(packageJsonPath);
+  public readonly targets: spec.AssemblyTargets;
+  public readonly metadata?: { readonly [name: string]: string };
 
-  let bundleDependencies: { [name: string]: string } | undefined;
-  for (const name of pkg.bundleDependencies ?? pkg.bundledDependencies ?? []) {
-    const version = pkg.dependencies?.[name];
-    if (!version) {
-      throw new Error(
-        `The "package.json" file has "${name}" in "bundleDependencies", but it is not declared in "dependencies"`,
+  public readonly jsiiVersionFormat: 'short' | 'full';
+
+  public readonly tsc?: ts.CompilerOptions;
+  public readonly excludeTypescript?: readonly string[];
+
+  /** @internal */
+  public constructor(
+    public readonly projectRoot: string,
+    public readonly packageJson: JsonObject,
+  ) {
+    this._diagnostics = Array.from(packageJson.diagnostics);
+
+    this.deprecated = packageJson.get('deprecated')?.map((prop) => {
+      if (prop.value instanceof JsonString) {
+        return prop.value.raw;
+      } else if (prop.value instanceof JsonBoolean) {
+        if (!prop.value.raw) return undefined;
+        this._diagnostics.push(
+          prop.value.diagnostic(
+            `We recommend to set a deprecation message instead of 'true'`,
+            ts.DiagnosticCategory.Warning,
+          ),
+        );
+        return 'Deprecated';
+      }
+      this._diagnostics.push(
+        prop.diagnostic(
+          `Unsupported value (only boolean and string is allowed)`,
+        ),
       );
-    }
+      return undefined;
+    });
 
-    if (pkg.peerDependencies && name in pkg.peerDependencies) {
-      throw new Error(
-        `The "package.json" file has "${name}" in "bundleDependencies", and also in "peerDependencies"`,
+    this.description = packageJson
+      .get('description')
+      ?.map(this.#stringValueOrDefault(undefined));
+
+    this.homepage = packageJson
+      .get('homepage')
+      ?.map(this.#stringValueOrDefault(undefined));
+
+    this.license = this.#requireStringProperty(
+      packageJson,
+      'license',
+      'UNLICENSED',
+      validateLicense,
+    );
+
+    this.main = this.#requireStringProperty(packageJson, 'main', 'index.js');
+
+    this.name = this.#requireStringProperty(packageJson, 'name', 'No name');
+
+    this.stability = packageJson.get('stability')?.map((prop) => {
+      if (prop.value instanceof JsonString) {
+        try {
+          return validateStability(prop.value.raw);
+        } catch (e) {
+          this._diagnostics.push(prop.value.diagnostic(e.message ?? e.stack));
+          return (prop.value.raw as any) as spec.Stability;
+        }
+      }
+      this._diagnostics.push(
+        prop.value.diagnostic(
+          `Unsupported value (valid values are: ${Object.values(spec.Stability)
+            .map((s) => `"${s}"`)
+            .join(', ')})`,
+        ),
       );
-    }
+      return spec.Stability.Experimental;
+    });
 
-    bundleDependencies = bundleDependencies ?? {};
-    bundleDependencies[name] = _resolveVersion(version, projectRoot).version!;
-  }
+    this.types = this.#requireStringProperty(
+      packageJson,
+      'types',
+      'index.d.ts',
+    );
 
-  let addedPeerDependency = false;
-  Object.entries(pkg.dependencies ?? {}).forEach(([name, version]) => {
-    if (name in (bundleDependencies ?? {})) {
-      return;
-    }
-    version = _resolveVersion(version as any, projectRoot).version;
-    pkg.peerDependencies = pkg.peerDependencies ?? {};
-    const peerVersion = _resolveVersion(pkg.peerDependencies[name], projectRoot)
-      .version;
-    if (peerVersion === version) {
-      return;
-    }
-    if (!fixPeerDependencies) {
-      if (peerVersion) {
-        throw new Error(
-          `The "package.json" file has different version requirements for "${name}" in "dependencies" (${version}) versus "peerDependencies" (${peerVersion})`,
+    this.version = this.#requireStringProperty(packageJson, 'version', '0.0.0');
+
+    this.keywords = packageJson.get('keywords')?.map((prop) => {
+      if (prop.value instanceof JsonArray) {
+        return prop.value.elements
+          .map((elt) => {
+            if (elt instanceof JsonString) {
+              return elt.raw;
+            }
+            this._diagnostics.push(
+              elt.diagnostic(`Unsupported value (only string is allowed)`),
+            );
+            // Cheating invalid values out
+            return (undefined as any) as string;
+          })
+          .filter((val) => val != null);
+      }
+      this._diagnostics.push(
+        prop.value.diagnostic(`Unsupported value (only string[] is allowed)`),
+      );
+      return undefined;
+    });
+
+    this.author =
+      packageJson.get('author')?.map((prop) => {
+        return this.#extractPerson(prop.value, 'author');
+      }) ?? this.#missingValueFor(packageJson, 'author', PHONY_PERSON);
+
+    this.contributors = packageJson.get('contributors')?.map((prop) => {
+      if (prop.value instanceof JsonArray) {
+        return prop.value.elements.map((elt) =>
+          this.#extractPerson(elt, 'contributor'),
         );
       }
-      throw new Error(
-        `The "package.json" file has "${name}" in "dependencies", but not in "peerDependencies"`,
+      this._diagnostics.push(
+        prop.value.diagnostic(`Unsupported value (only array is allowed)`),
       );
-    }
-    if (peerVersion) {
-      LOG.warn(
-        `Changing "peerDependency" on "${name}" from "${peerVersion}" to ${version}`,
-      );
-    } else {
-      LOG.warn(`Recording missing "peerDependency" on "${name}" at ${version}`);
-    }
-    pkg.peerDependencies[name] = version;
-    addedPeerDependency = true;
-  });
-  // Re-write "package.json" if we fixed up "peerDependencies" and were told to automatically fix.
-  // Yes, we should never have addedPeerDependencies if not fixPeerDependency, but I still check again.
-  if (addedPeerDependency && fixPeerDependencies) {
-    await fs.writeJson(packageJsonPath, pkg, { encoding: 'utf8', spaces: 2 });
+      return undefined;
+    });
+
+    this.repository =
+      packageJson.get('repository')?.map((prop) => {
+        if (prop.value instanceof JsonString) {
+          try {
+            return parseRepository(prop.value.raw);
+          } catch (error) {
+            this._diagnostics.push(
+              prop.value.diagnostic(error.message ?? error.stack),
+            );
+            return PHONY_REPOSITORY;
+          }
+        }
+        if (prop.value instanceof JsonObject) {
+          return this.#extractRepository(prop.value);
+        }
+        this._diagnostics.push(
+          prop.value.diagnostic(
+            `Unsupported value (only string or object is allowed)`,
+          ),
+        );
+        return PHONY_REPOSITORY;
+      }) ?? this.#missingValueFor(packageJson, 'repository', PHONY_REPOSITORY);
+
+    const jsiiConfigurationBlock = packageJson
+      .get('jsii')
+      ?.map(this.#extractObject);
+
+    this.targets = {
+      ...jsiiConfigurationBlock
+        ?.get('targets')
+        ?.map(this.#extractObject)
+        ?.map((json) => json.raw),
+      js: { npm: this.name },
+    };
+
+    this.metadata = jsiiConfigurationBlock
+      ?.get('metadata')
+      ?.map((prop) => prop.value.raw);
+
+    this.jsiiVersionFormat =
+      jsiiConfigurationBlock?.get('versionFormat')?.map((prop) => {
+        if (prop.value instanceof JsonString) {
+          if (prop.value.raw === 'full' || prop.value.raw === 'short') {
+            return prop.value.raw;
+          }
+        }
+        this._diagnostics.push(
+          prop.value.diagnostic(
+            `Unsupported value (only "full" and "short" are allowed)`,
+          ),
+        );
+        return 'full';
+      }) ?? 'full';
+
+    this.excludeTypescript = jsiiConfigurationBlock
+      ?.get('excludeTypescript')
+      ?.map((prop) => {
+        if (prop instanceof JsonArray) {
+          return prop.elements
+            ?.map((elt) => {
+              if (elt instanceof JsonString) {
+                return elt.raw;
+              }
+              this._diagnostics.push(
+                elt.diagnostic(`Unsupported value (only string is allowed)`),
+              );
+              // Cheating bad values out
+              return (undefined as any) as string;
+            })
+            .filter((val) => val != null);
+        }
+        this._diagnostics.push(
+          prop.value.diagnostic(`Unsupported value (only string[] is allowed)`),
+        );
+        return undefined;
+      });
+
+    this.tsc = jsiiConfigurationBlock
+      ?.get('tsc')
+      ?.map((prop) => prop.value.raw);
+
+    const dependencies = this.#validateDependencies(
+      packageJson.get('devDependencies')?.map(this.#extractDependencies) ?? {},
+      packageJson.get('dependencies')?.map(this.#extractDependencies) ?? {},
+      packageJson.get('peerDependencies')?.map(this.#extractDependencies) ?? {},
+      (
+        packageJson.get('bundledDependencies') ??
+        packageJson.get('bundleDependencies')
+      )?.map((prop) => {
+        if (!(prop.value instanceof JsonArray)) {
+          this._diagnostics.push(
+            prop.value.diagnostic(
+              `Unsupported value (only string[] is allowed)`,
+            ),
+          );
+          return undefined;
+        }
+        const result = new Array<JsonString>();
+        for (const elt of prop.value.elements) {
+          if (!(elt instanceof JsonString)) {
+            this._diagnostics.push(
+              elt.diagnostic(`Unsupported value (only string is allowed)`),
+            );
+            continue;
+          }
+          result.push(elt);
+        }
+        return result;
+      }) ?? [],
+    );
+
+    this.dependencies = dependencies
+      .filter((info) => info.isRuntime && !info.isBundled)
+      .reduce((res, { name, version }) => {
+        res[name] = version;
+        return res;
+      }, {} as Record<string, string>);
+    this.devDependencies = dependencies
+      .filter((info) => info.isDev && !info.isBundled)
+      .reduce((res, { name, version }) => {
+        res[name] = version;
+        return res;
+      }, {} as Record<string, string>);
+    this.peerDependencies = dependencies
+      .filter((info) => info.isPeer && !info.isBundled)
+      .reduce((res, { name, version }) => {
+        res[name] = version;
+        return res;
+      }, {} as Record<string, string>);
+    this.bundleDependencies = dependencies
+      .filter((info) => info.isBundled)
+      .reduce((res, { name, version }) => {
+        res[name] = version;
+        return res;
+      }, {} as Record<string, string>);
+
+    this.dependencyClosure = new Array<spec.Assembly>().concat(
+      ...dependencies
+        .filter((dep) => !dep.isBundled && (dep.isRuntime || dep.isPeer))
+        .map(this.#resolveAssembly),
+    );
   }
 
-  const transitiveAssemblies: { [name: string]: spec.Assembly } = {};
-  const dependencies = await _loadDependencies(
-    pkg.dependencies,
-    projectRoot,
-    transitiveAssemblies,
-    new Set<string>(Object.keys(bundleDependencies ?? {})),
-  );
-  const peerDependencies = await _loadDependencies(
-    pkg.peerDependencies,
-    projectRoot,
-    transitiveAssemblies,
-  );
+  public get diagnostics(): readonly ts.Diagnostic[] {
+    return this._diagnostics;
+  }
 
-  const transitiveDependencies = Object.values(transitiveAssemblies);
-
-  return {
-    projectRoot,
-    packageJson: pkg,
-
-    name: _required(
-      pkg.name,
-      'The "package.json" file must specify the "name" attribute',
-    ),
-    version: _required(
-      pkg.version,
-      'The "package.json" file must specify the "version" attribute',
-    ),
-    deprecated: pkg.deprecated,
-    stability: _validateStability(pkg.stability, pkg.deprecated),
-    author: _toPerson(
-      _required(
-        pkg.author,
-        'The "package.json" file must specify the "author" attribute',
-      ),
-      'author',
-    ),
-    repository: _toRepository(
-      _required(
-        pkg.repository,
-        'The "package.json" file must specify the "repository" attribute',
-      ),
-    ),
-    license: _validateLicense(pkg.license),
-    keywords: pkg.keywords,
-
-    main: _required(
-      pkg.main,
-      'The "package.json" file must specify the "main" attribute',
-    ),
-    types: _required(
-      pkg.types,
-      'The "package.json" file must specify the "types" attribute',
-    ),
-
-    dependencies,
-    peerDependencies,
-    dependencyClosure: transitiveDependencies,
-    bundleDependencies,
-    targets: {
-      ..._required(
-        pkg.jsii,
-        'The "package.json" file must specify the "jsii" attribute',
-      ).targets,
-      js: { npm: pkg.name },
-    },
-    metadata: pkg.jsii?.metadata,
-    jsiiVersionFormat: _validateVersionFormat(pkg.jsii.versionFormat ?? 'full'),
-
-    description: pkg.description,
-    homepage: pkg.homepage,
-    contributors: (pkg.contributors as any[])?.map((contrib, index) =>
-      _toPerson(contrib, `contributors[${index}]`, 'contributor'),
-    ),
-
-    excludeTypescript: pkg.jsii?.excludeTypescript ?? [],
-    projectReferences: pkg.jsii?.projectReferences,
-    tsc: {
-      outDir: pkg.jsii?.tsc?.outDir,
-      rootDir: pkg.jsii?.tsc?.rootDir,
-    },
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #missingValueFor = <T>(
+    obj: JsonObject,
+    key: string,
+    defaultValue: T,
+  ): T => {
+    this._diagnostics.push(
+      obj.diagnostic(`Missing required entry for key "${key}"`),
+    );
+    return defaultValue;
   };
-}
 
-function _guessRepositoryType(url: string): string {
-  if (url.endsWith('.git')) {
-    return 'git';
-  }
-  const parts = /^([^:]+):\/\//.exec(url);
-  if (parts?.[1] !== 'http' && parts?.[1] !== 'https') {
-    return parts![1];
-  }
-  throw new Error(
-    `The "package.json" file must specify the "repository.type" attribute (could not guess from ${url})`,
-  );
-}
-
-async function _loadDependencies(
-  dependencies: { [name: string]: string } | undefined,
-  searchPath: string,
-  transitiveAssemblies: { [name: string]: spec.Assembly },
-  bundled = new Set<string>(),
-): Promise<{ [name: string]: string }> {
-  if (!dependencies) {
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #extractDependencies = (
+    prop: JsonObjectProperty,
+  ): ModeledDependencies => {
+    if (prop.value instanceof JsonObject) {
+      const result: ModeledDependencies = {};
+      for (const entry of prop.value.properties) {
+        const name = entry.name.text;
+        const version = entry.map(this.#stringValueOrDefault('*'));
+        result[name] = { prop: entry, version };
+      }
+      return result;
+    }
+    this._diagnostics.push(
+      prop.value.diagnostic(`Unsupported value (only object is allowed)`),
+    );
     return {};
-  }
-  const packageVersions: { [name: string]: string } = {};
-  for (const name of Object.keys(dependencies)) {
-    if (bundled.has(name)) {
-      continue;
-    }
-    const { version: versionString, localPackage } = _resolveVersion(
-      dependencies[name],
-      searchPath,
-    );
-    const version = new semver.Range(versionString!);
-    if (!version) {
-      throw new Error(
-        `Invalid semver expression for ${name}: ${versionString}`,
-      );
-    }
-    const pkg = _tryResolveAssembly(name, localPackage, searchPath);
-    LOG.debug(`Resolved dependency ${name} to ${pkg}`);
-    // eslint-disable-next-line no-await-in-loop
-    const assm = await loadAndValidateAssembly(pkg);
-    if (!version.intersects(new semver.Range(assm.version))) {
-      throw new Error(
-        `Declared dependency on version ${versionString} of ${name}, but version ${assm.version} was found`,
-      );
-    }
-    packageVersions[assm.name] =
-      packageVersions[assm.name] != null
-        ? intersect(versionString!, packageVersions[assm.name])
-        : versionString!;
-    transitiveAssemblies[assm.name] = assm;
-    const pkgDir = path.dirname(pkg);
-    if (assm.dependencies) {
-      // eslint-disable-next-line no-await-in-loop
-      await _loadDependencies(assm.dependencies, pkgDir, transitiveAssemblies);
-    }
-  }
-  return packageVersions;
-}
-
-const ASSEMBLY_CACHE = new Map<string, spec.Assembly>();
-
-/**
- * Load a JSII filename and validate it; cached to avoid redundant loads of the same JSII assembly
- */
-async function loadAndValidateAssembly(
-  jsiiFileName: string,
-): Promise<spec.Assembly> {
-  if (!ASSEMBLY_CACHE.has(jsiiFileName)) {
-    try {
-      ASSEMBLY_CACHE.set(
-        jsiiFileName,
-        spec.validateAssembly(await fs.readJson(jsiiFileName)),
-      );
-    } catch (e) {
-      throw new Error(`Error loading ${jsiiFileName}: ${e}`);
-    }
-  }
-  return ASSEMBLY_CACHE.get(jsiiFileName)!;
-}
-
-function _required<T>(value: T, message: string): T {
-  if (value == null) {
-    throw new Error(message);
-  }
-  return value;
-}
-
-function _toPerson(
-  value: any,
-  field: string,
-  defaultRole: string = field,
-): spec.Person {
-  if (typeof value === 'string') {
-    value = parsePerson(value);
-  }
-  return {
-    name: _required(
-      value.name,
-      `The "package.json" file must specify the "${field}.name" attribute`,
-    ),
-    roles: value.roles ? [...new Set(value.roles as string[])] : [defaultRole],
-    email: value.email,
-    url: value.url,
-    organization: value.organization ? value.organization : undefined,
   };
-}
 
-function _toRepository(
-  value: any,
-): { type: string; url: string; directory?: string } {
-  if (typeof value === 'string') {
-    value = parseRepository(value);
-  }
-  return {
-    url: _required(
-      value.url,
-      'The "package.json" file must specify the "repository.url" attribute',
-    ),
-    type: value.type || _guessRepositoryType(value.url),
-    directory: value.directory,
-  };
-}
-
-function _tryResolveAssembly(
-  mod: string,
-  localPackage: string | undefined,
-  searchPath: string,
-): string {
-  if (localPackage) {
-    const result = path.join(localPackage, '.jsii');
-    if (!fs.existsSync(result)) {
-      throw new Error(`Assembly does not exist: ${result}`);
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #extractObject = (
+    prop: JsonObjectProperty,
+  ): JsonObject | undefined => {
+    if (prop.value instanceof JsonObject) {
+      return prop.value;
     }
-    return result;
-  }
-  try {
-    const paths = [searchPath, path.join(searchPath, 'node_modules')];
-    return require.resolve(path.join(mod, '.jsii'), { paths });
-  } catch {
-    throw new Error(
-      `Unable to locate jsii assembly for "${mod}". If this module is not jsii-enabled, it must also be declared under bundledDependencies.`,
+    this._diagnostics.push(
+      prop.value.diagnostic(`Unsupported value (only object is allowed)`),
     );
-  }
-}
-
-function _validateLicense(id: string): string {
-  if (id === 'UNLICENSED') {
-    return id;
-  }
-  if (!spdx.has(id)) {
-    throw new Error(
-      `Invalid license identifier "${id}", see valid license identifiers at https://spdx.org/licenses/`,
-    );
-  }
-  return id;
-}
-
-function _validateVersionFormat(format: string): 'short' | 'full' {
-  if (format !== 'short' && format !== 'full') {
-    throw new Error(
-      `Invalid jsii.versionFormat "${format}", it must be either "short" or "full" (the default)`,
-    );
-  }
-  return format;
-}
-
-function _validateStability(
-  stability: string | undefined,
-  deprecated: string | undefined,
-): spec.Stability | undefined {
-  if (!stability && deprecated) {
-    stability = spec.Stability.Deprecated;
-  } else if (deprecated && stability !== spec.Stability.Deprecated) {
-    throw new Error(
-      `Package is deprecated (${deprecated}), but it's stability is ${stability} and not ${spec.Stability.Deprecated}`,
-    );
-  }
-  if (!stability) {
     return undefined;
-  }
-  if (!Object.values(spec.Stability).includes(stability as any)) {
-    throw new Error(
-      `Invalid stability "${stability}", it must be one of ${Object.values(
-        spec.Stability,
-      ).join(', ')}`,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #stringValueOrDefault = <T extends string | undefined>(
+    fallBackValue: T,
+    validator?: (val: string) => T | never,
+  ) => {
+    return (prop: JsonObjectProperty) => {
+      if (prop.value instanceof JsonString) {
+        const text = prop.value.raw;
+        try {
+          return validator ? validator(text) : text;
+        } catch (err) {
+          this._diagnostics.push(
+            prop.value.diagnostic(err.message ?? err.stack ?? 'Invalid value'),
+          );
+          return text;
+        }
+      }
+      this._diagnostics.push(
+        prop.value.diagnostic(`Unsupported value (only string is allowed)`),
+      );
+      return fallBackValue;
+    };
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #extractPerson = (
+    json: JsonNode,
+    defaultRole: string,
+  ): spec.Person => {
+    if (json instanceof JsonString) {
+      try {
+        return {
+          ...parsePerson(json.raw),
+          roles: [defaultRole],
+        };
+      } catch (error) {
+        this._diagnostics.push(json.diagnostic(error.message ?? error.stack));
+        return {
+          name: 'Invalid Name',
+          roles: [defaultRole],
+        };
+      }
+    }
+    if (json instanceof JsonObject) {
+      return this.#parsePerson(json, defaultRole);
+    }
+    this._diagnostics.push(
+      json.diagnostic(`Unsupported value (only string and object are allowed)`),
     );
-  }
-  return stability as spec.Stability;
+    return PHONY_PERSON;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #extractRepository = (json: JsonObject) => {
+    for (const prop of json.properties) {
+      if (!['type', 'url', 'directory'].includes(prop.name.text)) {
+        this._diagnostics.push(
+          prop.name.diagnostic(
+            `This property is unexpected and will be ignored`,
+            ts.DiagnosticCategory.Warning,
+          ),
+        );
+      }
+    }
+
+    const url = this.#requireStringProperty(json, 'url', 'https://localhost/');
+    const type =
+      json.get('type')?.map(this.#stringValueOrDefault(undefined)) ??
+      guessRepositoryType.call(this, url);
+    const directory = json
+      .get('directory')
+      ?.map(this.#stringValueOrDefault(undefined));
+
+    return { type, url, directory };
+
+    function guessRepositoryType(this: ProjectInfo, url: string): string {
+      if (url.endsWith('.git')) {
+        return 'git';
+      }
+      const parts = /^([^:]+):\/\//.exec(url);
+      if (parts?.[1] && parts[1] !== 'http' && parts[1] !== 'https') {
+        this._diagnostics.push(
+          json.diagnostic(
+            `Guessed the repository.type value from repository.url: "${parts[1]}"`,
+            ts.DiagnosticCategory.Message,
+          ),
+        );
+        return parts[1];
+      }
+      this._diagnostics.push(
+        json.diagnostic(
+          `Could not guess the repository.type value from repository.url ("${url}"). Please specify it manually.`,
+        ),
+      );
+      return 'unknown';
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #requireStringProperty = (
+    obj: JsonObject,
+    key: string,
+    fallbackValue: string,
+    validator?: (val: string) => string | never,
+  ) =>
+    obj.get(key)?.map(this.#stringValueOrDefault(fallbackValue, validator)) ??
+    this.#missingValueFor(obj, key, fallbackValue);
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #parsePerson = (
+    json: JsonObject,
+    defaultRole: string,
+  ): spec.Person => {
+    for (const prop of json.properties) {
+      if (
+        !['name', 'email', 'roles', 'url', 'organization'].includes(
+          prop.name.text,
+        )
+      ) {
+        this._diagnostics.push(
+          prop.name.diagnostic(
+            `This property is unexpected and will be ignored`,
+            ts.DiagnosticCategory.Warning,
+          ),
+        );
+      }
+    }
+
+    const name = this.#requireStringProperty(json, 'name', 'No Name');
+    const email = json.get('email')?.map(this.#stringValueOrDefault(undefined));
+    const roles = json.get('roles')?.map((roleProp) => {
+      if (roleProp.value instanceof JsonArray) {
+        return roleProp.value.elements.map((elt) => {
+          if (elt instanceof JsonString) {
+            return elt.raw;
+          }
+          this._diagnostics.push(
+            elt.diagnostic(`Unsupported value (only string is allowed)`),
+          );
+          return 'invalid';
+        });
+      }
+      this._diagnostics.push(
+        roleProp.value.diagnostic(
+          `Unsupported value (only string[] is allowed)`,
+        ),
+      );
+      return [defaultRole];
+    }) ?? [defaultRole];
+    const organization = json.get('organization')?.map((orgProp) => {
+      if (orgProp.value instanceof JsonBoolean) {
+        return orgProp.value.raw;
+      }
+      this._diagnostics.push(
+        orgProp.value.diagnostic(
+          `A boolean value was expected. This will be interpreted as "true".`,
+          ts.DiagnosticCategory.Warning,
+        ),
+      );
+      return true;
+    });
+    const url = json.get('url')?.map(this.#stringValueOrDefault(undefined));
+    return { name, roles, email, organization, url };
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #validateDependencies = (
+    devDeps: ModeledDependencies,
+    runtimeDeps: ModeledDependencies,
+    peerDeps: ModeledDependencies,
+    bundledDependencies: readonly JsonString[],
+  ) => {
+    const result = new Array<AssemblyDependency>();
+    for (const [name, { bundled, dev, runtime, peer }] of Object.entries(
+      allDependencies(this.projectRoot),
+    )) {
+      if (bundled != null) {
+        if (peer) {
+          this._diagnostics.push(
+            bundled.diagnostic(
+              `This is also declared as a peer dependency`,
+              ts.DiagnosticCategory.Warning,
+              peer.prop.name.diagnostic(
+                `This is where the peer dependency is declared`,
+                ts.DiagnosticCategory.Message,
+              ),
+            ),
+          );
+        }
+        if (runtime) {
+          this._diagnostics.push(
+            bundled.diagnostic(
+              `This is also declared as a runtime dependency. Declare a devDependency instead.`,
+              ts.DiagnosticCategory.Warning,
+              runtime.prop.name.diagnostic(
+                `This is where the runtime dependency is declared`,
+                ts.DiagnosticCategory.Message,
+              ),
+            ),
+          );
+        } else if (!dev) {
+          this._diagnostics.push(
+            bundled.diagnostic(
+              `Bundled dependencies must also be declared as devDependencies.`,
+              ts.DiagnosticCategory.Error,
+            ),
+          );
+        }
+      } else if (runtime != null && peer == null) {
+        this._diagnostics.push(
+          runtime.prop.name.diagnostic(
+            `Runtime dependencies should also be peer dependencies.`,
+            ts.DiagnosticCategory.Warning,
+          ),
+        );
+      } else if (
+        runtime != null &&
+        peer != null &&
+        runtime.version !== peer.version
+      ) {
+        this._diagnostics.push(
+          runtime.prop.value.diagnostic(
+            `The peer dependency declares a different version range: ${peer.version}`,
+            ts.DiagnosticCategory.Warning,
+            peer.prop.diagnostic(
+              `The other range is declared here`,
+              ts.DiagnosticCategory.Message,
+            ),
+          ),
+        );
+      }
+      if (dev != null && (runtime != null || peer != null)) {
+        this._diagnostics.push(
+          dev.prop.name.diagnostic(
+            `This development dependency is redundant (it is also declared as a runtime and/or peer dependency)`,
+            ts.DiagnosticCategory.Warning,
+            ...[
+              ...(runtime
+                ? [
+                    runtime.prop.name.diagnostic(
+                      `It's declared as a runtime dependency here`,
+                      ts.DiagnosticCategory.Message,
+                    ),
+                  ]
+                : []),
+              ...(peer
+                ? [
+                    peer.prop.name.diagnostic(
+                      `It's declared as a peer dependency here`,
+                      ts.DiagnosticCategory.Message,
+                    ),
+                  ]
+                : []),
+            ],
+          ),
+        );
+      }
+
+      const { version, pathOverride } = this.#determineVersion(
+        dev,
+        runtime,
+        peer,
+      );
+      result.push({
+        name,
+        anchor: peer?.prop ?? runtime?.prop ?? dev?.prop ?? bundled!,
+        isBundled: bundled != null,
+        isDev: dev != null,
+        isPeer: peer != null,
+        isRuntime: runtime != null,
+        version,
+        pathOverride,
+        semver: new Range(version),
+      });
+    }
+
+    return result;
+
+    function allDependencies(projectRoot: string) {
+      const result: Record<
+        string,
+        {
+          bundled?: JsonString;
+          dev?: ResolvedDependency;
+          runtime?: ResolvedDependency;
+          peer?: ResolvedDependency;
+        }
+      > = {};
+      for (const bundled of bundledDependencies) {
+        result[bundled.raw] = { bundled };
+      }
+      for (const [name, value] of Object.entries(devDeps)) {
+        result[name] = result[name] ?? {};
+        const { version: resolved, pathOverride } = resolveVersion(
+          value.version,
+          projectRoot,
+        );
+        result[name].dev = {
+          ...value,
+          resolved,
+          pathOverride,
+        };
+      }
+      for (const [name, value] of Object.entries(runtimeDeps)) {
+        result[name] = result[name] ?? {};
+        const { version: resolved, pathOverride } = resolveVersion(
+          value.version,
+          projectRoot,
+        );
+        result[name].runtime = {
+          ...value,
+          resolved,
+          pathOverride,
+        };
+      }
+      for (const [name, value] of Object.entries(peerDeps)) {
+        result[name] = result[name] ?? {};
+        const { version: resolved, pathOverride } = resolveVersion(
+          value.version,
+          projectRoot,
+        );
+        result[name].peer = {
+          ...value,
+          resolved,
+          pathOverride,
+        };
+      }
+      return result;
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #determineVersion = (
+    ...candidates: Array<ResolvedDependency | undefined>
+  ): { version: string; pathOverride?: string } => {
+    const store: Record<string, ResolvedDependency[]> = {};
+    let pathOverride: string | undefined;
+    for (const candidate of candidates) {
+      if (candidate == null) {
+        continue;
+      }
+      store[candidate.resolved] = store[candidate.resolved] ?? [];
+      store[candidate.resolved].push(candidate);
+      pathOverride = pathOverride ?? candidate.pathOverride;
+    }
+
+    const versions = Object.keys(store);
+    if (versions.length === 1) {
+      // All candidates resolve to the exact same version!
+      return { version: versions[0], pathOverride };
+    } else if (versions.length > 1) {
+      // Uh-ho, we have multiple candidates...
+      try {
+        // Happy case, there is an intersection to these requirements and we can use it.
+        return { version: intersect(...versions), pathOverride };
+      } catch {
+        // Sad case, there is no intersection, so we'll report an error and return '*'.
+        const [first, ...rest] = versions;
+        store[first][0].prop.value.diagnostic(
+          `This requirement is incomatible with other declarations (${rest.join(
+            ', ',
+          )})`,
+          ts.DiagnosticCategory.Error,
+          ...rest.map((ver) =>
+            store[ver][0].prop.value.diagnostic(
+              `Another requirement is declared here`,
+              ts.DiagnosticCategory.Message,
+            ),
+          ),
+        );
+      }
+    }
+
+    return { version: '*', pathOverride };
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  readonly #resolveAssembly = (dep: AssemblyDependency): spec.Assembly[] => {
+    return Array.from(
+      loadAssemblyClosure.call(this, dep.name, dep.semver, this.projectRoot),
+    );
+
+    function* loadAssemblyClosure(
+      this: ProjectInfo,
+      name: string,
+      semver: Range,
+      searchPath: string,
+      ...chain: string[]
+    ): Generator<spec.Assembly, void, unknown> {
+      const thisThing =
+        chain.length === 0
+          ? 'this dependency'
+          : `the transitive dependency ${chain.join('->')}->${name}`;
+
+      const modPath = resolveModule();
+      if (modPath == null) {
+        this._diagnostics.push(
+          dep.anchor.diagnostic(
+            `Unable to resolve the node package for ${thisThing} from ${searchPath}`,
+          ),
+        );
+        yield { ...PHONY_ASSEMBLY, name, version: semver.raw };
+        return;
+      }
+      const assmPath = join(modPath, spec.SPEC_FILE_NAME);
+      if (!pathExistsSync(assmPath)) {
+        this._diagnostics.push(
+          dep.anchor.diagnostic(
+            `Unable to find the .jsii assembly for ${thisThing}. Expected to find it at ${assmPath}`,
+          ),
+        );
+        yield { ...PHONY_ASSEMBLY, name, version: semver.raw };
+        return;
+      }
+      const rawAssm = readJsonSync(assmPath);
+      try {
+        const assm = spec.validateAssembly(rawAssm);
+        if (!semver.intersects(new Range(assm.version))) {
+          this._diagnostics.push(
+            dep.anchor.diagnostic(
+              `The .jsii assembly for ${thisThing} has version ${assm.version}, which is incompatible with the requirement of ${semver.raw}`,
+            ),
+          );
+        }
+        yield assm;
+        for (const [transDep, transVer] of Object.entries(
+          assm.dependencies ?? {},
+        )) {
+          for (const transAssm of loadAssemblyClosure.call(
+            this,
+            transDep,
+            new Range(transVer),
+            modPath,
+            ...chain,
+            name,
+          )) {
+            yield transAssm;
+          }
+        }
+      } catch (err) {
+        this._diagnostics.push(
+          dep.anchor.diagnostic(
+            `Invalid .jsii assembly found for ${thisThing}: ${
+              err.message ?? err.stack
+            }`,
+          ),
+        );
+        yield rawAssm as spec.Assembly;
+      }
+      return;
+
+      function resolveModule() {
+        if (dep.pathOverride) {
+          return resolve(searchPath, dep.pathOverride);
+        }
+        const paths = [searchPath, join(searchPath, 'node_modules')];
+        try {
+          return dirname(
+            require.resolve(join(name, 'package.json'), { paths }),
+          );
+        } catch {
+          return undefined;
+        }
+      }
+    }
+  };
 }
 
-function _resolveVersion(
-  dep: string,
+type ModeledDependencies = Record<string, ModeledDependency>;
+type ModeledDependency = { prop: JsonObjectProperty; version: string };
+type ResolvedDependency = ModeledDependency & {
+  resolved: string;
+  pathOverride?: string;
+};
+type AssemblyDependency = {
+  anchor: JsonNode;
+  name: string;
+  version: string;
+  semver: Range;
+  isPeer: boolean;
+  isRuntime: boolean;
+  isDev: boolean;
+  isBundled: boolean;
+  pathOverride: string | undefined;
+};
+
+const PHONY_PERSON = {
+  name: 'Invalid or missing configuration',
+  roles: ['invalid'],
+};
+const PHONY_REPOSITORY = {
+  type: 'invalid',
+  url: 'http://localhost/',
+  directory: undefined,
+};
+const PHONY_ASSEMBLY: spec.Assembly = {
+  schema: spec.SchemaVersion.LATEST,
+  name: 'not-found',
+  version: '*',
+  jsiiVersion: VERSION,
+  description: 'This assembly could not be found',
+  license: 'UNLICENSED',
+  homepage: 'https://localhost/',
+  repository: PHONY_REPOSITORY,
+  author: PHONY_PERSON,
+  fingerprint: '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=',
+};
+
+function resolveVersion(
+  str: string,
   searchPath: string,
-): { version: string | undefined; localPackage?: string } {
-  const matches = /^file:(.+)$/.exec(dep);
-  if (!matches) {
-    return { version: dep };
+): { version: string; pathOverride?: string } {
+  const matches = /^file:(.+)$/.exec(str);
+  if (matches == null) {
+    return { version: str };
   }
-  const localPackage = path.resolve(searchPath, matches[1]);
+  const localPackage = resolve(searchPath, matches[1]);
+
+  // Rendering as a caret version to maintain uniformity against the "standard".
   return {
-    // Rendering as a caret version to maintain uniformity against the "standard".
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    version: `^${require(path.join(localPackage, 'package.json')).version}`,
-    localPackage,
+    version: `^${require(join(localPackage, 'package.json')).version}`,
+    pathOverride: localPackage,
   };
 }

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -55,6 +55,7 @@
     "@types/jest-expect-message": "^1.0.2",
     "@types/node": "^10.17.26",
     "@types/semver": "^7.2.0",
+    "@types/supports-color": "^5.3.0",
     "@types/yargs": "^15.0.5",
     "clone": "^2.1.2",
     "eslint": "^7.2.0",
@@ -63,7 +64,8 @@
     "jest": "^26.0.1",
     "jest-expect-message": "^1.0.2",
     "jsii-build-tools": "^0.0.0",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "supports-color": "^7.1.0"
   },
   "jest": {
     "collectCoverage": true,

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -69,9 +69,9 @@ describe(Compiler, () => {
 });
 
 function _makeProjectInfo(sourceDir: string, types: string): ProjectInfo {
-  return {
+  return ({
+    diagnostics: [],
     projectRoot: sourceDir,
-    packageJson: undefined,
     types,
     main: types.replace(/(?:\.d)?\.ts(x?)/, '.js$1'),
     name: 'jsii', // That's what package.json would tell if we look up...
@@ -85,6 +85,5 @@ function _makeProjectInfo(sourceDir: string, types: string): ProjectInfo {
     dependencyClosure: [],
     bundleDependencies: {},
     targets: {},
-    excludeTypescript: [],
-  };
+  } as any) as ProjectInfo;
 }

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -94,9 +94,9 @@ function _messageText(
 }
 
 function _makeProjectInfo(types: string): ProjectInfo {
-  return {
+  return ({
+    diagnostics: [],
     projectRoot: SOURCE_DIR,
-    packageJson: undefined,
     types,
     main: types.replace(/(?:\.d)?\.ts(x?)/, '.js$1'),
     name: 'jsii', // That's what package.json would tell if we look up...
@@ -110,6 +110,5 @@ function _makeProjectInfo(types: string): ProjectInfo {
     dependencyClosure: [],
     bundleDependencies: {},
     targets: {},
-    excludeTypescript: [],
-  };
+  } as any) as ProjectInfo;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,6 +1609,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/supports-color@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-5.3.0.tgz#eb6a52e9531fb3ebcd401cec774d1bdfb571f793"
+  integrity sha512-WxwTXnHTIsk7srax1icjLgX+6w1MUAJbhyCpRP/45paEElsPDQUJZDgr1UpKuL2S3Tb+ZyX9MjWwmcSD4bUoOQ==
+
 "@types/tar-fs@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/tar-fs/-/tar-fs-2.0.0.tgz#db94cb4ea1cccecafe3d1a53812807efb4bbdbc1"


### PR DESCRIPTION
Produces source-linked diagnostic messages when inspecting the
`package.json` file for configuration values in the same way that
messages are generated for `.ts` files. This provides a nicer experience
as it allows to link multiple context entries (i.e: this `devDependency`
entry is redundant because of that `dependency` entry). It will also
integrate nicer with IDE problem markers.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
