### PR TITLE
fix(go): Only embed behavioral interfaces

### DIFF
--- a/packages/jsii-pacmak/lib/targets/golang/types/class.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/class.ts
@@ -32,7 +32,17 @@ export class GoClass extends GoStruct {
   }
 
   protected emitInterface(code: CodeMaker): void {
+    code.line('// Class interface'); // FIXME for debugging
     code.openBlock(`type ${this.interfaceName} interface`);
+
+    const extended = this.type.getInterfaces(true);
+
+    // embed extended interfaces
+    if (extended.length !== 0) {
+      for (const iface of extended) {
+        code.line(iface.fqn);
+      }
+    }
 
     for (const property of this.properties) {
       property.emitGetterDecl(code);

--- a/packages/jsii-pacmak/lib/targets/golang/types/go-type.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/types/go-type.ts
@@ -126,15 +126,6 @@ export abstract class GoStruct extends GoType implements GoEmitter {
     code.line('// Struct interface'); // FIXME for debugging
     code.openBlock(`type ${this.interfaceName} interface`);
 
-    const extended = this.type.getInterfaces(true);
-
-    // embed extended interfaces
-    if (extended.length !== 0) {
-      for (const iface of extended) {
-        code.line(iface.fqn);
-      }
-    }
-
     for (const property of this.properties) {
       property.emitGetterDecl(code);
     }

--- a/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
+++ b/packages/jsii-pacmak/test/__snapshots__/jsii-pacmak.test.ts.snap
@@ -484,6 +484,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type BaseIface interface {
     TypeName() jsii.Any
 }
@@ -515,7 +516,6 @@ func (b *Base) TypeName() jsii.Any  {
 
 // Struct interface
 type BasePropsIface interface {
-    @scope/jsii-calc-base-of-base.VeryBaseProps
     GetFoo() jsii.Any
     GetBar() string
 }
@@ -1693,6 +1693,7 @@ type IVeryBaseInterface interface {
     Foo()
 }
 
+// Class interface
 type StaticConsumerIface interface {
     Consume() jsii.Any
 }
@@ -1710,6 +1711,7 @@ func (s *StaticConsumer) Consume() jsii.Any  {
     return nil
 }
 
+// Class interface
 type VeryIface interface {
     Hey() float64
 }
@@ -4582,7 +4584,9 @@ func (m MyFirstStruct) GetFirstOptional() []string {
 }
 
 
+// Class interface
 type NumberIface interface {
+    @scope/jsii-calc-lib.IDoublable
     GetValue() float64
     SetValue()
     GetDoubleValue() float64
@@ -4645,6 +4649,7 @@ func (n *Number) ToString() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type NumericValueIface interface {
     GetValue() float64
     SetValue()
@@ -4696,6 +4701,7 @@ func (n *NumericValue) ToString() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type OperationIface interface {
     GetValue() float64
     SetValue()
@@ -4789,6 +4795,7 @@ type IReflectable interface {
     GetEntries() []ReflectableEntry
 }
 
+// Class interface
 type NestingClassIface interface {
 }
 
@@ -4796,6 +4803,7 @@ type NestingClassIface interface {
 type NestingClass struct {
 }
 
+// Class interface
 type NestedClassIface interface {
     GetProperty() string
     SetProperty()
@@ -4863,6 +4871,7 @@ func (r ReflectableEntry) GetValue() jsii.Any {
 }
 
 
+// Class interface
 type ReflectorIface interface {
     AsMap() map[string]jsii.Any
 }
@@ -38654,7 +38663,9 @@ import (
     "composition"
 )
 
+// Class interface
 type AbstractClassIface interface {
+    jsii-calc.IInterfaceImplementedByAbstractClass
     GetAbstractProperty() string
     SetAbstractProperty()
     GetPropFromInterface() string
@@ -38716,6 +38727,7 @@ func (a *AbstractClass) NonAbstractMethod() float64  {
     return 0.0
 }
 
+// Class interface
 type AbstractClassBaseIface interface {
     GetAbstractProperty() string
     SetAbstractProperty()
@@ -38747,6 +38759,7 @@ func (a AbstractClassBase) SetAbstractProperty(val string) {
     a.AbstractProperty = val
 }
 
+// Class interface
 type AbstractClassReturnerIface interface {
     GetReturnAbstractFromProperty() AbstractClassBase
     SetReturnAbstractFromProperty()
@@ -38798,6 +38811,7 @@ func (a *AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstrac
     return nil
 }
 
+// Class interface
 type AbstractSuiteIface interface {
     GetProperty() string
     SomeMethod() string
@@ -38848,7 +38862,9 @@ func (a *AbstractSuite) WorkItAll() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type AddIface interface {
+    @scope/jsii-calc-lib.IFriendly
     GetValue() float64
     SetValue()
     GetLhs() jsii.Any
@@ -38932,6 +38948,7 @@ func (a *Add) Hello() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type AllTypesIface interface {
     GetEnumPropertyValue() float64
     SetEnumPropertyValue()
@@ -39199,6 +39216,7 @@ const (
     AllTypesEnumThisIsGreat AllTypesEnum = "THIS_IS_GREAT"
 )
 
+// Class interface
 type AllowedMethodNamesIface interface {
     GetBar() jsii.Any
     GetFoo() string
@@ -39258,6 +39276,7 @@ func (a *AllowedMethodNames) SetFoo() jsii.Any  {
     return nil
 }
 
+// Class interface
 type AmbiguousParametersIface interface {
     GetProps() StructParameterType
     SetProps()
@@ -39300,7 +39319,9 @@ func (a AmbiguousParameters) SetScope(val Bell) {
     a.Scope = val
 }
 
+// Class interface
 type AnonymousImplementationProviderIface interface {
+    jsii-calc.IAnonymousImplementationProvider
     ProvideAsClass() Implementation
     ProvideAsInterface() IAnonymouslyImplementMe
 }
@@ -39339,6 +39360,7 @@ func (a *AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImple
     return nil
 }
 
+// Class interface
 type AsyncVirtualMethodsIface interface {
     CallMe() float64
     CallMe2() float64
@@ -39418,6 +39440,7 @@ func (a *AsyncVirtualMethods) OverrideMeToo() float64  {
     return 0.0
 }
 
+// Class interface
 type AugmentableClassIface interface {
     MethodOne() jsii.Any
     MethodTwo() jsii.Any
@@ -39457,6 +39480,7 @@ func (a *AugmentableClass) MethodTwo() jsii.Any  {
     return nil
 }
 
+// Class interface
 type BaseJsii976Iface interface {
 }
 
@@ -39476,7 +39500,9 @@ func NewBaseJsii976() BaseJsii976Iface {
     }
 }
 
+// Class interface
 type BellIface interface {
+    jsii-calc.IBell
     GetRung() bool
     SetRung()
     Ring() jsii.Any
@@ -39517,7 +39543,9 @@ func (b *Bell) Ring() jsii.Any  {
     return nil
 }
 
+// Class interface
 type BinaryOperationIface interface {
+    @scope/jsii-calc-lib.IFriendly
     GetValue() float64
     SetValue()
     GetLhs() jsii.Any
@@ -39601,6 +39629,7 @@ func (b *BinaryOperation) Hello() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type BurriedAnonymousObjectIface interface {
     Check() bool
     GiveItBack() jsii.Any
@@ -39640,6 +39669,7 @@ func (b *BurriedAnonymousObject) GiveItBack() jsii.Any  {
     return nil
 }
 
+// Class interface
 type CalculatorIface interface {
     GetValue() float64
     SetValue()
@@ -39864,7 +39894,6 @@ func (c CalculatorProps) GetMaximumValue() float64 {
 
 // Struct interface
 type ChildStruct982Iface interface {
-    jsii-calc.ParentStruct982
     GetFoo() string
     GetBar() float64
 }
@@ -39884,7 +39913,10 @@ func (c ChildStruct982) GetBar() float64 {
 }
 
 
+// Class interface
 type ClassThatImplementsTheInternalInterfaceIface interface {
+    jsii-calc.INonInternalInterface
+    jsii-calc.IAnotherPublicInterface
     GetA() string
     SetA()
     GetB() string
@@ -39948,7 +39980,10 @@ func (c ClassThatImplementsTheInternalInterface) SetD(val string) {
     c.D = val
 }
 
+// Class interface
 type ClassThatImplementsThePrivateInterfaceIface interface {
+    jsii-calc.INonInternalInterface
+    jsii-calc.IAnotherPublicInterface
     GetA() string
     SetA()
     GetB() string
@@ -40012,6 +40047,7 @@ func (c ClassThatImplementsThePrivateInterface) SetE(val string) {
     c.E = val
 }
 
+// Class interface
 type ClassWithCollectionsIface interface {
     GetStaticArray() []string
     SetStaticArray()
@@ -40096,6 +40132,7 @@ func (c *ClassWithCollections) CreateAMap() map[string]string  {
     return nil
 }
 
+// Class interface
 type ClassWithDocsIface interface {
 }
 
@@ -40115,6 +40152,7 @@ func NewClassWithDocs() ClassWithDocsIface {
     }
 }
 
+// Class interface
 type ClassWithJavaReservedWordsIface interface {
     GetInt() string
     SetInt()
@@ -40156,6 +40194,7 @@ func (c *ClassWithJavaReservedWords) Import() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type ClassWithMutableObjectLiteralPropertyIface interface {
     GetMutableObject() IMutableObjectLiteral
     SetMutableObject()
@@ -40187,7 +40226,9 @@ func (c ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObje
     c.MutableObject = val
 }
 
+// Class interface
 type ClassWithPrivateConstructorAndAutomaticPropertiesIface interface {
+    jsii-calc.IInterfaceWithProperties
     GetReadOnlyString() string
     SetReadOnlyString()
     GetReadWriteString() string
@@ -40227,6 +40268,7 @@ func (c *ClassWithPrivateConstructorAndAutomaticProperties) Create() ClassWithPr
     return ClassWithPrivateConstructorAndAutomaticProperties{}
 }
 
+// Class interface
 type ConfusingToJacksonIface interface {
     GetUnionProperty() jsii.Any
     SetUnionProperty()
@@ -40281,6 +40323,7 @@ func (c ConfusingToJacksonStruct) GetUnionProperty() jsii.Any {
 }
 
 
+// Class interface
 type ConstructorPassesThisOutIface interface {
 }
 
@@ -40300,6 +40343,7 @@ func NewConstructorPassesThisOut(consumer jsii-calc.PartiallyInitializedThisCons
     }
 }
 
+// Class interface
 type ConstructorsIface interface {
     HiddenInterface() IPublicInterface
     HiddenInterfaces() []IPublicInterface
@@ -40389,6 +40433,7 @@ func (c *Constructors) MakeInterfaces() []IPublicInterface  {
     return nil
 }
 
+// Class interface
 type ConsumePureInterfaceIface interface {
     WorkItBaby() StructB
 }
@@ -40418,6 +40463,7 @@ func (c *ConsumePureInterface) WorkItBaby() StructB  {
     return nil
 }
 
+// Class interface
 type ConsumerCanRingBellIface interface {
     StaticImplementedByObjectLiteral() bool
     StaticImplementedByPrivateClass() bool
@@ -40517,6 +40563,7 @@ func (c *ConsumerCanRingBell) WhenTypedAsClass() bool  {
     return true
 }
 
+// Class interface
 type ConsumersOfThisCrazyTypeSystemIface interface {
     ConsumeAnotherPublicInterface() string
     ConsumeNonInternalInterface() jsii.Any
@@ -40556,6 +40603,7 @@ func (c *ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface() jsii.Any 
     return nil
 }
 
+// Class interface
 type DataRendererIface interface {
     Render() string
     RenderArbitrary() string
@@ -40605,6 +40653,7 @@ func (d *DataRenderer) RenderMap() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type DefaultedConstructorArgumentIface interface {
     GetArg1() float64
     SetArg1()
@@ -40658,6 +40707,7 @@ func (d DefaultedConstructorArgument) SetArg2(val string) {
     d.Arg2 = val
 }
 
+// Class interface
 type Demonstrate982Iface interface {
     TakeThis() ChildStruct982
     TakeThisToo() ParentStruct982
@@ -40697,6 +40747,7 @@ func (d *Demonstrate982) TakeThisToo() ParentStruct982  {
     return nil
 }
 
+// Class interface
 type DeprecatedClassIface interface {
     GetReadonlyProperty() string
     SetReadonlyProperty()
@@ -40773,7 +40824,6 @@ func (d DeprecatedStruct) GetReadonlyProperty() string {
 
 // Struct interface
 type DerivedStructIface interface {
-    @scope/jsii-calc-lib.MyFirstStruct
     GetAnumber() float64
     GetAstring() string
     GetFirstOptional() []string
@@ -40852,7 +40902,6 @@ func (d DiamondInheritanceBaseLevelStruct) GetBaseLevelProperty() string {
 
 // Struct interface
 type DiamondInheritanceFirstMidLevelStructIface interface {
-    jsii-calc.DiamondInheritanceBaseLevelStruct
     GetBaseLevelProperty() string
     GetFirstMidLevelProperty() string
 }
@@ -40874,7 +40923,6 @@ func (d DiamondInheritanceFirstMidLevelStruct) GetFirstMidLevelProperty() string
 
 // Struct interface
 type DiamondInheritanceSecondMidLevelStructIface interface {
-    jsii-calc.DiamondInheritanceBaseLevelStruct
     GetBaseLevelProperty() string
     GetSecondMidLevelProperty() string
 }
@@ -40896,9 +40944,6 @@ func (d DiamondInheritanceSecondMidLevelStruct) GetSecondMidLevelProperty() stri
 
 // Struct interface
 type DiamondInheritanceTopLevelStructIface interface {
-    jsii-calc.DiamondInheritanceBaseLevelStruct
-    jsii-calc.DiamondInheritanceFirstMidLevelStruct
-    jsii-calc.DiamondInheritanceSecondMidLevelStruct
     GetBaseLevelProperty() string
     GetFirstMidLevelProperty() string
     GetSecondMidLevelProperty() string
@@ -40930,6 +40975,7 @@ func (d DiamondInheritanceTopLevelStruct) GetTopLevelProperty() string {
 }
 
 
+// Class interface
 type DisappointingCollectionSourceIface interface {
     GetMaybeList() []string
     SetMaybeList()
@@ -40960,6 +41006,7 @@ func (d DisappointingCollectionSource) SetMaybeMap(val map[string]float64) {
     d.MaybeMap = val
 }
 
+// Class interface
 type DoNotOverridePrivatesIface interface {
     ChangePrivatePropertyValue() jsii.Any
     PrivateMethodValue() string
@@ -41009,6 +41056,7 @@ func (d *DoNotOverridePrivates) PrivatePropertyValue() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type DoNotRecognizeAnyAsOptionalIface interface {
     Method() jsii.Any
 }
@@ -41038,6 +41086,7 @@ func (d *DoNotRecognizeAnyAsOptional) Method() jsii.Any  {
     return nil
 }
 
+// Class interface
 type DocumentedClassIface interface {
     Greet() float64
     Hola() jsii.Any
@@ -41077,6 +41126,7 @@ func (d *DocumentedClass) Hola() jsii.Any  {
     return nil
 }
 
+// Class interface
 type DontComplainAboutVariadicAfterOptionalIface interface {
     OptionalAndVariadic() string
 }
@@ -41106,7 +41156,11 @@ func (d *DontComplainAboutVariadicAfterOptional) OptionalAndVariadic() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type DoubleTroubleIface interface {
+    jsii-calc.IFriendlyRandomGenerator
+    jsii-calc.IRandomNumberGenerator
+    @scope/jsii-calc-lib.IFriendly
     Hello() string
     Next() float64
 }
@@ -41145,6 +41199,7 @@ func (d *DoubleTrouble) Next() float64  {
     return 0.0
 }
 
+// Class interface
 type DynamicPropertyBearerIface interface {
     GetDynamicProperty() string
     SetDynamicProperty()
@@ -41187,6 +41242,7 @@ func (d DynamicPropertyBearer) SetValueStore(val string) {
     d.ValueStore = val
 }
 
+// Class interface
 type DynamicPropertyBearerChildIface interface {
     GetDynamicProperty() string
     SetDynamicProperty()
@@ -41250,6 +41306,7 @@ func (d *DynamicPropertyBearerChild) OverrideValue() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type EnumDispenserIface interface {
     RandomIntegerLikeEnum() AllTypesEnum
     RandomStringLikeEnum() StringEnum
@@ -41277,6 +41334,7 @@ func (e *EnumDispenser) RandomStringLikeEnum() StringEnum  {
     return "ENUM_DUMMY"
 }
 
+// Class interface
 type EraseUndefinedHashValuesIface interface {
     DoesKeyExist() bool
     Prop1IsNull() map[string]jsii.Any
@@ -41347,6 +41405,7 @@ func (e EraseUndefinedHashValuesOptions) GetOption2() string {
 }
 
 
+// Class interface
 type ExperimentalClassIface interface {
     GetReadonlyProperty() string
     SetReadonlyProperty()
@@ -41421,6 +41480,7 @@ func (e ExperimentalStruct) GetReadonlyProperty() string {
 }
 
 
+// Class interface
 type ExportedBaseClassIface interface {
     GetSuccess() bool
     SetSuccess()
@@ -41473,6 +41533,7 @@ func (e ExtendsInternalInterface) GetProp() string {
 }
 
 
+// Class interface
 type ExternalClassIface interface {
     GetReadonlyProperty() string
     SetReadonlyProperty()
@@ -41547,6 +41608,7 @@ func (e ExternalStruct) GetReadonlyProperty() string {
 }
 
 
+// Class interface
 type GiveMeStructsIface interface {
     GetStructLiteral() jsii.Any
     SetStructLiteral()
@@ -41623,6 +41685,7 @@ func (g Greetee) GetName() string {
 }
 
 
+// Class interface
 type GreetingAugmenterIface interface {
     BetterGreeting() string
 }
@@ -41851,6 +41914,7 @@ type IStructReturningDelegate interface {
     ReturnStruct() StructB
 }
 
+// Class interface
 type ImplementInternalInterfaceIface interface {
     GetProp() string
     SetProp()
@@ -41882,6 +41946,7 @@ func (i ImplementInternalInterface) SetProp(val string) {
     i.Prop = val
 }
 
+// Class interface
 type ImplementationIface interface {
     GetValue() float64
     SetValue()
@@ -41913,7 +41978,9 @@ func (i Implementation) SetValue(val float64) {
     i.Value = val
 }
 
+// Class interface
 type ImplementsInterfaceWithInternalIface interface {
+    jsii-calc.IInterfaceWithInternal
     Visible() jsii.Any
 }
 
@@ -41942,7 +42009,9 @@ func (i *ImplementsInterfaceWithInternal) Visible() jsii.Any  {
     return nil
 }
 
+// Class interface
 type ImplementsInterfaceWithInternalSubclassIface interface {
+    jsii-calc.IInterfaceWithInternal
     Visible() jsii.Any
 }
 
@@ -41971,6 +42040,7 @@ func (i *ImplementsInterfaceWithInternalSubclass) Visible() jsii.Any  {
     return nil
 }
 
+// Class interface
 type ImplementsPrivateInterfaceIface interface {
     GetPrivate() string
     SetPrivate()
@@ -42004,8 +42074,6 @@ func (i ImplementsPrivateInterface) SetPrivate(val string) {
 
 // Struct interface
 type ImplictBaseOfBaseIface interface {
-    @scope/jsii-calc-base-of-base.VeryBaseProps
-    @scope/jsii-calc-base.BaseProps
     GetFoo() jsii.Any
     GetBar() string
     GetGoo() string
@@ -42031,7 +42099,9 @@ func (i ImplictBaseOfBase) GetGoo() string {
 }
 
 
+// Class interface
 type InbetweenClassIface interface {
+    jsii-calc.IPublicInterface2
     Hello() jsii.Any
     Ciao() string
 }
@@ -42070,6 +42140,7 @@ func (i *InbetweenClass) Ciao() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type InterfaceCollectionsIface interface {
     ListOfInterfaces() []IBell
     ListOfStructs() []StructA
@@ -42117,6 +42188,7 @@ func (i *InterfaceCollections) MapOfStructs() map[string]StructA  {
     return nil
 }
 
+// Class interface
 type InterfacesMakerIface interface {
     MakeInterfaces() []jsii.Any
 }
@@ -42134,6 +42206,7 @@ func (i *InterfacesMaker) MakeInterfaces() []jsii.Any  {
     return nil
 }
 
+// Class interface
 type IsomorphismIface interface {
     Myself() Isomorphism
 }
@@ -42163,6 +42236,7 @@ func (i *Isomorphism) Myself() Isomorphism  {
     return Isomorphism{}
 }
 
+// Class interface
 type JSII417DerivedIface interface {
     GetHasRoot() bool
     SetHasRoot()
@@ -42244,6 +42318,7 @@ func (j *JSII417Derived) Baz() jsii.Any  {
     return nil
 }
 
+// Class interface
 type JSII417PublicBaseOfBaseIface interface {
     GetHasRoot() bool
     SetHasRoot()
@@ -42295,6 +42370,7 @@ func (j *JSII417PublicBaseOfBase) Foo() jsii.Any  {
     return nil
 }
 
+// Class interface
 type JSObjectLiteralForInterfaceIface interface {
     GiveMeFriendly() jsii.Any
     GiveMeFriendlyGenerator() IFriendlyRandomGenerator
@@ -42334,6 +42410,7 @@ func (j *JSObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomG
     return nil
 }
 
+// Class interface
 type JSObjectLiteralToNativeIface interface {
     ReturnLiteral() JsObjectLiteralToNativeClass
 }
@@ -42363,6 +42440,7 @@ func (j *JSObjectLiteralToNative) ReturnLiteral() JsObjectLiteralToNativeClass  
     return JsObjectLiteralToNativeClass{}
 }
 
+// Class interface
 type JSObjectLiteralToNativeClassIface interface {
     GetPropA() string
     SetPropA()
@@ -42405,6 +42483,7 @@ func (j JSObjectLiteralToNativeClass) SetPropB(val float64) {
     j.PropB = val
 }
 
+// Class interface
 type JavaReservedWordsIface interface {
     GetWhile() string
     SetWhile()
@@ -42956,7 +43035,10 @@ func (j *JavaReservedWords) Volatile() jsii.Any  {
     return nil
 }
 
+// Class interface
 type Jsii487DerivedIface interface {
+    jsii-calc.IJsii487External2
+    jsii-calc.IJsii487External
 }
 
 // Struct proxy
@@ -42975,7 +43057,9 @@ func NewJsii487Derived() Jsii487DerivedIface {
     }
 }
 
+// Class interface
 type Jsii496DerivedIface interface {
+    jsii-calc.IJsii496
 }
 
 // Struct proxy
@@ -42994,6 +43078,7 @@ func NewJsii496Derived() Jsii496DerivedIface {
     }
 }
 
+// Class interface
 type JsiiAgentIface interface {
     GetValue() string
     SetValue()
@@ -43025,6 +43110,7 @@ func (j JsiiAgent) SetValue(val string) {
     j.Value = val
 }
 
+// Class interface
 type JsonFormatterIface interface {
     AnyArray() jsii.Any
     AnyBooleanFalse() jsii.Any
@@ -43211,6 +43297,7 @@ func (l LoadBalancedFargateServiceProps) GetPublicTasks() bool {
 }
 
 
+// Class interface
 type MethodNamedPropertyIface interface {
     GetElite() float64
     SetElite()
@@ -43252,7 +43339,12 @@ func (m *MethodNamedProperty) Property() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type MultiplyIface interface {
+    @scope/jsii-calc-lib.IFriendly
+    jsii-calc.IFriendlier
+    @scope/jsii-calc-lib.IFriendly
+    jsii-calc.IRandomNumberGenerator
     GetValue() float64
     SetValue()
     GetLhs() jsii.Any
@@ -43366,7 +43458,10 @@ func (m *Multiply) Next() float64  {
     return 0.0
 }
 
+// Class interface
 type NegateIface interface {
+    jsii-calc.IFriendlier
+    @scope/jsii-calc-lib.IFriendly
     GetValue() float64
     SetValue()
     GetOperand() jsii.Any
@@ -43458,6 +43553,7 @@ func (n *Negate) Hello() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type NestedClassInstanceIface interface {
     MakeInstance() jsii.Any
 }
@@ -43490,6 +43586,7 @@ func (n NestedStruct) GetNumberProp() float64 {
 }
 
 
+// Class interface
 type NodeStandardLibraryIface interface {
     GetOsPlatform() string
     SetOsPlatform()
@@ -43551,6 +43648,7 @@ func (n *NodeStandardLibrary) FsReadFileSync() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type NullShouldBeTreatedAsUndefinedIface interface {
     GetChangeMeToUndefined() string
     SetChangeMeToUndefined()
@@ -43633,6 +43731,7 @@ func (n NullShouldBeTreatedAsUndefinedData) GetThisShouldBeUndefined() jsii.Any 
 }
 
 
+// Class interface
 type NumberGeneratorIface interface {
     GetGenerator() IRandomNumberGenerator
     SetGenerator()
@@ -43684,6 +43783,7 @@ func (n *NumberGenerator) NextTimes100() float64  {
     return 0.0
 }
 
+// Class interface
 type ObjectRefsInCollectionsIface interface {
     SumFromArray() float64
     SumFromMap() float64
@@ -43723,6 +43823,7 @@ func (o *ObjectRefsInCollections) SumFromMap() float64  {
     return 0.0
 }
 
+// Class interface
 type ObjectWithPropertyProviderIface interface {
     Provide() IObjectWithProperty
 }
@@ -43740,6 +43841,7 @@ func (o *ObjectWithPropertyProvider) Provide() IObjectWithProperty  {
     return nil
 }
 
+// Class interface
 type OldIface interface {
     DoAThing() jsii.Any
 }
@@ -43769,6 +43871,7 @@ func (o *Old) DoAThing() jsii.Any  {
     return nil
 }
 
+// Class interface
 type OptionalArgumentInvokerIface interface {
     InvokeWithOptional() jsii.Any
     InvokeWithoutOptional() jsii.Any
@@ -43808,6 +43911,7 @@ func (o *OptionalArgumentInvoker) InvokeWithoutOptional() jsii.Any  {
     return nil
 }
 
+// Class interface
 type OptionalConstructorArgumentIface interface {
     GetArg1() float64
     SetArg1()
@@ -43876,6 +43980,7 @@ func (o OptionalStruct) GetField() string {
 }
 
 
+// Class interface
 type OptionalStructConsumerIface interface {
     GetParameterWasUndefined() bool
     SetParameterWasUndefined()
@@ -43918,6 +44023,7 @@ func (o OptionalStructConsumer) SetFieldValue(val string) {
     o.FieldValue = val
 }
 
+// Class interface
 type OverridableProtectedMemberIface interface {
     GetOverrideReadOnly() string
     GetOverrideReadWrite() string
@@ -43988,6 +44094,7 @@ func (o *OverridableProtectedMember) ValueFromProtected() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type OverrideReturnsObjectIface interface {
     Test() float64
 }
@@ -44032,6 +44139,7 @@ func (p ParentStruct982) GetFoo() string {
 }
 
 
+// Class interface
 type PartiallyInitializedThisConsumerIface interface {
     ConsumePartiallyInitializedThis() string
 }
@@ -44061,6 +44169,7 @@ func (p *PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis() str
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type PolymorphismIface interface {
     SayHello() string
 }
@@ -44090,6 +44199,7 @@ func (p *Polymorphism) SayHello() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type PowerIface interface {
     GetValue() float64
     SetValue()
@@ -44208,6 +44318,7 @@ func (p *Power) ToString() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type PropertyNamedPropertyIface interface {
     GetProperty() string
     SetProperty()
@@ -44250,6 +44361,7 @@ func (p PropertyNamedProperty) SetYetAnoterOne(val bool) {
     p.YetAnoterOne = val
 }
 
+// Class interface
 type PublicClassIface interface {
     Hello() jsii.Any
 }
@@ -44279,6 +44391,7 @@ func (p *PublicClass) Hello() jsii.Any  {
     return nil
 }
 
+// Class interface
 type PythonReservedWordsIface interface {
     And() jsii.Any
     As() jsii.Any
@@ -44618,6 +44731,7 @@ func (p *PythonReservedWords) Yield() jsii.Any  {
     return nil
 }
 
+// Class interface
 type ReferenceEnumFromScopedPackageIface interface {
     GetFoo() jsii.Any
     SetFoo()
@@ -44669,6 +44783,7 @@ func (r *ReferenceEnumFromScopedPackage) SaveFoo() jsii.Any  {
     return nil
 }
 
+// Class interface
 type ReturnsPrivateImplementationOfInterfaceIface interface {
     GetPrivateImplementation() IPrivatelyImplemented
     SetPrivateImplementation()
@@ -44721,6 +44836,7 @@ func (r RootStruct) GetNestedStruct() NestedStruct {
 }
 
 
+// Class interface
 type RootStructValidatorIface interface {
     Validate() jsii.Any
 }
@@ -44738,6 +44854,7 @@ func (r *RootStructValidator) Validate() jsii.Any  {
     return nil
 }
 
+// Class interface
 type RuntimeTypeCheckingIface interface {
     MethodWithDefaultedArguments() jsii.Any
     MethodWithOptionalAnyArgument() jsii.Any
@@ -44808,6 +44925,7 @@ func (s SecondLevelStruct) GetDeeperOptionalProp() string {
 }
 
 
+// Class interface
 type SingleInstanceTwoTypesIface interface {
     Interface1() InbetweenClass
     Interface2() IPublicInterface
@@ -44847,6 +44965,7 @@ func (s *SingleInstanceTwoTypes) Interface2() IPublicInterface  {
     return nil
 }
 
+// Class interface
 type SingletonIntIface interface {
     IsSingletonInt() bool
 }
@@ -44870,6 +44989,7 @@ const (
     SingletonIntEnumSingletonInt SingletonIntEnum = "SINGLETON_INT"
 )
 
+// Class interface
 type SingletonStringIface interface {
     IsSingletonString() bool
 }
@@ -44914,6 +45034,7 @@ func (s SmellyStruct) GetYetAnoterOne() bool {
 }
 
 
+// Class interface
 type SomeTypeJsii976Iface interface {
     ReturnAnonymous() jsii.Any
     ReturnReturn() IReturnJsii976
@@ -44953,6 +45074,7 @@ func (s *SomeTypeJsii976) ReturnReturn() IReturnJsii976  {
     return nil
 }
 
+// Class interface
 type StableClassIface interface {
     GetReadonlyProperty() string
     SetReadonlyProperty()
@@ -45027,6 +45149,7 @@ func (s StableStruct) GetReadonlyProperty() string {
 }
 
 
+// Class interface
 type StaticContextIface interface {
     GetStaticVariable() bool
     SetStaticVariable()
@@ -45056,6 +45179,7 @@ func (s *StaticContext) CanAccessStaticContext() bool  {
     return true
 }
 
+// Class interface
 type StaticsIface interface {
     GetBar() float64
     SetBar()
@@ -45181,6 +45305,7 @@ const (
     StringEnumC StringEnum = "C"
 )
 
+// Class interface
 type StripInternalIface interface {
     GetYouSeeMe() string
     SetYouSeeMe()
@@ -45287,6 +45412,7 @@ func (s StructParameterType) GetProps() bool {
 }
 
 
+// Class interface
 type StructPassingIface interface {
     HowManyVarArgsDidIPass() float64
     RoundTrip() TopLevelStruct
@@ -45326,6 +45452,7 @@ func (s *StructPassing) RoundTrip() TopLevelStruct  {
     return nil
 }
 
+// Class interface
 type StructUnionConsumerIface interface {
     IsStructA() bool
     IsStructB() bool
@@ -45386,6 +45513,7 @@ func (s StructWithJavaReservedWords) GetThat() string {
 }
 
 
+// Class interface
 type SumIface interface {
     GetValue() float64
     SetValue()
@@ -45492,6 +45620,7 @@ func (s *Sum) ToString() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type SupportsNiceJavaBuilderIface interface {
     GetBar() float64
     SetBar()
@@ -45577,6 +45706,7 @@ func (s SupportsNiceJavaBuilderProps) GetId() string {
 }
 
 
+// Class interface
 type SupportsNiceJavaBuilderWithRequiredPropsIface interface {
     GetBar() float64
     SetBar()
@@ -45630,6 +45760,7 @@ func (s SupportsNiceJavaBuilderWithRequiredProps) SetPropId(val string) {
     s.PropId = val
 }
 
+// Class interface
 type SyncVirtualMethodsIface interface {
     GetReadonlyProperty() string
     SetReadonlyProperty()
@@ -45816,6 +45947,7 @@ func (s *SyncVirtualMethods) WriteA() jsii.Any  {
     return nil
 }
 
+// Class interface
 type ThrowerIface interface {
     ThrowError() jsii.Any
 }
@@ -45872,6 +46004,7 @@ func (t TopLevelStruct) GetOptional() string {
 }
 
 
+// Class interface
 type UmaskCheckIface interface {
     Mode() float64
 }
@@ -45889,6 +46022,7 @@ func (u *UmaskCheck) Mode() float64  {
     return 0.0
 }
 
+// Class interface
 type UnaryOperationIface interface {
     GetValue() float64
     SetValue()
@@ -45972,7 +46106,9 @@ func (u UnionProperties) GetFoo() jsii.Any {
 }
 
 
+// Class interface
 type UpcasingReflectableIface interface {
+    @scope/jsii-calc-lib.submodule.IReflectable
     GetReflector() jsii.Any
     SetReflector()
     GetEntries() []jsii.Any
@@ -46014,6 +46150,7 @@ func (u UpcasingReflectable) SetEntries(val []jsii.Any) {
     u.Entries = val
 }
 
+// Class interface
 type UseBundledDependencyIface interface {
     Value() jsii.Any
 }
@@ -46043,6 +46180,7 @@ func (u *UseBundledDependency) Value() jsii.Any  {
     return nil
 }
 
+// Class interface
 type UseCalcBaseIface interface {
     Hello() jsii.Any
 }
@@ -46072,6 +46210,7 @@ func (u *UseCalcBase) Hello() jsii.Any  {
     return nil
 }
 
+// Class interface
 type UsesInterfaceWithPropertiesIface interface {
     GetObj() IInterfaceWithProperties
     SetObj()
@@ -46133,6 +46272,7 @@ func (u *UsesInterfaceWithProperties) WriteAndRead() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type VariadicInvokerIface interface {
     AsArray() []float64
 }
@@ -46162,6 +46302,7 @@ func (v *VariadicInvoker) AsArray() []float64  {
     return nil
 }
 
+// Class interface
 type VariadicMethodIface interface {
     AsArray() []float64
 }
@@ -46191,6 +46332,7 @@ func (v *VariadicMethod) AsArray() []float64  {
     return nil
 }
 
+// Class interface
 type VirtualMethodPlaygroundIface interface {
     OverrideMeAsync() float64
     OverrideMeSync() float64
@@ -46260,6 +46402,7 @@ func (v *VirtualMethodPlayground) SumSync() float64  {
     return 0.0
 }
 
+// Class interface
 type VoidCallbackIface interface {
     GetMethodWasCalled() bool
     SetMethodWasCalled()
@@ -46311,6 +46454,7 @@ func (v *VoidCallback) OverrideMe() jsii.Any  {
     return nil
 }
 
+// Class interface
 type WithPrivatePropertyInConstructorIface interface {
     GetSuccess() bool
     SetSuccess()
@@ -46352,6 +46496,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type CompositeOperationIface interface {
     GetValue() float64
     SetValue()
@@ -46464,6 +46609,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type BaseIface interface {
     GetProp() string
     SetProp()
@@ -46495,6 +46641,7 @@ func (b Base) SetProp(val string) {
     b.Prop = val
 }
 
+// Class interface
 type DerivedIface interface {
     GetProp() string
     SetProp()
@@ -46536,6 +46683,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type FooIface interface {
     GetBar() string
     SetBar()
@@ -46617,6 +46765,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type ClassWithSelfIface interface {
     GetSelf() string
     SetSelf()
@@ -46658,6 +46807,7 @@ func (c *ClassWithSelf) Method() string  {
     return "NOOP_RETURN_STRING"
 }
 
+// Class interface
 type ClassWithSelfKwargIface interface {
     GetProps() StructWithSelf
     SetProps()
@@ -46721,7 +46871,9 @@ import (
     "jsiicalc"
 )
 
+// Class interface
 type MyClassIface interface {
+    jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced
     GetAwesomeness() child.Awesomeness
     SetAwesomeness()
     GetDefinedAt() string
@@ -46846,6 +46998,7 @@ const (
     GoodnessAmazinglyGood Goodness = "AMAZINGLY_GOOD"
 )
 
+// Class interface
 type InnerClassIface interface {
     GetStaticProp() SomeStruct
     SetStaticProp()
@@ -46879,7 +47032,6 @@ func (i InnerClass) SetStaticProp(val SomeStruct) {
 
 // Struct interface
 type KwargsPropsIface interface {
-    jsii-calc.submodule.child.SomeStruct
     GetProp() SomeEnum
     GetExtra() string
 }
@@ -46899,6 +47051,7 @@ func (k KwargsProps) GetExtra() string {
 }
 
 
+// Class interface
 type OuterClassIface interface {
     GetInnerClass() InnerClass
     SetInnerClass()
@@ -46976,6 +47129,7 @@ import (
     "github.com/aws-cdk/jsii/jsii"
 )
 
+// Class interface
 type KwargsIface interface {
     Method() bool
 }
@@ -47004,7 +47158,9 @@ import (
     "child"
 )
 
+// Class interface
 type NamespacedIface interface {
+    jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced
     GetDefinedAt() string
     SetDefinedAt()
     GetGoodness() child.Goodness


### PR DESCRIPTION
Previously, datatype structs were being embedded in the struct
interface. This fix moves the logic for looking up inherited interfaces
into classes only.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
