### PR TITLE
chore: add Apache-2 license headers to TypeScript files

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -7,6 +7,7 @@ plugins:
   - '@typescript-eslint'
   - import
   - prettier
+  - header
 
 parser: '@typescript-eslint/parser'
 parserOptions:
@@ -38,6 +39,11 @@ rules:
 
   'prettier/prettier':
     - error
+
+  header/header:
+    - error
+    - line
+    - " Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n SPDX-License-Identifier: Apache-2.0"
 
   '@typescript-eslint/array-type':
     - error

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-header": "^3.0.0",
     "lerna": "^3.22.1",
     "standard-version": "^8.0.0"
   },

--- a/packages/@jsii/integ-test/test/build-cdk.test.ts
+++ b/packages/@jsii/integ-test/test/build-cdk.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Octokit } from '@octokit/rest';
 import * as dotenv from 'dotenv';
 import { mkdtemp, readdir, remove } from 'fs-extra';

--- a/packages/@jsii/integ-test/utils/index.ts
+++ b/packages/@jsii/integ-test/utils/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cp from 'child_process';
 import { IncomingMessage } from 'http';
 import * as https from 'https';

--- a/packages/@jsii/java-runtime/JsiiVersion.t.js
+++ b/packages/@jsii/java-runtime/JsiiVersion.t.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const version = require('@jsii/runtime/package.json').version.replace(/\+.+$/, ''); // omit "+build" postfix;
-process.stdout.write(`package software.amazon.jsii;
+process.stdout.write(`// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package software.amazon.jsii;
 
 @javax.annotation.Generated(value = "${path.basename(__filename)}", date = "${new Date().toISOString()}")
 final class JsiiVersion {

--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -2,6 +2,9 @@ const packageInfo = require('./package.json');
 const { groupId, artifactId, version } = require('./lib').maven;
 
 process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/packages/@jsii/java-runtime/user.xml.t.js
+++ b/packages/@jsii/java-runtime/user.xml.t.js
@@ -2,6 +2,8 @@ const jsiiJavaRuntime = require('@jsii/java-runtime');
 const path = require('path');
 
 process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <settings xmlns="http://maven.apache.org/POM/4.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">

--- a/packages/@jsii/kernel/lib/api.ts
+++ b/packages/@jsii/kernel/lib/api.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export const TOKEN_REF = '$jsii.byref';
 export const TOKEN_INTERFACES = '$jsii.interfaces';
 export const TOKEN_DATE = '$jsii.date';

--- a/packages/@jsii/kernel/lib/index.ts
+++ b/packages/@jsii/kernel/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './kernel';
 
 import * as api from './api';

--- a/packages/@jsii/kernel/lib/kernel.ts
+++ b/packages/@jsii/kernel/lib/kernel.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
 import * as os from 'os';

--- a/packages/@jsii/kernel/lib/objects.ts
+++ b/packages/@jsii/kernel/lib/objects.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import * as api from './api';
 import { EMPTY_OBJECT_FQN } from './serialization';

--- a/packages/@jsii/kernel/lib/serialization.ts
+++ b/packages/@jsii/kernel/lib/serialization.ts
@@ -1,4 +1,7 @@
-/**
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
  * Handling of types in JSII
  *
  * Types will be serialized according to the following table:

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import { join } from 'path';

--- a/packages/@jsii/kernel/test/recording.ts
+++ b/packages/@jsii/kernel/test/recording.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import { Kernel } from '../lib';
 

--- a/packages/@jsii/kernel/test/serialization.test.ts
+++ b/packages/@jsii/kernel/test/serialization.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { CANONICAL_ANY, OptionalValue, PrimitiveType } from '@jsii/spec';
 import { TOKEN_REF } from '../lib/api';
 import { ObjectTable } from '../lib/objects';

--- a/packages/@jsii/runtime/lib/host.ts
+++ b/packages/@jsii/runtime/lib/host.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { api, Kernel } from '@jsii/kernel';
 import { Input, InputOutput } from './in-out';
 import { EventEmitter } from 'events';

--- a/packages/@jsii/runtime/lib/in-out.ts
+++ b/packages/@jsii/runtime/lib/in-out.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { SyncStdio } from './sync-stdio';
 import { api } from '@jsii/kernel';
 

--- a/packages/@jsii/runtime/lib/index.ts
+++ b/packages/@jsii/runtime/lib/index.ts
@@ -1,2 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './host';
 export * from './in-out';

--- a/packages/@jsii/runtime/lib/program.ts
+++ b/packages/@jsii/runtime/lib/program.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as packageInfo from '../package.json';
 import { KernelHost } from './host';
 import { InputOutput } from './in-out';

--- a/packages/@jsii/runtime/lib/sync-stdio.ts
+++ b/packages/@jsii/runtime/lib/sync-stdio.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
 
 const STDIN_FD = 0;

--- a/packages/@jsii/runtime/test/kernel-host.test.ts
+++ b/packages/@jsii/runtime/test/kernel-host.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as child from 'child_process';
 import * as fs from 'fs';
 import { api } from '@jsii/kernel';

--- a/packages/@jsii/runtime/test/playback.test.ts
+++ b/packages/@jsii/runtime/test/playback.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as child from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/packages/@jsii/runtime/test/stress.test.ts
+++ b/packages/@jsii/runtime/test/stress.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { InputOutput, Input, Output } from '../lib/in-out';
 import { KernelHost } from '../lib/host';
 

--- a/packages/@jsii/spec/lib/assembly.ts
+++ b/packages/@jsii/spec/lib/assembly.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export const SPEC_FILE_NAME = '.jsii';
 
 /**

--- a/packages/@jsii/spec/lib/configuration.ts
+++ b/packages/@jsii/spec/lib/configuration.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Stability } from './assembly';
 
 /**

--- a/packages/@jsii/spec/lib/index.ts
+++ b/packages/@jsii/spec/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './assembly';
 export * from './configuration';
 export * from './name-tree';

--- a/packages/@jsii/spec/lib/name-tree.ts
+++ b/packages/@jsii/spec/lib/name-tree.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from './assembly';
 
 /**

--- a/packages/@jsii/spec/lib/validate-assembly.ts
+++ b/packages/@jsii/spec/lib/validate-assembly.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Schema, Validator } from 'jsonschema';
 import { Assembly } from './assembly';
 

--- a/packages/@jsii/spec/test/name-tree.test.ts
+++ b/packages/@jsii/spec/test/name-tree.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { NameTree } from '../lib/name-tree';
 import * as spec from '../lib/assembly';
 

--- a/packages/@jsii/spec/test/validate-assembly.test.ts
+++ b/packages/@jsii/spec/test/validate-assembly.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { readFileSync, readdirSync } from 'fs';
 import { resolve } from 'path';
 import { validateAssembly } from '../lib/validate-assembly';

--- a/packages/codemaker/lib/case-utils.ts
+++ b/packages/codemaker/lib/case-utils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as camelcase from 'camelcase';
 import * as decamelize from 'decamelize';
 

--- a/packages/codemaker/lib/codemaker.ts
+++ b/packages/codemaker/lib/codemaker.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as util from 'util';
 import * as caseutils from './case-utils';
 import FileBuffer from './filebuff';

--- a/packages/codemaker/lib/filebuff.ts
+++ b/packages/codemaker/lib/filebuff.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 

--- a/packages/codemaker/lib/index.ts
+++ b/packages/codemaker/lib/index.ts
@@ -1,2 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './codemaker';
 export * from './case-utils';

--- a/packages/codemaker/test/case-utils.test.ts
+++ b/packages/codemaker/test/case-utils.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as caseUtils from '../lib/case-utils';
 
 test('toCamelCase', () => {

--- a/packages/codemaker/test/filebuff.test.ts
+++ b/packages/codemaker/test/filebuff.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import FileBuffer from '../lib/filebuff';

--- a/packages/codemaker/test/source.test.ts
+++ b/packages/codemaker/test/source.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { CodeMaker } from '../lib';

--- a/packages/jsii-config/bin/jsii-config.ts
+++ b/packages/jsii-config/bin/jsii-config.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as yargs from 'yargs';
 import { promisify } from 'util';
 import { writeFile } from 'fs';

--- a/packages/jsii-config/lib/index.ts
+++ b/packages/jsii-config/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { readFilePromise } from './util';
 import prompt from './prompt';
 import validatePackageJson from './validate';

--- a/packages/jsii-config/lib/prompt.ts
+++ b/packages/jsii-config/lib/prompt.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as inquirer from 'inquirer';
 import { PackageJson } from '@jsii/spec';
 import getQuestions from './questions';

--- a/packages/jsii-config/lib/questions.ts
+++ b/packages/jsii-config/lib/questions.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { QuestionCollection } from 'inquirer';
 import schema, { ConfigPromptsSchema, BasePackageJson } from './schema';
 import { getNestedValue, flattenKeys } from './util';

--- a/packages/jsii-config/lib/schema.ts
+++ b/packages/jsii-config/lib/schema.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Question, Separator } from 'inquirer';
 import { Config, PackageJson, Stability } from '@jsii/spec';
 

--- a/packages/jsii-config/lib/util.ts
+++ b/packages/jsii-config/lib/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { readFile } from 'fs';
 
 /*

--- a/packages/jsii-config/lib/validate.ts
+++ b/packages/jsii-config/lib/validate.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { BasePackageJson } from './schema';
 
 /*

--- a/packages/jsii-config/test/index.test.ts
+++ b/packages/jsii-config/test/index.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
 import * as inquirer from 'inquirer';
 import jsiiConfig from '../lib';

--- a/packages/jsii-config/test/util.ts
+++ b/packages/jsii-config/test/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { BasePackageJson } from '../lib/schema';
 
 export const packageJsonObject: BasePackageJson = {

--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import * as spec from '@jsii/spec';

--- a/packages/jsii-diff/generate.sh
+++ b/packages/jsii-diff/generate.sh
@@ -9,6 +9,9 @@ if [ -z "${commit}" ]; then
 fi
 
 cat > lib/version.ts <<HERE
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Generated at $(date -u +"%Y-%m-%dT%H:%M:%SZ") by generate.sh
 
 /** The qualified version number for this JSII compiler. */

--- a/packages/jsii-diff/lib/classes-ifaces.ts
+++ b/packages/jsii-diff/lib/classes-ifaces.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as reflect from 'jsii-reflect';
 import * as log4js from 'log4js';
 import { compareStabilities } from './stability';

--- a/packages/jsii-diff/lib/diagnostics.ts
+++ b/packages/jsii-diff/lib/diagnostics.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Stability } from '@jsii/spec';
 import { ApiMismatch, Mismatches } from './types';
 

--- a/packages/jsii-diff/lib/enums.ts
+++ b/packages/jsii-diff/lib/enums.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as reflect from 'jsii-reflect';
 import { compareStabilities } from './stability';
 import { ComparisonContext } from './types';

--- a/packages/jsii-diff/lib/index.ts
+++ b/packages/jsii-diff/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as reflect from 'jsii-reflect';
 import { Stability } from '@jsii/spec';
 import * as log4js from 'log4js';

--- a/packages/jsii-diff/lib/stability.ts
+++ b/packages/jsii-diff/lib/stability.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as reflect from 'jsii-reflect';
 import * as spec from '@jsii/spec';
 import { ApiElement, ComparisonContext } from './types';

--- a/packages/jsii-diff/lib/type-analysis.ts
+++ b/packages/jsii-diff/lib/type-analysis.ts
@@ -1,4 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /* eslint-disable complexity */
+
 import * as reflect from 'jsii-reflect';
 import { flatMap } from './util';
 

--- a/packages/jsii-diff/lib/types.ts
+++ b/packages/jsii-diff/lib/types.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as reflect from 'jsii-reflect';
 import { Stability } from '@jsii/spec';
 

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';

--- a/packages/jsii-diff/test/classes.test.ts
+++ b/packages/jsii-diff/test/classes.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { expectError, expectNoError } from './util';
 
 // ----------------------------------------------------------------------

--- a/packages/jsii-diff/test/diagnostics.test.ts
+++ b/packages/jsii-diff/test/diagnostics.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { classifyDiagnostics, hasErrors } from '../lib/diagnostics';
 import { compare } from './util';
 

--- a/packages/jsii-diff/test/enums.test.ts
+++ b/packages/jsii-diff/test/enums.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { expectError, expectNoError } from './util';
 
 // Note: an enum with one value behaves weirdly in TypeScript -- it does type analysis to the singleton element.

--- a/packages/jsii-diff/test/structs.test.ts
+++ b/packages/jsii-diff/test/structs.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { expectError, expectNoError } from './util';
 
 // ----------------------------------------------------------------------

--- a/packages/jsii-diff/test/type-unions.test.ts
+++ b/packages/jsii-diff/test/type-unions.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { expectError, expectNoError } from './util';
 
 jest.setTimeout(50_000);

--- a/packages/jsii-diff/test/util.ts
+++ b/packages/jsii-diff/test/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { sourceToAssemblyHelper } from 'jsii';
 import * as reflect from 'jsii-reflect';
 import { compareAssemblies } from '../lib';

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as path from 'path';
 import * as process from 'process';
 import * as yargs from 'yargs';

--- a/packages/jsii-pacmak/generate.sh
+++ b/packages/jsii-pacmak/generate.sh
@@ -9,6 +9,9 @@ if [ -z "${commit}" ]; then
 fi
 
 cat > lib/version.ts <<HERE
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Generated at $(date -u +"%Y-%m-%dT%H:%M:%SZ") by generate.sh
 
 /** The qualified version number for jsii */

--- a/packages/jsii-pacmak/lib/builder.ts
+++ b/packages/jsii-pacmak/lib/builder.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as path from 'path';
 import * as logging from './logging';
 import { JsiiModule } from './packaging';

--- a/packages/jsii-pacmak/lib/generator.ts
+++ b/packages/jsii-pacmak/lib/generator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as clone from 'clone';
 import { CodeMaker } from 'codemaker';
 import * as crypto from 'crypto';

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -1,1 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export { Target } from './target';

--- a/packages/jsii-pacmak/lib/logging.ts
+++ b/packages/jsii-pacmak/lib/logging.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export enum Level {
   WARN = -1,
   QUIET = 0,

--- a/packages/jsii-pacmak/lib/markdown.ts
+++ b/packages/jsii-pacmak/lib/markdown.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as commonmark from 'commonmark';
 
 /**

--- a/packages/jsii-pacmak/lib/npm-modules.ts
+++ b/packages/jsii-pacmak/lib/npm-modules.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as spec from '@jsii/spec';

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Scratch, shell } from './util';
 import * as logging from '../lib/logging';
 import * as reflect from 'jsii-reflect';

--- a/packages/jsii-pacmak/lib/target.ts
+++ b/packages/jsii-pacmak/lib/target.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import * as spec from '@jsii/spec';

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
 import * as path from 'path';

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { CodeMaker } from 'codemaker';
 import * as spec from '@jsii/spec';
 import * as xmlbuilder from 'xmlbuilder';

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as clone from 'clone';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { CodeMaker } from 'codemaker';
 import * as spec from '@jsii/spec';
 import { DotNetTypeResolver } from './dotnettyperesolver';

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnettyperesolver.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnettyperesolver.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import { toPascalCase } from 'codemaker';
 import { DotNetDependency } from './filegenerator';

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { CodeMaker } from 'codemaker';
 import { Assembly } from '@jsii/spec';
 import * as path from 'path';

--- a/packages/jsii-pacmak/lib/targets/dotnet/nameutils.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/nameutils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import { toCamelCase } from 'codemaker';
 

--- a/packages/jsii-pacmak/lib/targets/index.ts
+++ b/packages/jsii-pacmak/lib/targets/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { OneByOneBuilder, TargetBuilder, BuildOptions } from '../builder';
 
 import { DotnetBuilder } from './dotnet';

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as clone from 'clone';
 import { toPascalCase, toSnakeCase } from 'codemaker/lib/case-utils';
 import * as fs from 'fs-extra';

--- a/packages/jsii-pacmak/lib/targets/js.ts
+++ b/packages/jsii-pacmak/lib/targets/js.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import { Generator } from '../generator';
 import { PackageInfo, Target } from '../target';

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { CodeMaker, toSnakeCase } from 'codemaker';
 import * as escapeStringRegexp from 'escape-string-regexp';
 import * as fs from 'fs-extra';

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   Assembly,
   OptionalValue,

--- a/packages/jsii-pacmak/lib/targets/python/util.ts
+++ b/packages/jsii-pacmak/lib/targets/python/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 const PYTHON_KEYWORDS = new Set([
   'False',
   'None',

--- a/packages/jsii-pacmak/lib/targets/version-utils.ts
+++ b/packages/jsii-pacmak/lib/targets/version-utils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Comparator, Range } from 'semver';
 
 /**

--- a/packages/jsii-pacmak/lib/timer.ts
+++ b/packages/jsii-pacmak/lib/timer.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * A single timer
  */

--- a/packages/jsii-pacmak/lib/toposort.ts
+++ b/packages/jsii-pacmak/lib/toposort.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export type KeyFunc<T> = (x: T) => string;
 export type DepFunc<T> = (x: T) => string[];
 

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';

--- a/packages/jsii-pacmak/test/npm-modules.test.ts
+++ b/packages/jsii-pacmak/test/npm-modules.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as mockfs from 'mock-fs';
 import { findJsiiModules } from '../lib/npm-modules';
 

--- a/packages/jsii-pacmak/test/python.test.ts
+++ b/packages/jsii-pacmak/test/python.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { md2rst } from '../lib/markdown';
 
 test('code to literal blocks', () => {

--- a/packages/jsii-pacmak/test/targets/python/type-name.test.ts
+++ b/packages/jsii-pacmak/test/targets/python/type-name.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   Assembly,
   SchemaVersion,

--- a/packages/jsii-pacmak/test/targets/version-utils.test.ts
+++ b/packages/jsii-pacmak/test/targets/version-utils.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   toMavenVersionRange,
   toNuGetVersionRange,

--- a/packages/jsii-reflect/bin/jsii-tree.ts
+++ b/packages/jsii-reflect/bin/jsii-tree.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as colors from 'colors/safe';
 import * as yargs from 'yargs';
 import { TypeSystem, TypeSystemTree } from '../lib';

--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { ClassType } from './class';
 import { Dependency } from './dependency';

--- a/packages/jsii-reflect/lib/callable.ts
+++ b/packages/jsii-reflect/lib/callable.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';

--- a/packages/jsii-reflect/lib/class.ts
+++ b/packages/jsii-reflect/lib/class.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Initializer } from './initializer';

--- a/packages/jsii-reflect/lib/dependency.ts
+++ b/packages/jsii-reflect/lib/dependency.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { TypeSystem } from './type-system';
 
 export class Dependency {

--- a/packages/jsii-reflect/lib/docs.ts
+++ b/packages/jsii-reflect/lib/docs.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Stability } from '@jsii/spec';
 import { TypeSystem } from './type-system';

--- a/packages/jsii-reflect/lib/enum.ts
+++ b/packages/jsii-reflect/lib/enum.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';

--- a/packages/jsii-reflect/lib/index.ts
+++ b/packages/jsii-reflect/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './assembly';
 export * from './class';
 export * from './callable';

--- a/packages/jsii-reflect/lib/initializer.ts
+++ b/packages/jsii-reflect/lib/initializer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Callable } from './callable';
 import { Documentable } from './docs';
 import { Overridable } from './overridable';

--- a/packages/jsii-reflect/lib/interface.ts
+++ b/packages/jsii-reflect/lib/interface.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Method } from './method';

--- a/packages/jsii-reflect/lib/method.ts
+++ b/packages/jsii-reflect/lib/method.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Callable } from './callable';

--- a/packages/jsii-reflect/lib/module-like.ts
+++ b/packages/jsii-reflect/lib/module-like.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { ClassType } from './class';
 import { EnumType } from './enum';
 import { InterfaceType } from './interface';

--- a/packages/jsii-reflect/lib/optional-value.ts
+++ b/packages/jsii-reflect/lib/optional-value.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { TypeReference } from './type-ref';
 import { TypeSystem } from './type-system';

--- a/packages/jsii-reflect/lib/overridable.ts
+++ b/packages/jsii-reflect/lib/overridable.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Type } from './type';
 
 export interface Overridable {

--- a/packages/jsii-reflect/lib/parameter.ts
+++ b/packages/jsii-reflect/lib/parameter.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Callable } from './callable';
 import { Docs, Documentable } from './docs';

--- a/packages/jsii-reflect/lib/property.ts
+++ b/packages/jsii-reflect/lib/property.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { Docs, Documentable } from './docs';

--- a/packages/jsii-reflect/lib/reference-type.ts
+++ b/packages/jsii-reflect/lib/reference-type.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { InterfaceType } from './interface';

--- a/packages/jsii-reflect/lib/source.ts
+++ b/packages/jsii-reflect/lib/source.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Assembly } from './assembly';
 
 /**

--- a/packages/jsii-reflect/lib/submodule.ts
+++ b/packages/jsii-reflect/lib/submodule.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { ModuleLike } from './module-like';
 import { Type } from './type';
 import { TypeSystem } from './type-system';

--- a/packages/jsii-reflect/lib/tree.ts
+++ b/packages/jsii-reflect/lib/tree.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as colors from 'colors/safe';
 import { Stability } from '@jsii/spec';
 import { AsciiTree } from 'oo-ascii-tree';

--- a/packages/jsii-reflect/lib/type-member.ts
+++ b/packages/jsii-reflect/lib/type-member.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { Documentable } from './docs';
 import { Initializer } from './initializer';
 import { Method } from './method';

--- a/packages/jsii-reflect/lib/type-ref.ts
+++ b/packages/jsii-reflect/lib/type-ref.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Type } from './type';
 import { TypeSystem } from './type-system';

--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
 import * as jsii from '@jsii/spec';
 import * as path from 'path';

--- a/packages/jsii-reflect/lib/type.ts
+++ b/packages/jsii-reflect/lib/type.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as jsii from '@jsii/spec';
 import { Assembly } from './assembly';
 import { ClassType } from './class';

--- a/packages/jsii-reflect/lib/util.ts
+++ b/packages/jsii-reflect/lib/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export function indexBy<T>(xs: T[], f: (x: T) => string): { [key: string]: T } {
   const ret: { [key: string]: T } = {};
   for (const x of xs) {

--- a/packages/jsii-reflect/test/independent.test.ts
+++ b/packages/jsii-reflect/test/independent.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { PackageInfo, sourceToAssemblyHelper } from 'jsii';
 import * as reflect from '../lib';
 

--- a/packages/jsii-reflect/test/jsii-tree.test.ts
+++ b/packages/jsii-reflect/test/jsii-tree.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import { promisify } from 'util';

--- a/packages/jsii-reflect/test/type-system.test.ts
+++ b/packages/jsii-reflect/test/type-system.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import { Stability } from '@jsii/spec';
 import * as path from 'path';

--- a/packages/jsii-reflect/test/util.ts
+++ b/packages/jsii-reflect/test/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { sourceToAssemblyHelper } from 'jsii/lib/helpers';
 import { Assembly, TypeSystem } from '../lib';
 

--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as yargs from 'yargs';
 import {

--- a/packages/jsii-rosetta/lib/commands/convert.ts
+++ b/packages/jsii-rosetta/lib/commands/convert.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { AstHandler, AstRendererOptions } from '../renderer';
 import { TranslateResult, Translator } from '../translate';
 import { MarkdownRenderer } from '../markdown/markdown-renderer';

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { loadAssemblies, allTypeScriptSnippets } from '../jsii/assemblies';
 import * as logging from '../logging';
 import * as os from 'os';

--- a/packages/jsii-rosetta/lib/commands/extract_worker.ts
+++ b/packages/jsii-rosetta/lib/commands/extract_worker.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Pool worker for extract.ts
  */

--- a/packages/jsii-rosetta/lib/commands/read.ts
+++ b/packages/jsii-rosetta/lib/commands/read.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   LanguageTablet,
   TranslatedSnippet,

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { TypeScriptSnippet, SnippetParameters } from './snippet';

--- a/packages/jsii-rosetta/lib/index.ts
+++ b/packages/jsii-rosetta/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './translate';
 export { renderTree } from './o-tree';
 export { JavaVisitor } from './languages/java';

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as path from 'path';

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer } from '../renderer';
 import { typeContainsUndefined } from '../typescript/types';

--- a/packages/jsii-rosetta/lib/jsii/packages.ts
+++ b/packages/jsii-rosetta/lib/jsii/packages.ts
@@ -1,4 +1,7 @@
-/**
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
  * Resolve a package name in an example to a JSII assembly
  *
  * We assume we've changed directory to the directory where we need to resolve from.

--- a/packages/jsii-rosetta/lib/languages/csharp.ts
+++ b/packages/jsii-rosetta/lib/languages/csharp.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { DefaultVisitor } from './default';
 import { AstRenderer, nimpl } from '../renderer';

--- a/packages/jsii-rosetta/lib/languages/default.ts
+++ b/packages/jsii-rosetta/lib/languages/default.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer, AstHandler, nimpl, CommentSyntax } from '../renderer';
 import { OTree, NO_SYNTAX } from '../o-tree';

--- a/packages/jsii-rosetta/lib/languages/index.ts
+++ b/packages/jsii-rosetta/lib/languages/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { PythonVisitor } from './python';
 import { AstHandler } from '../renderer';
 import { CSharpVisitor } from './csharp';

--- a/packages/jsii-rosetta/lib/languages/java.ts
+++ b/packages/jsii-rosetta/lib/languages/java.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { DefaultVisitor } from './default';
 import { AstRenderer } from '../renderer';

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer, nimpl, CommentSyntax } from '../renderer';
 import {

--- a/packages/jsii-rosetta/lib/languages/visualize.ts
+++ b/packages/jsii-rosetta/lib/languages/visualize.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer, AstHandler, nimpl, CommentSyntax } from '../renderer';
 import { OTree } from '../o-tree';

--- a/packages/jsii-rosetta/lib/logging.ts
+++ b/packages/jsii-rosetta/lib/logging.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as util from 'util';
 
 export enum Level {

--- a/packages/jsii-rosetta/lib/markdown/escapes.ts
+++ b/packages/jsii-rosetta/lib/markdown/escapes.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export interface Escaper {
   /**
    * Escape for use in XML/HTML text

--- a/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
+++ b/packages/jsii-rosetta/lib/markdown/extract-snippets.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import { visitCommonMarkTree } from '../markdown/markdown';
 import { TypeScriptSnippet } from '../snippet';

--- a/packages/jsii-rosetta/lib/markdown/index.ts
+++ b/packages/jsii-rosetta/lib/markdown/index.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { transformMarkdown } from './markdown';
 import { JavaDocRenderer } from './javadoc-renderer';
 import { CSharpXmlCommentRenderer } from './xml-comment-renderer';

--- a/packages/jsii-rosetta/lib/markdown/javadoc-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/javadoc-renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import { RendererContext } from './markdown';
 import {

--- a/packages/jsii-rosetta/lib/markdown/markdown-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/markdown-renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import {
   cmNodeChildren,

--- a/packages/jsii-rosetta/lib/markdown/markdown.ts
+++ b/packages/jsii-rosetta/lib/markdown/markdown.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 
 export function transformMarkdown(

--- a/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-code-renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import { CommonMarkVisitor } from './markdown';
 import { CodeBlock } from './types';

--- a/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { ReplaceCodeTransform } from './replace-code-renderer';
 import {
   TypeScriptSnippet,

--- a/packages/jsii-rosetta/lib/markdown/structure-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/structure-renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import { CommonMarkRenderer, prefixLines, RendererContext } from './markdown';
 

--- a/packages/jsii-rosetta/lib/markdown/types.ts
+++ b/packages/jsii-rosetta/lib/markdown/types.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export interface CodeBlock {
   source: string;
   language: string;

--- a/packages/jsii-rosetta/lib/markdown/xml-comment-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/xml-comment-renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as cm from 'commonmark';
 import { prefixLines, RendererContext } from './markdown';
 import { MarkdownRenderer, para, stripPara } from './markdown-renderer';

--- a/packages/jsii-rosetta/lib/o-tree.ts
+++ b/packages/jsii-rosetta/lib/o-tree.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export interface OTreeOptions {
   /**
    * Adjust indentation with the given number

--- a/packages/jsii-rosetta/lib/renderer.ts
+++ b/packages/jsii-rosetta/lib/renderer.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { NO_SYNTAX, OTree, UnknownSyntax, Span } from './o-tree';
 import {

--- a/packages/jsii-rosetta/lib/rosetta.ts
+++ b/packages/jsii-rosetta/lib/rosetta.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as spec from '@jsii/spec';

--- a/packages/jsii-rosetta/lib/snippet.ts
+++ b/packages/jsii-rosetta/lib/snippet.ts
@@ -1,4 +1,7 @@
-/**
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
  * A piece of TypeScript code found in an assembly, ready to be translated
  */
 export interface TypeScriptSnippet {

--- a/packages/jsii-rosetta/lib/tablets/key.ts
+++ b/packages/jsii-rosetta/lib/tablets/key.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as crypto from 'crypto';
 import { TypeScriptSnippet } from '../snippet';
 

--- a/packages/jsii-rosetta/lib/tablets/schema.ts
+++ b/packages/jsii-rosetta/lib/tablets/schema.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Tablet file schema
  */

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import {
   TabletSchema,

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as logging from './logging';
 import * as ts from 'typescript';
 import { AstRenderer, AstHandler, AstRendererOptions } from './renderer';

--- a/packages/jsii-rosetta/lib/typescript/ast-utils.ts
+++ b/packages/jsii-rosetta/lib/typescript/ast-utils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { Span } from '../o-tree';
 import { AstRenderer } from '../renderer';

--- a/packages/jsii-rosetta/lib/typescript/imports.ts
+++ b/packages/jsii-rosetta/lib/typescript/imports.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer } from '../renderer';
 import {

--- a/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
+++ b/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 
 export class TypeScriptCompiler {

--- a/packages/jsii-rosetta/lib/typescript/types.ts
+++ b/packages/jsii-rosetta/lib/typescript/types.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 import { AstRenderer } from '../renderer';
 

--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 
 export function startsWithUppercase(x: string): boolean {

--- a/packages/jsii-rosetta/test/jsii/assemblies.test.ts
+++ b/packages/jsii-rosetta/test/jsii/assemblies.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as mockfs from 'mock-fs';
 import * as spec from '@jsii/spec';
 import { allTypeScriptSnippets } from '../../lib/jsii/assemblies';

--- a/packages/jsii-rosetta/test/jsii/astutils.test.ts
+++ b/packages/jsii-rosetta/test/jsii/astutils.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { calculateVisibleSpans } from '../../lib/typescript/ast-utils';
 
 test('full text visible by default', () => {

--- a/packages/jsii-rosetta/test/markdown/javadoc.test.ts
+++ b/packages/jsii-rosetta/test/markdown/javadoc.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { markDownToStructure, markDownToJavaDoc } from '../../lib';
 
 const DEBUG = false;

--- a/packages/jsii-rosetta/test/markdown/roundtrip.test.ts
+++ b/packages/jsii-rosetta/test/markdown/roundtrip.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { transformMarkdown } from '../../lib/markdown/markdown';
 import { MarkdownRenderer } from '../../lib/markdown/markdown-renderer';
 import { StructureRenderer } from '../../lib/markdown/structure-renderer';

--- a/packages/jsii-rosetta/test/markdown/xmldoccomments.test.ts
+++ b/packages/jsii-rosetta/test/markdown/xmldoccomments.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { markDownToStructure, markDownToXmlDoc } from '../../lib';
 
 const DEBUG = false;

--- a/packages/jsii-rosetta/test/otree.test.ts
+++ b/packages/jsii-rosetta/test/otree.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { OTree, renderTree } from '../lib/o-tree';
 
 test('test indentation', () => {

--- a/packages/jsii-rosetta/test/rosetta.test.ts
+++ b/packages/jsii-rosetta/test/rosetta.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   Rosetta,
   LanguageTablet,

--- a/packages/jsii-rosetta/test/translations.test.ts
+++ b/packages/jsii-rosetta/test/translations.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { JavaVisitor, PythonVisitor, SnippetTranslator } from '../lib';

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as log4js from 'log4js';
 import * as path from 'path';
 import * as process from 'process';

--- a/packages/jsii/generate.sh
+++ b/packages/jsii/generate.sh
@@ -10,6 +10,9 @@ if [ -z "${commit}" ]; then
 fi
 
 cat > lib/version.ts <<HERE
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 // Generated at $(date -u +"%Y-%m-%dT%H:%M:%SZ") by generate.sh
 
 /** The short version number for this JSII compiler (e.g: \`X.Y.Z\`) */

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as Case from 'case';
 import * as colors from 'colors/safe';
 import * as crypto from 'crypto';

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as Case from 'case';
 import * as colors from 'colors/safe';
 import * as fs from 'fs-extra';

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Doc Comment parsing
  *

--- a/packages/jsii/lib/emitter.ts
+++ b/packages/jsii/lib/emitter.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as ts from 'typescript';
 
 /**

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Helper routines for use with the jsii compiler
  *

--- a/packages/jsii/lib/index.ts
+++ b/packages/jsii/lib/index.ts
@@ -1,1 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './helpers';

--- a/packages/jsii/lib/literate.ts
+++ b/packages/jsii/lib/literate.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * A tiny module to include annotated (working!) code snippets into the documentation
  *

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';
 import * as log4js from 'log4js';

--- a/packages/jsii/lib/reserved-words.ts
+++ b/packages/jsii/lib/reserved-words.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export function isReservedName(name: string): string[] | undefined {
   const reserved = new Array<string>();
   if (CSHARP_RESERVED.has(name)) {

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as log4js from 'log4js';
 import * as ts from 'typescript';
 

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as Case from 'case';
 import * as spec from '@jsii/spec';
 import * as ts from 'typescript';

--- a/packages/jsii/lib/warnings.ts
+++ b/packages/jsii/lib/warnings.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Indicates which warnings are currently enabled. By default all warnings are
  * enabled, and can be silenced through the --silence-warning option.

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { mkdtemp, remove, writeFile, readFile } from 'fs-extra';
 import { tmpdir } from 'os';
 import { join } from 'path';

--- a/packages/jsii/test/docs.test.ts
+++ b/packages/jsii/test/docs.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as spec from '@jsii/spec';
 import { Stability } from '@jsii/spec';
 import { sourceToAssemblyHelper as compile } from '../lib';

--- a/packages/jsii/test/enums.test.ts
+++ b/packages/jsii/test/enums.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { sourceToAssemblyHelper } from '../lib';
 
 // ----------------------------------------------------------------------

--- a/packages/jsii/test/literate.test.ts
+++ b/packages/jsii/test/literate.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import {
   includeAndRenderExamples,
   typescriptSourceToMarkdown,

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as clone from 'clone';
 import * as fs from 'fs-extra';
 import * as spec from '@jsii/spec';

--- a/packages/jsii/test/utils.test.ts
+++ b/packages/jsii/test/utils.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import { parsePerson, parseRepository } from '../lib/utils';
 
 describe('parsePerson', () => {

--- a/packages/oo-ascii-tree/lib/ascii-tree.ts
+++ b/packages/oo-ascii-tree/lib/ascii-tree.ts
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * A tree of nodes that can be ASCII visualized.
  */

--- a/packages/oo-ascii-tree/lib/index.ts
+++ b/packages/oo-ascii-tree/lib/index.ts
@@ -1,1 +1,3 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 export * from './ascii-tree';

--- a/packages/oo-ascii-tree/test/tree.test.ts
+++ b/packages/oo-ascii-tree/test/tree.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,6 +3775,11 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-header@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz#0e048b5f0adfdd9754142d59d551ae6bfdaf90ad"
+  integrity sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==
+
 eslint-plugin-import@^2.21.2:
   version "2.21.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
@@ -3793,6 +3798,13 @@ eslint-plugin-import@^2.21.2:
     read-pkg-up "^2.0.0"
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
+
+eslint-plugin-prettier@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
+  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-prettier@^3.1.4:
   version "3.1.4"


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
