### PR TITLE
chore: start testing with .NET 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1.6.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8
@@ -97,7 +97,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1.6.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8
@@ -231,7 +231,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes (this is matrix-based)
       - name: Set up .NET ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1.6.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Set up Java ${{ matrix.java }}
@@ -312,7 +312,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1.6.0
+        uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,7 +204,7 @@ jobs:
             python: '3.6'
           # Test alternate .NETs
           - java: '8'
-            dotnet: '5.0.0-rc1' # Pre-release matching requires exact version for now
+            dotnet: '5.0.100-rc.1' # Pre-release matching requires exact version for now
             node: '10'
             os: ubuntu-latest
             python: '3.6'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.6.0
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8
@@ -97,7 +97,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.6.0
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8
@@ -231,7 +231,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes (this is matrix-based)
       - name: Set up .NET ${{ matrix.dotnet }}
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.6.0
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Set up Java ${{ matrix.java }}
@@ -312,7 +312,7 @@ jobs:
     steps:
       # Set up all of our standard runtimes
       - name: Set up .NET 3.1
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v1.6.0
         with:
           dotnet-version: '3.1.x'
       - name: Set up Java 8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           path: ${{ github.workspace }}/dist/
 
   test:
-    name: Test (${{ matrix.os }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
+    name: Test (${{ matrix.os }} / dotnet ${{ matrix.dotnet }} / java ${{ matrix.java }} / node ${{ matrix.node }} / python ${{ matrix.python }})
     needs: build
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,6 +202,12 @@ jobs:
             java: '8'
             node: '10'
             python: '3.6'
+          # Test alternate .NETs
+          - java: '8'
+            dotnet: '5.0.0-rc1' # Pre-release matching requires exact version for now
+            node: '10'
+            os: ubuntu-latest
+            python: '3.6'
           # Test alternate Javas
           - java: '11'
             dotnet: '3.1.x'

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
@@ -8,6 +8,8 @@
 
         <IsPackable>false</IsPackable>
         <VSTestLogger>xunit</VSTestLogger>
+
+        <RollForward>Major</RollForward>
     </PropertyGroup>
 
     <ItemGroup>

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
@@ -9,6 +9,8 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
         <VSTestLogger>xunit</VSTestLogger>
+
+        <RollForward>Major</RollForward>
     </PropertyGroup>
 
     <ItemGroup>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
@@ -7,6 +7,8 @@
 
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
@@ -7,6 +7,8 @@
 
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since .NET 5 is due for GA later this year, start testing on the current release candidate to ensure everything works smoothly.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
