### PR TITLE
fix(rosetta): use of keyword 'lambda' produces invalid Python code

### DIFF
--- a/packages/jsii-rosetta/test/translations/identifiers/keyword.cs
+++ b/packages/jsii-rosetta/test/translations/identifiers/keyword.cs
@@ -1,0 +1,4 @@
+using Scope.Aws.Lambda;
+new ClassFromLambda(new Struct {
+    Key = "lambda.amazonaws.com"
+});

--- a/packages/jsii-rosetta/test/translations/identifiers/keyword.java
+++ b/packages/jsii-rosetta/test/translations/identifiers/keyword.java
@@ -1,0 +1,4 @@
+import scope.aws.lambda.*;
+ClassFromLambda.Builder.create()
+        .key("lambda.amazonaws.com")
+        .build();

--- a/packages/jsii-rosetta/test/translations/identifiers/keyword.py
+++ b/packages/jsii-rosetta/test/translations/identifiers/keyword.py
@@ -1,0 +1,4 @@
+import scope.aws_lambda as awslambda
+awslambda.ClassFromLambda(
+    key="lambda.amazonaws.com"
+)

--- a/packages/jsii-rosetta/test/translations/identifiers/keyword.py
+++ b/packages/jsii-rosetta/test/translations/identifiers/keyword.py
@@ -1,4 +1,4 @@
-import scope.aws_lambda as awslambda
-awslambda.ClassFromLambda(
+import scope.aws_lambda as lambda_
+lambda_.ClassFromLambda(
     key="lambda.amazonaws.com"
 )

--- a/packages/jsii-rosetta/test/translations/identifiers/keyword.ts
+++ b/packages/jsii-rosetta/test/translations/identifiers/keyword.ts
@@ -1,0 +1,4 @@
+import * as lambda from '@scope/aws-lambda';
+new lambda.ClassFromLambda({
+  key: 'lambda.amazonaws.com'
+});


### PR DESCRIPTION
Replace all 'lambda' identifiers with 'awslambda'

fixes https://github.com/aws/aws-cdk/issues/9169



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
