### PR TITLE
chore(superchain): install awscli from pip instead of yum

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -20,7 +20,8 @@ RUN rpm --import "https://packages.microsoft.com/keys/microsoft.asc"            
 
 # Install Python 3
 RUN yum -y install python3 python3-pip                                                                                  \
-  && python3 -m pip install --no-input --upgrade pip setuptools wheel twine black                                       \
+  && python3 -m pip install --no-input --upgrade pip                                                                    \
+  && python3 -m pip install --no-input --upgrade awscli black setuptools twine wheel                                    \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install Ruby 2.6+
@@ -67,7 +68,7 @@ RUN amazon-linux-extras install docker                                          
 VOLUME /var/lib/docker
 
 # Install shared dependencies
-RUN yum -y install awscli git gzip openssl rsync unzip which zip                                                        \
+RUN yum -y install git gzip openssl rsync unzip which zip                                                               \
   && yum clean all && rm -rf /var/cache/yum
 
 # Install Node 10+


### PR DESCRIPTION
The version of awscli in the yum repository appears to be somewhat outdated, and lacks
support for certain recent services and features. Moving to the recommended way to
install (using pip) will ensure the most recent release is installed every time the
image is re-built.

The recommended install/upgrade instructions are hosted at:
https://docs.aws.amazon.com/cli/latest/userguide/install-linux-al2017.html#install-amazon-linux-pip

Fixes #1905



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
