### PR TITLE
chore: add workflow to run "yarn upgrade" periodically

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -1,0 +1,62 @@
+name: Yarn Upgrade
+
+on:
+  schedule:
+    # Every wednesday at 13:37 UTC
+    - cron: 37 13 * * 3
+  workflow_dispatch: {}
+
+jobs:
+  upgrade:
+    name: Yarn Upgrade
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check Out
+        uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@b2.1.0
+        with:
+          node-version: 10
+
+      - name: Locate Yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Restore Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |-
+            ${{ runner.os }}-yarn-
+
+      - name: Run "ncu -u" in root
+        run: npx -p npm-check-updates ncu -u
+
+      # If "ncu -u" changed something... we must first invoke "yarn install"
+      - name: Run "yarn install"
+        run: yarn install
+
+      - name: Run "yarn upgrade"
+        run: yarn upgrade
+
+      - name: Make Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          # Git commit details
+          branch: automation/yarn-upgrade
+          commit-message: |-
+            chore: npm-check-updates && yarn upgrade
+
+            Ran npm-check-updates and yarn upgrade to keep the `yarn.lock` file up-to-date.
+          # Pull Request details
+          title: 'chore: npm-check-updates && yarn upgrade'
+          body: |-
+            Ran npm-check-updates and yarn upgrade to keep the `yarn.lock` file up-to-date.
+          labels: contribution/core,dependencies
+          team-reviewers: aws/aws-cdk-team
+          # Privileged token so automated PR validation happens
+          token: ${{ secrets.AUTO_APPROVE_GITHUB_TOKEN }}
+


### PR DESCRIPTION
This makes sure our lockfile remains up-to-date, including for
transitive dependencies, and reduces the likelihood of receiving a
sevurity notification from GitHub for one of those.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
