### PR TITLE
chore(golang): generate datatype interfaces

### DIFF
--- a/packages/jsii-pacmak/lib/targets/golang/module.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/module.ts
@@ -1,9 +1,9 @@
 import { CodeMaker } from 'codemaker';
 import { Assembly, Submodule as JsiiSubmodule } from 'jsii-reflect';
-import { GoClass, Enum, Interface } from './types';
+import { GoClass, Enum, Struct, Interface } from './types';
 
 export interface ModuleTypes {
-  [fqn: string]: Interface | Enum | GoClass;
+  [fqn: string]: Interface | Enum | GoClass | Struct;
 }
 
 export class Module {
@@ -14,8 +14,10 @@ export class Module {
   public constructor(assembly: Assembly, submodule?: JsiiSubmodule) {
     this.assembly = submodule ?? assembly;
     assembly.types.forEach((type) => {
-      let t: Enum | Interface | GoClass | undefined;
-      if (type.isInterfaceType()) {
+      let t: Enum | Interface | GoClass | Struct | undefined;
+      if (type.isInterfaceType() && type.datatype) {
+        t = new Struct(type);
+      } else if (type.isInterfaceType()) {
         t = new Interface(type);
       } else if (type.isClassType()) {
         t = new GoClass(type);

--- a/packages/jsii-pacmak/lib/targets/golang/types/index.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/index.ts
@@ -3,3 +3,4 @@ export * from './enum';
 export * from './go-type';
 export * from './go-type-reference';
 export * from './interface';
+export * from './struct';

--- a/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
@@ -1,0 +1,64 @@
+import { GoType } from './go-type';
+import { TypeMapper } from './interface'; // TODO replace with GoTypeRef
+import { InterfaceType, Property } from 'jsii-reflect';
+import { CodeMaker } from 'codemaker';
+
+// JSII datatype interfaces, aka structs
+export class Struct extends GoType {
+  public readonly properties: StructProperty[];
+
+  public constructor(public type: InterfaceType) {
+    super(type);
+
+    // TODO check if datatype? (isDataType() on jsii-reflect seems wrong)
+    this.properties = Object.values(this.type.getProperties()).map(
+      (prop) => new StructProperty(prop),
+    );
+  }
+
+  // needs to generate both a Go interface and a struct
+  public emit(code: CodeMaker): void {
+    this.generateInterface(code);
+    this.generateStruct(code);
+  }
+
+  private generateInterface(code: CodeMaker): void {
+    code.openBlock(`type ${this.localName} interface`);
+
+    this.properties.forEach((property) => property.emitGetter(code));
+
+    code.closeBlock();
+    code.line();
+  }
+
+  private generateStruct(code: CodeMaker): void {
+    code.openBlock(`type ${this.localName} struct`);
+
+    this.properties.forEach((property) => property.emitProperty(code));
+
+    code.closeBlock();
+    code.line();
+  }
+}
+
+// StructProperty encapsulates logic for public properties on the concrete struct
+export class StructProperty {
+  public readonly name: string;
+  public readonly returnType: string;
+
+  public constructor(public readonly property: Property) {
+    this.name = this.property.name;
+    const returnType = new TypeMapper(property.type).mapType(); // TODO replace with GoTypeRef
+    this.returnType = returnType;
+  }
+
+  public emitProperty(code: CodeMaker) {
+    const propName = code.toPascalCase(this.name);
+    code.line(`${propName} ${this.returnType}`); // TODO figure out gofmt for indentation?
+  }
+
+  public emitGetter(code: CodeMaker) {
+    const propName = code.toPascalCase(this.name);
+    code.line(`Get${propName}() ${this.returnType}`);
+  }
+}

--- a/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
@@ -1,7 +1,7 @@
 import { GoType } from './go-type';
 import { TypeMapper } from './interface'; // TODO replace with GoTypeRef
 import { InterfaceType, Property } from 'jsii-reflect';
-import { CodeMaker } from 'codemaker';
+import { CodeMaker, toPascalCase } from 'codemaker';
 
 // JSII datatype interfaces, aka structs
 export class Struct extends GoType {
@@ -12,14 +12,15 @@ export class Struct extends GoType {
 
     // TODO check if datatype? (isDataType() on jsii-reflect seems wrong)
     this.properties = Object.values(this.type.getProperties()).map(
-      (prop) => new StructProperty(prop),
+      (prop) => new StructProperty(this, prop),
     );
   }
 
-  // needs to generate both a Go interface and a struct
+  // needs to generate both a Go interface and a struct, as well as the methods on the struct
   public emit(code: CodeMaker): void {
     this.generateInterface(code);
     this.generateStruct(code);
+    this.generateImpl(code);
   }
 
   private generateInterface(code: CodeMaker): void {
@@ -39,26 +40,49 @@ export class Struct extends GoType {
     code.closeBlock();
     code.line();
   }
+
+  private generateImpl(code: CodeMaker): void {
+    code.line();
+    this.properties.forEach((property) => property.emitMethod(code));
+    code.line();
+  }
 }
 
 // StructProperty encapsulates logic for public properties on the concrete struct
 export class StructProperty {
   public readonly name: string;
+  public readonly getter: string;
   public readonly returnType: string;
 
-  public constructor(public readonly property: Property) {
-    this.name = this.property.name;
+  public constructor(
+    public readonly parent: Struct,
+    public readonly property: Property,
+  ) {
+    this.name = toPascalCase(this.property.name);
+    this.getter = `Get${this.name}`;
     const returnType = new TypeMapper(property.type).mapType(); // TODO replace with GoTypeRef
     this.returnType = returnType;
   }
 
   public emitProperty(code: CodeMaker) {
-    const propName = code.toPascalCase(this.name);
-    code.line(`${propName} ${this.returnType}`); // TODO figure out gofmt for indentation?
+    code.line(`${this.name} ${this.returnType}`); // TODO figure out gofmt for indentation?
   }
 
   public emitGetter(code: CodeMaker) {
-    const propName = code.toPascalCase(this.name);
-    code.line(`Get${propName}() ${this.returnType}`);
+    code.line(`${this.getter}() ${this.returnType}`);
+  }
+
+  public emitMethod(code: CodeMaker) {
+    const receiver = this.parent.localName;
+    const instanceArg = receiver.substring(0, 1).toLowerCase();
+
+    code.openBlock(
+      `func (${instanceArg} ${receiver}) ${
+        this.getter
+      }()${` ${this.returnType}`}`,
+    );
+    code.line(`return ${instanceArg}.${this.name}`);
+    code.closeBlock();
+    code.line();
   }
 }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -1077,6 +1077,12 @@ type BaseProps struct {
     Bar string
 }
 
+
+func (b BaseProps) GetBar() string {
+    return b.Bar
+}
+
+
 type IBaseInterface interface {
     Bar()
 }
@@ -2692,6 +2698,12 @@ type VeryBaseProps interface {
 type VeryBaseProps struct {
     Foo Very
 }
+
+
+func (v VeryBaseProps) GetFoo() Very {
+    return v.Foo
+}
+
 
 
 `;
@@ -6405,6 +6417,20 @@ type MyFirstStruct struct {
     FirstOptional Array<string>
 }
 
+
+func (m MyFirstStruct) GetAnumber() number {
+    return m.Anumber
+}
+
+func (m MyFirstStruct) GetAstring() string {
+    return m.Astring
+}
+
+func (m MyFirstStruct) GetFirstOptional() Array<string> {
+    return m.FirstOptional
+}
+
+
 type NumberIface interface {
 }
 
@@ -6434,6 +6460,20 @@ type StructWithOnlyOptionals struct {
     Optional2 number
     Optional3 boolean
 }
+
+
+func (s StructWithOnlyOptionals) GetOptional1() string {
+    return s.Optional1
+}
+
+func (s StructWithOnlyOptionals) GetOptional2() number {
+    return s.Optional2
+}
+
+func (s StructWithOnlyOptionals) GetOptional3() boolean {
+    return s.Optional3
+}
+
 
 type ValueIface interface {
 }
@@ -49464,6 +49504,16 @@ type CalculatorProps struct {
     MaximumValue number
 }
 
+
+func (c CalculatorProps) GetInitialValue() number {
+    return c.InitialValue
+}
+
+func (c CalculatorProps) GetMaximumValue() number {
+    return c.MaximumValue
+}
+
+
 type ChildStruct982 interface {
     GetBar() number
 }
@@ -49471,6 +49521,12 @@ type ChildStruct982 interface {
 type ChildStruct982 struct {
     Bar number
 }
+
+
+func (c ChildStruct982) GetBar() number {
+    return c.Bar
+}
+
 
 type ClassThatImplementsTheInternalInterfaceIface interface {
 }
@@ -49568,6 +49624,12 @@ type ConfusingToJacksonStruct interface {
 type ConfusingToJacksonStruct struct {
     UnionProperty @scope/jsii-calc-lib.IFriendly | Array<@scope/jsii-calc-lib.IFriendly | jsii-calc.AbstractClass>
 }
+
+
+func (c ConfusingToJacksonStruct) GetUnionProperty() @scope/jsii-calc-lib.IFriendly | Array<@scope/jsii-calc-lib.IFriendly | jsii-calc.AbstractClass> {
+    return c.UnionProperty
+}
+
 
 type ConstructorPassesThisOutIface interface {
 }
@@ -49739,6 +49801,12 @@ type DeprecatedStruct struct {
     ReadonlyProperty string
 }
 
+
+func (d DeprecatedStruct) GetReadonlyProperty() string {
+    return d.ReadonlyProperty
+}
+
+
 type DerivedStruct interface {
     GetAnotherRequired() date
     GetBool() boolean
@@ -49757,6 +49825,32 @@ type DerivedStruct struct {
     OptionalArray Array<string>
 }
 
+
+func (d DerivedStruct) GetAnotherRequired() date {
+    return d.AnotherRequired
+}
+
+func (d DerivedStruct) GetBool() boolean {
+    return d.Bool
+}
+
+func (d DerivedStruct) GetNonPrimitive() DoubleTrouble {
+    return d.NonPrimitive
+}
+
+func (d DerivedStruct) GetAnotherOptional() Map<string => @scope/jsii-calc-lib.Value> {
+    return d.AnotherOptional
+}
+
+func (d DerivedStruct) GetOptionalAny() any {
+    return d.OptionalAny
+}
+
+func (d DerivedStruct) GetOptionalArray() Array<string> {
+    return d.OptionalArray
+}
+
+
 type DiamondInheritanceBaseLevelStruct interface {
     GetBaseLevelProperty() string
 }
@@ -49764,6 +49858,12 @@ type DiamondInheritanceBaseLevelStruct interface {
 type DiamondInheritanceBaseLevelStruct struct {
     BaseLevelProperty string
 }
+
+
+func (d DiamondInheritanceBaseLevelStruct) GetBaseLevelProperty() string {
+    return d.BaseLevelProperty
+}
+
 
 type DiamondInheritanceFirstMidLevelStruct interface {
     GetFirstMidLevelProperty() string
@@ -49773,6 +49873,12 @@ type DiamondInheritanceFirstMidLevelStruct struct {
     FirstMidLevelProperty string
 }
 
+
+func (d DiamondInheritanceFirstMidLevelStruct) GetFirstMidLevelProperty() string {
+    return d.FirstMidLevelProperty
+}
+
+
 type DiamondInheritanceSecondMidLevelStruct interface {
     GetSecondMidLevelProperty() string
 }
@@ -49781,6 +49887,12 @@ type DiamondInheritanceSecondMidLevelStruct struct {
     SecondMidLevelProperty string
 }
 
+
+func (d DiamondInheritanceSecondMidLevelStruct) GetSecondMidLevelProperty() string {
+    return d.SecondMidLevelProperty
+}
+
+
 type DiamondInheritanceTopLevelStruct interface {
     GetTopLevelProperty() string
 }
@@ -49788,6 +49900,12 @@ type DiamondInheritanceTopLevelStruct interface {
 type DiamondInheritanceTopLevelStruct struct {
     TopLevelProperty string
 }
+
+
+func (d DiamondInheritanceTopLevelStruct) GetTopLevelProperty() string {
+    return d.TopLevelProperty
+}
+
 
 type DisappointingCollectionSourceIface interface {
 }
@@ -49905,6 +50023,16 @@ type EraseUndefinedHashValuesOptions struct {
     Option2 string
 }
 
+
+func (e EraseUndefinedHashValuesOptions) GetOption1() string {
+    return e.Option1
+}
+
+func (e EraseUndefinedHashValuesOptions) GetOption2() string {
+    return e.Option2
+}
+
+
 type ExperimentalClassIface interface {
 }
 
@@ -49932,6 +50060,12 @@ type ExperimentalStruct struct {
     ReadonlyProperty string
 }
 
+
+func (e ExperimentalStruct) GetReadonlyProperty() string {
+    return e.ReadonlyProperty
+}
+
+
 type ExportedBaseClassIface interface {
 }
 
@@ -49948,6 +50082,16 @@ type ExtendsInternalInterface struct {
     Boom boolean
     Prop string
 }
+
+
+func (e ExtendsInternalInterface) GetBoom() boolean {
+    return e.Boom
+}
+
+func (e ExtendsInternalInterface) GetProp() string {
+    return e.Prop
+}
+
 
 type ExternalClassIface interface {
 }
@@ -49976,6 +50120,12 @@ type ExternalStruct struct {
     ReadonlyProperty string
 }
 
+
+func (e ExternalStruct) GetReadonlyProperty() string {
+    return e.ReadonlyProperty
+}
+
+
 type GiveMeStructsIface interface {
 }
 
@@ -50002,6 +50152,12 @@ type Greetee interface {
 type Greetee struct {
     Name string
 }
+
+
+func (g Greetee) GetName() string {
+    return g.Name
+}
+
 
 type GreetingAugmenterIface interface {
 }
@@ -50213,6 +50369,12 @@ type ImplictBaseOfBase interface {
 type ImplictBaseOfBase struct {
     Goo date
 }
+
+
+func (i ImplictBaseOfBase) GetGoo() date {
+    return i.Goo
+}
+
 
 type InbetweenClassIface interface {
 }
@@ -50640,6 +50802,28 @@ type LoadBalancedFargateServiceProps struct {
     PublicTasks boolean
 }
 
+
+func (l LoadBalancedFargateServiceProps) GetContainerPort() number {
+    return l.ContainerPort
+}
+
+func (l LoadBalancedFargateServiceProps) GetCpu() string {
+    return l.Cpu
+}
+
+func (l LoadBalancedFargateServiceProps) GetMemoryMiB() string {
+    return l.MemoryMiB
+}
+
+func (l LoadBalancedFargateServiceProps) GetPublicLoadBalancer() boolean {
+    return l.PublicLoadBalancer
+}
+
+func (l LoadBalancedFargateServiceProps) GetPublicTasks() boolean {
+    return l.PublicTasks
+}
+
+
 type MethodNamedPropertyIface interface {
 }
 
@@ -50715,6 +50899,12 @@ type NestedStruct struct {
     NumberProp number
 }
 
+
+func (n NestedStruct) GetNumberProp() number {
+    return n.NumberProp
+}
+
+
 type NodeStandardLibraryIface interface {
 }
 
@@ -50762,6 +50952,16 @@ type NullShouldBeTreatedAsUndefinedData struct {
     ArrayWithThreeElementsAndUndefinedAsSecondArgument Array<any>
     ThisShouldBeUndefined any
 }
+
+
+func (n NullShouldBeTreatedAsUndefinedData) GetArrayWithThreeElementsAndUndefinedAsSecondArgument() Array<any> {
+    return n.ArrayWithThreeElementsAndUndefinedAsSecondArgument
+}
+
+func (n NullShouldBeTreatedAsUndefinedData) GetThisShouldBeUndefined() any {
+    return n.ThisShouldBeUndefined
+}
+
 
 type NumberGeneratorIface interface {
 }
@@ -50843,6 +51043,12 @@ type OptionalStruct struct {
     Field string
 }
 
+
+func (o OptionalStruct) GetField() string {
+    return o.Field
+}
+
+
 type OptionalStructConsumerIface interface {
 }
 
@@ -50888,6 +51094,12 @@ type ParentStruct982 interface {
 type ParentStruct982 struct {
     Foo string
 }
+
+
+func (p ParentStruct982) GetFoo() string {
+    return p.Foo
+}
+
 
 type PartiallyInitializedThisConsumerIface interface {
 }
@@ -51102,6 +51314,16 @@ type RootStruct struct {
     NestedStruct NestedStruct
 }
 
+
+func (r RootStruct) GetStringProp() string {
+    return r.StringProp
+}
+
+func (r RootStruct) GetNestedStruct() NestedStruct {
+    return r.NestedStruct
+}
+
+
 type RootStructValidatorIface interface {
 }
 
@@ -51139,6 +51361,16 @@ type SecondLevelStruct struct {
     DeeperRequiredProp string
     DeeperOptionalProp string
 }
+
+
+func (s SecondLevelStruct) GetDeeperRequiredProp() string {
+    return s.DeeperRequiredProp
+}
+
+func (s SecondLevelStruct) GetDeeperOptionalProp() string {
+    return s.DeeperOptionalProp
+}
+
 
 type SingleInstanceTwoTypesIface interface {
 }
@@ -51196,6 +51428,16 @@ type SmellyStruct struct {
     YetAnoterOne boolean
 }
 
+
+func (s SmellyStruct) GetProperty() string {
+    return s.Property
+}
+
+func (s SmellyStruct) GetYetAnoterOne() boolean {
+    return s.YetAnoterOne
+}
+
+
 type SomeTypeJsii976Iface interface {
 }
 
@@ -51236,6 +51478,12 @@ type StableStruct interface {
 type StableStruct struct {
     ReadonlyProperty string
 }
+
+
+func (s StableStruct) GetReadonlyProperty() string {
+    return s.ReadonlyProperty
+}
+
 
 type StaticContextIface interface {
 }
@@ -51296,6 +51544,20 @@ type StructA struct {
     OptionalString string
 }
 
+
+func (s StructA) GetRequiredString() string {
+    return s.RequiredString
+}
+
+func (s StructA) GetOptionalNumber() number {
+    return s.OptionalNumber
+}
+
+func (s StructA) GetOptionalString() string {
+    return s.OptionalString
+}
+
+
 type StructB interface {
     GetRequiredString() string
     GetOptionalBoolean() boolean
@@ -51308,6 +51570,20 @@ type StructB struct {
     OptionalStructA StructA
 }
 
+
+func (s StructB) GetRequiredString() string {
+    return s.RequiredString
+}
+
+func (s StructB) GetOptionalBoolean() boolean {
+    return s.OptionalBoolean
+}
+
+func (s StructB) GetOptionalStructA() StructA {
+    return s.OptionalStructA
+}
+
+
 type StructParameterType interface {
     GetScope() string
     GetProps() boolean
@@ -51317,6 +51593,16 @@ type StructParameterType struct {
     Scope string
     Props boolean
 }
+
+
+func (s StructParameterType) GetScope() string {
+    return s.Scope
+}
+
+func (s StructParameterType) GetProps() boolean {
+    return s.Props
+}
+
 
 type StructPassingIface interface {
 }
@@ -51360,6 +51646,24 @@ type StructWithJavaReservedWords struct {
     That string
 }
 
+
+func (s StructWithJavaReservedWords) GetDefault() string {
+    return s.Default
+}
+
+func (s StructWithJavaReservedWords) GetAssert() string {
+    return s.Assert
+}
+
+func (s StructWithJavaReservedWords) GetResult() string {
+    return s.Result
+}
+
+func (s StructWithJavaReservedWords) GetThat() string {
+    return s.That
+}
+
+
 type SumIface interface {
 }
 
@@ -51385,6 +51689,16 @@ type SupportsNiceJavaBuilderProps struct {
     Bar number
     Id string
 }
+
+
+func (s SupportsNiceJavaBuilderProps) GetBar() number {
+    return s.Bar
+}
+
+func (s SupportsNiceJavaBuilderProps) GetId() string {
+    return s.Id
+}
+
 
 type SupportsNiceJavaBuilderWithRequiredPropsIface interface {
 }
@@ -51469,6 +51783,20 @@ type TopLevelStruct struct {
     Optional string
 }
 
+
+func (t TopLevelStruct) GetRequired() string {
+    return t.Required
+}
+
+func (t TopLevelStruct) GetSecondLevel() number | jsii-calc.SecondLevelStruct {
+    return t.SecondLevel
+}
+
+func (t TopLevelStruct) GetOptional() string {
+    return t.Optional
+}
+
+
 type UmaskCheckIface interface {
 }
 
@@ -51495,6 +51823,16 @@ type UnionProperties struct {
     Bar string | number | jsii-calc.AllTypes
     Foo string | number
 }
+
+
+func (u UnionProperties) GetBar() string | number | jsii-calc.AllTypes {
+    return u.Bar
+}
+
+func (u UnionProperties) GetFoo() string | number {
+    return u.Foo
+}
+
 
 type UpcasingReflectableIface interface {
 }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -1073,6 +1073,10 @@ type BaseProps interface {
     GetBar() string
 }
 
+type BaseProps struct {
+    Bar string
+}
+
 type IBaseInterface interface {
     Bar()
 }
@@ -2683,6 +2687,10 @@ func (v *Very) Hey() number {
 
 type VeryBaseProps interface {
     GetFoo() Very
+}
+
+type VeryBaseProps struct {
+    Foo Very
 }
 
 
@@ -6391,6 +6399,12 @@ type MyFirstStruct interface {
     GetFirstOptional() Array<string>
 }
 
+type MyFirstStruct struct {
+    Anumber number
+    Astring string
+    FirstOptional Array<string>
+}
+
 type NumberIface interface {
 }
 
@@ -6413,6 +6427,12 @@ type StructWithOnlyOptionals interface {
     GetOptional1() string
     GetOptional2() number
     GetOptional3() boolean
+}
+
+type StructWithOnlyOptionals struct {
+    Optional1 string
+    Optional2 number
+    Optional3 boolean
 }
 
 type ValueIface interface {
@@ -49439,8 +49459,17 @@ type CalculatorProps interface {
     GetMaximumValue() number
 }
 
+type CalculatorProps struct {
+    InitialValue number
+    MaximumValue number
+}
+
 type ChildStruct982 interface {
     GetBar() number
+}
+
+type ChildStruct982 struct {
+    Bar number
 }
 
 type ClassThatImplementsTheInternalInterfaceIface interface {
@@ -49534,6 +49563,10 @@ func (c *ConfusingToJackson) MakeStructInstance() ConfusingToJacksonStruct {
 
 type ConfusingToJacksonStruct interface {
     GetUnionProperty() @scope/jsii-calc-lib.IFriendly | Array<@scope/jsii-calc-lib.IFriendly | jsii-calc.AbstractClass>
+}
+
+type ConfusingToJacksonStruct struct {
+    UnionProperty @scope/jsii-calc-lib.IFriendly | Array<@scope/jsii-calc-lib.IFriendly | jsii-calc.AbstractClass>
 }
 
 type ConstructorPassesThisOutIface interface {
@@ -49702,6 +49735,10 @@ type DeprecatedStruct interface {
     GetReadonlyProperty() string
 }
 
+type DeprecatedStruct struct {
+    ReadonlyProperty string
+}
+
 type DerivedStruct interface {
     GetAnotherRequired() date
     GetBool() boolean
@@ -49711,20 +49748,45 @@ type DerivedStruct interface {
     GetOptionalArray() Array<string>
 }
 
+type DerivedStruct struct {
+    AnotherRequired date
+    Bool boolean
+    NonPrimitive DoubleTrouble
+    AnotherOptional Map<string => @scope/jsii-calc-lib.Value>
+    OptionalAny any
+    OptionalArray Array<string>
+}
+
 type DiamondInheritanceBaseLevelStruct interface {
     GetBaseLevelProperty() string
+}
+
+type DiamondInheritanceBaseLevelStruct struct {
+    BaseLevelProperty string
 }
 
 type DiamondInheritanceFirstMidLevelStruct interface {
     GetFirstMidLevelProperty() string
 }
 
+type DiamondInheritanceFirstMidLevelStruct struct {
+    FirstMidLevelProperty string
+}
+
 type DiamondInheritanceSecondMidLevelStruct interface {
     GetSecondMidLevelProperty() string
 }
 
+type DiamondInheritanceSecondMidLevelStruct struct {
+    SecondMidLevelProperty string
+}
+
 type DiamondInheritanceTopLevelStruct interface {
     GetTopLevelProperty() string
+}
+
+type DiamondInheritanceTopLevelStruct struct {
+    TopLevelProperty string
 }
 
 type DisappointingCollectionSourceIface interface {
@@ -49838,6 +49900,11 @@ type EraseUndefinedHashValuesOptions interface {
     GetOption2() string
 }
 
+type EraseUndefinedHashValuesOptions struct {
+    Option1 string
+    Option2 string
+}
+
 type ExperimentalClassIface interface {
 }
 
@@ -49861,6 +49928,10 @@ type ExperimentalStruct interface {
     GetReadonlyProperty() string
 }
 
+type ExperimentalStruct struct {
+    ReadonlyProperty string
+}
+
 type ExportedBaseClassIface interface {
 }
 
@@ -49871,6 +49942,11 @@ type ExportedBaseClass struct {
 type ExtendsInternalInterface interface {
     GetBoom() boolean
     GetProp() string
+}
+
+type ExtendsInternalInterface struct {
+    Boom boolean
+    Prop string
 }
 
 type ExternalClassIface interface {
@@ -49896,6 +49972,10 @@ type ExternalStruct interface {
     GetReadonlyProperty() string
 }
 
+type ExternalStruct struct {
+    ReadonlyProperty string
+}
+
 type GiveMeStructsIface interface {
 }
 
@@ -49917,6 +49997,10 @@ func (g *GiveMeStructs) ReadFirstNumber() number {
 
 type Greetee interface {
     GetName() string
+}
+
+type Greetee struct {
+    Name string
 }
 
 type GreetingAugmenterIface interface {
@@ -50124,6 +50208,10 @@ type ImplementsPrivateInterface struct {
 
 type ImplictBaseOfBase interface {
     GetGoo() date
+}
+
+type ImplictBaseOfBase struct {
+    Goo date
 }
 
 type InbetweenClassIface interface {
@@ -50544,6 +50632,14 @@ type LoadBalancedFargateServiceProps interface {
     GetPublicTasks() boolean
 }
 
+type LoadBalancedFargateServiceProps struct {
+    ContainerPort number
+    Cpu string
+    MemoryMiB string
+    PublicLoadBalancer boolean
+    PublicTasks boolean
+}
+
 type MethodNamedPropertyIface interface {
 }
 
@@ -50615,6 +50711,10 @@ type NestedStruct interface {
     GetNumberProp() number
 }
 
+type NestedStruct struct {
+    NumberProp number
+}
+
 type NodeStandardLibraryIface interface {
 }
 
@@ -50656,6 +50756,11 @@ func (n *NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
 type NullShouldBeTreatedAsUndefinedData interface {
     GetArrayWithThreeElementsAndUndefinedAsSecondArgument() Array<any>
     GetThisShouldBeUndefined() any
+}
+
+type NullShouldBeTreatedAsUndefinedData struct {
+    ArrayWithThreeElementsAndUndefinedAsSecondArgument Array<any>
+    ThisShouldBeUndefined any
 }
 
 type NumberGeneratorIface interface {
@@ -50734,6 +50839,10 @@ type OptionalStruct interface {
     GetField() string
 }
 
+type OptionalStruct struct {
+    Field string
+}
+
 type OptionalStructConsumerIface interface {
 }
 
@@ -50774,6 +50883,10 @@ func (o *OverrideReturnsObject) Test() number {
 
 type ParentStruct982 interface {
     GetFoo() string
+}
+
+type ParentStruct982 struct {
+    Foo string
 }
 
 type PartiallyInitializedThisConsumerIface interface {
@@ -50984,6 +51097,11 @@ type RootStruct interface {
     GetNestedStruct() NestedStruct
 }
 
+type RootStruct struct {
+    StringProp string
+    NestedStruct NestedStruct
+}
+
 type RootStructValidatorIface interface {
 }
 
@@ -51015,6 +51133,11 @@ func (r *RuntimeTypeChecking) MethodWithOptionalArguments() {
 type SecondLevelStruct interface {
     GetDeeperRequiredProp() string
     GetDeeperOptionalProp() string
+}
+
+type SecondLevelStruct struct {
+    DeeperRequiredProp string
+    DeeperOptionalProp string
 }
 
 type SingleInstanceTwoTypesIface interface {
@@ -51068,6 +51191,11 @@ type SmellyStruct interface {
     GetYetAnoterOne() boolean
 }
 
+type SmellyStruct struct {
+    Property string
+    YetAnoterOne boolean
+}
+
 type SomeTypeJsii976Iface interface {
 }
 
@@ -51103,6 +51231,10 @@ const (
 
 type StableStruct interface {
     GetReadonlyProperty() string
+}
+
+type StableStruct struct {
+    ReadonlyProperty string
 }
 
 type StaticContextIface interface {
@@ -51158,15 +51290,32 @@ type StructA interface {
     GetOptionalString() string
 }
 
+type StructA struct {
+    RequiredString string
+    OptionalNumber number
+    OptionalString string
+}
+
 type StructB interface {
     GetRequiredString() string
     GetOptionalBoolean() boolean
     GetOptionalStructA() StructA
 }
 
+type StructB struct {
+    RequiredString string
+    OptionalBoolean boolean
+    OptionalStructA StructA
+}
+
 type StructParameterType interface {
     GetScope() string
     GetProps() boolean
+}
+
+type StructParameterType struct {
+    Scope string
+    Props boolean
 }
 
 type StructPassingIface interface {
@@ -51204,6 +51353,13 @@ type StructWithJavaReservedWords interface {
     GetThat() string
 }
 
+type StructWithJavaReservedWords struct {
+    Default string
+    Assert string
+    Result string
+    That string
+}
+
 type SumIface interface {
 }
 
@@ -51223,6 +51379,11 @@ type SupportsNiceJavaBuilder struct {
 type SupportsNiceJavaBuilderProps interface {
     GetBar() number
     GetId() string
+}
+
+type SupportsNiceJavaBuilderProps struct {
+    Bar number
+    Id string
 }
 
 type SupportsNiceJavaBuilderWithRequiredPropsIface interface {
@@ -51302,6 +51463,12 @@ type TopLevelStruct interface {
     GetOptional() string
 }
 
+type TopLevelStruct struct {
+    Required string
+    SecondLevel number | jsii-calc.SecondLevelStruct
+    Optional string
+}
+
 type UmaskCheckIface interface {
 }
 
@@ -51322,6 +51489,11 @@ type UnaryOperation struct {
 type UnionProperties interface {
     GetBar() string | number | jsii-calc.AllTypes
     GetFoo() string | number
+}
+
+type UnionProperties struct {
+    Bar string | number | jsii-calc.AllTypes
+    Foo string | number
 }
 
 type UpcasingReflectableIface interface {

--- a/packages/jsii-reflect/lib/type.ts
+++ b/packages/jsii-reflect/lib/type.ts
@@ -77,7 +77,7 @@ export abstract class Type implements Documentable, SourceLocatable {
    * Determines whether this is a Data Type (that is, an interface with no methods) or not.
    */
   public isDataType(): this is InterfaceType {
-    return false;
+    return false; // TODO how is this different from isInterfaceType?
   }
 
   /**


### PR DESCRIPTION
Implements code generation logic for datatype interfaces, with emit method generating both a Go interface and Go struct and implementation of the interface.

TODO: isDataType() in jsii-reflect seems wrong -- would be nice to
leverage this method in module.ts.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
