### PR TITLE
chore: run integration test with node 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,10 +319,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '8'
-      - name: Set up Node 12
+      - name: Set up Node 10
         uses: actions/setup-node@v2.1.1
         with:
-          node-version: '12'
+          node-version: '10'
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
It is currently broken because the latest version of `yargs` (16.0.3)
introduced an `exports` map in it's `package.json` that prevents access
to it's `package.json`. This is used by `decdk` when trying to load the
type system, and currently fails.

The breakage only occurs when using `node >= 12` (as the `exports`
map feature was introduced there), so this PR changes the node runtime
used to run integration tests from `node 12` to `node 10`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
