### PR TITLE
fix(pacmak): python pack fails when installing 'black' via pip

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -34,11 +34,6 @@ import { die, toPythonIdentifier } from './python/util';
 const spdxLicenseList = require('spdx-license-list');
 
 export default class Python extends Target {
-  private static readonly BLACK_INSTALL_DIR: string = path.join(
-    os.homedir(),
-    'python-black',
-  );
-
   protected readonly generator: PythonGenerator;
 
   public constructor(options: TargetOptions) {
@@ -81,26 +76,31 @@ export default class Python extends Target {
       return 'black';
     }
 
-    const exists = await fs.pathExists(Python.BLACK_INSTALL_DIR);
+    const blackInstallDir = path.join(
+      os.homedir(),
+      '.jsii-cache',
+      'python-black',
+    );
+    const exists = await fs.pathExists(blackInstallDir);
     if (!exists) {
       info(
-        `No existing black installation. Install afresh at ${Python.BLACK_INSTALL_DIR}...`,
+        `No existing black installation. Install afresh at ${blackInstallDir}...`,
       );
-      await fs.mkdir(Python.BLACK_INSTALL_DIR);
+      await fs.mkdirp(blackInstallDir);
       await shell(
         'python3',
-        ['-m', 'venv', path.join(Python.BLACK_INSTALL_DIR, '.env')],
+        ['-m', 'venv', path.join(blackInstallDir, '.env')],
         {
-          cwd: Python.BLACK_INSTALL_DIR,
+          cwd: blackInstallDir,
         },
       );
       await shell(
-        path.join(Python.BLACK_INSTALL_DIR, '.env', 'bin', 'pip'),
+        path.join(blackInstallDir, '.env', 'bin', 'pip'),
         ['install', 'black'],
-        { cwd: Python.BLACK_INSTALL_DIR },
+        { cwd: blackInstallDir },
       );
     }
-    return path.join(Python.BLACK_INSTALL_DIR, '.env', 'bin', 'black');
+    return path.join(blackInstallDir, '.env', 'bin', 'black');
   }
 }
 

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -33,7 +33,7 @@ export function resolveDependencyDirectory(
 export async function shell(
   cmd: string,
   args: string[],
-  options: ShellOptions,
+  options: ShellOptions = {},
 ): Promise<string> {
   // eslint-disable-next-line @typescript-eslint/require-await
   async function spawn1() {

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -30,7 +30,7 @@
     "watch": "tsc --build -w",
     "lint": "eslint . --ext .js,.ts --ignore-path=.gitignore",
     "lint:fix": "yarn lint --fix",
-    "test": "/bin/bash test/diff-test.sh && /bin/bash test/build-test.sh && jest",
+    "test": "jest && /bin/bash test/diff-test.sh && /bin/bash test/build-test.sh",
     "test:update": "UPDATE_DIFF=1 /bin/bash test/diff-test.sh && /bin/bash test/build-test.sh && jest -u",
     "package": "package-js"
   },

--- a/packages/jsii-pacmak/test/targets/python.test.ts
+++ b/packages/jsii-pacmak/test/targets/python.test.ts
@@ -1,0 +1,51 @@
+import * as util from '../../lib/util';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import Python from '../../lib/targets/python';
+import { Assembly } from 'jsii-reflect';
+import { Rosetta } from 'jsii-rosetta';
+
+describe('python', () => {
+  describe('blackPath', () => {
+    const shellMock = jest.fn();
+    const osMock = jest.fn();
+    let tmpdir: string;
+
+    beforeEach(async () => {
+      // eslint-disable-next-line no-import-assign
+      Object.defineProperty(util, 'shell', { value: shellMock });
+      // eslint-disable-next-line no-import-assign
+      Object.defineProperty(os, 'homedir', { value: osMock });
+      tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'jsii-pacmak-black-'));
+      osMock.mockImplementation(() => tmpdir);
+    });
+
+    afterEach(async () => {
+      shellMock.mockClear();
+      osMock.mockClear();
+      await fs.remove(tmpdir);
+    });
+
+    test('black is installed globally', async () => {
+      shellMock.mockImplementation((cmd: string, args: string[], _) => {
+        return new Promise((ok, ko) => {
+          if (cmd === 'which' && args[0] === 'black') {
+            ok('/path/to/black');
+          }
+          ko(`Unexpected call to shell ${cmd} ${args}`);
+        });
+      });
+
+      const python = new Python({
+        targetName: 'python',
+        packageDir: '/dir',
+        assembly: {} as Assembly,
+        rosetta: new Rosetta(),
+        arguments: {},
+      });
+      const path = await (python as any).blackPath();
+      expect(path).toBe('black');
+    });
+  });
+});

--- a/packages/jsii-pacmak/test/targets/python.test.ts
+++ b/packages/jsii-pacmak/test/targets/python.test.ts
@@ -9,43 +9,100 @@ import { Rosetta } from 'jsii-rosetta';
 describe('python', () => {
   describe('blackPath', () => {
     const shellMock = jest.fn();
-    const osMock = jest.fn();
-    let tmpdir: string;
+    const homedirMock = jest.fn();
+    let homedir: string;
+    let python: Python;
 
     beforeEach(async () => {
       // eslint-disable-next-line no-import-assign
       Object.defineProperty(util, 'shell', { value: shellMock });
       // eslint-disable-next-line no-import-assign
-      Object.defineProperty(os, 'homedir', { value: osMock });
-      tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'jsii-pacmak-black-'));
-      osMock.mockImplementation(() => tmpdir);
-    });
-
-    afterEach(async () => {
-      shellMock.mockClear();
-      osMock.mockClear();
-      await fs.remove(tmpdir);
-    });
-
-    test('black is installed globally', async () => {
-      shellMock.mockImplementation((cmd: string, args: string[], _) => {
-        return new Promise((ok, ko) => {
-          if (cmd === 'which' && args[0] === 'black') {
-            ok('/path/to/black');
-          }
-          ko(`Unexpected call to shell ${cmd} ${args}`);
-        });
-      });
-
-      const python = new Python({
+      Object.defineProperty(os, 'homedir', { value: homedirMock });
+      homedir = await fs.mkdtemp(path.join(os.tmpdir(), 'jsii-pacmak-black-'));
+      homedirMock.mockImplementation(() => homedir);
+      python = new Python({
         targetName: 'python',
         packageDir: '/dir',
         assembly: {} as Assembly,
         rosetta: new Rosetta(),
         arguments: {},
       });
-      const path = await (python as any).blackPath();
+    });
+
+    afterEach(async () => {
+      shellMock.mockClear();
+      homedirMock.mockClear();
+      await fs.remove(homedir);
+    });
+
+    test('black is installed globally', async () => {
+      let badShellCommand: string | undefined;
+      shellMock.mockImplementation((cmd: string, args: string[], _) => {
+        return new Promise((ok, ko) => {
+          if (cmd === 'which' && args[0] === 'black') {
+            ok('/path/to/black');
+          } else {
+            badShellCommand = `Unexpected call to shell [${cmd} ${args}]`;
+            ko(badShellCommand);
+          }
+        });
+      });
+
+      const path = await (python as any).blackPath(); // call private method blackPath()
+      expect(badShellCommand).toBeUndefined();
       expect(path).toBe('black');
+    });
+
+    test('black is installed if not found globally', async () => {
+      shellMock.mockImplementation((cmd: string, args: string[], _) => {
+        return new Promise((ok, ko) => {
+          if (cmd === 'which' && args[0] === 'black') {
+            ko('black not found');
+          } else if (
+            /pip.?$/.test(cmd) &&
+            args[0] === 'show' &&
+            args[1] === 'black'
+          ) {
+            ko();
+          } else {
+            ok();
+          }
+        });
+      });
+
+      const path = await (python as any).blackPath(); // call private method blackPath()
+      expect(path).toBe(`${homedir}/.jsii-cache/python-black/.env/bin/black`);
+    });
+
+    test('local cache is reused', async () => {
+      let installCount = 0;
+      shellMock.mockImplementation((cmd: string, args: string[], _) => {
+        return new Promise((ok, ko) => {
+          if (cmd === 'which' && args[0] === 'black') {
+            ko('black not found');
+          } else if (
+            /pip.?$/.test(cmd) &&
+            args[0] === 'show' &&
+            args[1] === 'black'
+          ) {
+            ko();
+          } else if (
+            /pip.?$/.test(cmd) &&
+            args[0] === 'install' &&
+            args[1] === 'black'
+          ) {
+            installCount++;
+            ok();
+          } else {
+            ok();
+          }
+        });
+      });
+
+      await (python as any).blackPath();
+      await (python as any).blackPath();
+      await (python as any).blackPath();
+      expect(installCount).toEqual(1);
     });
   });
 });

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -20,7 +20,7 @@ RUN rpm --import "https://packages.microsoft.com/keys/microsoft.asc"            
 
 # Install Python 3
 RUN yum -y install python3 python3-pip                                                                                  \
-  && python3 -m pip install --upgrade pip setuptools wheel twine                                                        \
+  && python3 -m pip install --upgrade pip setuptools wheel twine black                                                  \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install Ruby 2.6+


### PR DESCRIPTION
The failure is because of intermittent unavailability of black or one of
its packages from the PyPI index.

Instead, install back into the environment, i.e., superchain, and use
that.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
