### PR TITLE
fix(kernel): tarball unpacking does not behave like 'npm install'

### DIFF
--- a/packages/@jsii/kernel/lib/kernel.ts
+++ b/packages/@jsii/kernel/lib/kernel.ts
@@ -109,7 +109,7 @@ export class Kernel {
     fs.mkdirpSync(packageDir);
 
     // Force umask to have npm-install-like permissions
-    const umask = process.umask(0o022);
+    const originalUmask = process.umask(0o022);
     try {
       // untar the archive to its final location
       tar.extract({
@@ -122,7 +122,7 @@ export class Kernel {
       });
     } finally {
       // Reset umask to the initial value
-      process.umask(umask);
+      process.umask(originalUmask);
     }
 
     // read .jsii metadata from the root of the package

--- a/packages/@jsii/kernel/lib/kernel.ts
+++ b/packages/@jsii/kernel/lib/kernel.ts
@@ -107,14 +107,23 @@ export class Kernel {
 
     // Create the install directory (there may be several path components for @scoped/packages)
     fs.mkdirpSync(packageDir);
-    // untar the archive to its final location
-    tar.extract({
-      strict: true,
-      file: req.tarball,
-      cwd: packageDir,
-      strip: 1, // Removes the 'package/' path element from entries
-      sync: true,
-    });
+
+    // Force umask to have npm-install-like permissions
+    const umask = process.umask(0o022);
+    try {
+      // untar the archive to its final location
+      tar.extract({
+        cwd: packageDir,
+        file: req.tarball,
+        strict: true,
+        strip: 1, // Removes the 'package/' path element from entries
+        sync: true,
+        unlink: true,
+      });
+    } finally {
+      // Reset umask to the initial value
+      process.umask(umask);
+    }
 
     // read .jsii metadata from the root of the package
     const jsiiMetadataFile = path.join(packageDir, spec.SPEC_FILE_NAME);

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -75,6 +75,28 @@ defineTest.skip = function (
   return defineTest(name, method, test.skip);
 };
 
+test('load preserves file permissions', async () => {
+  // Changing the umask to 077 (which would neutralize group/other permissions)
+  const originalUmask = process.umask(0o077);
+
+  try {
+    const kernel = await createCalculatorSandbox(
+      'load_preserves_file_permissions',
+    );
+
+    const result = kernel.sinvoke({
+      fqn: 'jsii-calc.UmaskCheck',
+      method: 'mode',
+    });
+    expect(result.result).toBe(0o644);
+
+    return closeRecording(kernel);
+  } finally {
+    // Restore the original umask
+    process.umask(originalUmask);
+  }
+});
+
 defineTest('stats() return sandbox statistics', (sandbox) => {
   const stats = sandbox.stats({});
   expect(stats.objectCount).toBe(0);

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -2502,3 +2502,20 @@ export abstract class Isomorphism {
         return this;
     }
 }
+
+/**
+ * Checks the current file permissions are cool (no funky UMASK down-scoping happened)
+ *
+ * @see https://github.com/aws/jsii/issues/1765
+ */
+export class UmaskCheck {
+    /**
+     * This should return 0o644 (-rw-r--r--)
+     */
+    public static mode(): number {
+        // The bit-masking is to remove the file type information from .mode
+        return fs.statSync(__filename).mode & 0o0777;
+    }
+
+    private constructor() {}
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -11869,6 +11869,40 @@
         }
       ]
     },
+    "jsii-calc.UmaskCheck": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "see": "https://github.com/aws/jsii/issues/1765",
+        "stability": "experimental",
+        "summary": "Checks the current file permissions are cool (no funky UMASK down-scoping happened)."
+      },
+      "fqn": "jsii-calc.UmaskCheck",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2511
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "This should return 0o644 (-rw-r--r--)."
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2515
+          },
+          "name": "mode",
+          "returns": {
+            "type": {
+              "primitive": "number"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "UmaskCheck"
+    },
     "jsii-calc.UnaryOperation": {
       "abstract": true,
       "assembly": "jsii-calc",
@@ -13162,5 +13196,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "miVjqwWxNOLMY7fR23c/SVvfiGqkgqLgG+18qp4f8MM="
+  "fingerprint": "/0S7DMfFaE1kfja4CpY5k0Gl6j6opo50SUPCiBgy3Zg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/.jsii
@@ -11869,6 +11869,40 @@
         }
       ]
     },
+    "jsii-calc.UmaskCheck": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "see": "https://github.com/aws/jsii/issues/1765",
+        "stability": "experimental",
+        "summary": "Checks the current file permissions are cool (no funky UMASK down-scoping happened)."
+      },
+      "fqn": "jsii-calc.UmaskCheck",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 2511
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "This should return 0o644 (-rw-r--r--)."
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 2515
+          },
+          "name": "mode",
+          "returns": {
+            "type": {
+              "primitive": "number"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "UmaskCheck"
+    },
     "jsii-calc.UnaryOperation": {
       "abstract": true,
       "assembly": "jsii-calc",
@@ -13162,5 +13196,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "miVjqwWxNOLMY7fR23c/SVvfiGqkgqLgG+18qp4f8MM="
+  "fingerprint": "/0S7DMfFaE1kfja4CpY5k0Gl6j6opo50SUPCiBgy3Zg="
 }

--- a/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UmaskCheck.cs
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/UmaskCheck.cs
@@ -1,0 +1,40 @@
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Checks the current file permissions are cool (no funky UMASK down-scoping happened).</summary>
+    /// <remarks>
+    /// <strong>Stability</strong>: Experimental
+    /// 
+    /// <strong>See</strong>: https://github.com/aws/jsii/issues/1765
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UmaskCheck), fullyQualifiedName: "jsii-calc.UmaskCheck")]
+    public class UmaskCheck : DeputyBase
+    {
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected UmaskCheck(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected UmaskCheck(DeputyProps props): base(props)
+        {
+        }
+
+        /// <summary>This should return 0o644 (-rw-r--r--).</summary>
+        /// <remarks>
+        /// <strong>Stability</strong>: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "mode", returnsJson: "{\"type\":{\"primitive\":\"number\"}}")]
+        public static double Mode()
+        {
+            return InvokeStaticMethod<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.UmaskCheck), new System.Type[]{}, new object[]{});
+        }
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UmaskCheck.java
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/java/software/amazon/jsii/tests/calculator/UmaskCheck.java
@@ -1,0 +1,32 @@
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Checks the current file permissions are cool (no funky UMASK down-scoping happened).
+ * <p>
+ * EXPERIMENTAL
+ * <p>
+ * @see https://github.com/aws/jsii/issues/1765
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.UmaskCheck")
+public class UmaskCheck extends software.amazon.jsii.JsiiObject {
+
+    protected UmaskCheck(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected UmaskCheck(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * This should return 0o644 (-rw-r--r--).
+     * <p>
+     * EXPERIMENTAL
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public static @org.jetbrains.annotations.NotNull java.lang.Number mode() {
+        return software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.UmaskCheck.class, "mode", java.lang.Number.class);
+    }
+}

--- a/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/resources/software/amazon/jsii/tests/calculator/$Module.txt
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/java/src/main/resources/software/amazon/jsii/tests/calculator/$Module.txt
@@ -184,6 +184,7 @@ jsii-calc.SupportsNiceJavaBuilderWithRequiredProps=software.amazon.jsii.tests.ca
 jsii-calc.SyncVirtualMethods=software.amazon.jsii.tests.calculator.SyncVirtualMethods
 jsii-calc.Thrower=software.amazon.jsii.tests.calculator.Thrower
 jsii-calc.TopLevelStruct=software.amazon.jsii.tests.calculator.TopLevelStruct
+jsii-calc.UmaskCheck=software.amazon.jsii.tests.calculator.UmaskCheck
 jsii-calc.UnaryOperation=software.amazon.jsii.tests.calculator.UnaryOperation
 jsii-calc.UnionProperties=software.amazon.jsii.tests.calculator.UnionProperties
 jsii-calc.UpcasingReflectable=software.amazon.jsii.tests.calculator.UpcasingReflectable

--- a/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
+++ b/packages/jsii-pacmak/test/expected.jsii-calc/python/src/jsii_calc/__init__.py
@@ -8452,6 +8452,26 @@ class TopLevelStruct:
         )
 
 
+class UmaskCheck(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UmaskCheck"):
+    """Checks the current file permissions are cool (no funky UMASK down-scoping happened).
+
+    see
+    :see: https://github.com/aws/jsii/issues/1765
+    stability
+    :stability: experimental
+    """
+
+    @jsii.member(jsii_name="mode")
+    @builtins.classmethod
+    def mode(cls) -> jsii.Number:
+        """This should return 0o644 (-rw-r--r--).
+
+        stability
+        :stability: experimental
+        """
+        return jsii.sinvoke(cls, "mode", [])
+
+
 class UnaryOperation(
     scope.jsii_calc_lib.Operation,
     metaclass=jsii.JSIIAbstractClass,
@@ -9794,6 +9814,7 @@ __all__ = [
     "SyncVirtualMethods",
     "Thrower",
     "TopLevelStruct",
+    "UmaskCheck",
     "UnaryOperation",
     "UnionProperties",
     "UpcasingReflectable",

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1739,6 +1739,11 @@ exports[`jsii-tree --all 1`] = `
  │   │   ├── <initializer>() initializer (experimental)
  │   │   └─┬ throwError() method (experimental)
  │   │     └── returns: void
+ │   ├─┬ class UmaskCheck (experimental)
+ │   │ └─┬ members
+ │   │   └─┬ static mode() method (experimental)
+ │   │     ├── static
+ │   │     └── returns: number
  │   ├─┬ class UnaryOperation (experimental)
  │   │ ├── base: Operation
  │   │ └─┬ members
@@ -2799,6 +2804,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class SupportsNiceJavaBuilderWithRequiredProps
  │   ├── class SyncVirtualMethods
  │   ├── class Thrower
+ │   ├── class UmaskCheck
  │   ├─┬ class UnaryOperation
  │   │ └── base: Operation
  │   ├─┬ class UpcasingReflectable
@@ -3731,6 +3737,9 @@ exports[`jsii-tree --members 1`] = `
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
  │   │   └── throwError() method
+ │   ├─┬ class UmaskCheck
+ │   │ └─┬ members
+ │   │   └── static mode() method
  │   ├─┬ class UnaryOperation
  │   │ └─┬ members
  │   │   ├── <initializer>(operand) initializer
@@ -4301,6 +4310,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class SupportsNiceJavaBuilderWithRequiredProps
  │   ├── class SyncVirtualMethods
  │   ├── class Thrower
+ │   ├── class UmaskCheck
  │   ├── class UnaryOperation
  │   ├── class UpcasingReflectable
  │   ├── class UseBundledDependency

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -125,6 +125,7 @@ Array [
   "jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
   "jsii-calc.SyncVirtualMethods",
   "jsii-calc.Thrower",
+  "jsii-calc.UmaskCheck",
   "jsii-calc.UnaryOperation",
   "jsii-calc.UpcasingReflectable",
   "jsii-calc.UseBundledDependency",


### PR DESCRIPTION
In it's wisdom, `npm install` does override the process' `umask` to
`0o022` before unpackging the tarball, to ensure the produced install
has the kind of permissions that one would expect, regardless of the
system-configured `umask`.

Because `@jsii/kernel` did not reproduce this behavior, loaded libraries
could be unpacked with unexpectedly tight permissions, leading to weird
issues when those files were used in contexts that required those
permissions. For example, this is the cause of aws/aws-cdk#8233.

Fixes #1765



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
