### PR TITLE
feat: add go to superchain

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -62,6 +62,13 @@ ENV M2_HOME=/usr/local/apache-maven                                             
     M2=/usr/local/apache-maven/bin                                                                                      \
     MAVEN_OPTS="-Xms256m -Xmx512m"
 
+# Install Go
+RUN curl -sL https://golang.org/dl/go1.15.2.linux-amd64.tar.gz -o /tmp/go.tar.gz                                        \
+  && mkdir -p /usr/local && (cd /usr/local && tar -xzf /tmp/go.tar.gz)
+ENV GOROOT=/usr/local/go
+ENV PATH="$GOROOT/bin:$PATH"
+    
+
 # Install Docker
 RUN amazon-linux-extras install docker                                                                                  \
   && yum clean all && rm -rf /var/cache/yum

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -15,6 +15,7 @@ SDK             | Version
 `Javascript`    | `node >= 10.19.0` with `npm >= 6.13.4`
 `PowerShell`    | `pwsh >= 6.2.3`
 `Python 3`      | `python3 >= 3.7.4` with `pip3 >= 20.0.2`
+`Go`            | `go >= 1.15.2`
 `Ruby`          | `ruby >= 2.6.3p62`
 
 ## Included Tools & Utilities


### PR DESCRIPTION
Adds go toolchain to superchain Dockerfile to make available for go
runtime library development.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
