### PR TITLE
chore(jsii): better errors around use of hidden types

### DIFF
--- a/packages/jsii/test/__snapshots__/negatives.test.js.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.js.snap
@@ -1,0 +1,581 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`behavior-requires-iprefix 1`] = `
+"neg.behavior-requires-iprefix.ts:1:18 - error TS9999: JSII: Interface contains behavior: name should be \\"ISomething\\"
+
+1 export interface Something {
+                   ~~~~~~~~~
+"
+`;
+
+exports[`class-name 1`] = `
+"error TS0: Type names must use PascalCase: myclass
+"
+`;
+
+exports[`class-name.1 1`] = `
+"error TS0: Type names must use PascalCase: My_class
+"
+`;
+
+exports[`compilation-error 1`] = `
+"neg.compilation-error.ts:1:1 - error TS2304: Cannot find name 'boom'.
+
+1 boom! > CompilerErrorIsHere;
+  ~~~~
+neg.compilation-error.ts:1:9 - error TS2304: Cannot find name 'CompilerErrorIsHere'.
+
+1 boom! > CompilerErrorIsHere;
+          ~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`const-enum 1`] = `
+"neg.const-enum.ts:1:1 - error TS9999: JSII: Exported enum cannot be declared 'const'
+
+  1 export const enum NotAllowed {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  2   ThisEnum,
+    ~~~~~~~~~~~
+... 
+  5   ForJsii,
+    ~~~~~~~~~~
+  6 }
+    ~
+"
+`;
+
+exports[`double-interface-members 1`] = `
+"neg.double-interface-members.ts:2:3 - error TS9999: JSII: The property 'foo' in data type 'A' must be 'readonly' since data is passed by-value
+
+2   foo: number;
+    ~~~~~~~~~~~~
+neg.double-interface-members.ts:4:1 - error TS9999: JSII: Interface declares same member as inherited interface: foo
+
+4 export interface B extends A {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5   foo: number;
+  ~~~~~~~~~~~~~~
+6 }
+  ~
+neg.double-interface-members.ts:5:3 - error TS9999: JSII: The property 'foo' in data type 'B' must be 'readonly' since data is passed by-value
+
+5   foo: number;
+    ~~~~~~~~~~~~
+"
+`;
+
+exports[`double-interface-members-deeper 1`] = `
+"neg.double-interface-members-deeper.ts:9:1 - error TS9999: JSII: Interface declares same member as inherited interface: foo
+
+ 9 export interface IC extends IB {
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+10   foo(): void;
+   ~~~~~~~~~~~~~~
+11 }
+   ~
+"
+`;
+
+exports[`double-interface-members-method 1`] = `
+"neg.double-interface-members-method.ts:4:1 - error TS9999: JSII: Interface declares same member as inherited interface: foo
+
+4 export interface IB extends IA {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5   foo(): void;
+  ~~~~~~~~~~~~~~
+6 }
+  ~
+"
+`;
+
+exports[`downgrade-to-readonly 1`] = `
+"error TS0: jsii.Implementation#property changes immutability of property when implementing jsii.IInterface
+"
+`;
+
+exports[`enum-members.1 1`] = `
+"error TS0: Enum members must use ALL_CAPS: Goo
+"
+`;
+
+exports[`enum-name.1 1`] = `
+"error TS0: Type names must use PascalCase: myEnum
+"
+`;
+
+exports[`enum-name.2 1`] = `
+"error TS0: Type names must use PascalCase: My_Enum
+"
+`;
+
+exports[`expose-unexported-type-external 1`] = `
+"error TS0: Exported APIs cannot use un-exported type jsii.UnexportedType
+"
+`;
+
+exports[`expose-unexported-type-internal 1`] = `
+"neg.expose-unexported-type-internal.ts:7:10 - error TS9999: JSII: Type \\"UnexportedType\\" cannot be used as the property type because it is private or @internal
+
+7   public p?: UnexportedType;
+           ~
+
+  neg.expose-unexported-type-internal.ts:4:7
+    4 class UnexportedType {}
+            ~~~~~~~~~~~~~~
+    The referenced type is declared here
+"
+`;
+
+exports[`expose-unexported-type-internal-in-namespace 1`] = `
+"neg.expose-unexported-type-internal-in-namespace.ts:9:10 - error TS9999: JSII: Cannot use internal type MyNamespace.UnexportedType as a property type in exported declarations
+
+9   public p?: MyNamespace.UnexportedType;
+           ~
+
+  neg.expose-unexported-type-internal-in-namespace.ts:5:16
+    5   export class UnexportedType {}
+                     ~~~~~~~~~~~~~~
+    The referenced type is declared here
+"
+`;
+
+exports[`expose-unexported-type-this 1`] = `
+"neg.expose-unexported-type-this.ts:10:38 - warning TS9999: JSII: 'boolean' is a reserved word in Java. Using this name may cause problems when generating language bindings. Consider using a different name.
+
+10   public constructor(public readonly boolean = true) {
+                                        ~~~~~~~
+neg.expose-unexported-type-this.ts:10:38 - warning TS9999: JSII: 'boolean' is a reserved word in Java. Using this name may cause problems when generating language bindings. Consider using a different name.
+
+10   public constructor(public readonly boolean = true) {
+                                        ~~~~~~~
+neg.expose-unexported-type-this.ts:4:10 - error TS9999: JSII: Type \\"this\\" (aka: \\"HiddenBaseClass\\") cannot be used as the return type because it is private or @internal
+
+4   public returnsThis() {
+           ~~~~~~~~~~~
+
+  neg.expose-unexported-type-this.ts:3:16
+    3 abstract class HiddenBaseClass {
+                     ~~~~~~~~~~~~~~~
+    The referenced type is declared here
+"
+`;
+
+exports[`extend-struct 1`] = `
+"error TS9999: JSII: Attempted to extend struct jsii.Struct from regular interface jsii.IIllegal
+"
+`;
+
+exports[`implement-struct 1`] = `
+"neg.implement-struct.ts:6:1 - error TS9999: JSII: Attempted to implement struct jsii.Struct from class jsii.Illegal
+
+  6 export class Illegal implements Struct {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  7   public readonly field: string = 'foo';
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... 
+ 11   }
+    ~~~
+ 12 }
+    ~
+"
+`;
+
+exports[`implementation-changes-types.1 1`] = `
+"error TS0: jsii.Something#returnSomething changes the return type when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`implementation-changes-types.2 1`] = `
+"error TS0: jsii.ISomethingElse#returnSomething changes the return type when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`implementation-changes-types.3 1`] = `
+"error TS0: jsii.Something#takeSomething changes type of argument _argument when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass
+"
+`;
+
+exports[`implementation-changes-types.4 1`] = `
+"error TS0: jsii.Something#something changes the type of property when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`implementation-changes-types.5 1`] = `
+"error TS0: jsii.ISomethingElse#something changes the type of property when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`implementing-method-changes-optionality 1`] = `
+"error TS0: jsii.Implementor#method changes the optionality of paramerter _optional when implementing jsii.IInterface (expected true, found false)
+"
+`;
+
+exports[`implementing-method-changes-optionality.1 1`] = `
+"error TS0: jsii.Implementor#method changes the optionality of paramerter _optional when overriding jsii.AbstractClass (expected true, found false)
+"
+`;
+
+exports[`implementing-method-changes-optionality.2 1`] = `
+"error TS0: jsii.Implementor#method changes the optionality of paramerter _optional when overriding jsii.ParentClass (expected true, found false)
+"
+`;
+
+exports[`implementing-property-changes-optionality 1`] = `
+"error TS0: jsii.Implementor#property changes optionality of property when implementing jsii.IInterface
+"
+`;
+
+exports[`implementing-property-changes-optionality.1 1`] = `
+"error TS0: jsii.Implementor#property changes optionality of property when overriding jsii.AbstractClass
+"
+`;
+
+exports[`implementing-property-changes-optionality.2 1`] = `
+"error TS0: jsii.Implementor#property changes optionality of property when overriding jsii.ParentClass
+"
+`;
+
+exports[`implements-class 1`] = `
+"neg.implements-class.ts:1:1 - error TS9999: JSII: Inheritance clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
+
+  1 export class NotAnInterface {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  2   public meaningOfTheUniverse() {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... 
+  4   }
+    ~~~
+  5 }
+    ~
+"
+`;
+
+exports[`inheritance-changes-types.1 1`] = `
+"error TS0: jsii.SomethingSpecific#returnSomething changes the return type when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`inheritance-changes-types.2 1`] = `
+"error TS0: jsii.SomethingSpecific#returnSomething changes the return type when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`inheritance-changes-types.3 1`] = `
+"error TS0: jsii.SomethingSpecific#takeSomething changes type of argument _argument when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass
+"
+`;
+
+exports[`inheritance-changes-types.4 1`] = `
+"error TS0: jsii.SomethingSpecific#something changes the type of property when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`inheritance-changes-types.5 1`] = `
+"error TS0: jsii.SomethingElse#something changes the type of property when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
+"
+`;
+
+exports[`internal-underscore-class.5 1`] = `
+"neg.internal-underscore-class.5.ts:3:10 - error TS9999: JSII: propertyWithInternalButNotUnderscorePrefix: the name of members marked as @internal must begin with an underscore
+
+3   public propertyWithInternalButNotUnderscorePrefix?: string;
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-class.6 1`] = `
+"neg.internal-underscore-class.6.ts:2:10 - error TS9999: JSII: _propertyWithUnderscoreButNoInternal: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
+
+2   public _propertyWithUnderscoreButNoInternal?: string;
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-class.7 1`] = `
+"neg.internal-underscore-class.7.ts:3:10 - error TS9999: JSII: methodWithInternalButNoUnderscore: the name of members marked as @internal must begin with an underscore
+
+3   public methodWithInternalButNoUnderscore(): string {
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-class.8 1`] = `
+"neg.internal-underscore-class.8.ts:2:3 - error TS9999: JSII: _methodWithUnderscoreButNoInternal: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
+
+2   _methodWithUnderscoreButNoInternal(): void;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-interface.1 1`] = `
+"neg.internal-underscore-interface.1.ts:3:3 - error TS9999: JSII: propertyWithInternalButNotUnderscorePrefix: the name of members marked as @internal must begin with an underscore
+
+3   propertyWithInternalButNotUnderscorePrefix: string;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-interface.2 1`] = `
+"neg.internal-underscore-interface.2.ts:2:3 - error TS9999: JSII: _propertyWithUnderscoreButNoInternal: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
+
+2   _propertyWithUnderscoreButNoInternal: string;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-interface.3 1`] = `
+"neg.internal-underscore-interface.3.ts:3:3 - error TS9999: JSII: methodWithInternalButNoUnderscore: the name of members marked as @internal must begin with an underscore
+
+3   methodWithInternalButNoUnderscore(): string;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`internal-underscore-interface.4 1`] = `
+"neg.internal-underscore-interface.4.ts:2:10 - error TS9999: JSII: _methodWithUnderscoreButNoInternal: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
+
+2   public _methodWithUnderscoreButNoInternal() {
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`method-name.1 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: METHOD
+"
+`;
+
+exports[`method-name.2 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: hello_world
+"
+`;
+
+exports[`method-name.3 1`] = `
+"error TS0: Methods and properties cannot have names like getXxx() - those conflict with Java property getters by the same name
+"
+`;
+
+exports[`method-name.4 1`] = `
+"error TS0: Methods and properties cannot have names like setXxx() - those conflict with Java property setters by the same name
+"
+`;
+
+exports[`mix-datatype-and-arg-name 1`] = `
+"neg.mix-datatype-and-arg-name.ts:10:3 - error TS9999: JSII: Name occurs in both function arguments and in datatype properties, rename one: dontWorry
+
+10   public dance(dontWorry: string, lyrics: Lyrics) {
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+11     return \`\${dontWorry}: \${lyrics.beHappy}\`;
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+12   }
+   ~~~
+"
+`;
+
+exports[`mutable-datatype 1`] = `
+"neg.mutable-datatype.ts:3:3 - error TS9999: JSII: The property 'notOkay' in data type 'DataType' must be 'readonly' since data is passed by-value
+
+3   notOkay: number; // properties should be \\"readonly\\"
+    ~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`non-optional-after-optional-ctor 1`] = `
+"neg.non-optional-after-optional-ctor.ts:2:3 - error TS9999: JSII: Parameter _arg2 cannot be optional, as it precedes non-optional parameter _arg3
+
+2   constructor(_arg1: string, _arg2 = 'hello', _arg3: string) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+3     return;
+  ~~~~~~~~~~~
+4   }
+  ~~~
+"
+`;
+
+exports[`non-optional-after-optional-method 1`] = `
+"neg.non-optional-after-optional-method.ts:2:3 - error TS9999: JSII: Parameter _arg2 cannot be optional, as it precedes non-optional parameter _argX
+
+2   public foo(_arg1: string, _arg2 = 'hello', _argX: string, _arg4?: boolean) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+3     return;
+  ~~~~~~~~~~~
+4   }
+  ~~~
+"
+`;
+
+exports[`omit.1 1`] = `
+"neg.omit.1.ts:7:33 - error TS9999: JSII: Illegal \\"extends\\" value for an exported API: MappedType
+
+7 export interface BarBaz extends Omit<FooBar, 'foo'> {
+                                  ~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`omit.2 1`] = `
+"neg.omit.2.ts:7:32 - error TS9999: JSII: Illegal \\"implements\\" value for an exported API: MappedType
+
+7 export class BarBaz implements Omit<FooBar, 'foo'> {
+                                 ~~~~~~~~~~~~~~~~~~~
+"
+`;
+
+exports[`omit.3 1`] = `
+"neg.omit.3.ts:8:3 - error TS9999: JSII: Only string-indexed map types are supported
+
+8   bar(): Omit<FooBar, 'foo'>;
+    ~~~
+"
+`;
+
+exports[`omit.4 1`] = `
+"neg.omit.4.ts:8:7 - error TS9999: JSII: Only string-indexed map types are supported
+
+8   bar(opts: Omit<FooBar, 'foo'>): void;
+        ~~~~
+"
+`;
+
+exports[`prohibited-member-name 1`] = `
+"neg.prohibited-member-name.ts:4:3 - error TS9999: JSII: Prohibited member name: equals
+
+4   public equals(): boolean {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+5     return true;
+  ~~~~~~~~~~~~~~~~
+6   }
+  ~~~
+"
+`;
+
+exports[`property-name.1 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: PROP
+"
+`;
+
+exports[`property-name.2 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: my_Prop
+"
+`;
+
+exports[`property-name.3 1`] = `
+"error TS0: Methods and properties cannot have names like getXxx() - those conflict with Java property getters by the same name
+"
+`;
+
+exports[`reserved.emits-warning 1`] = `
+"neg.reserved.emits-warning.ts:2:14 - warning TS9999: JSII: 'None' is a reserved word in Python. Using this name may cause problems when generating language bindings. Consider using a different name.
+
+2 export class None {
+               ~~~~
+neg.reserved.emits-warning.ts:3:19 - warning TS9999: JSII: 'do' is a reserved word in C#, Java. Using this name may cause problems when generating language bindings. Consider using a different name.
+
+3   public readonly do: boolean = true;
+                    ~~
+neg.reserved.emits-warning.ts:5:10 - warning TS9999: JSII: 'assert' is a reserved word in Java, Python. Using this name may cause problems when generating language bindings. Consider using a different name.
+
+5   public assert(_internal: boolean): void {
+           ~~~~~~
+"
+`;
+
+exports[`static-const-name 1`] = `
+"error TS0: Static constant names must use TRUMP_CASE, PascalCase or camelCase: snake_case
+"
+`;
+
+exports[`static-member-mixing.1 1`] = `
+"neg.static-member-mixing.1.ts:11:1 - error TS9999: JSII: non-static member 'funFunction' of class 'Sub' conflicts with static member in ancestor 'SuperDuper'
+
+ 11 export class Sub extends Super {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 12   public funFunction() {
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+... 
+ 14   }
+    ~~~
+ 15 }
+    ~
+"
+`;
+
+exports[`static-member-mixing.2 1`] = `
+"neg.static-member-mixing.2.ts:1:1 - error TS9999: JSII: member 'funFunction' of class 'TheClass' cannot be declared both statically and non-statically
+
+  1 export class TheClass {
+    ~~~~~~~~~~~~~~~~~~~~~~~
+  2   public static funFunction() {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... 
+  8   }
+    ~~~
+  9 }
+    ~
+"
+`;
+
+exports[`static-method-name 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: METHOD
+"
+`;
+
+exports[`static-method-name.1 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: MethodIsNotCamelCase
+"
+`;
+
+exports[`static-prop-name.1 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: Prop
+"
+`;
+
+exports[`static-prop-name.2 1`] = `
+"error TS0: Method and non-static non-readonly property names must use camelCase: PROP
+"
+`;
+
+exports[`struct-extends-interface 1`] = `
+"neg.struct-extends-interface.ts:6:18 - error TS9999: JSII: Interface contains behavior: name should be \\"IStruct\\"
+
+6 export interface Struct extends IInterface {
+                   ~~~~~~
+"
+`;
+
+exports[`submodules-cannot-have-colliding-names 1`] = `
+"neg.submodules-cannot-have-colliding-names.ts:3:14 - error TS9999: JSII: Submodule \\"ns1\\" conflicts with \\"Ns1\\". Restricted names are: ns1, Ns1
+
+3 export class Ns1 {
+               ~~~
+
+  neg.submodules-cannot-have-colliding-names.ts:1:13
+    1 export * as ns1 from './namespaced';
+                  ~~~
+    This is the conflicting submodule declaration.
+"
+`;
+
+exports[`submodules-cannot-share-symbols 1`] = `
+"namespaced/index.ts:1:14 - error TS9999: JSII: Symbol is re-exported under two distinct submodules (ns1 and ns2)
+
+1 export class Declaration {
+               ~~~~~~~~~~~
+
+  neg.submodules-cannot-share-symbols.ts:1:8
+    1 export * as ns1 from './namespaced';
+             ~~~~~~~~
+    Symbol is exported under the \\"ns1\\" submodule
+  neg.submodules-cannot-share-symbols.ts:2:8
+    2 export * as ns2 from './namespaced';
+             ~~~~~~~~
+    Symbol is exported under the \\"ns2\\" submodule
+"
+`;
+
+exports[`submodules-must-be-camel-cased 1`] = `
+"neg.submodules-must-be-camel-cased.ts:1:13 - error TS9999: JSII: Submodule namespaces must be camelCased or snake_cased. Consider renaming to \\"ns1\\".
+
+1 export * as Ns1 from './namespaced';
+              ~~~
+"
+`;

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -6,6 +6,12 @@ import { ProjectInfo } from '../lib/project-info';
 
 const SOURCE_DIR = path.join(__dirname, 'negatives');
 
+const formatHost: ts.FormatDiagnosticsHost = {
+  getCanonicalFileName: ts.sys.realpath ?? ts.sys.resolvePath,
+  getCurrentDirectory: () => SOURCE_DIR,
+  getNewLine: () => '\n',
+};
+
 for (const source of fs.readdirSync(SOURCE_DIR)) {
   if (
     !source.startsWith('neg.') ||
@@ -18,30 +24,33 @@ for (const source of fs.readdirSync(SOURCE_DIR)) {
   test(
     source.replace(/neg\.(.+)\.ts/, '$1'),
     async () => {
-      const [expectations, strict] = await _getExpectedErrorMessage(filePath);
-      expect(
-        expectations.length,
-        `Expected error messages should be specified using ${MATCH_ERROR_MARKER}`,
-      ).toBeGreaterThan(0);
+      const { strict } = await _getPragmas(filePath);
       const compiler = new Compiler({
         projectInfo: _makeProjectInfo(source),
         failOnWarnings: strict,
       });
       const emitResult = await compiler.emit(path.join(SOURCE_DIR, source));
+
       expect(emitResult.emitSkipped).toBeTruthy();
-      const errors = emitResult.diagnostics.filter(
-        (diag) =>
-          diag.category === ts.DiagnosticCategory.Error ||
-          (strict && diag.category === ts.DiagnosticCategory.Warning),
-      );
-      for (const expectation of expectations) {
-        expect(
-          errors.find((e) => _messageText(e).includes(expectation)),
-          `No error contained: ${expectation}. Errors: \n${errors
-            .map((e, i) => `[${i}] ${e.messageText.toString()}`)
-            .join('\n')}`,
-        ).toBeDefined();
-      }
+
+      const diagnostics = emitResult.diagnostics
+        .filter(
+          // Remove suggestion diagnostics, we don't care much for those for now...
+          (diag) => diag.category !== ts.DiagnosticCategory.Suggestion,
+        )
+        .map((diag) =>
+          ts.formatDiagnosticsWithColorAndContext([diag], formatHost),
+        )
+        .sort();
+
+      expect(diagnostics.length).toBeGreaterThan(0);
+      expect(
+        diagnostics
+          // Remove ANSI color codes from the message so it's nicer in the snapshots file
+          // eslint-disable-next-line no-control-regex
+          .map((diag) => diag.replace(/\x1B\[[0-9;]*[a-z]/gi, ''))
+          .join(''),
+      ).toMatchSnapshot();
 
       // Cleaning up...
       return Promise.all(
@@ -65,32 +74,12 @@ for (const source of fs.readdirSync(SOURCE_DIR)) {
   );
 }
 
-const MATCH_ERROR_MARKER = '///!MATCH_ERROR:';
 const STRICT_MARKER = '///!STRICT!';
-async function _getExpectedErrorMessage(
-  file: string,
-): Promise<[string[], boolean]> {
+async function _getPragmas(file: string): Promise<{ strict: boolean }> {
   const data = await fs.readFile(file, { encoding: 'utf8' });
   const lines = data.split('\n');
-  const matches = lines
-    .filter((line) => line.startsWith(MATCH_ERROR_MARKER))
-    .map((line) => line.substr(MATCH_ERROR_MARKER.length).trim());
   const strict = lines.some((line) => line.startsWith(STRICT_MARKER));
-  return [matches, strict];
-}
-
-function _messageText(
-  diagnostic: ts.Diagnostic | ts.DiagnosticMessageChain,
-): string {
-  if (typeof diagnostic.messageText === 'string') {
-    return diagnostic.messageText;
-  }
-  if (diagnostic.messageText.next) {
-    return `${diagnostic.messageText.messageText}|${_messageText(
-      diagnostic.messageText.next[0],
-    )}`;
-  }
-  return diagnostic.messageText.messageText;
+  return { strict };
 }
 
 function _makeProjectInfo(types: string): ProjectInfo {

--- a/packages/jsii/test/negatives/neg.behavior-requires-iprefix.ts
+++ b/packages/jsii/test/negatives/neg.behavior-requires-iprefix.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Interface contains behavior: name should be "ISomething"
-
 export interface Something {
   // The presence of this method requires an I prefix on the interface
   doSomething(): void;

--- a/packages/jsii/test/negatives/neg.class-name.1.ts
+++ b/packages/jsii/test/negatives/neg.class-name.1.ts
@@ -1,5 +1,1 @@
-///!MATCH_ERROR: Type names must use PascalCase: My_class
-
-export class My_class {
-
-}
+export class My_class {}

--- a/packages/jsii/test/negatives/neg.class-name.ts
+++ b/packages/jsii/test/negatives/neg.class-name.ts
@@ -1,5 +1,1 @@
-///!MATCH_ERROR: Type names must use PascalCase: myclass
-
-export class myclass {
-
-}
+export class myclass {}

--- a/packages/jsii/test/negatives/neg.compilation-error.ts
+++ b/packages/jsii/test/negatives/neg.compilation-error.ts
@@ -1,4 +1,1 @@
-///!MATCH_ERROR: Cannot find name 'boom'.
-///!MATCH_ERROR: Cannot find name 'CompilerErrorIsHere'.
-
-boom! >CompilerErrorIsHere
+boom! > CompilerErrorIsHere;

--- a/packages/jsii/test/negatives/neg.const-enum.ts
+++ b/packages/jsii/test/negatives/neg.const-enum.ts
@@ -1,8 +1,6 @@
-///!MATCH_ERROR: Exported enum cannot be declared 'const'
-
 export const enum NotAllowed {
   ThisEnum,
   GetsInlined,
   AndSoItGetsLost,
-  ForJsii
+  ForJsii,
 }

--- a/packages/jsii/test/negatives/neg.double-interface-members-deeper.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members-deeper.ts
@@ -1,15 +1,11 @@
-///!MATCH_ERROR: Interface declares same member as inherited interface: foo
-
 export interface IA {
   foo(): void;
 }
 
 export interface IB extends IA {
-    bar(): void;
+  bar(): void;
 }
 
 export interface IC extends IB {
   foo(): void;
 }
-
-

--- a/packages/jsii/test/negatives/neg.double-interface-members-method.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members-method.ts
@@ -1,9 +1,6 @@
-///!MATCH_ERROR: Interface declares same member as inherited interface: foo
-
 export interface IA {
   foo(): void;
 }
 export interface IB extends IA {
   foo(): void;
 }
-

--- a/packages/jsii/test/negatives/neg.double-interface-members.ts
+++ b/packages/jsii/test/negatives/neg.double-interface-members.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Interface declares same member as inherited interface: foo
-
 export interface A {
   foo: number;
 }

--- a/packages/jsii/test/negatives/neg.enum-members.1.ts
+++ b/packages/jsii/test/negatives/neg.enum-members.1.ts
@@ -1,6 +1,4 @@
-///!MATCH_ERROR: Enum members must use ALL_CAPS: Goo
-
 export enum MyEnum {
-    FOO,
-    Goo
+  FOO,
+  Goo,
 }

--- a/packages/jsii/test/negatives/neg.enum-name.1.ts
+++ b/packages/jsii/test/negatives/neg.enum-name.1.ts
@@ -1,6 +1,4 @@
-///!MATCH_ERROR: Type names must use PascalCase: myEnum
-
 export enum myEnum {
-    FOO,
-    GOO
+  FOO,
+  GOO,
 }

--- a/packages/jsii/test/negatives/neg.enum-name.2.ts
+++ b/packages/jsii/test/negatives/neg.enum-name.2.ts
@@ -1,6 +1,4 @@
-///!MATCH_ERROR: Type names must use PascalCase: My_Enum
-
 export enum My_Enum {
-    FOO,
-    GOO
+  FOO,
+  GOO,
 }

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-external.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-external.ts
@@ -1,10 +1,8 @@
-///!MATCH_ERROR: Exported APIs cannot use un-exported type jsii.UnexportedType
-
 // Attempt to expose an unexported type defined in another file should fial
 // because that type will not be available in the module spec.
 
 import { UnexportedType } from './mylib';
 
 export class ExportedType {
-    public p?: UnexportedType;
+  public p?: UnexportedType;
 }

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-internal-in-namespace.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-internal-in-namespace.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Cannot internal type MyNamespace.UnexportedType as a property type in exported declarations
-
 // Attempt to expose an unexported type defined in this file should fail
 // because that type will not be available in the module spec.
 

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-internal-in-namespace.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-internal-in-namespace.ts
@@ -1,13 +1,12 @@
-///!MATCH_ERROR: Cannot use private type MyNamespace.UnexportedType in exported declarations
+///!MATCH_ERROR: Cannot internal type MyNamespace.UnexportedType as a property type in exported declarations
 
 // Attempt to expose an unexported type defined in this file should fail
 // because that type will not be available in the module spec.
 
 namespace MyNamespace {
-    export class UnexportedType {
-    }
+  export class UnexportedType {}
 }
 
 export class ExportedType {
-    public p?: MyNamespace.UnexportedType;
+  public p?: MyNamespace.UnexportedType;
 }

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-internal.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-internal.ts
@@ -1,12 +1,10 @@
-///!MATCH_ERROR: Cannot use private type UnexportedType in exported declarations
+///!MATCH_ERROR: Type "UnexportedType" cannot be used as the property type because it is private or @internal
 
 // Attempt to expose an unexported type defined in this file should fail
 // because that type will not be available in the module spec.
 
-class UnexportedType {
-
-}
+class UnexportedType {}
 
 export class ExportedType {
-    public p?: UnexportedType;
+  public p?: UnexportedType;
 }

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-internal.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-internal.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Type "UnexportedType" cannot be used as the property type because it is private or @internal
-
 // Attempt to expose an unexported type defined in this file should fail
 // because that type will not be available in the module spec.
 

--- a/packages/jsii/test/negatives/neg.expose-unexported-type-this.ts
+++ b/packages/jsii/test/negatives/neg.expose-unexported-type-this.ts
@@ -1,0 +1,13 @@
+// Attempt to return "this" from a hidden base class
+
+abstract class HiddenBaseClass {
+  public returnsThis() {
+    return this;
+  }
+}
+
+export class PublicClass extends HiddenBaseClass {
+  public constructor(public readonly boolean = true) {
+    super();
+  }
+}

--- a/packages/jsii/test/negatives/neg.extend-struct.ts
+++ b/packages/jsii/test/negatives/neg.extend-struct.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Attempted to extend struct jsii.Struct from regular interface jsii.IIllegal
-
 // Attempt to extend a Struct (aka data type) from a regular interface will fail.
 export interface Struct {
   readonly field: string;

--- a/packages/jsii/test/negatives/neg.implement-struct.ts
+++ b/packages/jsii/test/negatives/neg.implement-struct.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Attempted to implement struct jsii.Struct from class jsii.Illegal
-
 // Attempt to implement a Struct (aka data type) will fail.
 export interface Struct {
   readonly field: string;

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.1.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.1.ts
@@ -1,14 +1,12 @@
-///!MATCH_ERROR: jsii.Something#returnSomething changes the return type when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export interface ISomething {
-    returnSomething(): Superclass;
+  returnSomething(): Superclass;
 }
 
 export class Something implements ISomething {
-    public returnSomething(): Subclass {
-        return 5;
-    }
+  public returnSomething(): Subclass {
+    return 5;
+  }
 }

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.2.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.2.ts
@@ -1,14 +1,12 @@
-///!MATCH_ERROR: jsii.ISomethingElse#returnSomething changes the return type when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export interface ISomething {
-    returnSomething(): Superclass;
+  returnSomething(): Superclass;
 }
 
 export class ISomethingElse implements ISomething {
-    public returnSomething(): Subclass {
-        return new Subclass();
-    }
+  public returnSomething(): Subclass {
+    return new Subclass();
+  }
 }

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.3.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.3.ts
@@ -1,14 +1,12 @@
-///!MATCH_ERROR: jsii.Something#takeSomething changes type of argument _argument when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export interface ISomething {
-    takeSomething(argument: Superclass): void;
+  takeSomething(argument: Superclass): void;
 }
 
 export class Something implements ISomething {
-    public takeSomething(_argument: Subclass): void {
-        // Nothing
-    }
+  public takeSomething(_argument: Subclass): void {
+    // Nothing
+  }
 }

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.4.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.4.ts
@@ -1,12 +1,10 @@
-///!MATCH_ERROR: jsii.Something#something changes the type of property when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export interface ISomething {
-    something: Superclass;
+  something: Superclass;
 }
 
 export class Something implements ISomething {
-    public something: Subclass = new Subclass();
+  public something: Subclass = new Subclass();
 }

--- a/packages/jsii/test/negatives/neg.implementation-changes-types.5.ts
+++ b/packages/jsii/test/negatives/neg.implementation-changes-types.5.ts
@@ -1,18 +1,16 @@
-///!MATCH_ERROR: jsii.ISomethingElse#something changes the type of property when implementing jsii.ISomething (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export interface ISomething {
-    something: Superclass;
+  something: Superclass;
 }
 
 export interface ISomethingElse extends ISomething {
-    addUnrelatedMember: number;
+  addUnrelatedMember: number;
 }
 
 // Should still fail even though 2-level inheritance
 export class Something implements ISomethingElse {
-    public something: Subclass = new Subclass();
-    public addUnrelatedMember: number = 1;
+  public something: Subclass = new Subclass();
+  public addUnrelatedMember: number = 1;
 }

--- a/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.1.ts
+++ b/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#method changes the optionality of paramerter _optional when overriding jsii.AbstractClass (expected true, found false)
-
 // Attempt to change optionality of method parameter
 export abstract class AbstractClass {
   public abstract method(required: string, optional?: number): void;

--- a/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.2.ts
+++ b/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#method changes the optionality of paramerter _optional when overriding jsii.ParentClass (expected true, found false)
-
 // Attempt to change optionality of method parameter
 export class ParentClass {
   public method(_required: string, _optional?: number): void {

--- a/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.ts
+++ b/packages/jsii/test/negatives/neg.implementing-method-changes-optionality.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#method changes the optionality of paramerter _optional when implementing jsii.IInterface (expected true, found false)
-
 // Attempt to change optionality of method parameter
 export interface IInterface {
   method(required: string, optional?: number): void;

--- a/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.1.ts
+++ b/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#property changes optionality of property when overriding jsii.AbstractClass
-
 // Attempt to change optionality of method parameter
 export abstract class AbstractClass {
   public abstract property?: string;

--- a/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.2.ts
+++ b/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#property changes optionality of property when overriding jsii.ParentClass
-
 // Attempt to change optionality of method parameter
 export class ParentClass {
   public property?: string = undefined;

--- a/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.ts
+++ b/packages/jsii/test/negatives/neg.implementing-property-changes-optionality.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: jsii.Implementor#property changes optionality of property when implementing jsii.IInterface
-
 // Attempt to change optionality of method parameter
 export interface IInterface {
   property?: string;

--- a/packages/jsii/test/negatives/neg.implements-class.ts
+++ b/packages/jsii/test/negatives/neg.implements-class.ts
@@ -1,14 +1,12 @@
-///!MATCH_ERROR: Inheritance clause of jsii.TryingToImplementClass uses jsii.NotAnInterface as an interface
-
 export class NotAnInterface {
-    public meaningOfTheUniverse() {
-        return 42;
-    }
+  public meaningOfTheUniverse() {
+    return 42;
+  }
 }
 
 // While valid typescript, this is illegal in the vast majority of languages
 export class TryingToImplementClass implements NotAnInterface {
-    public meaningOfTheUniverse() {
-        return 1337;
-    }
+  public meaningOfTheUniverse() {
+    return 1337;
+  }
 }

--- a/packages/jsii/test/negatives/neg.inheritance-changes-types.1.ts
+++ b/packages/jsii/test/negatives/neg.inheritance-changes-types.1.ts
@@ -1,16 +1,14 @@
-///!MATCH_ERROR: jsii.SomethingSpecific#returnSomething changes the return type when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export class Something {
-    public returnSomething(): Superclass {
-        return new Superclass();
-    }
+  public returnSomething(): Superclass {
+    return new Superclass();
+  }
 }
 
 export class SomethingSpecific extends Something {
-    public returnSomething(): Subclass {
-        return 5;
-    }
+  public returnSomething(): Subclass {
+    return 5;
+  }
 }

--- a/packages/jsii/test/negatives/neg.inheritance-changes-types.2.ts
+++ b/packages/jsii/test/negatives/neg.inheritance-changes-types.2.ts
@@ -1,16 +1,14 @@
-///!MATCH_ERROR: jsii.SomethingSpecific#returnSomething changes the return type when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export class Something {
-    public returnSomething(): Superclass {
-        return new Superclass();
-    }
+  public returnSomething(): Superclass {
+    return new Superclass();
+  }
 }
 
 export class SomethingSpecific extends Something {
-    public returnSomething(): Subclass {
-        return new Subclass();
-    }
+  public returnSomething(): Subclass {
+    return new Subclass();
+  }
 }

--- a/packages/jsii/test/negatives/neg.inheritance-changes-types.3.ts
+++ b/packages/jsii/test/negatives/neg.inheritance-changes-types.3.ts
@@ -1,16 +1,14 @@
-///!MATCH_ERROR: jsii.SomethingSpecific#takeSomething changes type of argument _argument when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export class Something {
-    public takeSomething(_argument: Superclass): void {
-        // Nothing
-    }
+  public takeSomething(_argument: Superclass): void {
+    // Nothing
+  }
 }
 
 export class SomethingSpecific extends Something {
-    public takeSomething(_argument: Subclass): void {
-        // Nothing
-    }
+  public takeSomething(_argument: Subclass): void {
+    // Nothing
+  }
 }

--- a/packages/jsii/test/negatives/neg.inheritance-changes-types.4.ts
+++ b/packages/jsii/test/negatives/neg.inheritance-changes-types.4.ts
@@ -1,12 +1,10 @@
-///!MATCH_ERROR: jsii.SomethingSpecific#something changes the type of property when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export class Something {
-    public something: Superclass;
+  public something = new Superclass();
 }
 
 export class SomethingSpecific extends Something {
-    public something: Subclass = new Subclass();
+  public something: Subclass = new Subclass();
 }

--- a/packages/jsii/test/negatives/neg.inheritance-changes-types.5.ts
+++ b/packages/jsii/test/negatives/neg.inheritance-changes-types.5.ts
@@ -1,18 +1,16 @@
-///!MATCH_ERROR: jsii.SomethingElse#something changes the type of property when overriding jsii.Something (expected jsii.Superclass, found jsii.Subclass)
-
 export class Superclass {}
 export class Subclass extends Superclass {}
 
 export class Something {
-    public something: Superclass;
+  public something: Superclass = new Superclass();
 }
 
 export class SomethingElse extends Something {
-    public addUnrelatedMember: number;
+  public addUnrelatedMember: number = 3;
 }
 
 // Should still fail even though 2-level inheritance
 export class SomethingDifferent extends SomethingElse {
-    public something: Subclass = new Subclass();
-    public addUnrelatedMember: number = 1;
+  public something: Subclass = new Subclass();
+  public addUnrelatedMember: number = 1;
 }

--- a/packages/jsii/test/negatives/neg.internal-underscore-class.5.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-class.5.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: the name of members marked as @internal must begin with an underscore
-
 export class MyClass {
   /** @internal */
   public propertyWithInternalButNotUnderscorePrefix?: string;

--- a/packages/jsii/test/negatives/neg.internal-underscore-class.6.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-class.6.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
-
 export class MyClass {
   public _propertyWithUnderscoreButNoInternal?: string;
 }

--- a/packages/jsii/test/negatives/neg.internal-underscore-class.7.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-class.7.ts
@@ -1,6 +1,6 @@
-///!MATCH_ERROR: the name of members marked as @internal must begin with an underscore
-
 export class MyClass {
   /** @internal */
-  public methodWithInternalButNoUnderscore(): string { return 'hi'; }
+  public methodWithInternalButNoUnderscore(): string {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.internal-underscore-class.8.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-class.8.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
-
 export interface IMyInterface {
-  _methodWithUnderscoreButNoInternal();
+  _methodWithUnderscoreButNoInternal(): void;
 }

--- a/packages/jsii/test/negatives/neg.internal-underscore-interface.1.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-interface.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: the name of members marked as @internal must begin with an underscore
-
 export interface IMyInterface {
   /** @internal */
   propertyWithInternalButNotUnderscorePrefix: string;

--- a/packages/jsii/test/negatives/neg.internal-underscore-interface.2.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-interface.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
-
 export interface IMyInterface {
   _propertyWithUnderscoreButNoInternal: string;
 }

--- a/packages/jsii/test/negatives/neg.internal-underscore-interface.3.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-interface.3.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: the name of members marked as @internal must begin with an underscore
-
 export interface IMyInterface {
   /** @internal */
   methodWithInternalButNoUnderscore(): string;

--- a/packages/jsii/test/negatives/neg.internal-underscore-interface.4.ts
+++ b/packages/jsii/test/negatives/neg.internal-underscore-interface.4.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: members with names that begin with an underscore must be marked as @internal via a JSDoc tag
-
 export class MyClass {
   public _methodWithUnderscoreButNoInternal() {
     return;

--- a/packages/jsii/test/negatives/neg.method-name.1.ts
+++ b/packages/jsii/test/negatives/neg.method-name.1.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: METHOD
-
 export class MyClass {
-    public METHOD() {
-        return "hi";
-    }
+  public METHOD() {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.method-name.2.ts
+++ b/packages/jsii/test/negatives/neg.method-name.2.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: hello_world
-
 export class MyClass {
-    public hello_world() {
-        return "hi";
-    }
+  public hello_world() {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.method-name.3.ts
+++ b/packages/jsii/test/negatives/neg.method-name.3.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Methods and properties cannot have names like getXxx() - those conflict with Java property getters by the same name
-
 export class MyClass {
-    public getFoo() {
-        return "hi";
-    }
+  public getFoo() {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.method-name.4.ts
+++ b/packages/jsii/test/negatives/neg.method-name.4.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Methods and properties cannot have names like setXxx() - those conflict with Java property setters by the same name
-
 export class MyClass {
-    public setFoo(_value: string) {
-        return "hi";
-    }
+  public setFoo(_value: string) {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.mix-datatype-and-arg-name.ts
+++ b/packages/jsii/test/negatives/neg.mix-datatype-and-arg-name.ts
@@ -1,8 +1,6 @@
-///!MATCH_ERROR: Name occurs in both function arguments and in datatype properties, rename one: dontWorry
-
 export interface Lyrics {
-  dontWorry: string;
-  beHappy: string;
+  readonly dontWorry: string;
+  readonly beHappy: string;
 }
 
 export class MyClass {

--- a/packages/jsii/test/negatives/neg.mutable-datatype.ts
+++ b/packages/jsii/test/negatives/neg.mutable-datatype.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: The property 'notOkay' in data type 'DataType' must be 'readonly' since data is passed by-value
-
 export interface DataType {
   readonly okay: string;
   notOkay: number; // properties should be "readonly"

--- a/packages/jsii/test/negatives/neg.non-optional-after-optional-ctor.ts
+++ b/packages/jsii/test/negatives/neg.non-optional-after-optional-ctor.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Parameter _arg2 cannot be optional, as it precedes non-optional parameter _arg3
-
 export class NonOptionalAfterOptional {
-    constructor(_arg1: string, _arg2 = 'hello', _arg3: string) {
-        return;
-    }
+  constructor(_arg1: string, _arg2 = 'hello', _arg3: string) {
+    return;
+  }
 }

--- a/packages/jsii/test/negatives/neg.non-optional-after-optional-method.ts
+++ b/packages/jsii/test/negatives/neg.non-optional-after-optional-method.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Parameter _arg2 cannot be optional, as it precedes non-optional parameter _argX
-
 export class NonOptionalAfterOptional {
-    public foo(_arg1: string, _arg2 = 'hello', _argX: string, _arg4?: boolean) {
-        return;
-    }
+  public foo(_arg1: string, _arg2 = 'hello', _argX: string, _arg4?: boolean) {
+    return;
+  }
 }

--- a/packages/jsii/test/negatives/neg.omit.1.ts
+++ b/packages/jsii/test/negatives/neg.omit.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Illegal "extends" value for an exported API
-
 export interface FooBar {
   readonly foo: string;
   readonly bar: string;

--- a/packages/jsii/test/negatives/neg.omit.2.ts
+++ b/packages/jsii/test/negatives/neg.omit.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Illegal "implements" value for an exported API
-
 export interface FooBar {
   readonly foo: string;
   readonly bar: string;

--- a/packages/jsii/test/negatives/neg.omit.3.ts
+++ b/packages/jsii/test/negatives/neg.omit.3.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Only string-indexed map types are supported
-
 export interface FooBar {
   readonly foo: string;
   readonly bar: string;

--- a/packages/jsii/test/negatives/neg.omit.4.ts
+++ b/packages/jsii/test/negatives/neg.omit.4.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Only string-indexed map types are supported
-
 export interface FooBar {
   readonly foo: string;
   readonly bar: string;

--- a/packages/jsii/test/negatives/neg.property-name.1.ts
+++ b/packages/jsii/test/negatives/neg.property-name.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: PROP
-
 export class MyClass {
-    public PROP?: number;
+  public PROP?: number;
 }

--- a/packages/jsii/test/negatives/neg.property-name.2.ts
+++ b/packages/jsii/test/negatives/neg.property-name.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: my_Prop
-
 export class MyClass {
-    public my_Prop?: number;
+  public my_Prop?: number;
 }

--- a/packages/jsii/test/negatives/neg.property-name.3.ts
+++ b/packages/jsii/test/negatives/neg.property-name.3.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Methods and properties cannot have names like getXxx() - those conflict with Java property getters by the same name
-
 export class MyClass {
-    public getFoo?: number;
+  public getFoo?: number;
 }

--- a/packages/jsii/test/negatives/neg.reserved.emits-warning.ts
+++ b/packages/jsii/test/negatives/neg.reserved.emits-warning.ts
@@ -1,13 +1,8 @@
 ///!STRICT!
-///!MATCH_ERROR: 'None' is a reserved word in Python.
-///!MATCH_ERROR: 'assert' is a reserved word in Java, Python.
-///!MATCH_ERROR: 'do' is a reserved word in C#, Java.
-///!MATCH_ERROR: 'internal' is a reserved word in C#.
-
 export class None {
   public readonly do: boolean = true;
 
-  public assert(internal: boolean): void {
+  public assert(_internal: boolean): void {
     throw new Error();
   }
 }

--- a/packages/jsii/test/negatives/neg.static-const-name.ts
+++ b/packages/jsii/test/negatives/neg.static-const-name.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Static constant names must use TRUMP_CASE, PascalCase or camelCase: snake_case
-
 export class MyClass {
-    static readonly snake_case = 123;
+  static readonly snake_case = 123;
 }

--- a/packages/jsii/test/negatives/neg.static-member-mixing.1.ts
+++ b/packages/jsii/test/negatives/neg.static-member-mixing.1.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: non-static member 'funFunction' of class 'Sub' conflicts with static member in ancestor 'SuperDuper'
-
 export class SuperDuper {
   public static funFunction() {
     // Empty

--- a/packages/jsii/test/negatives/neg.static-member-mixing.2.ts
+++ b/packages/jsii/test/negatives/neg.static-member-mixing.2.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: member 'funFunction' of class 'TheClass' cannot be declared both statically and non-statically
-
 export class TheClass {
   public static funFunction() {
     // Empty

--- a/packages/jsii/test/negatives/neg.static-method-name.1.ts
+++ b/packages/jsii/test/negatives/neg.static-method-name.1.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: MethodIsNotCamelCase
-
 export class MyClass {
-    MethodIsNotCamelCase() {
-        return "hi";
-    }
+  MethodIsNotCamelCase() {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.static-method-name.ts
+++ b/packages/jsii/test/negatives/neg.static-method-name.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: METHOD
-
 export class MyClass {
-    METHOD() {
-        return "hi";
-    }
+  METHOD() {
+    return 'hi';
+  }
 }

--- a/packages/jsii/test/negatives/neg.static-prop-name.1.ts
+++ b/packages/jsii/test/negatives/neg.static-prop-name.1.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: Prop
-
 export class MyClass {
-    static get Prop() {
-        return 123;
-    }
+  static get Prop() {
+    return 123;
+  }
 }

--- a/packages/jsii/test/negatives/neg.static-prop-name.2.ts
+++ b/packages/jsii/test/negatives/neg.static-prop-name.2.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Method and non-static non-readonly property names must use camelCase: PROP
-
 export class MyClass {
-    static get PROP() {
-        return 123;
-    }
+  static get PROP() {
+    return 123;
+  }
 }

--- a/packages/jsii/test/negatives/neg.struct-extends-interface.ts
+++ b/packages/jsii/test/negatives/neg.struct-extends-interface.ts
@@ -1,5 +1,3 @@
-///!MATCH_ERROR: Interface contains behavior: name should be "IStruct"
-
 // Attempt to extend an interface from a struct (aka data type)
 export interface IInterface {
   readonly field: string;

--- a/packages/jsii/test/negatives/neg.submodules-cannot-have-colliding-names.ts
+++ b/packages/jsii/test/negatives/neg.submodules-cannot-have-colliding-names.ts
@@ -1,7 +1,5 @@
-///!MATCH_ERROR: Submodule "ns1" conflicts with "Ns1".
-
 export * as ns1 from './namespaced';
 
 export class Ns1 {
-  private constructor() { }
+  private constructor() {}
 }

--- a/packages/jsii/test/negatives/neg.submodules-cannot-share-symbols.ts
+++ b/packages/jsii/test/negatives/neg.submodules-cannot-share-symbols.ts
@@ -1,4 +1,2 @@
-///!MATCH_ERROR: Symbol is re-exported under two distinct submodules
-
 export * as ns1 from './namespaced';
 export * as ns2 from './namespaced';

--- a/packages/jsii/test/negatives/neg.submodules-must-be-camel-cased.ts
+++ b/packages/jsii/test/negatives/neg.submodules-must-be-camel-cased.ts
@@ -1,3 +1,1 @@
-///!MATCH_ERROR: Submodule namespaces must be camelCased or snake_cased. Consider renaming to "ns1"
-
 export * as Ns1 from './namespaced';


### PR DESCRIPTION
When a hidden (that is, `@internal` or not exported) type is used in a
visible (`public` or `protected` on an exported type) API, the error
produced would refer to the unusable type, but would not give any
indication of where it was being used from.

This makes several enhancements to this process:
- Qualify the kind of use for the type (return, parameter, ...)
- Attach the error to the resolving node (usage location)
- Provide a related message with the unusable type's declaration
- Specifically message around "this" (used or inferred as a return type)

This is going to particularly enhance the experience of folks extending
internal base types, where those internal base types declare members
that return hidden types (or "this").

Fixes #1860



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
