### PR TITLE
fix(rosetta): variadic arguments may use kwargs syntax in Python

### DIFF
--- a/packages/jsii-rosetta/lib/renderer.ts
+++ b/packages/jsii-rosetta/lib/renderer.ts
@@ -79,6 +79,26 @@ export class AstRenderer<C> {
     return filterVisible(nodes).map(this.convert.bind(this));
   }
 
+  public convertWithModifier(
+    nodes: readonly ts.Node[],
+    makeContext: (
+      context: this,
+      node: ts.Node,
+      index: number,
+    ) => AstRenderer<C>,
+  ): OTree[] {
+    const vis = assignVisibility(nodes);
+    const result = new Array<OTree>();
+    for (const [idx, { node, visible, maskingVoid }] of vis.entries()) {
+      const renderedNode = visible ? node : maskingVoid;
+      if (renderedNode) {
+        const context = makeContext(this, renderedNode, idx);
+        result.push(context.convert(renderedNode));
+      }
+    }
+    return result;
+  }
+
   /**
    * Convert a set of nodes, but update the context for the last one.
    *

--- a/packages/jsii-rosetta/test/translations/statements/vararg_any_call.cs
+++ b/packages/jsii-rosetta/test/translations/statements/vararg_any_call.cs
@@ -1,0 +1,7 @@
+public void Test(Array _args)
+{
+}
+
+Test(new Struct { Key = "Value", Also = 1337 });
+
+Test(new Struct { Key = "Value" }, new Struct { Also = 1337 });

--- a/packages/jsii-rosetta/test/translations/statements/vararg_any_call.java
+++ b/packages/jsii-rosetta/test/translations/statements/vararg_any_call.java
@@ -1,0 +1,6 @@
+public void test(Array _args) {
+}
+
+test(Map.of("Key", "Value", "also", 1337));
+
+test(Map.of("Key", "Value"), Map.of("also", 1337));

--- a/packages/jsii-rosetta/test/translations/statements/vararg_any_call.py
+++ b/packages/jsii-rosetta/test/translations/statements/vararg_any_call.py
@@ -1,0 +1,6 @@
+def test(_args):
+    pass
+
+test({"Key": "Value", "also": 1337})
+
+test({"Key": "Value"}, {"also": 1337})

--- a/packages/jsii-rosetta/test/translations/statements/vararg_any_call.ts
+++ b/packages/jsii-rosetta/test/translations/statements/vararg_any_call.ts
@@ -1,0 +1,7 @@
+function test(..._args: any[]): void {
+  // ...
+}
+
+test({ Key: 'Value', also: 1337 });
+
+test({ Key: 'Value' }, { also: 1337 });


### PR DESCRIPTION
When processing function calls, the signature of the function was not
considered when it was available, and an object literal used as the
final argument of a variadic call would be rendered as keyword arguments
when this is actually not a correct way to render variadic values.

This change attempts to read the resolved signature of the function
beging called, in order to correctly render variadic values.

Fixes #1821



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
