### PR TITLE
chore: dial down integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -377,7 +377,20 @@ jobs:
       - name: Integration Test
         run: |-
           npx lerna run build
-          ./pack.sh
+
+          # In the interest of speed, only process monocdk-experiment / aws-cdk-lib:
+
+          npx lerna exec --scope=monocdk-experiment --scope=aws-cdk-lib --      \
+            ${ROSETTA}                                                          \
+            --compile                                                           \
+            --output ./dist/samples.tabl.json                                   \
+            --directory .                                                       \
+            --verbose
+
+          npx lerna exec --scope=monocdk-experiment --scope=aws-cdk-lib --      \
+            ${PACMAK}                                                           \
+            --rosetta-tablet ./dist/samples.tabl.json                           \
+            --verbose
         env:
           CDK_BUILD_JSII: ${{ github.workspace }}/node_modules/.bin/jsii
           CDK_PACKAGE_JSII_PACMAK: ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
@@ -386,9 +399,13 @@ jobs:
           JSII: ${{ github.workspace }}/node_modules/.bin/jsii
           PACMAK: ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
           ROSETTA: ${{ github.workspace }}/node_modules/.bin/jsii-rosetta
+          # Node Options
+          NODE_OPTIONS: --experimental-workers
         working-directory: aws-cdk
       - name: Upload Result
         uses: actions/upload-artifact@v2
         with:
           name: integ-test-result
-          path: ${{ github.workspace }}/aws-cdk/dist/
+          path: |-
+            ${{ github.workspace }}/aws-cdk/dist/
+            ${{ github.workspace }}/aws-cdk/**/dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -374,32 +374,40 @@ jobs:
         run: |-
           npm install --no-save ${{ runner.temp }}/js/*.tgz
           npm install --no-save ${{ runner.temp }}/private/*.tgz --only=prod
-      - name: Integration Test
+
+          # Setting environment variables for next jobs
+          echo "::set-env name=JSII::${{ github.workspace }}/node_modules/.bin/jsii"
+          echo "::set-env name=CDK_BUILD_JSII::${{ github.workspace }}/node_modules/.bin/jsii"
+
+          echo "::set-env name=PACMAK::${{ github.workspace }}/node_modules/.bin/jsii-pacmak"
+          echo "::set-env name=CDK_PACKAGE_JSII_PACMAK::${{ github.workspace }}/node_modules/.bin/jsii-pacmak"
+
+          echo "::set-env name=ROSETTA::${{ github.workspace }}/node_modules/.bin/jsii-rosetta"
+          echo "::set-env name=CDK_PACKAGE_JSII_ROSETTA::${{ github.workspace }}/node_modules/.bin/jsii-rosetta"
+
+      - name: Integration Test (build)
         run: |-
           npx lerna run build
+        working-directory: aws-cdk
 
-          # In the interest of speed, only process monocdk-experiment / aws-cdk-lib:
-
+        # In the interest of speed, only process monocdk-experiment / aws-cdk-lib from now on
+      - name: Integration Test (jsii-rosetta)
+        run: |-
           npx lerna exec --scope=monocdk-experiment --scope=aws-cdk-lib --      \
             ${ROSETTA}                                                          \
             --compile                                                           \
             --output ./dist/samples.tabl.json                                   \
             --directory .                                                       \
             --verbose
-
+        working-directory: aws-cdk
+      - name: Integration Test (jsii-pacmak)
+        run: |-
           npx lerna exec --scope=monocdk-experiment --scope=aws-cdk-lib --      \
             ${PACMAK}                                                           \
             --rosetta-tablet ./dist/samples.tabl.json                           \
             --verbose
-        env:
-          CDK_BUILD_JSII: ${{ github.workspace }}/node_modules/.bin/jsii
-          CDK_PACKAGE_JSII_PACMAK: ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
-          CDK_PACKAGE_JSII_ROSETTA: ${{ github.workspace }}/node_modules/.bin/jsii-rosetta
-          # Alternative environment variables:
-          JSII: ${{ github.workspace }}/node_modules/.bin/jsii
-          PACMAK: ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
-          ROSETTA: ${{ github.workspace }}/node_modules/.bin/jsii-rosetta
         working-directory: aws-cdk
+
       - name: Upload Result
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,8 +399,6 @@ jobs:
           JSII: ${{ github.workspace }}/node_modules/.bin/jsii
           PACMAK: ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
           ROSETTA: ${{ github.workspace }}/node_modules/.bin/jsii-rosetta
-          # Node Options
-          NODE_OPTIONS: --experimental-workers
         working-directory: aws-cdk
       - name: Upload Result
         uses: actions/upload-artifact@v2

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs-extra';
+import * as path from 'path';
 import {
   TabletSchema,
   TranslatedSnippetSchema,
@@ -68,6 +69,7 @@ export class LanguageTablet {
   }
 
   public async save(filename: string) {
+    await fs.mkdirp(path.dirname(filename));
     await fs.writeJson(filename, this.toSchema(), {
       encoding: 'utf-8',
       spaces: 2,


### PR DESCRIPTION
Since this integration test is rather slow (generating all CDK in a
2-CPU instance), focus it on running `jsii-rosetta` and `jsii-pacmak`
only on the `monocdk-experiment` package (and it's future `aws-cdk-lib`
name, for good measure).

This hopefully is going to allow the tests to return *much* faster, at
least until we can safely offload this to a self-hosted github runner.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
