### PR TITLE
feat(java): use covariant types for collection elements

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -477,6 +477,9 @@ interface JavaProp {
   // The java type for the property (eg: 'List<String>')
   fieldJavaType: string;
 
+  // The java type for the parameter (e.g: 'List<? extends SomeType>')
+  paramJavaType: string;
+
   // The NativeType representation of the property's type
   fieldNativeType: string;
 
@@ -849,7 +852,6 @@ class JavaGenerator extends Generator {
 
   protected onInterfaceProperty(_ifc: spec.InterfaceType, prop: spec.Property) {
     const getterType = this.toDecoratedJavaType(prop);
-    const setterTypes = this.toDecoratedJavaTypes(prop);
     const propName = this.code.toPascalCase(
       JavaGenerator.safeJavaPropertyName(prop.name),
     );
@@ -867,6 +869,7 @@ class JavaGenerator extends Generator {
     }
 
     if (!prop.immutable) {
+      const setterTypes = this.toDecoratedJavaTypes(prop);
       for (const type of setterTypes) {
         this.code.line();
         this.addJavaDocs(prop);
@@ -1186,7 +1189,7 @@ class JavaGenerator extends Generator {
 
     for (const prop of consts) {
       const constName = this.renderConstName(prop);
-      const propType = this.toNativeType(prop.type, true);
+      const propType = this.toNativeType(prop.type, { forMarshalling: true });
       const statement = `software.amazon.jsii.JsiiObject.jsiiStaticGet(${javaClass}.class, "${prop.name}", ${propType})`;
       this.code.line(
         `${constName} = ${this.wrapCollection(
@@ -1222,7 +1225,9 @@ class JavaGenerator extends Generator {
     overrides = !!prop.overrides,
   ) {
     const getterType = this.toDecoratedJavaType(prop);
-    const setterTypes = this.toDecoratedJavaTypes(prop);
+    const setterTypes = this.toDecoratedJavaTypes(prop, {
+      covariant: prop.static,
+    });
     const propName = this.code.toPascalCase(
       JavaGenerator.safeJavaPropertyName(prop.name),
     );
@@ -1251,7 +1256,9 @@ class JavaGenerator extends Generator {
           statement = 'this.jsiiGet(';
         }
 
-        statement += `"${prop.name}", ${this.toNativeType(prop.type, true)})`;
+        statement += `"${prop.name}", ${this.toNativeType(prop.type, {
+          forMarshalling: true,
+        })})`;
 
         this.code.line(
           `return ${this.wrapCollection(statement, prop.type, prop.optional)};`,
@@ -1469,9 +1476,12 @@ class JavaGenerator extends Generator {
       nullable: !!property.optional,
       fieldName: this.code.toCamelCase(safeName),
       fieldJavaType: this.toJavaType(property.type),
+      paramJavaType: this.toJavaType(property.type, { covariant: true }),
       fieldNativeType: this.toNativeType(property.type),
-      fieldJavaClass: `${this.toJavaType(property.type, true)}.class`,
-      javaTypes: this.toJavaTypes(property.type),
+      fieldJavaClass: `${this.toJavaType(property.type, {
+        forMarshalling: true,
+      })}.class`,
+      javaTypes: this.toJavaTypes(property.type, { covariant: true }),
       immutable: property.immutable || false,
       inherited,
     };
@@ -1525,7 +1535,7 @@ class JavaGenerator extends Generator {
         fieldName: this.code.toCamelCase(
           JavaGenerator.safeJavaPropertyName(param.name),
         ),
-        javaType: this.toJavaType(param.type),
+        javaType: this.toJavaType(param.type, { covariant: true }),
       }));
 
     const builtType = this.toJavaType(cls);
@@ -1625,7 +1635,9 @@ class JavaGenerator extends Generator {
           },
         ],
       };
-      for (const javaType of this.toJavaTypes(prop.type.spec!)) {
+      for (const javaType of this.toJavaTypes(prop.type.spec!, {
+        covariant: true,
+      })) {
         this.addJavaDocs(setter);
         this.emitStabilityAnnotations(prop.spec);
         this.code.openBlock(
@@ -1713,10 +1725,23 @@ class JavaGenerator extends Generator {
       }
       this.code.line(' */');
       this.emitStabilityAnnotations(prop.spec);
+      // We add an explicit cast if both types are generic but they are not identical (one is covariant, the other isn't)
+      const explicitCast =
+        type.includes('<') &&
+        prop.fieldJavaType.includes('<') &&
+        type !== prop.fieldJavaType
+          ? `(${prop.fieldJavaType})`
+          : '';
+      if (explicitCast !== '') {
+        // We'll be doing a safe, but unchecked cast, so suppress that warning
+        this.code.line('@SuppressWarnings("unchecked")');
+      }
       this.code.openBlock(
         `public ${builderName} ${prop.fieldName}(${type} ${prop.fieldName})`,
       );
-      this.code.line(`this.${prop.fieldName} = ${prop.fieldName};`);
+      this.code.line(
+        `this.${prop.fieldName} = ${explicitCast}${prop.fieldName};`,
+      );
       this.code.line('return this;');
       this.code.closeBlock();
     }
@@ -1856,8 +1881,11 @@ class JavaGenerator extends Generator {
       ' * Constructor that initializes the object based on literal property values passed by the {@link Builder}.',
     );
     this.code.line(' */');
+    if (props.some((prop) => prop.fieldJavaType !== prop.paramJavaType)) {
+      this.code.line('@SuppressWarnings("unchecked")');
+    }
     const constructorArgs = props
-      .map((prop) => `final ${prop.fieldJavaType} ${prop.fieldName}`)
+      .map((prop) => `final ${prop.paramJavaType} ${prop.fieldName}`)
       .join(', ');
     this.code.openBlock(
       `private ${INTERFACE_PROXY_CLASS_NAME}(${constructorArgs})`,
@@ -1866,8 +1894,12 @@ class JavaGenerator extends Generator {
       'super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);',
     );
     props.forEach((prop) => {
+      const explicitCast =
+        prop.fieldJavaType !== prop.paramJavaType
+          ? `(${prop.fieldJavaType})`
+          : '';
       this.code.line(
-        `this.${prop.fieldName} = ${_validateIfNonOptional(
+        `this.${prop.fieldName} = ${explicitCast}${_validateIfNonOptional(
           prop.fieldName,
           prop,
         )};`,
@@ -2168,8 +2200,11 @@ class JavaGenerator extends Generator {
     return this.toJavaType({ fqn: cls.base });
   }
 
-  private toDecoratedJavaType(optionalValue: spec.OptionalValue): string {
-    const result = this.toDecoratedJavaTypes(optionalValue);
+  private toDecoratedJavaType(
+    optionalValue: spec.OptionalValue,
+    { covariant = false } = {},
+  ): string {
+    const result = this.toDecoratedJavaTypes(optionalValue, { covariant });
     if (result.length > 1) {
       return `${
         optionalValue.optional ? ANN_NULLABLE : ANN_NOT_NULL
@@ -2178,15 +2213,21 @@ class JavaGenerator extends Generator {
     return result[0];
   }
 
-  private toDecoratedJavaTypes(optionalValue: spec.OptionalValue): string[] {
-    return this.toJavaTypes(optionalValue.type).map(
+  private toDecoratedJavaTypes(
+    optionalValue: spec.OptionalValue,
+    { covariant = false } = {},
+  ): string[] {
+    return this.toJavaTypes(optionalValue.type, { covariant }).map(
       (nakedType) =>
         `${optionalValue.optional ? ANN_NULLABLE : ANN_NOT_NULL} ${nakedType}`,
     );
   }
 
-  private toJavaType(type: spec.TypeReference, forMarshalling = false): string {
-    const types = this.toJavaTypes(type, forMarshalling);
+  private toJavaType(
+    type: spec.TypeReference,
+    opts?: { forMarshalling?: boolean; covariant?: boolean },
+  ): string {
+    const types = this.toJavaTypes(type, opts);
     if (types.length > 1) {
       return 'java.lang.Object';
     }
@@ -2195,15 +2236,14 @@ class JavaGenerator extends Generator {
 
   private toNativeType(
     type: spec.TypeReference,
-    forMarshalling = false,
-    recursing = false,
+    { forMarshalling = false, covariant = false, recursing = false } = {},
   ): string {
     if (spec.isCollectionTypeReference(type)) {
-      const nativeElementType = this.toNativeType(
-        type.collection.elementtype,
+      const nativeElementType = this.toNativeType(type.collection.elementtype, {
         forMarshalling,
-        true,
-      );
+        covariant,
+        recursing: true,
+      });
       switch (type.collection.kind) {
         case spec.CollectionKind.Array:
           return `software.amazon.jsii.NativeType.listOf(${nativeElementType})`;
@@ -2216,27 +2256,30 @@ class JavaGenerator extends Generator {
       }
     }
     return recursing
-      ? `software.amazon.jsii.NativeType.forClass(${this.toJavaType(
-          type,
+      ? `software.amazon.jsii.NativeType.forClass(${this.toJavaType(type, {
           forMarshalling,
-        )}.class)`
-      : `${this.toJavaType(type, forMarshalling)}.class`;
+          covariant,
+        })}.class)`
+      : `${this.toJavaType(type, { forMarshalling, covariant })}.class`;
   }
 
   private toJavaTypes(
     typeref: spec.TypeReference,
-    forMarshalling = false,
+    { forMarshalling = false, covariant = false } = {},
   ): string[] {
     if (spec.isPrimitiveTypeReference(typeref)) {
       return [this.toJavaPrimitive(typeref.primitive)];
     } else if (spec.isCollectionTypeReference(typeref)) {
-      return [this.toJavaCollection(typeref, forMarshalling)];
+      return [this.toJavaCollection(typeref, { forMarshalling, covariant })];
     } else if (spec.isNamedTypeReference(typeref)) {
       return [this.toNativeFqn(typeref.fqn)];
     } else if (typeref.union) {
       const types = new Array<string>();
       for (const subtype of typeref.union.types) {
-        for (const t of this.toJavaTypes(subtype, forMarshalling)) {
+        for (const t of this.toJavaTypes(subtype, {
+          forMarshalling,
+          covariant,
+        })) {
           types.push(t);
         }
       }
@@ -2247,22 +2290,38 @@ class JavaGenerator extends Generator {
 
   private toJavaCollection(
     ref: spec.CollectionTypeReference,
-    forMarshalling: boolean,
+    {
+      forMarshalling,
+      covariant,
+    }: { forMarshalling: boolean; covariant: boolean },
   ) {
-    const elementJavaType = this.toJavaType(ref.collection.elementtype);
+    const elementJavaType = this.toJavaType(ref.collection.elementtype, {
+      covariant,
+    });
+    const typeConstraint = covariant
+      ? makeCovariant(elementJavaType)
+      : elementJavaType;
     switch (ref.collection.kind) {
       case spec.CollectionKind.Array:
         return forMarshalling
           ? 'java.util.List'
-          : `java.util.List<${elementJavaType}>`;
+          : `java.util.List<${typeConstraint}>`;
       case spec.CollectionKind.Map:
         return forMarshalling
           ? 'java.util.Map'
-          : `java.util.Map<java.lang.String, ${elementJavaType}>`;
+          : `java.util.Map<java.lang.String, ${typeConstraint}>`;
       default:
         throw new Error(
           `Unsupported collection kind: ${ref.collection.kind as any}`,
         );
+    }
+
+    function makeCovariant(javaType: string): string {
+      // Don't emit a covariant expression for String (it's `final` in Java), or generic types (List<X>, Map<String,X>, ...)
+      if (javaType === 'java.lang.String' || javaType.includes('<')) {
+        return javaType;
+      }
+      return `? extends ${javaType}`;
     }
   }
 
@@ -2335,7 +2394,9 @@ class JavaGenerator extends Generator {
     statement += `"${method.name}"`;
 
     if (method.returns) {
-      statement += `, ${this.toNativeType(method.returns.type, true)}`;
+      statement += `, ${this.toNativeType(method.returns.type, {
+        forMarshalling: true,
+      })}`;
     } else {
       statement += ', software.amazon.jsii.NativeType.VOID';
     }
@@ -2396,10 +2457,13 @@ class JavaGenerator extends Generator {
     const params = [];
     if (method.parameters) {
       for (const p of method.parameters) {
+        // We can render covariant parameters only for methods that aren't overridable... so only for static methods currently.
         params.push(
-          `final ${this.toDecoratedJavaType(p)}${
-            p.variadic ? '...' : ''
-          } ${JavaGenerator.safeJavaPropertyName(p.name)}`,
+          `final ${this.toDecoratedJavaType(p, {
+            covariant: (method as spec.Method).static,
+          })}${p.variadic ? '...' : ''} ${JavaGenerator.safeJavaPropertyName(
+            p.name,
+          )}`,
         );
       }
     }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -40373,7 +40373,7 @@ public interface ConfusingToJacksonStruct extends software.amazon.jsii.JsiiSeria
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder unionProperty(java.util.List<java.lang.Object> unionProperty) {
+        public Builder unionProperty(java.util.List<? extends java.lang.Object> unionProperty) {
             this.unionProperty = unionProperty;
             return this;
         }
@@ -41395,8 +41395,9 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder anotherOptional(java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional) {
-            this.anotherOptional = anotherOptional;
+        @SuppressWarnings("unchecked")
+        public Builder anotherOptional(java.util.Map<java.lang.String, ? extends software.amazon.jsii.tests.calculator.lib.Value> anotherOptional) {
+            this.anotherOptional = (java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value>)anotherOptional;
             return this;
         }
 
@@ -41505,12 +41506,13 @@ public interface DerivedStruct extends software.amazon.jsii.JsiiSerializable, so
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(final java.time.Instant anotherRequired, final java.lang.Boolean bool, final software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive, final java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value> anotherOptional, final java.lang.Object optionalAny, final java.util.List<java.lang.String> optionalArray, final java.lang.Number anumber, final java.lang.String astring, final java.util.List<java.lang.String> firstOptional) {
+        @SuppressWarnings("unchecked")
+        private Jsii$Proxy(final java.time.Instant anotherRequired, final java.lang.Boolean bool, final software.amazon.jsii.tests.calculator.DoubleTrouble nonPrimitive, final java.util.Map<java.lang.String, ? extends software.amazon.jsii.tests.calculator.lib.Value> anotherOptional, final java.lang.Object optionalAny, final java.util.List<java.lang.String> optionalArray, final java.lang.Number anumber, final java.lang.String astring, final java.util.List<java.lang.String> firstOptional) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
             this.anotherRequired = java.util.Objects.requireNonNull(anotherRequired, "anotherRequired is required");
             this.bool = java.util.Objects.requireNonNull(bool, "bool is required");
             this.nonPrimitive = java.util.Objects.requireNonNull(nonPrimitive, "nonPrimitive is required");
-            this.anotherOptional = anotherOptional;
+            this.anotherOptional = (java.util.Map<java.lang.String, software.amazon.jsii.tests.calculator.lib.Value>)anotherOptional;
             this.optionalAny = optionalAny;
             this.optionalArray = optionalArray;
             this.anumber = java.util.Objects.requireNonNull(anumber, "anumber is required");
@@ -48147,8 +48149,9 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
          * @return {@code this}
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
-        public Builder arrayWithThreeElementsAndUndefinedAsSecondArgument(java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument) {
-            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = arrayWithThreeElementsAndUndefinedAsSecondArgument;
+        @SuppressWarnings("unchecked")
+        public Builder arrayWithThreeElementsAndUndefinedAsSecondArgument(java.util.List<? extends java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument) {
+            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = (java.util.List<java.lang.Object>)arrayWithThreeElementsAndUndefinedAsSecondArgument;
             return this;
         }
 
@@ -48196,9 +48199,10 @@ public interface NullShouldBeTreatedAsUndefinedData extends software.amazon.jsii
         /**
          * Constructor that initializes the object based on literal property values passed by the {@link Builder}.
          */
-        private Jsii$Proxy(final java.util.List<java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument, final java.lang.Object thisShouldBeUndefined) {
+        @SuppressWarnings("unchecked")
+        private Jsii$Proxy(final java.util.List<? extends java.lang.Object> arrayWithThreeElementsAndUndefinedAsSecondArgument, final java.lang.Object thisShouldBeUndefined) {
             super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
-            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = java.util.Objects.requireNonNull(arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
+            this.arrayWithThreeElementsAndUndefinedAsSecondArgument = (java.util.List<java.lang.Object>)java.util.Objects.requireNonNull(arrayWithThreeElementsAndUndefinedAsSecondArgument, "arrayWithThreeElementsAndUndefinedAsSecondArgument is required");
             this.thisShouldBeUndefined = thisShouldBeUndefined;
         }
 


### PR DESCRIPTION
> Re-introducing feature reverted in #1675 

Using covariant expressions instead of just the type name enables a
better experience when using libraries such as Guava to build up
collections (`List` or `Map`) to use with the libraries. In particular,
collections of `any` are particularly annoying to use without covariant
typing because they'd force the user to manually specify generic
parameters in their code that add nothing to the safety of the program.

Fixes #1517



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
