### PR TITLE
chore: rename Module, Submodule

### DIFF
--- a/packages/jsii-pacmak/lib/targets/golang/base-package.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/base-package.ts
@@ -10,10 +10,10 @@ const JSII_MODULE_NAME = 'github.com/aws-cdk/jsii/jsii';
 export type ModuleType = Interface | Enum | GoClass | Struct;
 
 /*
- * Module represents a single `.go` source file within a package. This can be the root package file or a submodule
+ * BasePackage represents a single `.go` source file within a package. This can be the root package file or a submodule
  */
-export abstract class Module {
-  public readonly root: Module;
+export abstract class BasePackage {
+  public readonly root: BasePackage;
   public readonly file: string;
   public readonly submodules: InternalPackage[];
   public readonly types: ModuleType[];
@@ -24,7 +24,7 @@ export abstract class Module {
     public readonly moduleName: string,
     public readonly filePath: string,
     // If no root is provided, this module is the root
-    root?: Module,
+    root?: BasePackage,
   ) {
     this.file = `${filePath}.go`;
     this.root = root || this;
@@ -51,12 +51,12 @@ export abstract class Module {
   }
 
   /*
-   * Modules that types within this module reference
+   * BasePackages that types within this module reference
    */
-  public get dependencies(): Module[] {
+  public get dependencies(): BasePackage[] {
     return flatMap(
       this.types,
-      (t: ModuleType): Module[] => t.dependencies,
+      (t: ModuleType): BasePackage[] => t.dependencies,
     ).filter((mod) => mod.moduleName !== this.moduleName);
   }
 
@@ -121,10 +121,14 @@ export abstract class Module {
 /*
  * InternalPackage refers to any go package within a given JSII module.
  */
-export class InternalPackage extends Module {
-  public readonly parent: Module;
+export class InternalPackage extends BasePackage {
+  public readonly parent: BasePackage;
 
-  public constructor(root: Module, parent: Module, assembly: JsiiSubmodule) {
+  public constructor(
+    root: BasePackage,
+    parent: BasePackage,
+    assembly: JsiiSubmodule,
+  ) {
     const moduleName = goModuleName(assembly.name);
     const filePath = `${parent.filePath}/${moduleName}`;
 

--- a/packages/jsii-pacmak/lib/targets/golang/base-package.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/base-package.ts
@@ -2,7 +2,7 @@ import { CodeMaker } from 'codemaker';
 import { Type, Submodule as JsiiSubmodule } from 'jsii-reflect';
 import { EmitContext } from './emit-context';
 import { GoClass, Enum, Interface, Struct } from './types';
-import { findTypeInTree, goModuleName, flatMap } from './util';
+import { findTypeInTree, goPackageName, flatMap } from './util';
 
 // JSII golang runtime module name
 const JSII_MODULE_NAME = 'github.com/aws-cdk/jsii/jsii';
@@ -129,7 +129,7 @@ export class InternalPackage extends BasePackage {
     parent: BasePackage,
     assembly: JsiiSubmodule,
   ) {
-    const moduleName = goModuleName(assembly.name);
+    const moduleName = goPackageName(assembly.name);
     const filePath = `${parent.filePath}/${moduleName}`;
 
     super(assembly.types, assembly.submodules, moduleName, filePath, root);

--- a/packages/jsii-pacmak/lib/targets/golang/module.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/module.ts
@@ -15,7 +15,7 @@ export type ModuleType = Interface | Enum | GoClass | Struct;
 export abstract class Module {
   public readonly root: Module;
   public readonly file: string;
-  public readonly submodules: Submodule[];
+  public readonly submodules: InternalPackage[];
   public readonly types: ModuleType[];
 
   public constructor(
@@ -29,7 +29,7 @@ export abstract class Module {
     this.file = `${filePath}.go`;
     this.root = root || this;
     this.submodules = this.submoduleSpec.map(
-      (sm) => new Submodule(this.root, this, sm),
+      (sm) => new InternalPackage(this.root, this, sm),
     );
 
     this.types = this.typeSpec.map(
@@ -82,7 +82,7 @@ export abstract class Module {
     this.emitTypes(code);
     code.closeFile(this.file);
 
-    this.emitSubmodules(context);
+    this.emitInternalPackages(context);
   }
 
   private emitHeader(code: CodeMaker) {
@@ -105,7 +105,7 @@ export abstract class Module {
     code.line();
   }
 
-  public emitSubmodules(context: EmitContext) {
+  public emitInternalPackages(context: EmitContext) {
     for (const submodule of this.submodules) {
       submodule.emit(context);
     }
@@ -118,7 +118,10 @@ export abstract class Module {
   }
 }
 
-export class Submodule extends Module {
+/*
+ * InternalPackage refers to any go package within a given JSII module.
+ */
+export class InternalPackage extends Module {
   public readonly parent: Module;
 
   public constructor(root: Module, parent: Module, assembly: JsiiSubmodule) {

--- a/packages/jsii-pacmak/lib/targets/golang/package.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/package.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { EmitContext } from './emit-context';
 import { ReadmeFile } from './readme-file';
 import { BasePackage } from './base-package';
-import { goModuleName } from './util';
+import { goPackageName } from './util';
 
 /*
  * A go JSII Package
@@ -14,7 +14,7 @@ export class Package extends BasePackage {
   public readonly assembly: Assembly;
 
   public constructor(assembly: Assembly) {
-    const moduleName = goModuleName(assembly.name);
+    const moduleName = goPackageName(assembly.name);
     const filePath = join(...moduleName.split('.'));
 
     super(

--- a/packages/jsii-pacmak/lib/targets/golang/package.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/package.ts
@@ -2,15 +2,15 @@ import { Assembly } from 'jsii-reflect';
 import { join } from 'path';
 import { EmitContext } from './emit-context';
 import { ReadmeFile } from './readme-file';
-import { Module } from './module';
+import { BasePackage } from './base-package';
 import { goModuleName } from './util';
 
 /*
  * A go JSII Package
  *
- * Extends `Module` for root source package emit logic
+ * Extends `BasePackage` for root source package emit logic
  */
-export class Package extends Module {
+export class Package extends BasePackage {
   public readonly assembly: Assembly;
 
   public constructor(assembly: Assembly) {

--- a/packages/jsii-pacmak/lib/targets/golang/types/class.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/class.ts
@@ -3,7 +3,7 @@ import { CodeMaker } from 'codemaker';
 import { GoTypeRef } from './go-type-reference';
 import { GoType, GoEmitter } from './go-type';
 import { TypeField } from './type-field';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 import { getFieldDependencies } from '../util';
 
 // String appended to all go Class Interfaces
@@ -133,7 +133,7 @@ export class GoClass extends GoType implements GoEmitter {
   public readonly methods: ClassMethod[];
   public readonly interfaceName: string;
 
-  public constructor(parent: Module, public type: ClassType) {
+  public constructor(parent: BasePackage, public type: ClassType) {
     super(parent, type);
 
     this.properties = Object.values(this.type.getProperties()).map(
@@ -180,7 +180,7 @@ export class GoClass extends GoType implements GoEmitter {
     code.line();
   }
 
-  public get dependencies(): Module[] {
+  public get dependencies(): BasePackage[] {
     return [
       ...getFieldDependencies(this.properties),
       ...getFieldDependencies(this.methods),

--- a/packages/jsii-pacmak/lib/targets/golang/types/enum.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/enum.ts
@@ -1,10 +1,10 @@
 import { CodeMaker } from 'codemaker';
 import { EnumType } from 'jsii-reflect';
 import { GoType } from './go-type';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 
 export class Enum extends GoType {
-  public constructor(parent: Module, public type: EnumType) {
+  public constructor(parent: BasePackage, public type: EnumType) {
     super(parent, type);
   }
 
@@ -26,7 +26,7 @@ export class Enum extends GoType {
     code.line();
   }
 
-  public get dependencies(): Module[] {
+  public get dependencies(): BasePackage[] {
     return [];
   }
 }

--- a/packages/jsii-pacmak/lib/targets/golang/types/go-type-reference.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/go-type-reference.ts
@@ -1,5 +1,5 @@
 import { TypeReference } from 'jsii-reflect';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 import { GoType } from './go-type';
 import { toPascalCase } from 'codemaker';
 
@@ -30,7 +30,7 @@ class PrimitiveMapper {
  */
 export class GoTypeRef {
   public constructor(
-    public readonly root: Module,
+    public readonly root: BasePackage,
     public readonly reference: TypeReference,
   ) {}
 
@@ -55,9 +55,9 @@ export class GoTypeRef {
   }
 
   /*
-   * Return the name of a type for reference from the `Module` passed in
+   * Return the name of a type for reference from the `BasePackage` passed in
    */
-  public scopedName(scope: Module): string {
+  public scopedName(scope: BasePackage): string {
     // type references a primitie
     if (this.reference.primitive) {
       return new PrimitiveMapper(this.reference.primitive).goPrimitive;

--- a/packages/jsii-pacmak/lib/targets/golang/types/go-type.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/go-type.ts
@@ -1,13 +1,13 @@
 import { CodeMaker } from 'codemaker';
 import { Type } from 'jsii-reflect';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 
 export interface GoEmitter {
   emit(code: CodeMaker): void;
 }
 
 export class GoType {
-  public constructor(public parent: Module, public type: Type) {}
+  public constructor(public parent: BasePackage, public type: Type) {}
 
   public get name() {
     return this.type.name;

--- a/packages/jsii-pacmak/lib/targets/golang/types/interface.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/interface.ts
@@ -2,12 +2,12 @@ import { CodeMaker } from 'codemaker';
 import { InterfaceType, Method, Property } from 'jsii-reflect';
 import { GoType } from './go-type';
 import { GoTypeRef } from './go-type-reference';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 
 export class Interface extends GoType {
-  public readonly dependencies: Module[] = [];
+  public readonly dependencies: BasePackage[] = [];
 
-  public constructor(parent: Module, public type: InterfaceType) {
+  public constructor(parent: BasePackage, public type: InterfaceType) {
     super(parent, type);
   }
 

--- a/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/struct.ts
@@ -1,6 +1,6 @@
 import { GoType } from './go-type';
 import { GoTypeRef } from './go-type-reference';
-import { Module } from '../module';
+import { BasePackage } from '../base-package';
 import { InterfaceType, Property } from 'jsii-reflect';
 import { CodeMaker, toPascalCase } from 'codemaker';
 
@@ -9,9 +9,9 @@ const STRUCT_INTERFACE_SUFFIX = 'Iface';
 // JSII datatype interfaces, aka structs
 export class Struct extends GoType {
   public readonly properties: StructProperty[];
-  public readonly dependencies: Module[] = [];
+  public readonly dependencies: BasePackage[] = [];
 
-  public constructor(parent: Module, public type: InterfaceType) {
+  public constructor(parent: BasePackage, public type: InterfaceType) {
     super(parent, type);
 
     // TODO check if datatype? (isDataType() on jsii-reflect seems wrong)

--- a/packages/jsii-pacmak/lib/targets/golang/util.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/util.ts
@@ -1,11 +1,11 @@
-import { Module, ModuleType } from './module';
+import { BasePackage, ModuleType } from './base-package';
 import { TypeField } from './types';
 
 /*
  * Recursively search module for type with fqn
  */
 export function findTypeInTree(
-  module: Module,
+  module: BasePackage,
   fqn: string,
 ): ModuleType | undefined {
   const result = module.types.find((t) => t.type.fqn === fqn);
@@ -38,8 +38,8 @@ export function flatMap<T, R>(
 /*
  * Return module dependencies of a class or interface fields
  */
-export function getFieldDependencies(fields: TypeField[]): Module[] {
-  return fields.reduce((accum: Module[], field) => {
+export function getFieldDependencies(fields: TypeField[]): BasePackage[] {
+  return fields.reduce((accum: BasePackage[], field) => {
     return field.references?.type?.parent
       ? [...accum, field.references?.type.parent]
       : accum;

--- a/packages/jsii-pacmak/lib/targets/golang/util.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/util.ts
@@ -22,7 +22,7 @@ export function findTypeInTree(
 /*
  * Format NPM package names as idiomatic Go module name
  */
-export function goModuleName(name: string): string {
+export function goPackageName(name: string): string {
   return name.replace('@', '').replace(/[^a-z0-9.]/gi, '');
 }
 


### PR DESCRIPTION
Since `Module` has a somewhat special meaning in Go due to the `go mod` dependency management system, the `Module` class is being renamed to `BasePackage`, and `Submodule` to `InternalPackage`. This reserves the `Module` name for code related to dependency management.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
