### PR TITLE
fix(rosetta): OOpsie -- couldn't find root file back on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
           name: release-package
           path: ${{ github.workspace }}/dist/
   test:
-    name: Test (${{ runner.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
+    name: Test (${{ matrix.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,11 @@ on:
 env:
   DOTNET_NOLOGO: true
 
+# This workflows currently has the following jobs:
+# - build                   : Builds the source tree as-is
+#   - test                  : Runs all unit tests against the build result
+# - create-release-package  : Prepares a release package with the "real" version
+
 jobs:
   build:
     name: Build
@@ -75,6 +80,60 @@ jobs:
             !**/.env/**
             !**/node_modules/**
             !**/project/.m2/**
+
+  create-release-package:
+    name: Create Release Package
+    runs-on: ubuntu-latest
+    steps:
+      # Set up all of our standard runtimes
+      - name: Set up .NET 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+      - name: Set up Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Set up Node 12
+        uses: actions/setup-node@v2.1.1
+        with:
+          node-version: '12'
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: 'Linux: Install python3-venv'
+        if: runner.os == 'Linux'
+        run: sudo apt install -y python3-venv
+      - name: 'Windows: Expose python3 command'
+        if: runner.os == 'Windows'
+        shell: bash
+        run: cp ${pythonLocation}/python.exe ${pythonLocation}/python3.exe
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Locate Caches
+        id: cache-locations
+        run: |-
+          # Need to have PIP >= 20.1 for "pip cache dir" to work
+          python3 -m pip install --upgrade pip
+          echo "::set-output name=pip-cache::$(python3 -m pip cache dir)"
+          echo "::set-output name=yarn-cache::$(yarn cache dir)"
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |-
+            ${{ steps.cache-locations.outputs.pip-cache }}
+            ${{ steps.cache-locations.outputs.yarn-cache }}
+            ~/.m2/repository
+            ~/.nuget/packages
+          key: ${{ runner.os }}-node@12-python@3.6-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |-
+            ${{ runner.os }}-node@12-python@3.6-
+            ${{ runner.os }}-node@12-
+            ${{ runner.os }}-
+      # Prepare dependencies and build
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
       # Determine a prerelease version (depending on whether this is a PR or Push event)
       - name: Standard Version (PR)
         if: github.event_name == 'pull_request'
@@ -93,7 +152,7 @@ jobs:
       # Now we'll be preparing a release package (with the "real" version)
       - name: Align Versions
         run: ./scripts/align-version.sh
-      - name: Rebuild
+      - name: Full Build
         run: yarn build
       - name: Package Libraries
         run: yarn package
@@ -102,7 +161,6 @@ jobs:
         with:
           name: release-package
           path: ${{ github.workspace }}/dist/
-
   test:
     name: Test (${{ matrix.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
           name: release-package
           path: ${{ github.workspace }}/dist/
   test:
-    name: Test (${{ matrix.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
+    name: Test (${{ runner.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.6'
-      - name: 'Linux: Install python3-venv'
-        if: runner.os == 'Linux'
+      - name: Install python3-venv
         run: sudo apt install -y python3-venv
-      - name: 'Windows: Expose python3 command'
-        if: runner.os == 'Windows'
-        shell: bash
-        run: cp ${pythonLocation}/python.exe ${pythonLocation}/python3.exe
       - name: Check out
         uses: actions/checkout@v2
       - name: Locate Caches
@@ -102,13 +97,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.6'
-      - name: 'Linux: Install python3-venv'
-        if: runner.os == 'Linux'
+      - name: Install python3-venv
         run: sudo apt install -y python3-venv
-      - name: 'Windows: Expose python3 command'
-        if: runner.os == 'Windows'
-        shell: bash
-        run: cp ${pythonLocation}/python.exe ${pythonLocation}/python3.exe
       - name: Check out
         uses: actions/checkout@v2
       - name: Locate Caches

--- a/packages/@jsii/dotnet-runtime-test/package.json
+++ b/packages/@jsii/dotnet-runtime-test/package.json
@@ -24,9 +24,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "gen": "/bin/bash ./generate.sh",
-    "build": "npm run gen && tsc --build && /bin/bash ./build.sh",
-    "test": "/bin/bash ./test.sh",
+    "gen": "bash ./generate.sh",
+    "build": "npm run gen && tsc --build && bash ./build.sh",
+    "test": "bash ./test.sh",
     "test:update": "UPDATE_DIFF=1 npm run test"
   },
   "devDependencies": {

--- a/packages/@jsii/dotnet-runtime/package.json
+++ b/packages/@jsii/dotnet-runtime/package.json
@@ -30,10 +30,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "gen": "/bin/bash ./generate.sh",
-    "build": "npm run gen && tsc --build && /bin/bash ./build.sh",
+    "gen": "bash ./generate.sh",
+    "build": "npm run gen && tsc --build && bash ./build.sh",
     "dist-clean": "rm -rf dist && dotnet clean -c Release ./src/Amazon.JSII.Runtime.sln",
-    "test": "/bin/bash ./test.sh",
+    "test": "bash ./test.sh",
     "test:update": "UPDATE_DIFF=1 npm run test",
     "package": "package-dotnet ./src/Amazon.JSII.Runtime.sln && package-private"
   },

--- a/packages/@jsii/java-runtime-test/package.json
+++ b/packages/@jsii/java-runtime-test/package.json
@@ -23,7 +23,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "/bin/bash ./generate.sh",
+    "build": "bash ./generate.sh",
     "test": "node ./user.xml.t.js > ./project/user.xml && cd project && mvn -B test --settings=user.xml",
     "test:update": "UPDATE_DIFF=1 npm run test"
   },

--- a/packages/@jsii/java-runtime/package.json
+++ b/packages/@jsii/java-runtime/package.json
@@ -24,7 +24,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "gen": "/bin/bash ./generate.sh",
+    "gen": "bash ./generate.sh",
     "build": "tsc --build && npm run gen && cd project && mvn -B deploy -D altDeploymentRepository=local::default::file://${PWD}/../maven-repo --settings=user.xml",
     "dist-clean": "rm -rf dist maven-repo && cd project && mvn -B clean --settings=user.xml",
     "test": "echo 'Tests are run as part of the build target'",

--- a/packages/@jsii/runtime/package.json
+++ b/packages/@jsii/runtime/package.json
@@ -25,7 +25,7 @@
     "jsii-runtime": "bin/jsii-runtime"
   },
   "scripts": {
-    "build": "tsc --build && chmod +x bin/jsii-runtime && /bin/bash ./bundle.sh && npm run lint",
+    "build": "tsc --build && chmod +x bin/jsii-runtime && bash ./bundle.sh && npm run lint",
     "watch": "tsc --build -w",
     "lint": "eslint . --ext .js,.ts --ignore-path=.gitignore --ignore-pattern=webpack.config.js",
     "lint:fix": "yarn lint --fix",

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -25,13 +25,13 @@
     "jsii-pacmak": "bin/jsii-pacmak"
   },
   "scripts": {
-    "gen": "/bin/bash generate.sh",
+    "gen": "bash generate.sh",
     "build": "npm run gen && tsc --build && chmod +x bin/jsii-pacmak && npm run lint",
     "watch": "tsc --build -w",
     "lint": "eslint . --ext .js,.ts --ignore-path=.gitignore",
     "lint:fix": "yarn lint --fix",
-    "test": "jest && /bin/bash test/diff-test.sh && /bin/bash test/build-test.sh",
-    "test:update": "UPDATE_DIFF=1 /bin/bash test/diff-test.sh && /bin/bash test/build-test.sh && jest -u",
+    "test": "jest && bash test/diff-test.sh && bash test/build-test.sh",
+    "test:update": "UPDATE_DIFF=1 bash test/diff-test.sh && bash test/build-test.sh && jest -u",
     "package": "package-js"
   },
   "dependencies": {

--- a/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
+++ b/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
@@ -73,13 +73,10 @@ export class TypeScriptCompiler {
       ),
     });
 
-    const rootFiles = program
-      .getSourceFiles()
-      .filter((f) => f.fileName === filename);
-    if (rootFiles.length === 0) {
+    const rootFile = program.getSourceFile(filename);
+    if (rootFile == null) {
       throw new Error("Oopsie -- couldn't find root file back");
     }
-    const rootFile = rootFiles[0];
 
     return { program, rootFile };
   }

--- a/packages/jsii-rosetta/test/jsii/assemblies.test.ts
+++ b/packages/jsii-rosetta/test/jsii/assemblies.test.ts
@@ -146,7 +146,7 @@ test('Backwards compatibility with literate integ tests', () => {
     expect(snippets[0].completeSource).toEqual('# Some literate source file');
     expect(
       snippets[0]?.parameters?.[SnippetParameters.$COMPILATION_DIRECTORY],
-    ).toEqual('/package/test');
+    ).toEqual(path.normalize('/package/test'));
   } finally {
     mockfs.restore();
   }

--- a/packages/jsii-rosetta/test/translations.test.ts
+++ b/packages/jsii-rosetta/test/translations.test.ts
@@ -75,11 +75,11 @@ function makeTests() {
       });
       afterAll(() => {
         // Print the AST for tests that failed (to help debugging)
-        if (anyFailed) {
+        if (anyFailed && translator) {
           const vis = translator.renderUsing(new VisualizeAstVisitor(true));
           console.log(`${vis}\n`);
         }
-        (translator as any) = undefined; // Need this to properly release memory
+        translator = undefined as any; // Need this to properly release memory
       });
 
       SUPPORTED_LANGUAGES.forEach((supportedLanguage) => {


### PR DESCRIPTION
The root file was located by comparing file paths in a way that was not
adjusting path separators for Windows, and the result was inability to
match normalized paths with Unix-style ones.

This normalizes paths before attempting to match them, so that the match
can succeed.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
