### PR TITLE
chore: fix mergify configuration

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -43,9 +43,9 @@ pull_request_rules:
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
       # One test for Python 3.6, 3.7, and 3.8
-      - status-success~=^Test \(.* python 3\.6 .*$
-      - status-success~=^Test \(.* python 3\.7 .*$
-      - status-success~=^Test \(.* python 3\.8 .*$
+      - status-success~=^Test \(.* python 3\.6[ )].*$
+      - status-success~=^Test \(.* python 3\.7[ )].*$
+      - status-success~=^Test \(.* python 3\.8[ )].*$
 
   - name: Synchronize that PR to upstream and merge it (squash)
     actions:
@@ -88,9 +88,9 @@ pull_request_rules:
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
       # One test for Python 3.6, 3.7, and 3.8
-      - status-success~=^Test \(.* python 3\.6 .*$
-      - status-success~=^Test \(.* python 3\.7 .*$
-      - status-success~=^Test \(.* python 3\.8 .*$
+      - status-success~=^Test \(.* python 3\.6[ )].*$
+      - status-success~=^Test \(.* python 3\.7[ )].*$
+      - status-success~=^Test \(.* python 3\.8[ )].*$
 
   - name: Synchronize that PR to upstream and merge it (no-squash)
     actions:
@@ -133,9 +133,9 @@ pull_request_rules:
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
       # One test for Python 3.6, 3.7, and 3.8
-      - status-success~=^Test \(.* python 3\.6 .*$
-      - status-success~=^Test \(.* python 3\.7 .*$
-      - status-success~=^Test \(.* python 3\.8 .*$
+      - status-success~=^Test \(.* python 3\.6[ )].*$
+      - status-success~=^Test \(.* python 3\.7[ )].*$
+      - status-success~=^Test \(.* python 3\.8[ )].*$
 
   - name: Clean branch up
     actions:


### PR DESCRIPTION
The Python test matcher was not working because Python is currently
last in the test chain, and hence the version is not followed by a
white space.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
