### PR TITLE
chore: stop using the delete operator

### DIFF
--- a/packages/@jsii/integ-test/utils/index.ts
+++ b/packages/@jsii/integ-test/utils/index.ts
@@ -17,12 +17,13 @@ export function minutes(num: number): number {
  * Used to track and clean up processes if tests fail or timeout
  */
 export class ProcessManager {
-  private readonly processes: {
-    [pid: string]: {
+  private readonly processes = new Map<
+    cp.ChildProcess['pid'],
+    {
       proc: cp.ChildProcess;
       promise: Promise<void>;
-    };
-  } = {};
+    }
+  >();
 
   /**
    * kill all still running processes
@@ -41,11 +42,11 @@ export class ProcessManager {
   }
 
   private add(proc: cp.ChildProcess, promise: Promise<void>) {
-    this.processes[proc.pid] = { proc, promise };
+    this.processes.set(proc.pid, { proc, promise });
   }
 
   private remove(proc: cp.ChildProcess) {
-    delete this.processes[proc.pid];
+    this.processes.delete(proc.pid);
   }
 
   /**

--- a/packages/@jsii/kernel/lib/objects.ts
+++ b/packages/@jsii/kernel/lib/objects.ts
@@ -75,7 +75,7 @@ export function tagJsiiConstructor(constructor: any, fqn: string) {
  * type.
  */
 export class ObjectTable {
-  private objects: { [objid: string]: RegisteredObject } = {};
+  private readonly objects = new Map<string, RegisteredObject>();
   private nextid = 10000;
 
   public constructor(
@@ -103,7 +103,7 @@ export class ObjectTable {
         for (const iface of existingRef[api.TOKEN_INTERFACES] ?? []) {
           allIfaces.add(iface);
         }
-        this.objects[existingRef[api.TOKEN_REF]].interfaces = (obj as any)[
+        this.objects.get(existingRef[api.TOKEN_REF])!.interfaces = (obj as any)[
           IFACES_SYMBOL
         ] = existingRef[
           api.TOKEN_INTERFACES
@@ -115,7 +115,7 @@ export class ObjectTable {
     interfaces = this.removeRedundant(interfaces, fqn);
 
     const objid = this.makeId(fqn);
-    this.objects[objid] = { instance: obj, fqn, interfaces };
+    this.objects.set(objid, { instance: obj, fqn, interfaces });
     tagObject(obj, objid, interfaces);
 
     return { [api.TOKEN_REF]: objid, [api.TOKEN_INTERFACES]: interfaces };
@@ -130,7 +130,7 @@ export class ObjectTable {
     }
 
     const objid = objref[api.TOKEN_REF];
-    const obj = this.objects[objid];
+    const obj = this.objects.get(objid);
     if (!obj) {
       throw new Error(`Object ${objid} not found`);
     }
@@ -142,11 +142,11 @@ export class ObjectTable {
    */
   public deleteObject(objref: api.ObjRef) {
     this.findObject(objref); // make sure object exists
-    delete this.objects[objref[api.TOKEN_REF]];
+    this.objects.delete(objref[api.TOKEN_REF]);
   }
 
   public get count(): number {
-    return Object.keys(this.objects).length;
+    return this.objects.size;
   }
 
   private makeId(fqn: string) {

--- a/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
@@ -8,6 +8,7 @@
     "url": "https://aws.amazon.com"
   },
   "description": "An example transitive dependency for jsii-calc.",
+  "fingerprint": "XzppfL+BknRpBHYygvGjf8OOXrTyNAx6cllN3vONLoU=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -150,6 +151,5 @@
       ]
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "XzppfL+BknRpBHYygvGjf8OOXrTyNAx6cllN3vONLoU="
+  "version": "0.0.0"
 }

--- a/packages/@scope/jsii-calc-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base/test/assembly.jsii
@@ -38,6 +38,7 @@
     }
   },
   "description": "An example direct dependency for jsii-calc.",
+  "fingerprint": "wIp2/3p7NHxnOxUbXktrzg6Y+CqdjDLxChiFLMaYQXc=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -156,6 +157,5 @@
       "name": "IBaseInterface"
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "wIp2/3p7NHxnOxUbXktrzg6Y+CqdjDLxChiFLMaYQXc="
+  "version": "0.0.0"
 }

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -68,6 +68,7 @@
     "deprecated": "Really just deprecated for shows...",
     "stability": "deprecated"
   },
+  "fingerprint": "/PrQbD8BlAtg3N9iuntBks7Q/oIyS45A/S7RvNATePA=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -765,6 +766,5 @@
       "namespace": "submodule"
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "/PrQbD8BlAtg3N9iuntBks7Q/oIyS45A/S7RvNATePA="
+  "version": "0.0.0"
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -140,6 +140,7 @@
   "docs": {
     "stability": "stable"
   },
+  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "keywords": [
@@ -14111,6 +14112,5 @@
       ]
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA="
+  "version": "0.0.0"
 }

--- a/packages/jsii-config/test/index.test.ts
+++ b/packages/jsii-config/test/index.test.ts
@@ -89,15 +89,15 @@ describe('jsii-config', () => {
             maven: {
               groupId: 'software.amazon.module',
               artifactId: 'core',
-              versionSuffix: '',
+              versionSuffix: '' as string | undefined,
             },
           },
           dotnet: {
             namespace: 'Amazon.Module',
             packageId: 'Amazon.Module',
             iconUrl: undefined,
-            versionSuffix: '',
-            signAssembly: false,
+            versionSuffix: '' as string | undefined,
+            signAssembly: false as boolean | undefined,
           },
         },
       },
@@ -258,10 +258,10 @@ describe('jsii-config', () => {
     it('returns new config with empty values removed', async () => {
       const subject = await jsiiConfig('./package.json');
       const expected = { ...configAnswers };
-      delete expected.jsii.targets.dotnet.iconUrl;
-      delete expected.jsii.targets.dotnet.signAssembly;
-      delete expected.jsii.targets.dotnet.versionSuffix;
-      delete expected.jsii.targets.java.maven.versionSuffix;
+      expected.jsii.targets.dotnet.iconUrl = undefined;
+      expected.jsii.targets.dotnet.signAssembly = undefined;
+      expected.jsii.targets.dotnet.versionSuffix = undefined;
+      expected.jsii.targets.java.maven.versionSuffix = undefined;
 
       expect(subject).toEqual({
         ...packageJsonObject,

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -622,7 +622,7 @@ class JavaGenerator extends Generator {
 
   protected onEndAssembly(assm: spec.Assembly, fingerprint: boolean) {
     this.emitMavenPom(assm, fingerprint);
-    delete this.emitFullGeneratorInfo;
+    this.emitFullGeneratorInfo = undefined;
   }
 
   protected getAssemblyOutputDir(mod: spec.Assembly) {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -66,6 +66,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/dotnet/Amazon.JSII
     }
   },
   "description": "An example direct dependency for jsii-calc.",
+  "fingerprint": "wIp2/3p7NHxnOxUbXktrzg6Y+CqdjDLxChiFLMaYQXc=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -184,8 +185,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/dotnet/Amazon.JSII
       "name": "IBaseInterface"
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "wIp2/3p7NHxnOxUbXktrzg6Y+CqdjDLxChiFLMaYQXc="
+  "version": "0.0.0"
 }
 
 `;
@@ -476,6 +476,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
     "url": "https://aws.amazon.com"
   },
   "description": "An example transitive dependency for jsii-calc.",
+  "fingerprint": "XzppfL+BknRpBHYygvGjf8OOXrTyNAx6cllN3vONLoU=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -618,8 +619,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
       ]
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "XzppfL+BknRpBHYygvGjf8OOXrTyNAx6cllN3vONLoU="
+  "version": "0.0.0"
 }
 
 `;
@@ -988,6 +988,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/dotnet/Amazon.JSII.
     "deprecated": "Really just deprecated for shows...",
     "stability": "deprecated"
   },
+  "fingerprint": "/PrQbD8BlAtg3N9iuntBks7Q/oIyS45A/S7RvNATePA=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "license": "Apache-2.0",
@@ -1685,8 +1686,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/dotnet/Amazon.JSII.
       "namespace": "submodule"
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "/PrQbD8BlAtg3N9iuntBks7Q/oIyS45A/S7RvNATePA="
+  "version": "0.0.0"
 }
 
 `;
@@ -3480,6 +3480,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
   "docs": {
     "stability": "stable"
   },
+  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA=",
   "homepage": "https://github.com/aws/jsii",
   "jsiiVersion": "0.0.0",
   "keywords": [
@@ -17451,8 +17452,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
       ]
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA="
+  "version": "0.0.0"
 }
 
 `;

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -158,12 +158,12 @@ export class Assembler implements Emitter {
     ) {
       LOG.debug('Skipping emit due to errors.');
       // Clearing ``this._types`` to allow contents to be garbage-collected.
-      delete this._types;
+      this._types = {};
       try {
         return { diagnostics: this._diagnostics, emitSkipped: true };
       } finally {
         // Clearing ``this._diagnostics`` to allow contents to be garbage-collected.
-        delete this._diagnostics;
+        this._diagnostics = [];
       }
     }
 
@@ -221,10 +221,10 @@ export class Assembler implements Emitter {
       };
     } finally {
       // Clearing ``this._types`` to allow contents to be garbage-collected.
-      delete this._types;
+      this._types = {};
 
       // Clearing ``this._diagnostics`` to allow contents to be garbage-collected.
-      delete this._diagnostics;
+      this._diagnostics = [];
     }
 
     async function _loadReadme(this: Assembler) {
@@ -1789,7 +1789,7 @@ export class Assembler implements Emitter {
 
         // If the name starts with an "I" it is not intended as a datatype, so switch that off.
         if (jsiiType.datatype && interfaceName) {
-          delete jsiiType.datatype;
+          jsiiType.datatype = undefined;
         }
 
         // Okay, this is a data type, check that all properties are readonly
@@ -2475,7 +2475,7 @@ export class Assembler implements Emitter {
             offender,
           ),
         );
-        delete current.optional;
+        current.optional = undefined;
       }
     }
   }
@@ -2571,7 +2571,8 @@ interface SubmoduleSpec {
 }
 
 function _fingerprint(assembly: spec.Assembly): spec.Assembly {
-  delete assembly.fingerprint;
+  // Remove the fingerprint entry prior to computing it...
+  (assembly as any).fingerprint = undefined;
   assembly = sortJson(assembly);
   const fingerprint = crypto
     .createHash('sha256')

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -12,8 +12,8 @@ import { JSII_DIAGNOSTICS_CODE } from './utils';
 export class Code<
   T extends DiagnosticMessageFormatter = DiagnosticMessageFormatter
 > {
-  private static readonly byCode: { [code: number]: Code } = {};
-  private static readonly byName: { [name: string]: Code } = {};
+  private static readonly byCode = new Map<number, Code>();
+  private static readonly byName = new Map<string, Code>();
 
   /**
    * @internal
@@ -87,9 +87,9 @@ export class Code<
    */
   public static lookup(codeOrName: string | number): Code | undefined {
     if (typeof codeOrName === 'number') {
-      return this.byCode[codeOrName];
+      return this.byCode.get(codeOrName);
     }
-    return this.byName[codeOrName];
+    return this.byName.get(codeOrName);
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
@@ -118,17 +118,18 @@ export class Code<
     this.#defaultCategory = defaultCategory;
     this.#formatter = formatter;
 
-    if (code in Code.byCode) {
+    if (Code.byCode.has(code)) {
       throw new Error(
         `Attempted to create two instances of ${this.constructor.name} with code ${code}`,
       );
     }
-    if (name in Code.byName) {
+    if (Code.byName.has(name)) {
       throw new Error(
         `Attempted to create two instances of ${this.constructor.name} with name ${name}`,
       );
     }
-    Code.byCode[code] = Code.byName[name] = this;
+    Code.byCode.set(code, this);
+    Code.byName.set(name, this);
   }
 
   /**

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -34,7 +34,7 @@ export class Validator implements Emitter {
       });
     } finally {
       // Clearing ``this._diagnostics`` to allow contents to be garbage-collected.
-      delete this._diagnostics;
+      this._diagnostics = [];
     }
   }
 }

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -36,7 +36,7 @@ describe('loadProjectInfo', () => {
       expect(info.version).toBe(BASE_PROJECT.version);
       expect(info.description).toBe(BASE_PROJECT.description);
       expect(info.license).toBe(BASE_PROJECT.license);
-      expect(_stripUndefined(info.author)).toEqual({
+      expect(info.author).toEqual({
         ...BASE_PROJECT.author,
         roles: ['author'],
       });
@@ -107,7 +107,7 @@ describe('loadProjectInfo', () => {
         const info = await loadProjectInfo(projectRoot, {
           fixPeerDependencies: false,
         });
-        expect(info?.contributors?.map(_stripUndefined)).toEqual(
+        expect(info?.contributors).toEqual(
           contributors.map((c) => ({ ...c, roles: ['contributor'] })),
         );
       },
@@ -160,7 +160,7 @@ describe('loadProjectInfo', () => {
           `The "package.json" file has "${TEST_DEP_ASSEMBLY.name}" in "dependencies", but not in "peerDependencies"`,
         ),
       (info) => {
-        delete info.peerDependencies[TEST_DEP_ASSEMBLY.name];
+        info.peerDependencies[TEST_DEP_ASSEMBLY.name] = undefined;
       },
     ));
 
@@ -173,7 +173,7 @@ describe('loadProjectInfo', () => {
         expect(info.peerDependencies[TEST_DEP_ASSEMBLY.name]).toBe('^1.2.3');
       },
       (info) => {
-        delete info.peerDependencies[TEST_DEP_ASSEMBLY.name];
+        info.peerDependencies[TEST_DEP_ASSEMBLY.name] = undefined;
       },
     ));
 
@@ -297,25 +297,4 @@ async function _withTestProject<T>(
   } finally {
     await fs.remove(tmpdir);
   }
-}
-
-/**
- * Removes keys from an object if the associated value is ``undefined``.
- *
- * @param obj the object to be stripped.
- *
- * @return ``obj`` after it has been stripped.
- */
-function _stripUndefined(
-  obj: { [key: string]: any } | undefined,
-): { [key: string]: any } | undefined {
-  if (!obj) {
-    return obj;
-  }
-  for (const key of Object.keys(obj)) {
-    if (obj[key] === undefined) {
-      delete obj[key];
-    }
-  }
-  return obj;
 }


### PR DESCRIPTION
It can adversely impact the performance of software through causing extraneous
hidden class transitions on the object. Those can be saved by never deleting
properties, instead assigning a blank/empty value.

For some cases, replaced object stores with Map instances, as the constant
mutations of the object store cause hidden class pollution, which Map does
avoid.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
