### PR TITLE
chore: no more eslint warn rules

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -54,14 +54,13 @@ rules:
     - allowSingleLine: true
 
   '@typescript-eslint/explicit-module-boundary-types':
-    - warn
-    - allowArgumentsExplicitlyTypedAsAny: true
+    - off
 
   '@typescript-eslint/explicit-member-accessibility':
     - error
 
   '@typescript-eslint/member-ordering':
-    - warn
+    - error
     - default:
       - static-field
       - static-method
@@ -126,8 +125,7 @@ rules:
     - error
 
   'complexity':
-    - warn
-    - 20
+    - off
 
   'consistent-return':
     - error
@@ -153,7 +151,7 @@ rules:
     - error
 
   'no-await-in-loop':
-    - warn
+    - off
 
   'no-caller':
     - error
@@ -166,7 +164,7 @@ rules:
     - error
 
   'no-extra-bind':
-    - warn
+    - error
 
   'no-implied-eval':
     - error
@@ -184,7 +182,7 @@ rules:
     - error
 
   'no-return-await':
-    - warn
+    - error
 
   'no-unused-expressions':
     - error

--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -151,7 +151,7 @@ rules:
     - error
 
   'no-await-in-loop':
-    - off
+    - error
 
   'no-caller':
     - error

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -21,15 +21,15 @@ export interface LoadedAssembly {
 export async function loadAssemblies(assemblyLocations: string[]) {
   const ret: LoadedAssembly[] = [];
   for (const loc of assemblyLocations) {
-    const stat = await fs.stat(loc);
+    const stat = await fs.stat(loc); // eslint-disable-line no-await-in-loop
     if (stat.isDirectory()) {
       ret.push({
-        assembly: await loadAssemblyFromFile(path.join(loc, '.jsii')),
+        assembly: await loadAssemblyFromFile(path.join(loc, '.jsii')), // eslint-disable-line no-await-in-loop
         directory: loc,
       });
     } else {
       ret.push({
-        assembly: await loadAssemblyFromFile(loc),
+        assembly: await loadAssemblyFromFile(loc), // eslint-disable-line no-await-in-loop
         directory: path.dirname(loc),
       });
     }


### PR DESCRIPTION
Either linter rules are enforced or relaxed, nothing inbetween.

Converts existing warn rules to error or turn off.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
