### PR TITLE
fix(dontet): iso-8601 date strings get turned into DateTime

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/generate.sh
+++ b/packages/@jsii/dotnet-runtime-test/generate.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 test="./test"
+genRoot="${test}/generated"
 
-# Generate NuGet packages for jsii-calc and its dependencies.
-jsii-pacmak -t dotnet --recurse -o ${test}/generated ../../jsii-calc
+# Clean up before we start working
+rm -rf genRoot
+
+# Generate .NET projects for jsii-calc and its dependencies.
+jsii-pacmak -t dotnet --code-only --recurse -o ${genRoot} ../../jsii-calc
+
+# Hack around project references to de-duplicate Amazon.JSII.Runtime in generated code.
+for csproj in ${genRoot}/dotnet/*/*.csproj
+do
+  dotnet remove ${csproj} package Amazon.JSII.Runtime
+  dotnet add    ${csproj} reference ../dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
+done
 
 # Generate Directory.Build.props
 /usr/bin/env node ./Directory.Build.props.t.js > ${test}/Directory.Build.props

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.FSharp/Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj
@@ -24,14 +24,18 @@
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Newtonsoft.Json" />
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="XunitXml.TestLogger" />
-        <DotNetCliToolReference Include="dotnet-xunit"/>
+        <DotNetCliToolReference Include="dotnet-xunit" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\dotnet-runtime\src\Amazon.JSII.Runtime\Amazon.JSII.Runtime.csproj" />
+        <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId.csproj" />
+        <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj" />
+        <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj" />
+        <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId\Amazon.JSII.Tests.CalculatorPackageId.csproj" />
     </ItemGroup>
 
 </Project>

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.sln
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Runtime.IntegrationTests", "Amazon.JSII.Runtime.IntegrationTests\Amazon.JSII.Runtime.IntegrationTests.csproj", "{CE3CAFBD-25F8-422D-925A-8F9CCEA1F548}"
@@ -8,6 +8,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.JsonModel", "..\..\dotnet-runtime\src\Amazon.JSII.JsonModel\Amazon.JSII.JsonModel.csproj", "{1E0BFD79-D221-425D-ADFF-1DF939BCFC58}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Amazon.JSII.Runtime.IntegrationTests.FSharp", "Amazon.JSII.Runtime.IntegrationTests.FSharp\Amazon.JSII.Runtime.IntegrationTests.FSharp.fsproj", "{224406B0-12D5-408C-91E9-7420F72C2855}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "generated", "generated", "{5B76E4C5-B66F-4263-87A4-111E944AB744}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet", "dotnet", "{37A4E9E1-89D6-42FC-AF9D-4C4453D29857}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId", "generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId.csproj", "{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId", "generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj", "{A1287897-A767-4F1E-B83E-874797851732}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Tests.CalculatorPackageId.LibPackageId", "generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj", "{A2830012-1C9D-4D42-80B1-61A360AFA3C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.JSII.Tests.CalculatorPackageId", "generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId\Amazon.JSII.Tests.CalculatorPackageId.csproj", "{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,5 +43,28 @@ Global
 		{224406B0-12D5-408C-91E9-7420F72C2855}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{224406B0-12D5-408C-91E9-7420F72C2855}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{224406B0-12D5-408C-91E9-7420F72C2855}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1287897-A767-4F1E-B83E-874797851732}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1287897-A767-4F1E-B83E-874797851732}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1287897-A767-4F1E-B83E-874797851732}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1287897-A767-4F1E-B83E-874797851732}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2830012-1C9D-4D42-80B1-61A360AFA3C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2830012-1C9D-4D42-80B1-61A360AFA3C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2830012-1C9D-4D42-80B1-61A360AFA3C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2830012-1C9D-4D42-80B1-61A360AFA3C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{37A4E9E1-89D6-42FC-AF9D-4C4453D29857} = {5B76E4C5-B66F-4263-87A4-111E944AB744}
+		{BBF82641-F1B7-44CC-BFE6-C82E6B00BC13} = {37A4E9E1-89D6-42FC-AF9D-4C4453D29857}
+		{A1287897-A767-4F1E-B83E-874797851732} = {37A4E9E1-89D6-42FC-AF9D-4C4453D29857}
+		{A2830012-1C9D-4D42-80B1-61A360AFA3C9} = {37A4E9E1-89D6-42FC-AF9D-4C4453D29857}
+		{B246A5D7-FF6F-47B1-A47B-6B2B3205A2FC} = {37A4E9E1-89D6-42FC-AF9D-4C4453D29857}
 	EndGlobalSection
 EndGlobal

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
@@ -29,6 +29,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\dotnet-runtime\src\Amazon.JSII.Runtime\Amazon.JSII.Runtime.csproj" />
+      <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId.csproj" />
+      <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId\Amazon.JSII.Tests.CalculatorPackageId.BasePackageId.csproj" />
+      <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId\Amazon.JSII.Tests.CalculatorPackageId.LibPackageId.csproj" />
+      <ProjectReference Include="..\generated\dotnet\Amazon.JSII.Tests.CalculatorPackageId\Amazon.JSII.Tests.CalculatorPackageId.csproj" />
     </ItemGroup>
 
 </Project>

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -1476,5 +1476,41 @@ namespace Amazon.JSII.Runtime.IntegrationTests
                 return value;
             }
         }
+
+        [Fact(DisplayName = Prefix + nameof(Iso8601DoesNotDeserializeToDate))]
+        public void Iso8601DoesNotDeserializeToDate()
+        {
+            var now = $"{DateTime.UtcNow.ToString("s")}Z";
+            var wallClock = new WallClock(now);
+            var entropy = new MildEntropy(wallClock);
+
+            Assert.Equal(now, entropy.Increase());
+        }
+
+        private sealed class WallClock: DeputyBase, IWallClock
+        {
+            private String _frozenTime;
+
+            public WallClock(String frozenTime)
+            {
+                _frozenTime = frozenTime;
+            }
+
+            public String Iso8601Now()
+            {
+                return _frozenTime;
+            }
+        }
+
+        private sealed class MildEntropy: Entropy
+        {
+            public MildEntropy(IWallClock clock): base(clock)
+            {
+            }
+            public override String Repeat(String word)
+            {
+                return word;
+            }
+        }
     }
 }

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/Client.cs
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/Client.cs
@@ -100,7 +100,10 @@ namespace Amazon.JSII.Runtime.Services
 
         TResponse TryDeserialize<TResponse>(string responseJson) where TResponse : class, IKernelResponse
         {
-            JObject responseObject = (JObject)JsonConvert.DeserializeObject(responseJson)!;
+            JObject responseObject = (JObject)JsonConvert.DeserializeObject(responseJson, new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None
+            })!;
 
             if (responseObject.ContainsKey("error"))
             {

--- a/packages/@jsii/python-runtime/tests/test_compliance.py
+++ b/packages/@jsii/python-runtime/tests/test_compliance.py
@@ -1284,7 +1284,7 @@ def test_iso8601_does_not_deserialize_to_date():
         def repeat(self, word: str) -> str:
             return word
 
-    now = datetime.utcnow().isoformat() + 'Z'
+    now = datetime.utcnow().isoformat() + "Z"
     wall_clock = WallClock(now)
     entropy = MildEntropy(wall_clock)
 

--- a/packages/@jsii/python-runtime/tests/test_compliance.py
+++ b/packages/@jsii/python-runtime/tests/test_compliance.py
@@ -28,6 +28,7 @@ from jsii_calc import (
     DisappointingCollectionSource,
     DoNotOverridePrivates,
     DoubleTrouble,
+    Entropy,
     GreetingAugmenter,
     IBellRinger,
     IConcreteBellRinger,
@@ -37,6 +38,7 @@ from jsii_calc import (
     InterfaceCollections,
     IInterfaceWithProperties,
     IStructReturningDelegate,
+    IWallClock,
     Isomorphism,
     JsiiAgent,
     JSObjectLiteralForInterface,
@@ -1267,3 +1269,23 @@ def test_isomorphism_within_constructor():
 
 def test_kwargs_from_superinterface_are_working():
     assert Kwargs.method(extra="ordinary", prop=SomeEnum.SOME)
+
+
+def test_iso8601_does_not_deserialize_to_date():
+    @jsii.implements(IWallClock)
+    class WallClock:
+        def __init__(self, now: str):
+            self.now = now
+
+        def iso8601_now(self) -> str:
+            return self.now
+
+    class MildEntropy(Entropy):
+        def repeat(self, word: str) -> str:
+            return word
+
+    now = datetime.utcnow().isoformat() + 'Z'
+    wall_clock = WallClock(now)
+    entropy = MildEntropy(wall_clock)
+
+    assert now == entropy.increase()

--- a/packages/jsii-calc/lib/date.ts
+++ b/packages/jsii-calc/lib/date.ts
@@ -1,0 +1,58 @@
+/**
+ * This class is used to validate that serialization and deserialization does
+ * not interpret ISO-8601-formatted timestampts to the native date/time object,
+ * as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON
+ * parsing does *NOT* detect dates automatically in this way, so host libraries
+ * should not either).
+ */
+export abstract class Entropy {
+  /**
+   * Creates a new instance of Entropy.
+   *
+   * @param clock your implementation of `WallClock`
+   */
+  public constructor(private readonly clock: IWallClock) {}
+
+  /**
+   * Increases entropy by consuming time from the clock (yes, this is a long
+   * shot, please don't judge).
+   *
+   * @returns the time from the `WallClock`.
+   */
+  public increase(): string {
+    const now = this.clock.iso8601Now();
+
+    if (typeof now !== 'string') {
+      throw new Error(
+        `Now should have been a string, is a ${typeof now}. Check your (de)serializer`,
+      );
+    }
+
+    const result = this.repeat(now);
+
+    if (typeof result !== 'string') {
+      throw new Error(
+        `Repeat should return a string, but returned a ${typeof result}. Check your (de)serializer`,
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Implement this method such that it returns `word`.
+   * @param word the value to return.
+   * @returns `word`.
+   */
+  public abstract repeat(word: string): string;
+}
+
+/**
+ * Implement this interface.
+ */
+export interface IWallClock {
+  /**
+   * Returns the current time, formatted as an ISO-8601 string.
+   */
+  iso8601Now(): string;
+}

--- a/packages/jsii-calc/lib/index.ts
+++ b/packages/jsii-calc/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './calculator';
 export * from './compliance';
+export * from './date';
 export * from './documented';
 export * from './erasures';
 export * from './nested-class';

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -205,7 +205,7 @@
     "jsii-calc.submodule": {
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 9
+        "line": 10
       }
     },
     "jsii-calc.submodule.back_references": {
@@ -4427,6 +4427,90 @@
         }
       ]
     },
+    "jsii-calc.Entropy": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable",
+        "summary": "This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either)."
+      },
+      "fqn": "jsii-calc.Entropy",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Creates a new instance of Entropy."
+        },
+        "locationInModule": {
+          "filename": "lib/date.ts",
+          "line": 14
+        },
+        "parameters": [
+          {
+            "docs": {
+              "summary": "your implementation of `WallClock`."
+            },
+            "name": "clock",
+            "type": {
+              "fqn": "jsii-calc.IWallClock"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/date.ts",
+        "line": 8
+      },
+      "methods": [
+        {
+          "docs": {
+            "returns": "the time from the `WallClock`.",
+            "stability": "stable",
+            "summary": "Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge)."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 22
+          },
+          "name": "increase",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "returns": "`word`.",
+            "stability": "stable",
+            "summary": "Implement this method such that it returns `word`."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 47
+          },
+          "name": "repeat",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the value to return."
+              },
+              "name": "word",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "Entropy"
+    },
     "jsii-calc.EnumDispenser": {
       "assembly": "jsii-calc",
       "docs": {
@@ -6508,6 +6592,39 @@
         }
       ],
       "name": "IStructReturningDelegate"
+    },
+    "jsii-calc.IWallClock": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable",
+        "summary": "Implement this interface."
+      },
+      "fqn": "jsii-calc.IWallClock",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/date.ts",
+        "line": 53
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the current time, formatted as an ISO-8601 string."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 57
+          },
+          "name": "iso8601Now",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IWallClock"
     },
     "jsii-calc.ImplementInternalInterface": {
       "assembly": "jsii-calc",
@@ -14112,5 +14229,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA="
+  "fingerprint": "azqNkkl+/4FLzTVBLkOyHcokS4xLoYtHsri0z9kIehQ="
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -3044,6 +3044,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 DoubleTrouble.cs
        ┃           ┣━ 📄 DynamicPropertyBearer.cs
        ┃           ┣━ 📄 DynamicPropertyBearerChild.cs
+       ┃           ┣━ 📄 Entropy.cs
+       ┃           ┣━ 📄 EntropyProxy.cs
        ┃           ┣━ 📄 EnumDispenser.cs
        ┃           ┣━ 📄 EraseUndefinedHashValues.cs
        ┃           ┣━ 📄 EraseUndefinedHashValuesOptions.cs
@@ -3191,6 +3193,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 ISupportsNiceJavaBuilderProps.cs
        ┃           ┣━ 📄 ITopLevelStruct.cs
        ┃           ┣━ 📄 IUnionProperties.cs
+       ┃           ┣━ 📄 IWallClock.cs
+       ┃           ┣━ 📄 IWallClockProxy.cs
        ┃           ┣━ 📄 JavaReservedWords.cs
        ┃           ┣━ 📄 JSII417Derived.cs
        ┃           ┣━ 📄 JSII417PublicBaseOfBase.cs
@@ -3545,7 +3549,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     "jsii-calc.submodule": {
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 9
+        "line": 10
       }
     },
     "jsii-calc.submodule.back_references": {
@@ -7767,6 +7771,90 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
         }
       ]
     },
+    "jsii-calc.Entropy": {
+      "abstract": true,
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable",
+        "summary": "This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either)."
+      },
+      "fqn": "jsii-calc.Entropy",
+      "initializer": {
+        "docs": {
+          "stability": "stable",
+          "summary": "Creates a new instance of Entropy."
+        },
+        "locationInModule": {
+          "filename": "lib/date.ts",
+          "line": 14
+        },
+        "parameters": [
+          {
+            "docs": {
+              "summary": "your implementation of \`WallClock\`."
+            },
+            "name": "clock",
+            "type": {
+              "fqn": "jsii-calc.IWallClock"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/date.ts",
+        "line": 8
+      },
+      "methods": [
+        {
+          "docs": {
+            "returns": "the time from the \`WallClock\`.",
+            "stability": "stable",
+            "summary": "Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge)."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 22
+          },
+          "name": "increase",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "returns": "\`word\`.",
+            "stability": "stable",
+            "summary": "Implement this method such that it returns \`word\`."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 47
+          },
+          "name": "repeat",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the value to return."
+              },
+              "name": "word",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "Entropy"
+    },
     "jsii-calc.EnumDispenser": {
       "assembly": "jsii-calc",
       "docs": {
@@ -9848,6 +9936,39 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
         }
       ],
       "name": "IStructReturningDelegate"
+    },
+    "jsii-calc.IWallClock": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable",
+        "summary": "Implement this interface."
+      },
+      "fqn": "jsii-calc.IWallClock",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/date.ts",
+        "line": 53
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Returns the current time, formatted as an ISO-8601 string."
+          },
+          "locationInModule": {
+            "filename": "lib/date.ts",
+            "line": 57
+          },
+          "name": "iso8601Now",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IWallClock"
     },
     "jsii-calc.ImplementInternalInterface": {
       "assembly": "jsii-calc",
@@ -17452,7 +17573,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     }
   },
   "version": "0.0.0",
-  "fingerprint": "ary2D/3pPPIqMW0FmZnYMsKzvk8r29qmK5+1KyEcTQA="
+  "fingerprint": "azqNkkl+/4FLzTVBLkOyHcokS4xLoYtHsri0z9kIehQ="
 }
 
 `;
@@ -20939,6 +21060,84 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         public virtual string OriginalValue
         {
             get => GetInstanceProperty<string>();
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Entropy.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).</summary>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Entropy), fullyQualifiedName: "jsii-calc.Entropy", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"your implementation of \`WallClock\`.\\"},\\"name\\":\\"clock\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IWallClock\\"}}]")]
+    public abstract class Entropy : DeputyBase
+    {
+        /// <summary>Creates a new instance of Entropy.</summary>
+        /// <param name="clock">your implementation of \`WallClock\`.</param>
+        protected Entropy(Amazon.JSII.Tests.CalculatorNamespace.IWallClock clock): base(new DeputyProps(new object[]{clock}))
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Entropy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Entropy(DeputyProps props): base(props)
+        {
+        }
+
+        /// <summary>Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).</summary>
+        /// <returns>the time from the \`WallClock\`.</returns>
+        [JsiiMethod(name: "increase", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+        public virtual string Increase()
+        {
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+        }
+
+        /// <summary>Implement this method such that it returns \`word\`.</summary>
+        /// <param name="word">the value to return.</param>
+        /// <returns>\`word\`.</returns>
+        [JsiiMethod(name: "repeat", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the value to return.\\"},\\"name\\":\\"word\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
+        public abstract string Repeat(string word);
+
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/EntropyProxy.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).</summary>
+    [JsiiTypeProxy(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Entropy), fullyQualifiedName: "jsii-calc.Entropy")]
+    internal sealed class EntropyProxy : Amazon.JSII.Tests.CalculatorNamespace.Entropy
+    {
+        private EntropyProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Implement this method such that it returns \`word\`.</summary>
+        /// <param name="word">the value to return.</param>
+        /// <returns>\`word\`.</returns>
+        [JsiiMethod(name: "repeat", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the value to return.\\"},\\"name\\":\\"word\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
+        public override string Repeat(string word)
+        {
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{word});
         }
     }
 }
@@ -24562,6 +24761,51 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             {
                 return null;
             }
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IWallClock.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Implement this interface.</summary>
+    [JsiiInterface(nativeType: typeof(IWallClock), fullyQualifiedName: "jsii-calc.IWallClock")]
+    public interface IWallClock
+    {
+        /// <summary>Returns the current time, formatted as an ISO-8601 string.</summary>
+        [JsiiMethod(name: "iso8601Now", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+        string Iso8601Now();
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/IWallClockProxy.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Implement this interface.</summary>
+    [JsiiTypeProxy(nativeType: typeof(IWallClock), fullyQualifiedName: "jsii-calc.IWallClock")]
+    internal sealed class IWallClockProxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IWallClock
+    {
+        private IWallClockProxy(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Returns the current time, formatted as an ISO-8601 string.</summary>
+        [JsiiMethod(name: "iso8601Now", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+        public string Iso8601Now()
+        {
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
         }
     }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -3539,6 +3539,45 @@ func (d *DynamicPropertyBearerChild) OverrideValue(newValue string) string {
 }
 
 // Class interface
+type EntropyIface interface {
+    Increase() string
+    Repeat(word string) string
+}
+
+// This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
+// Struct proxy
+type Entropy struct {
+}
+
+// Creates a new instance of Entropy.
+func NewEntropy(clock IWallClock) EntropyIface {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Entropy",
+        Method: "Constructor",
+        Args: []string{"jsii-calc.IWallClock",},
+    })
+    return &Entropy{}
+}
+
+func (e *Entropy) Increase() string {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Entropy",
+        Method: "Increase",
+        Args: []string{},
+    })
+    return "NOOP_RETURN_STRING"
+}
+
+func (e *Entropy) Repeat(word string) string {
+    jsii.NoOpRequest(jsii.NoOpApiRequest {
+        Class: "Entropy",
+        Method: "Repeat",
+        Args: []string{"string",},
+    })
+    return "NOOP_RETURN_STRING"
+}
+
+// Class interface
 type EnumDispenserIface interface {
 }
 
@@ -4117,6 +4156,12 @@ type IStableInterface interface {
 // Verifies that a "pure" implementation of an interface works correctly.
 type IStructReturningDelegate interface {
     ReturnStruct() StructB
+}
+
+// Implement this interface.
+type IWallClock interface {
+    // Returns the current time, formatted as an ISO-8601 string.
+    Iso8601Now() string
 }
 
 // Class interface

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -2455,6 +2455,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 DoubleTrouble.java
           ┃                 ┣━ 📄 DynamicPropertyBearer.java
           ┃                 ┣━ 📄 DynamicPropertyBearerChild.java
+          ┃                 ┣━ 📄 Entropy.java
           ┃                 ┣━ 📄 EnumDispenser.java
           ┃                 ┣━ 📄 EraseUndefinedHashValues.java
           ┃                 ┣━ 📄 EraseUndefinedHashValuesOptions.java
@@ -2520,6 +2521,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 Isomorphism.java
           ┃                 ┣━ 📄 IStableInterface.java
           ┃                 ┣━ 📄 IStructReturningDelegate.java
+          ┃                 ┣━ 📄 IWallClock.java
           ┃                 ┣━ 📄 JavaReservedWords.java
           ┃                 ┣━ 📄 JSII417Derived.java
           ┃                 ┣━ 📄 JSII417PublicBaseOfBase.java
@@ -7504,6 +7506,79 @@ public class DynamicPropertyBearerChild extends software.amazon.jsii.tests.calcu
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/Entropy.java 1`] = `
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.Entropy")
+public abstract class Entropy extends software.amazon.jsii.JsiiObject {
+
+    protected Entropy(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Entropy(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * Creates a new instance of Entropy.
+     * <p>
+     * @param clock your implementation of \`WallClock\`. This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    protected Entropy(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IWallClock clock) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(clock, "clock is required") });
+    }
+
+    /**
+     * Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
+     * <p>
+     * @return the time from the \`WallClock\`.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public @org.jetbrains.annotations.NotNull java.lang.String increase() {
+        return this.jsiiCall("increase", java.lang.String.class);
+    }
+
+    /**
+     * Implement this method such that it returns \`word\`.
+     * <p>
+     * @return \`word\`.
+     * @param word the value to return. This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public abstract @org.jetbrains.annotations.NotNull java.lang.String repeat(final @org.jetbrains.annotations.NotNull java.lang.String word);
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.tests.calculator.Entropy {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+        }
+
+        /**
+         * Implement this method such that it returns \`word\`.
+         * <p>
+         * @return \`word\`.
+         * @param word the value to return. This parameter is required.
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
+        public @org.jetbrains.annotations.NotNull java.lang.String repeat(final @org.jetbrains.annotations.NotNull java.lang.String word) {
+            return this.jsiiCall("repeat", java.lang.String.class, new Object[] { java.util.Objects.requireNonNull(word, "word is required") });
+        }
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/EnumDispenser.java 1`] = `
 package software.amazon.jsii.tests.calculator;
 
@@ -10358,6 +10433,45 @@ public interface IStructReturningDelegate extends software.amazon.jsii.JsiiSeria
         @Override
         public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.StructB returnStruct() {
             return this.jsiiCall("returnStruct", software.amazon.jsii.tests.calculator.StructB.class);
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/IWallClock.java 1`] = `
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Implement this interface.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.IWallClock")
+@software.amazon.jsii.Jsii.Proxy(IWallClock.Jsii$Proxy.class)
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+public interface IWallClock extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     * Returns the current time, formatted as an ISO-8601 string.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    @org.jetbrains.annotations.NotNull java.lang.String iso8601Now();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    final static class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.IWallClock {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+        }
+
+        /**
+         * Returns the current time, formatted as an ISO-8601 string.
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
+        public @org.jetbrains.annotations.NotNull java.lang.String iso8601Now() {
+            return this.jsiiCall("iso8601Now", java.lang.String.class);
         }
     }
 }
@@ -19875,6 +19989,7 @@ jsii-calc.DontComplainAboutVariadicAfterOptional=software.amazon.jsii.tests.calc
 jsii-calc.DoubleTrouble=software.amazon.jsii.tests.calculator.DoubleTrouble
 jsii-calc.DynamicPropertyBearer=software.amazon.jsii.tests.calculator.DynamicPropertyBearer
 jsii-calc.DynamicPropertyBearerChild=software.amazon.jsii.tests.calculator.DynamicPropertyBearerChild
+jsii-calc.Entropy=software.amazon.jsii.tests.calculator.Entropy
 jsii-calc.EnumDispenser=software.amazon.jsii.tests.calculator.EnumDispenser
 jsii-calc.EraseUndefinedHashValues=software.amazon.jsii.tests.calculator.EraseUndefinedHashValues
 jsii-calc.EraseUndefinedHashValuesOptions=software.amazon.jsii.tests.calculator.EraseUndefinedHashValuesOptions
@@ -19925,6 +20040,7 @@ jsii-calc.IReturnJsii976=software.amazon.jsii.tests.calculator.IReturnJsii976
 jsii-calc.IReturnsNumber=software.amazon.jsii.tests.calculator.IReturnsNumber
 jsii-calc.IStableInterface=software.amazon.jsii.tests.calculator.IStableInterface
 jsii-calc.IStructReturningDelegate=software.amazon.jsii.tests.calculator.IStructReturningDelegate
+jsii-calc.IWallClock=software.amazon.jsii.tests.calculator.IWallClock
 jsii-calc.ImplementInternalInterface=software.amazon.jsii.tests.calculator.ImplementInternalInterface
 jsii-calc.Implementation=software.amazon.jsii.tests.calculator.Implementation
 jsii-calc.ImplementsInterfaceWithInternal=software.amazon.jsii.tests.calculator.ImplementsInterfaceWithInternal

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -3352,6 +3352,52 @@ class DynamicPropertyBearerChild(
         return jsii.get(self, "originalValue")
 
 
+class Entropy(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Entropy"):
+    """This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either)."""
+
+    @builtins.staticmethod
+    def __jsii_proxy_class__():
+        return _EntropyProxy
+
+    def __init__(self, clock: "IWallClock") -> None:
+        """Creates a new instance of Entropy.
+
+        :param clock: your implementation of \`\`WallClock\`\`.
+        """
+        jsii.create(Entropy, self, [clock])
+
+    @jsii.member(jsii_name="increase")
+    def increase(self) -> builtins.str:
+        """Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
+
+        :return: the time from the \`\`WallClock\`\`.
+        """
+        return jsii.invoke(self, "increase", [])
+
+    @jsii.member(jsii_name="repeat")
+    @abc.abstractmethod
+    def repeat(self, word: builtins.str) -> builtins.str:
+        """Implement this method such that it returns \`\`word\`\`.
+
+        :param word: the value to return.
+
+        :return: \`\`word\`\`.
+        """
+        ...
+
+
+class _EntropyProxy(Entropy):
+    @jsii.member(jsii_name="repeat")
+    def repeat(self, word: builtins.str) -> builtins.str:
+        """Implement this method such that it returns \`\`word\`\`.
+
+        :param word: the value to return.
+
+        :return: \`\`word\`\`.
+        """
+        return jsii.invoke(self, "repeat", [word])
+
+
 class EnumDispenser(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.EnumDispenser"):
     @jsii.member(jsii_name="randomIntegerLikeEnum")
     @builtins.classmethod
@@ -4888,6 +4934,31 @@ class _IStructReturningDelegateProxy:
     @jsii.member(jsii_name="returnStruct")
     def return_struct(self) -> "StructB":
         return jsii.invoke(self, "returnStruct", [])
+
+
+@jsii.interface(jsii_type="jsii-calc.IWallClock")
+class IWallClock(typing_extensions.Protocol):
+    """Implement this interface."""
+
+    @builtins.staticmethod
+    def __jsii_proxy_class__():
+        return _IWallClockProxy
+
+    @jsii.member(jsii_name="iso8601Now")
+    def iso8601_now(self) -> builtins.str:
+        """Returns the current time, formatted as an ISO-8601 string."""
+        ...
+
+
+class _IWallClockProxy:
+    """Implement this interface."""
+
+    __jsii_type__: typing.ClassVar[str] = "jsii-calc.IWallClock"
+
+    @jsii.member(jsii_name="iso8601Now")
+    def iso8601_now(self) -> builtins.str:
+        """Returns the current time, formatted as an ISO-8601 string."""
+        return jsii.invoke(self, "iso8601Now", [])
 
 
 class ImplementInternalInterface(
@@ -8489,6 +8560,7 @@ __all__ = [
     "DoubleTrouble",
     "DynamicPropertyBearer",
     "DynamicPropertyBearerChild",
+    "Entropy",
     "EnumDispenser",
     "EraseUndefinedHashValues",
     "EraseUndefinedHashValuesOptions",
@@ -8539,6 +8611,7 @@ __all__ = [
     "IReturnsNumber",
     "IStableInterface",
     "IStructReturningDelegate",
+    "IWallClock",
     "ImplementInternalInterface",
     "Implementation",
     "ImplementsInterfaceWithInternal",

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -836,6 +836,20 @@ exports[`jsii-tree --all 1`] = `
  │   │   └─┬ originalValue property (stable)
  │   │     ├── immutable
  │   │     └── type: string
+ │   ├─┬ class Entropy (stable)
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>(clock) initializer (stable)
+ │   │   │ └─┬ parameters
+ │   │   │   └─┬ clock
+ │   │   │     └── type: jsii-calc.IWallClock
+ │   │   ├─┬ increase() method (stable)
+ │   │   │ └── returns: string
+ │   │   └─┬ repeat(word) method (stable)
+ │   │     ├── abstract
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ word
+ │   │     │   └── type: string
+ │   │     └── returns: string
  │   ├─┬ class EnumDispenser (stable)
  │   │ └─┬ members
  │   │   ├─┬ static randomIntegerLikeEnum() method (stable)
@@ -2331,6 +2345,11 @@ exports[`jsii-tree --all 1`] = `
  │   │   └─┬ returnStruct() method (stable)
  │   │     ├── abstract
  │   │     └── returns: jsii-calc.StructB
+ │   ├─┬ interface IWallClock (stable)
+ │   │ └─┬ members
+ │   │   └─┬ iso8601Now() method (stable)
+ │   │     ├── abstract
+ │   │     └── returns: string
  │   ├─┬ interface ImplictBaseOfBase (stable)
  │   │ ├─┬ interfaces
  │   │ │ └── BaseProps
@@ -2851,6 +2870,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class DynamicPropertyBearer
  │   ├─┬ class DynamicPropertyBearerChild
  │   │ └── base: DynamicPropertyBearer
+ │   ├── class Entropy
  │   ├── class EnumDispenser
  │   ├── class EraseUndefinedHashValues
  │   ├── class ExperimentalClass
@@ -3019,6 +3039,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── interface IReturnsNumber
  │   ├── interface IStableInterface
  │   ├── interface IStructReturningDelegate
+ │   ├── interface IWallClock
  │   ├─┬ interface ImplictBaseOfBase
  │   │ └─┬ interfaces
  │   │   └── BaseProps
@@ -3467,6 +3488,11 @@ exports[`jsii-tree --members 1`] = `
  │   │   ├── <initializer>(originalValue) initializer
  │   │   ├── overrideValue(newValue) method
  │   │   └── originalValue property
+ │   ├─┬ class Entropy
+ │   │ └─┬ members
+ │   │   ├── <initializer>(clock) initializer
+ │   │   ├── increase() method
+ │   │   └── repeat(word) method
  │   ├─┬ class EnumDispenser
  │   │ └─┬ members
  │   │   ├── static randomIntegerLikeEnum() method
@@ -4126,6 +4152,9 @@ exports[`jsii-tree --members 1`] = `
  │   ├─┬ interface IStructReturningDelegate
  │   │ └─┬ members
  │   │   └── returnStruct() method
+ │   ├─┬ interface IWallClock
+ │   │ └─┬ members
+ │   │   └── iso8601Now() method
  │   ├─┬ interface ImplictBaseOfBase
  │   │ └─┬ members
  │   │   └── goo property
@@ -4440,6 +4469,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class DoubleTrouble
  │   ├── class DynamicPropertyBearer
  │   ├── class DynamicPropertyBearerChild
+ │   ├── class Entropy
  │   ├── class EnumDispenser
  │   ├── class EraseUndefinedHashValues
  │   ├── class ExperimentalClass
@@ -4568,6 +4598,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── interface IReturnsNumber
  │   ├── interface IStableInterface
  │   ├── interface IStructReturningDelegate
+ │   ├── interface IWallClock
  │   ├── interface ImplictBaseOfBase
  │   ├── interface PropBooleanValue
  │   ├── interface PropProperty

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -63,6 +63,7 @@ Array [
   "jsii-calc.DoubleTrouble",
   "jsii-calc.DynamicPropertyBearer",
   "jsii-calc.DynamicPropertyBearerChild",
+  "jsii-calc.Entropy",
   "jsii-calc.EnumDispenser",
   "jsii-calc.EraseUndefinedHashValues",
   "jsii-calc.ExperimentalClass",


### PR DESCRIPTION
When a ISO-8601-encoded date is passed from JavaScript to the .NET app,
the JSON deserializer would interpret that as a `DateTime` instead of
passing the string un-touched. This is a problem, since the jsii kernel
protocol has a dedicated wrapper key for DateTime values (`$jsii$date`).

This PR adds a compliance test around this particular scenario, and
disabled `DateTime` handling from the standard deserializer (the wrapped
values are still processed correctly).

> This PR also changes the way the .NET test package generates the
> tested libraries (`jsii-calc` & dependencies) so that instead of
> generating NuGet packages, it only generates C# projects. This makes
> the experience of debugging the tests **much** nicer, and reduces the
> likelihood of cached build artifacts getting in the way.

Fixes aws/aws-cdk#10513

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
