### PR TITLE
chore(go): generate inherited methods on class

### DIFF
--- a/packages/jsii-pacmak/lib/targets/golang/types/class.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/class.ts
@@ -14,7 +14,7 @@ export class GoClass extends GoStruct {
   public constructor(parent: Package, public type: ClassType) {
     super(parent, type);
 
-    this.methods = Object.values(this.type.getMethods()).map(
+    this.methods = Object.values(this.type.getMethods(true)).map(
       (method) => new ClassMethod(this, method),
     );
   }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -4587,6 +4587,8 @@ type NumberIface interface {
     SetValue()
     GetDoubleValue() float64
     SetDoubleValue()
+    TypeName() jsii.Any
+    ToString() string
 }
 
 // Struct proxy
@@ -4625,9 +4627,28 @@ func (n Number) SetDoubleValue(val float64) {
     n.DoubleValue = val
 }
 
+func (n *Number) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Number",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (n *Number) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Number",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
+}
+
 type NumericValueIface interface {
     GetValue() float64
     SetValue()
+    TypeName() jsii.Any
     ToString() string
 }
 
@@ -4657,6 +4678,15 @@ func (n NumericValue) SetValue(val float64) {
     n.Value = val
 }
 
+func (n *NumericValue) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "NumericValue",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
 func (n *NumericValue) ToString() string  {
     jsii.NoOpRequest(jsii.NoOpApiRequest {
         Class: "NumericValue",
@@ -4669,6 +4699,7 @@ func (n *NumericValue) ToString() string  {
 type OperationIface interface {
     GetValue() float64
     SetValue()
+    TypeName() jsii.Any
     ToString() string
 }
 
@@ -4696,6 +4727,15 @@ func NewOperation() OperationIface {
 
 func (o Operation) SetValue(val float64) {
     o.Value = val
+}
+
+func (o *Operation) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Operation",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
 }
 
 func (o *Operation) ToString() string  {
@@ -38815,7 +38855,9 @@ type AddIface interface {
     SetLhs()
     GetRhs() jsii.Any
     SetRhs()
+    TypeName() jsii.Any
     ToString() string
+    Hello() string
 }
 
 // Struct proxy
@@ -38863,10 +38905,28 @@ func (a Add) SetRhs(val jsii.Any) {
     a.Rhs = val
 }
 
+func (a *Add) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Add",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
 func (a *Add) ToString() string  {
     jsii.NoOpRequest(jsii.NoOpApiRequest {
         Class: "Add",
         Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
+}
+
+func (a *Add) Hello() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Add",
+        Method: "Hello",
         Parameters: []string{}
     })
     return "NOOP_RETURN_STRING"
@@ -39464,6 +39524,8 @@ type BinaryOperationIface interface {
     SetLhs()
     GetRhs() jsii.Any
     SetRhs()
+    TypeName() jsii.Any
+    ToString() string
     Hello() string
 }
 
@@ -39510,6 +39572,24 @@ func (b BinaryOperation) SetLhs(val jsii.Any) {
 
 func (b BinaryOperation) SetRhs(val jsii.Any) {
     b.Rhs = val
+}
+
+func (b *BinaryOperation) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "BinaryOperation",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (b *BinaryOperation) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "BinaryOperation",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
 }
 
 func (b *BinaryOperation) Hello() string  {
@@ -39581,6 +39661,8 @@ type CalculatorIface interface {
     SetMaxValue()
     GetUnionProperty() jsii.Any
     SetUnionProperty()
+    TypeName() jsii.Any
+    ToString() string
     Add() jsii.Any
     Mul() jsii.Any
     Neg() jsii.Any
@@ -39694,6 +39776,24 @@ func (c Calculator) SetMaxValue(val float64) {
 
 func (c Calculator) SetUnionProperty(val jsii.Any) {
     c.UnionProperty = val
+}
+
+func (c *Calculator) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Calculator",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (c *Calculator) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Calculator",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
 }
 
 func (c *Calculator) Add() jsii.Any  {
@@ -41843,6 +41943,7 @@ func (i *ImplementsInterfaceWithInternal) Visible() jsii.Any  {
 }
 
 type ImplementsInterfaceWithInternalSubclassIface interface {
+    Visible() jsii.Any
 }
 
 // Struct proxy
@@ -41859,6 +41960,15 @@ func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInterna
     return &ImplementsInterfaceWithInternalSubclass{
      // props
     }
+}
+
+func (i *ImplementsInterfaceWithInternalSubclass) Visible() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "ImplementsInterfaceWithInternalSubclass",
+        Method: "Visible",
+        Parameters: []string{}
+    })
+    return nil
 }
 
 type ImplementsPrivateInterfaceIface interface {
@@ -41922,6 +42032,7 @@ func (i ImplictBaseOfBase) GetGoo() string {
 
 
 type InbetweenClassIface interface {
+    Hello() jsii.Any
     Ciao() string
 }
 
@@ -41939,6 +42050,15 @@ func NewInbetweenClass() InbetweenClassIface {
     return &InbetweenClass{
      // props
     }
+}
+
+func (i *InbetweenClass) Hello() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "InbetweenClass",
+        Method: "Hello",
+        Parameters: []string{}
+    })
+    return nil
 }
 
 func (i *InbetweenClass) Ciao() string  {
@@ -42047,6 +42167,8 @@ type JSII417DerivedIface interface {
     GetHasRoot() bool
     SetHasRoot()
     GetProperty() string
+    MakeInstance() Jsii417PublicBaseOfBase
+    Foo() jsii.Any
     Bar() jsii.Any
     Baz() jsii.Any
 }
@@ -42084,6 +42206,24 @@ func (j JSII417Derived) SetHasRoot(val bool) {
 
 func (j JSII417Derived) SetProperty(val string) {
     j.Property = val
+}
+
+func (j *JSII417Derived) MakeInstance() Jsii417PublicBaseOfBase  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "JSII417Derived",
+        Method: "MakeInstance",
+        Parameters: []string{}
+    })
+    return Jsii417PublicBaseOfBase{}
+}
+
+func (j *JSII417Derived) Foo() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "JSII417Derived",
+        Method: "Foo",
+        Parameters: []string{}
+    })
+    return nil
 }
 
 func (j *JSII417Derived) Bar() jsii.Any  {
@@ -43119,10 +43259,12 @@ type MultiplyIface interface {
     SetLhs()
     GetRhs() jsii.Any
     SetRhs()
+    TypeName() jsii.Any
+    ToString() string
+    Hello() string
     Farewell() string
     Goodbye() string
     Next() float64
-    ToString() string
 }
 
 // Struct proxy
@@ -43170,6 +43312,33 @@ func (m Multiply) SetRhs(val jsii.Any) {
     m.Rhs = val
 }
 
+func (m *Multiply) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Multiply",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (m *Multiply) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Multiply",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
+}
+
+func (m *Multiply) Hello() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Multiply",
+        Method: "Hello",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
+}
+
 func (m *Multiply) Farewell() string  {
     jsii.NoOpRequest(jsii.NoOpApiRequest {
         Class: "Multiply",
@@ -43197,24 +43366,16 @@ func (m *Multiply) Next() float64  {
     return 0.0
 }
 
-func (m *Multiply) ToString() string  {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "ToString",
-        Parameters: []string{}
-    })
-    return "NOOP_RETURN_STRING"
-}
-
 type NegateIface interface {
     GetValue() float64
     SetValue()
     GetOperand() jsii.Any
     SetOperand()
+    TypeName() jsii.Any
+    ToString() string
     Farewell() string
     Goodbye() string
     Hello() string
-    ToString() string
 }
 
 // Struct proxy
@@ -43252,6 +43413,24 @@ func (n Negate) SetOperand(val jsii.Any) {
     n.Operand = val
 }
 
+func (n *Negate) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Negate",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (n *Negate) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Negate",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
+}
+
 func (n *Negate) Farewell() string  {
     jsii.NoOpRequest(jsii.NoOpApiRequest {
         Class: "Negate",
@@ -43274,15 +43453,6 @@ func (n *Negate) Hello() string  {
     jsii.NoOpRequest(jsii.NoOpApiRequest {
         Class: "Negate",
         Method: "Hello",
-        Parameters: []string{}
-    })
-    return "NOOP_RETURN_STRING"
-}
-
-func (n *Negate) ToString() string  {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "ToString",
         Parameters: []string{}
     })
     return "NOOP_RETURN_STRING"
@@ -43935,6 +44105,8 @@ type PowerIface interface {
     SetBase()
     GetPow() jsii.Any
     SetPow()
+    TypeName() jsii.Any
+    ToString() string
 }
 
 // Struct proxy
@@ -44016,6 +44188,24 @@ func (p Power) SetBase(val jsii.Any) {
 
 func (p Power) SetPow(val jsii.Any) {
     p.Pow = val
+}
+
+func (p *Power) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Power",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (p *Power) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Power",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
 }
 
 type PropertyNamedPropertyIface interface {
@@ -45209,6 +45399,8 @@ type SumIface interface {
     SetStringStyle()
     GetParts() []jsii.Any
     SetParts()
+    TypeName() jsii.Any
+    ToString() string
 }
 
 // Struct proxy
@@ -45280,6 +45472,24 @@ func (s Sum) SetStringStyle(val composition.CompositionStringStyle) {
 
 func (s Sum) SetParts(val []jsii.Any) {
     s.Parts = val
+}
+
+func (s *Sum) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Sum",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (s *Sum) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Sum",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
 }
 
 type SupportsNiceJavaBuilderIface interface {
@@ -45684,6 +45894,8 @@ type UnaryOperationIface interface {
     SetValue()
     GetOperand() jsii.Any
     SetOperand()
+    TypeName() jsii.Any
+    ToString() string
 }
 
 // Struct proxy
@@ -45719,6 +45931,24 @@ func (u UnaryOperation) SetValue(val float64) {
 
 func (u UnaryOperation) SetOperand(val jsii.Any) {
     u.Operand = val
+}
+
+func (u *UnaryOperation) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "UnaryOperation",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
+}
+
+func (u *UnaryOperation) ToString() string  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "UnaryOperation",
+        Method: "ToString",
+        Parameters: []string{}
+    })
+    return "NOOP_RETURN_STRING"
 }
 
 // Struct interface
@@ -46133,6 +46363,7 @@ type CompositeOperationIface interface {
     SetDecorationPrefixes()
     GetStringStyle() CompositionStringStyle
     SetStringStyle()
+    TypeName() jsii.Any
     ToString() string
 }
 
@@ -46196,6 +46427,15 @@ func (c CompositeOperation) SetDecorationPrefixes(val []string) {
 
 func (c CompositeOperation) SetStringStyle(val CompositionStringStyle) {
     c.StringStyle = val
+}
+
+func (c *CompositeOperation) TypeName() jsii.Any  {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "CompositeOperation",
+        Method: "TypeName",
+        Parameters: []string{}
+    })
+    return nil
 }
 
 func (c *CompositeOperation) ToString() string  {


### PR DESCRIPTION
Previously, GoClass methods were only being populated by methods
directly on the parent type. Calling `getMethods` with true also
gets any inherited methods, which should cause the class to correctly
implement its corresponding interface.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
