### PR TITLE
fix: pip dependency resolution failure in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,19 +194,19 @@ jobs:
             dotnet: '3.1.x'
             java: '8'
             node: '10'
-            python: '3.6'
+            python: '3.7'
           # Test using macOS
           - os: macos-latest
             dotnet: '3.1.x'
             java: '8'
             node: '10'
-            python: '3.6'
+            python: '3.7'
           # Test alternate Javas
           - java: '11'
             dotnet: '3.1.x'
             node: '10'
             os: ubuntu-latest
-            python: '3.6'
+            python: '3.7'
           # Test alternate Pythons
           - python: '3.7'
             dotnet: '3.1.x'
@@ -359,6 +359,8 @@ jobs:
       # Run the integration test
       - name: Install Dependencies
         run: |-
+          # Check for upgraded pip version from previous steps
+          python3 -m pip --version
           # Python tools used during packaging
           python3 -m pip install --upgrade pipx setuptools twine wheel
 


### PR DESCRIPTION
Attempts to fix intermittent pip module dependency resolution failure by
using the new `2020-resolver` feature flag.

NOTE: this may or may not actually work. Testing with PR verification
workflows.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
