### PR TITLE
fix(jsii): selective exports declarations are ignored

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -750,6 +750,23 @@ export class Assembler implements Emitter {
       return allTypes;
     }
 
+    if (ts.isExportSpecifier(node)) {
+      // This is what happens when one does `export { Symbol } from "./location";`
+      //                   ExportSpecifier:           ~~~~~~
+
+      const resolvedSymbol = this._typeChecker.getExportSpecifierLocalTargetSymbol(
+        node,
+      );
+      if (!resolvedSymbol) {
+        // A grammar error, compilation will already have failed
+        return [];
+      }
+      return this._visitNode(
+        resolvedSymbol.valueDeclaration ?? resolvedSymbol.declarations[0],
+        context,
+      );
+    }
+
     if ((ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) === 0) {
       return [];
     }

--- a/packages/jsii/test/export-specifier.test.ts
+++ b/packages/jsii/test/export-specifier.test.ts
@@ -1,0 +1,16 @@
+import { sourceToAssemblyHelper } from '../lib';
+
+test('export { Foo } from "./foo"', async () => {
+  const assembly = await sourceToAssemblyHelper({
+    'index.ts': 'export { Foo } from "./foo";',
+    'foo.ts': 'export class Foo { private constructor() {} }',
+  });
+
+  expect(assembly.types?.['testpkg.Foo']).toEqual({
+    assembly: 'testpkg',
+    fqn: 'testpkg.Foo',
+    kind: 'class',
+    locationInModule: { filename: 'foo.ts', line: 1 },
+    name: 'Foo',
+  });
+});


### PR DESCRIPTION
When specific symbols are exported from a module using the
*ExportDeclaration* syntax:

```ts
export { Foo } from './foo';
```

Those declarations would not be processed at all, because they lack the
`ts.ModifierFlags.Export` modifier (which is to be expected from a
declaration that **is** an export statement).

Added the necessary code (and a test) to ensure these statements are
correctly detected, and the exported symbols are correctly processed
into the output assembly.

Fixes #1818



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
