### PR TITLE
fix(pacmak): go bad local package imports

### DIFF
--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -398,7 +398,9 @@ defineTest(
         namespace: 'Amazon.JSII.Tests.CalculatorNamespace',
         packageId: 'Amazon.JSII.Tests.CalculatorPackageId',
       },
-      go: {},
+      go: {
+        moduleName: 'github.com/aws-cdk/jsii/jsii-calc/golang',
+      },
       java: {
         package: 'software.amazon.jsii.tests.calculator',
         maven: {

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -59,7 +59,9 @@
   "jsii": {
     "outdir": "dist",
     "targets": {
-      "go": {},
+      "go": {
+        "moduleName": "github.com/aws-cdk/jsii/jsii-calc/golang"
+      },
       "java": {
         "package": "software.amazon.jsii.tests.calculator",
         "maven": {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -245,7 +245,9 @@
       "namespace": "Amazon.JSII.Tests.CalculatorNamespace",
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
     },
-    "go": {},
+    "go": {
+      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/golang"
+    },
     "java": {
       "maven": {
         "artifactId": "calculator",
@@ -13968,5 +13970,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "Rp4Cw4yqvAfwyiUl5zmEHzvLlWXhUMNMwzWQYkG/1io="
+  "fingerprint": "Ddy05wOucU4yV7YP5fPUzEjiOsl5AGPrwJS7pXpJRPI="
 }

--- a/packages/jsii-pacmak/lib/targets/golang/package.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/package.ts
@@ -69,17 +69,11 @@ export abstract class Package {
   public get dependencyImports(): Set<string> {
     return new Set(
       this.dependencies.map((pack) => {
-        // If the package root isn't the same as the current packages root, the
-        // package is part of a different module and requires a full module path
-        if (pack.root !== this.root) {
-          const moduleName = pack.root.moduleName;
-          const prefix = moduleName !== '' ? `${moduleName}/` : '';
-          const rootPackageName = pack.root.packageName;
-          const suffix = pack.filePath !== '' ? `/${pack.filePath}` : '';
-          return `${prefix}${rootPackageName}${suffix}`;
-        }
-
-        return pack.packageName;
+        const moduleName = pack.root.moduleName;
+        const prefix = moduleName !== '' ? `${moduleName}/` : '';
+        const rootPackageName = pack.root.packageName;
+        const suffix = pack.filePath !== '' ? `/${pack.filePath}` : '';
+        return `${prefix}${rootPackageName}${suffix}`;
       }),
     );
   }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -3581,7 +3581,9 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
       "namespace": "Amazon.JSII.Tests.CalculatorNamespace",
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
     },
-    "go": {},
+    "go": {
+      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/golang"
+    },
     "java": {
       "maven": {
         "artifactId": "calculator",
@@ -17304,7 +17306,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     }
   },
   "version": "0.0.0",
-  "fingerprint": "Rp4Cw4yqvAfwyiUl5zmEHzvLlWXhUMNMwzWQYkG/1io="
+  "fingerprint": "Ddy05wOucU4yV7YP5fPUzEjiOsl5AGPrwJS7pXpJRPI="
 }
 
 `;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -847,7 +847,7 @@ package jsiicalc
 import (
     "github.com/aws-cdk/jsii/jsii"
     "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib"
-    "composition"
+    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/composition"
     "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
     "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbase"
     "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib/submodule"
@@ -8473,7 +8473,7 @@ package backreferences
 
 import (
     "github.com/aws-cdk/jsii/jsii"
-    "submodule"
+    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
 )
 
 // Struct interface
@@ -8681,8 +8681,7 @@ package nestedsubmodule
 
 import (
     "github.com/aws-cdk/jsii/jsii"
-    "deeplynested"
-    "child"
+    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
 )
 
 // Class interface
@@ -8725,9 +8724,8 @@ package submodule
 
 import (
     "github.com/aws-cdk/jsii/jsii"
-    "deeplynested"
-    "child"
-    "jsiicalc"
+    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
 )
 
 // Class interface


### PR DESCRIPTION
When generating import statements within go code, if the package was a
child of the package currently being generated, the import statement
would not include the module name.

When a package is part of a module though this caused invalid imports.
So for all package import statements moduleNames are now included when
provided in the jsii config.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
