### PR TITLE
feat(python): allow setting additional trove classifiers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,22 @@ The `python` target requires two configuration entries:
 * `module` - the name of the generated **Python** module, which will be used by
   users in `import` directives.
 * `distName` - the [PyPI] distribution name for the package.
+* `classifiers` - a list of [trove classifiers] to declare on the package. It is
+  the user's responsibility to specify *valid* values (the authoritative list of
+  valid [trove classifiers] is masted in the [pypa/trove-classifiers] package).
+  * Some classifiers are automatically included (and should not be added to the
+  `classifiers` property) based on relevant configuration from the
+  `package.json` file:
+    * `Development Status :: ` is determined based on the package's `stability`
+    * `License ::` is determined based on the package's `license`
+    * `Operating System :: OS Independent` is always set
+    * `Typing :: Typed` is always set
+  * Additionally, the following `Programming Language ::` classifiers are
+    already set (more could be added by the user if relevant):
+    * `Programming Language :: Python :: 3 :: Only`
+    * `Programming Language :: Python :: 3.6`
+    * `Programming Language :: Python :: 3.7`
+    * `Programming Language :: Python :: 3.8`
 
 Example:
 ```js
@@ -162,7 +178,11 @@ Example:
     "targets": {
       "python": {
         "module": "hello_jsii",   // Required
-        "distName": "hello-jsii"  // Required
+        "distName": "hello-jsii", // Required
+        "classifiers": [          // Optional
+          "Framework :: AWS CDK",
+          "Framework :: AWS CDK :: 1"
+        ]
       },
       // ...
     }
@@ -175,6 +195,8 @@ Example:
 The resulting package can be published to [PyPI].
 
 [PyPI]: https://pypi.org/
+[trove classifiers]: https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification
+[pypa/trove-classifiers]: https://github.com/pypa/trove-classifiers
 
 #### Configuring `Java`
 

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -406,7 +406,11 @@ defineTest(
         },
       },
       js: { npm: 'jsii-calc' },
-      python: { distName: 'jsii-calc', module: 'jsii_calc' },
+      python: {
+        distName: 'jsii-calc',
+        module: 'jsii_calc',
+        classifiers: ['Test :: Classifier :: Is Dummy'],
+      },
     });
     expect(sandbox.naming({ assembly: '@scope/jsii-calc-lib' }).naming).toEqual(
       {

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -73,7 +73,10 @@
       },
       "python": {
         "distName": "jsii-calc",
-        "module": "jsii_calc"
+        "module": "jsii_calc",
+        "classifiers": [
+          "Test :: Classifier :: Is Dummy"
+        ]
       }
     },
     "metadata": {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -247,6 +247,9 @@
       "npm": "jsii-calc"
     },
     "python": {
+      "classifiers": [
+        "Test :: Classifier :: Is Dummy"
+      ],
       "distName": "jsii-calc",
       "module": "jsii_calc"
     }
@@ -13819,5 +13822,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "NsqdwWgXi+kjrpLQtQ27eA/znULJ7TtXy03ht68N9Ms="
+  "fingerprint": "TXGVwLZ10oZ08NxDzu6i+fqPtaw5aEqME8+d+KEhL08="
 }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -7100,6 +7100,9 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
       "npm": "jsii-calc"
     },
     "python": {
+      "classifiers": [
+        "Test :: Classifier :: Is Dummy"
+      ],
       "distName": "jsii-calc",
       "module": "jsii_calc"
     }
@@ -20672,7 +20675,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     }
   },
   "version": "0.0.0",
-  "fingerprint": "NsqdwWgXi+kjrpLQtQ27eA/znULJ7TtXy03ht68N9Ms="
+  "fingerprint": "TXGVwLZ10oZ08NxDzu6i+fqPtaw5aEqME8+d+KEhL08="
 }
 
 `;
@@ -55774,7 +55777,8 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.8",
         "Typing :: Typed",
         "Development Status :: 4 - Beta",
-        "License :: OSI Approved"
+        "License :: OSI Approved",
+        "Test :: Classifier :: Is Dummy"
     ]
 }
 """


### PR DESCRIPTION
Setting the `jsii.targets.python.classifiers` property in `package.json`
to an array of strings will trigger insertion of those values in the
`classifiers` of the generated python package.

Classifiers are de-duplicated and normalized in `setup.py`. Some
classifiers prefixes are considered "managed" (an appropriate value is
automatically determined for those based on the package's metadata), and
while configuring those will not cause `jsii-pacmak` to fail, a warning
will be emitted as manually specifying any of those is usually a
Bad Idea™:

- `Development Status ::`
- `License ::`
- `Operating System ::`
- `Typing ::`

Existing (i.e: valid) trove classifiers are mastered in the
[`trove-classifiers`](https://github.com/pypa/trove-classifiers) PyPA
package.

This contributes to aws/cdk-ops#393



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
