### PR TITLE
chore: remove console.log from go pacmak gen

### DIFF
--- a/packages/jsii-pacmak/lib/targets/golang/documentation.ts
+++ b/packages/jsii-pacmak/lib/targets/golang/documentation.ts
@@ -4,10 +4,7 @@ import { Rosetta } from 'jsii-rosetta';
 import { CodeMaker } from 'codemaker';
 
 export class Documentation {
-  public constructor(
-    private readonly code: CodeMaker,
-    private readonly rosetta: Rosetta,
-  ) {}
+  public constructor(private readonly code: CodeMaker, _rosetta: Rosetta) {}
 
   /**
    * Emits all documentation depending on what is available in the jsii model
@@ -21,8 +18,6 @@ export class Documentation {
    * Stability/Deprecation description
    */
   public emit(docs: Docs): void {
-    console.log(this.rosetta); // Placeholder, until rosetta is used
-
     if (docs.toString() !== '') {
       const lines = docs.toString().split('\n');
       for (const line of lines) {


### PR DESCRIPTION
Removes a `console.log` statement from the go `Documentation` class that
was logging to `Rosetta` instance fo each emit invocation. This was
added to correct a lint error that the instances was not used that
wasn't easily surpressed.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
