### PR TITLE
fix(java): user.xml repository ID was not sanitized

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -300,7 +300,7 @@ export class JavaBuilder implements TargetBuilder {
                 id: profileName,
                 repositories: {
                   repository: localRepos.map((repo) => ({
-                    id: repo,
+                    id: repo.replace(/[\\/:"<>|?*]/g, '$'),
                     url: `file://${repo}`,
                   })),
                 },


### PR DESCRIPTION
It was generated from a path, but the value is not allowed to contain any of
`\`, `/`, `:`, `"`, `<`, `>`, `|`, `?`, `*`



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
