### PR TITLE
feat: turn off assembly validation

### DIFF
--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -269,10 +269,7 @@ async function loadAndValidateAssembly(
 ): Promise<spec.Assembly> {
   if (!ASSEMBLY_CACHE.has(jsiiFileName)) {
     try {
-      ASSEMBLY_CACHE.set(
-        jsiiFileName,
-        spec.validateAssembly(await fs.readJson(jsiiFileName)),
-      );
+      ASSEMBLY_CACHE.set(jsiiFileName, await fs.readJson(jsiiFileName));
     } catch (e) {
       throw new Error(`Error loading ${jsiiFileName}: ${e}`);
     }


### PR DESCRIPTION
As it turns out,
validating assemblies takes a non-trivial percentage of all time spent on JSII compilation.
Since the feature is not very important right now,
turn it off to speed-up builds.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
