### PR TITLE
fix(dotnet): abundant nullability warnings in generated code

### DIFF
--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Deputy/DeputyBase.cs
@@ -23,12 +23,12 @@ namespace Amazon.JSII.Runtime.Deputy
         /// </summary>
         protected sealed class DeputyProps
         {
-            public DeputyProps(object[]? arguments = null)
+            public DeputyProps(object?[]? arguments = null)
             {
-                Arguments = arguments ?? Array.Empty<object>();
+                Arguments = arguments ?? Array.Empty<object?>();
             }
 
-            public object[] Arguments { get; }
+            public object?[] Arguments { get; }
         }
 
         private const BindingFlags StaticMemberFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
@@ -220,18 +220,18 @@ namespace Amazon.JSII.Runtime.Deputy
 
         #region InvokeMethod
 
-        protected static void InvokeStaticVoidMethod(System.Type type, System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = "")
+        protected static void InvokeStaticVoidMethod(System.Type type, System.Type[] parameterTypes, object?[] arguments, [CallerMemberName] string methodName = "")
         {
             InvokeStaticMethod<object>(type, parameterTypes, arguments, methodName);
         }
 
-        protected void InvokeInstanceVoidMethod(System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = "")
+        protected void InvokeInstanceVoidMethod(System.Type[] parameterTypes, object?[] arguments, [CallerMemberName] string methodName = "")
         {
             InvokeInstanceMethod<object>(parameterTypes, arguments, methodName);
         }
         
         [return: MaybeNull]
-        protected static T InvokeStaticMethod<T>(System.Type type, System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = "")
+        protected static T InvokeStaticMethod<T>(System.Type type, System.Type[] parameterTypes, object?[] arguments, [CallerMemberName] string methodName = "")
         {
             JsiiTypeAttributeBase.Load(type.Assembly);
             
@@ -251,7 +251,7 @@ namespace Amazon.JSII.Runtime.Deputy
         }
 
         [return: MaybeNull]
-        protected T InvokeInstanceMethod<T>(System.Type[] parameterTypes, object[] arguments, [CallerMemberName] string methodName = "")
+        protected T InvokeInstanceMethod<T>(System.Type[] parameterTypes, object?[] arguments, [CallerMemberName] string methodName = "")
         {
             var methodAttribute = GetInstanceMethodAttribute(methodName, parameterTypes);
 

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -325,14 +325,10 @@ export class DotNetGenerator extends Generator {
       // Abstract classes have protected constructors.
       const visibility = cls.abstract ? 'protected' : 'public';
 
-      const hasOptional =
-        initializer.parameters?.find((param) => param.optional) != null
-          ? '?'
-          : '';
       const args =
         parametersBase.length > 0
-          ? `new object${hasOptional}[]{${parametersBase}}`
-          : `System.Array.Empty<object${hasOptional}>()`;
+          ? `new object?[]{${parametersBase}}`
+          : `System.Array.Empty<object?>()`;
       this.code.openBlock(
         `${visibility} ${className}(${parametersDefinition}): base(new DeputyProps(${args}))`,
       );
@@ -863,13 +859,15 @@ export class DotNetGenerator extends Generator {
     if (datatype || prop.const || prop.abstract) {
       this.code.line('get;');
     } else {
+      // If the property is non-optional, add a bang to silence compiler warning
+      const bang = prop.optional ? '' : '!';
       if (prop.static) {
         this.code.line(
-          `get => GetStaticProperty<${propTypeFQN}${isOptional}>(typeof(${className}));`,
+          `get => GetStaticProperty<${propTypeFQN}${isOptional}>(typeof(${className}))${bang};`,
         );
       } else {
         this.code.line(
-          `get => GetInstanceProperty<${propTypeFQN}${isOptional}>();`,
+          `get => GetInstanceProperty<${propTypeFQN}${isOptional}>()${bang};`,
         );
       }
     }
@@ -901,19 +899,24 @@ export class DotNetGenerator extends Generator {
     this.emitNewLineIfNecessary();
     this.flagFirstMemberWritten(true);
     const propType = this.typeresolver.toDotNetType(prop.type);
+    const isOptional = prop.optional ? '?' : '';
     this.dotnetDocGenerator.emitDocs(prop);
     this.dotnetRuntimeGenerator.emitAttributesForProperty(prop);
     const access = this.renderAccessLevel(prop);
     const propName = this.nameutils.convertPropertyName(prop.name);
     const staticKeyword = prop.static ? 'static ' : '';
 
-    this.code.openBlock(`${access} ${staticKeyword}${propType} ${propName}`);
+    this.code.openBlock(
+      `${access} ${staticKeyword}${propType}${isOptional} ${propName}`,
+    );
     this.code.line('get;');
     this.code.closeBlock();
     const className = this.typeresolver.toNativeFqn(cls.fqn);
+    // If the property is non-optional, add a bang to silence the compiler warning
+    const bang = prop.optional ? '' : '!';
     const initializer = prop.static
-      ? `= GetStaticProperty<${propType}>(typeof(${className}));`
-      : `= GetInstanceProperty<${propType}>(typeof(${className}));`;
+      ? `= GetStaticProperty<${propType}>(typeof(${className}))${bang};`
+      : `= GetInstanceProperty<${propType}>(typeof(${className}))${bang};`;
     this.code.line(initializer);
   }
 

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetruntimegenerator.ts
@@ -180,6 +180,8 @@ export class DotNetRuntimeGenerator {
           method.returns.optional ? '?' : ''
         }>`
       : '';
+    // If the method returns a non-optional value, apply a "!" to silence compilation warning.
+    const bang = method.returns && !method.returns.optional ? '!' : '';
     const typeofStatement = method.static ? `typeof(${className}), ` : '';
     const paramTypes = new Array<string>();
     const params = new Array<string>();
@@ -197,7 +199,7 @@ export class DotNetRuntimeGenerator {
       method.parameters?.find((param) => param.optional) != null ? '?' : '';
     return `${invokeMethodName}${returnType}(${typeofStatement}new System.Type[]{${paramTypes.join(
       ', ',
-    )}}, new object${hasOptional}[]{${params.join(', ')}});`;
+    )}}, new object${hasOptional}[]{${params.join(', ')}})${bang};`;
   }
 
   /**

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -240,7 +240,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base), fullyQualifiedName: "@scope/jsii-calc-base.Base")]
     public abstract class Base : DeputyBase
     {
-        protected Base(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected Base(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -262,7 +262,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
         [JsiiMethod(name: "typeName", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public virtual object TypeName()
         {
-            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -316,13 +316,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace
         [JsiiProperty(name: "bar", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Bar
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-base-of-base.Very\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>()!;
         }
     }
 }
@@ -786,7 +786,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very), fullyQualifiedName: "@scope/jsii-calc-base-of-base.Very")]
     public class Very : DeputyBase
     {
-        public Very(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Very(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -810,7 +810,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace
         [JsiiMethod(name: "hey", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double Hey()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -857,7 +857,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace
         [JsiiProperty(name: "foo", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-base-of-base.Very\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>()!;
         }
     }
 }
@@ -1820,7 +1820,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public double DoubleValue
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -1887,7 +1887,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -2188,7 +2188,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public double Anumber
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) A string value.</summary>
@@ -2199,7 +2199,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public string Astring
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -2238,7 +2238,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         /// <strong>Stability</strong>: Deprecated
         /// </remarks>
         [System.Obsolete()]
-        public Number(double @value): base(new DeputyProps(new object[]{@value}))
+        public Number(double @value): base(new DeputyProps(new object?[]{@value}))
         {
         }
 
@@ -2266,7 +2266,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public virtual double DoubleValue
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) The number.</summary>
@@ -2277,7 +2277,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -2299,7 +2299,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     [System.Obsolete()]
     public abstract class NumericValue : Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base
     {
-        protected NumericValue(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected NumericValue(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -2325,7 +2325,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) The value.</summary>
@@ -2370,7 +2370,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -2392,7 +2392,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
     [System.Obsolete()]
     public abstract class Operation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue
     {
-        protected Operation(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected Operation(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -2450,7 +2450,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) String representation of the value.</summary>
@@ -2461,7 +2461,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.LibNamespace
         [System.Obsolete()]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -2671,7 +2671,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
         [System.Obsolete()]
         public Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[] Entries
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[]>()!;
         }
     }
 }
@@ -2718,7 +2718,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
             /// <strong>Stability</strong>: Deprecated
             /// </remarks>
             [System.Obsolete()]
-            public NestedClass(): base(new DeputyProps(System.Array.Empty<object>()))
+            public NestedClass(): base(new DeputyProps(System.Array.Empty<object?>()))
             {
             }
 
@@ -2745,7 +2745,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
             [System.Obsolete()]
             public virtual string Property
             {
-                get => GetInstanceProperty<string>();
+                get => GetInstanceProperty<string>()!;
             }
         }
         /// <summary>(deprecated) This is a struct, nested within a class.</summary>
@@ -2789,7 +2789,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
             [System.Obsolete()]
             public string Name
             {
-                get => GetInstanceProperty<string>();
+                get => GetInstanceProperty<string>()!;
             }
         }
         #pragma warning disable CS8618
@@ -2885,7 +2885,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
         [System.Obsolete()]
         public string Key
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -2895,7 +2895,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
         [System.Obsolete()]
         public object Value
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
         }
     }
 }
@@ -2920,7 +2920,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
         /// <strong>Stability</strong>: Deprecated
         /// </remarks>
         [System.Obsolete()]
-        public Reflector(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Reflector(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -2947,7 +2947,7 @@ namespace Amazon.JSII.Tests.CustomSubmoduleName
         [System.Obsolete()]
         public virtual System.Collections.Generic.IDictionary<string, object> AsMap(Amazon.JSII.Tests.CustomSubmoduleName.IReflectable reflectable)
         {
-            return InvokeInstanceMethod<System.Collections.Generic.IDictionary<string, object>>(new System.Type[]{typeof(Amazon.JSII.Tests.CustomSubmoduleName.IReflectable)}, new object[]{reflectable});
+            return InvokeInstanceMethod<System.Collections.Generic.IDictionary<string, object>>(new System.Type[]{typeof(Amazon.JSII.Tests.CustomSubmoduleName.IReflectable)}, new object[]{reflectable})!;
         }
     }
 }
@@ -17631,7 +17631,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AbstractClass), fullyQualifiedName: "jsii-calc.AbstractClass")]
     public abstract class AbstractClass : Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase, Amazon.JSII.Tests.CalculatorNamespace.IInterfaceImplementedByAbstractClass
     {
-        protected AbstractClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected AbstractClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -17656,13 +17656,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "nonAbstractMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double NonAbstractMethod()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "propFromInterface", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string PropFromInterface
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -17679,7 +17679,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase), fullyQualifiedName: "jsii-calc.AbstractClassBase")]
     public abstract class AbstractClassBase : DeputyBase
     {
-        protected AbstractClassBase(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected AbstractClassBase(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -17724,7 +17724,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "abstractProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public override string AbstractProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -17748,13 +17748,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "abstractProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public override string AbstractProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiMethod(name: "abstractMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"name\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public override string AbstractMethod(string name)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{name});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{name})!;
         }
     }
 }
@@ -17771,7 +17771,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AbstractClassReturner), fullyQualifiedName: "jsii-calc.AbstractClassReturner")]
     public class AbstractClassReturner : DeputyBase
     {
-        public AbstractClassReturner(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AbstractClassReturner(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -17792,19 +17792,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "giveMeAbstract", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.AbstractClass\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.AbstractClass GiveMeAbstract()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.AbstractClass>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.AbstractClass>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "giveMeInterface", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IInterfaceImplementedByAbstractClass\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IInterfaceImplementedByAbstractClass GiveMeInterface()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IInterfaceImplementedByAbstractClass>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IInterfaceImplementedByAbstractClass>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "returnAbstractFromProperty", typeJson: "{\\"fqn\\":\\"jsii-calc.AbstractClassBase\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase ReturnAbstractFromProperty
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AbstractClassBase>()!;
         }
     }
 }
@@ -17822,7 +17822,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AbstractSuite), fullyQualifiedName: "jsii-calc.AbstractSuite")]
     public abstract class AbstractSuite : DeputyBase
     {
-        protected AbstractSuite(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected AbstractSuite(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -17849,7 +17849,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "workItAll", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"a \`string\`.\\"},\\"name\\":\\"seed\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual string WorkItAll(string seed)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{seed});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{seed})!;
         }
 
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
@@ -17881,14 +17881,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         protected override string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiMethod(name: "someMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"str\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         protected override string SomeMethod(string str)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{str});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{str})!;
         }
     }
 }
@@ -17909,7 +17909,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name="lhs">Left-hand side operand.</param>
         /// <param name="rhs">Right-hand side operand.</param>
-        public Add(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        public Add(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object?[]{lhs, rhs}))
         {
         }
 
@@ -17931,14 +17931,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "toString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) The value.</summary>
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -17960,7 +17960,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AllTypes), fullyQualifiedName: "jsii-calc.AllTypes")]
     public class AllTypes : DeputyBase
     {
-        public AllTypes(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AllTypes(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -17987,137 +17987,137 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "anyOut", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public virtual object AnyOut()
         {
-            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "enumMethod", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.StringEnum\\"}}", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.StringEnum\\"}}]")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.StringEnum EnumMethod(Amazon.JSII.Tests.CalculatorNamespace.StringEnum @value)
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.StringEnum>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.StringEnum)}, new object[]{@value});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.StringEnum>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.StringEnum)}, new object[]{@value})!;
         }
 
         [JsiiProperty(name: "enumPropertyValue", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double EnumPropertyValue
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiProperty(name: "anyArrayProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"array\\"}}")]
         public virtual object[] AnyArrayProperty
         {
-            get => GetInstanceProperty<object[]>();
+            get => GetInstanceProperty<object[]>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "anyMapProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, object> AnyMapProperty
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "anyProperty", typeJson: "{\\"primitive\\":\\"any\\"}")]
         public virtual object AnyProperty
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "arrayProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public virtual string[] ArrayProperty
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "booleanProperty", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool BooleanProperty
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "dateProperty", typeJson: "{\\"primitive\\":\\"date\\"}")]
         public virtual System.DateTime DateProperty
         {
-            get => GetInstanceProperty<System.DateTime>();
+            get => GetInstanceProperty<System.DateTime>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "enumProperty", typeJson: "{\\"fqn\\":\\"jsii-calc.AllTypesEnum\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum EnumProperty
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "jsonProperty", typeJson: "{\\"primitive\\":\\"json\\"}")]
         public virtual Newtonsoft.Json.Linq.JObject JsonProperty
         {
-            get => GetInstanceProperty<Newtonsoft.Json.Linq.JObject>();
+            get => GetInstanceProperty<Newtonsoft.Json.Linq.JObject>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "mapProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number> MapProperty
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "numberProperty", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double NumberProperty
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "stringProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string StringProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unionArrayProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"union\\":{\\"types\\":[{\\"primitive\\":\\"number\\"},{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}]}},\\"kind\\":\\"array\\"}}")]
         public virtual object[] UnionArrayProperty
         {
-            get => GetInstanceProperty<object[]>();
+            get => GetInstanceProperty<object[]>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unionMapProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"union\\":{\\"types\\":[{\\"primitive\\":\\"string\\"},{\\"primitive\\":\\"number\\"},{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"}]}},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, object> UnionMapProperty
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unionProperty", typeJson: "{\\"union\\":{\\"types\\":[{\\"primitive\\":\\"string\\"},{\\"primitive\\":\\"number\\"},{\\"fqn\\":\\"jsii-calc.Multiply\\"},{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"}]}}")]
         public virtual object UnionProperty
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unknownArrayProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"array\\"}}")]
         public virtual object[] UnknownArrayProperty
         {
-            get => GetInstanceProperty<object[]>();
+            get => GetInstanceProperty<object[]>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unknownMapProperty", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, object> UnknownMapProperty
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, object>>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "unknownProperty", typeJson: "{\\"primitive\\":\\"any\\"}")]
         public virtual object UnknownProperty
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
             set => SetInstanceProperty(value);
         }
 
@@ -18165,7 +18165,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AllowedMethodNames), fullyQualifiedName: "jsii-calc.AllowedMethodNames")]
     public class AllowedMethodNames : DeputyBase
     {
-        public AllowedMethodNames(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AllowedMethodNames(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18193,7 +18193,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "getFoo", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"withParam\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual string GetFoo(string withParam)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{withParam});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{withParam})!;
         }
 
         [JsiiMethod(name: "setBar", parametersJson: "[{\\"name\\":\\"_x\\",\\"type\\":{\\"primitive\\":\\"string\\"}},{\\"name\\":\\"_y\\",\\"type\\":{\\"primitive\\":\\"number\\"}},{\\"name\\":\\"_z\\",\\"type\\":{\\"primitive\\":\\"boolean\\"}}]")]
@@ -18223,7 +18223,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AmbiguousParameters), fullyQualifiedName: "jsii-calc.AmbiguousParameters", parametersJson: "[{\\"name\\":\\"scope\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.Bell\\"}},{\\"name\\":\\"props\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.StructParameterType\\"}}]")]
     public class AmbiguousParameters : DeputyBase
     {
-        public AmbiguousParameters(Amazon.JSII.Tests.CalculatorNamespace.Bell scope, Amazon.JSII.Tests.CalculatorNamespace.IStructParameterType props): base(new DeputyProps(new object[]{scope, props}))
+        public AmbiguousParameters(Amazon.JSII.Tests.CalculatorNamespace.Bell scope, Amazon.JSII.Tests.CalculatorNamespace.IStructParameterType props): base(new DeputyProps(new object?[]{scope, props}))
         {
         }
 
@@ -18244,13 +18244,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "props", typeJson: "{\\"fqn\\":\\"jsii-calc.StructParameterType\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IStructParameterType Props
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IStructParameterType>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IStructParameterType>()!;
         }
 
         [JsiiProperty(name: "scope", typeJson: "{\\"fqn\\":\\"jsii-calc.Bell\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Bell Scope
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Bell>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Bell>()!;
         }
     }
 }
@@ -18267,7 +18267,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AnonymousImplementationProvider), fullyQualifiedName: "jsii-calc.AnonymousImplementationProvider")]
     public class AnonymousImplementationProvider : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IAnonymousImplementationProvider
     {
-        public AnonymousImplementationProvider(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AnonymousImplementationProvider(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18288,13 +18288,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "provideAsClass", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.Implementation\\"}}", isOverride: true)]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Implementation ProvideAsClass()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Implementation>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Implementation>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "provideAsInterface", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IAnonymouslyImplementMe\\"}}", isOverride: true)]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe ProvideAsInterface()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -18311,7 +18311,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AsyncVirtualMethods), fullyQualifiedName: "jsii-calc.AsyncVirtualMethods")]
     public class AsyncVirtualMethods : DeputyBase
     {
-        public AsyncVirtualMethods(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AsyncVirtualMethods(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18332,14 +18332,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "callMe", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isAsync: true)]
         public virtual double CallMe()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Just calls "overrideMeToo".</summary>
         [JsiiMethod(name: "callMe2", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isAsync: true)]
         public virtual double CallMe2()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>This method calls the "callMe" async method indirectly, which will then invoke a virtual method.</summary>
@@ -18351,25 +18351,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "callMeDoublePromise", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isAsync: true)]
         public virtual double CallMeDoublePromise()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "dontOverrideMe", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double DontOverrideMe()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "overrideMe", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"mult\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]", isAsync: true)]
         public virtual double OverrideMe(double mult)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{mult});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{mult})!;
         }
 
         [JsiiMethod(name: "overrideMeToo", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isAsync: true)]
         public virtual double OverrideMeToo()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -18386,7 +18386,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AugmentableClass), fullyQualifiedName: "jsii-calc.AugmentableClass")]
     public class AugmentableClass : DeputyBase
     {
-        public AugmentableClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public AugmentableClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18430,7 +18430,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.BaseJsii976), fullyQualifiedName: "jsii-calc.BaseJsii976")]
     public class BaseJsii976 : DeputyBase
     {
-        public BaseJsii976(): base(new DeputyProps(System.Array.Empty<object>()))
+        public BaseJsii976(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18462,7 +18462,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Bell), fullyQualifiedName: "jsii-calc.Bell")]
     public class Bell : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IBell
     {
-        public Bell(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Bell(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18489,7 +18489,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "rung", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool Rung
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -18511,7 +18511,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name="lhs">Left-hand side operand.</param>
         /// <param name="rhs">Right-hand side operand.</param>
-        protected BinaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        protected BinaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object?[]{lhs, rhs}))
         {
         }
 
@@ -18533,21 +18533,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "hello", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Left-hand side operand.</summary>
         [JsiiProperty(name: "lhs", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Lhs
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
 
         /// <summary>Right-hand side operand.</summary>
         [JsiiProperty(name: "rhs", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Rhs
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
     }
 }
@@ -18577,7 +18577,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) String representation of the value.</summary>
@@ -18588,7 +18588,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -18606,7 +18606,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.BurriedAnonymousObject), fullyQualifiedName: "jsii-calc.BurriedAnonymousObject")]
     public abstract class BurriedAnonymousObject : DeputyBase
     {
-        protected BurriedAnonymousObject(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected BurriedAnonymousObject(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18627,7 +18627,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "check", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}")]
         public virtual bool Check()
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<bool>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Implement this method and have it return it's parameter.</summary>
@@ -18662,7 +18662,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "giveItBack", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the value that should be returned.\\"},\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"any\\"}}]")]
         public override object GiveItBack(object @value)
         {
-            return InvokeInstanceMethod<object>(new System.Type[]{typeof(object)}, new object[]{@value});
+            return InvokeInstanceMethod<object>(new System.Type[]{typeof(object)}, new object[]{@value})!;
         }
     }
 }
@@ -18752,35 +18752,35 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "readUnionValue", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double ReadUnionValue()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Returns the expression.</summary>
         [JsiiProperty(name: "expression", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Expression
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
 
         /// <summary>A log of all operations.</summary>
         [JsiiProperty(name: "operationsLog", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"},\\"kind\\":\\"array\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[] OperationsLog
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>()!;
         }
 
         /// <summary>A map of per operation name of all operations performed.</summary>
         [JsiiProperty(name: "operationsMap", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"},\\"kind\\":\\"array\\"}},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]> OperationsMap
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>>()!;
         }
 
         /// <summary>The current value.</summary>
         [JsiiProperty(name: "curr", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Curr
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
             set => SetInstanceProperty(value);
         }
 
@@ -18937,13 +18937,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "bar", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Bar
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Foo
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -18960,7 +18960,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassThatImplementsTheInternalInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsTheInternalInterface")]
     public class ClassThatImplementsTheInternalInterface : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.INonInternalInterface
     {
-        public ClassThatImplementsTheInternalInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ClassThatImplementsTheInternalInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -18981,28 +18981,28 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "a", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string A
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "b", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string B
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "c", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string C
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "d", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string D
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -19020,7 +19020,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassThatImplementsThePrivateInterface), fullyQualifiedName: "jsii-calc.ClassThatImplementsThePrivateInterface")]
     public class ClassThatImplementsThePrivateInterface : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.INonInternalInterface
     {
-        public ClassThatImplementsThePrivateInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ClassThatImplementsThePrivateInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19041,28 +19041,28 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "a", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string A
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "b", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string B
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "c", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string C
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "e", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string E
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -19080,7 +19080,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), fullyQualifiedName: "jsii-calc.ClassWithCollections", parametersJson: "[{\\"name\\":\\"map\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"map\\"}}},{\\"name\\":\\"array\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}}]")]
     public class ClassWithCollections : DeputyBase
     {
-        public ClassWithCollections(System.Collections.Generic.IDictionary<string, string> map, string[] array): base(new DeputyProps(new object[]{map, array}))
+        public ClassWithCollections(System.Collections.Generic.IDictionary<string, string> map, string[] array): base(new DeputyProps(new object?[]{map, array}))
         {
         }
 
@@ -19101,40 +19101,40 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "createAList", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}}")]
         public static string[] CreateAList()
         {
-            return InvokeStaticMethod<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "createAMap", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"map\\"}}}")]
         public static System.Collections.Generic.IDictionary<string, string> CreateAMap()
         {
-            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "staticArray", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public static string[] StaticArray
         {
-            get => GetStaticProperty<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections));
+            get => GetStaticProperty<string[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections))!;
             set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), value);
         }
 
         [JsiiProperty(name: "staticMap", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"map\\"}}")]
         public static System.Collections.Generic.IDictionary<string, string> StaticMap
         {
-            get => GetStaticProperty<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections));
+            get => GetStaticProperty<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections))!;
             set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithCollections), value);
         }
 
         [JsiiProperty(name: "array", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public virtual string[] Array
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "map", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"map\\"}}")]
         public virtual System.Collections.Generic.IDictionary<string, string> Map
         {
-            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, string>>();
+            get => GetInstanceProperty<System.Collections.Generic.IDictionary<string, string>>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -19166,7 +19166,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithDocs), fullyQualifiedName: "jsii-calc.ClassWithDocs")]
     public class ClassWithDocs : DeputyBase
     {
-        public ClassWithDocs(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ClassWithDocs(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19198,7 +19198,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithJavaReservedWords), fullyQualifiedName: "jsii-calc.ClassWithJavaReservedWords", parametersJson: "[{\\"name\\":\\"int\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class ClassWithJavaReservedWords : DeputyBase
     {
-        public ClassWithJavaReservedWords(string @int): base(new DeputyProps(new object[]{@int}))
+        public ClassWithJavaReservedWords(string @int): base(new DeputyProps(new object?[]{@int}))
         {
         }
 
@@ -19219,13 +19219,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "import", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"assert\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual string Import(string assert)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{assert});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{assert})!;
         }
 
         [JsiiProperty(name: "int", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Int
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -19242,7 +19242,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithMutableObjectLiteralProperty), fullyQualifiedName: "jsii-calc.ClassWithMutableObjectLiteralProperty")]
     public class ClassWithMutableObjectLiteralProperty : DeputyBase
     {
-        public ClassWithMutableObjectLiteralProperty(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ClassWithMutableObjectLiteralProperty(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19263,7 +19263,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "mutableObject", typeJson: "{\\"fqn\\":\\"jsii-calc.IMutableObjectLiteral\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IMutableObjectLiteral MutableObject
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IMutableObjectLiteral>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IMutableObjectLiteral>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -19299,19 +19299,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "create", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties\\"}}", parametersJson: "[{\\"name\\":\\"readOnlyString\\",\\"type\\":{\\"primitive\\":\\"string\\"}},{\\"name\\":\\"readWriteString\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public static Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties Create(string readOnlyString, string readWriteString)
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties), new System.Type[]{typeof(string), typeof(string)}, new object[]{readOnlyString, readWriteString});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ClassWithPrivateConstructorAndAutomaticProperties), new System.Type[]{typeof(string), typeof(string)}, new object[]{readOnlyString, readWriteString})!;
         }
 
         [JsiiProperty(name: "readOnlyString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadOnlyString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "readWriteString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadWriteString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -19330,7 +19330,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Composition.CompositeOperation), fullyQualifiedName: "jsii-calc.composition.CompositeOperation")]
     public abstract class CompositeOperation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation
     {
-        protected CompositeOperation(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected CompositeOperation(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19352,7 +19352,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
         [JsiiMethod(name: "toString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>The expression that this operation consists of.</summary>
@@ -19369,14 +19369,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>A set of postfixes to include in a decorated .toString().</summary>
         [JsiiProperty(name: "decorationPostfixes", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public virtual string[] DecorationPostfixes
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
             set => SetInstanceProperty(value);
         }
 
@@ -19384,7 +19384,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
         [JsiiProperty(name: "decorationPrefixes", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public virtual string[] DecorationPrefixes
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
             set => SetInstanceProperty(value);
         }
 
@@ -19392,7 +19392,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
         [JsiiProperty(name: "stringStyle", typeJson: "{\\"fqn\\":\\"jsii-calc.composition.CompositeOperation.CompositionStringStyle\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Composition.CompositeOperation.CompositionStringStyle StringStyle
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Composition.CompositeOperation.CompositionStringStyle>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Composition.CompositeOperation.CompositionStringStyle>()!;
             set => SetInstanceProperty(value);
         }
 
@@ -19434,7 +19434,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Composition
         [JsiiProperty(name: "expression", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Expression
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
     }
 }
@@ -19472,13 +19472,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "makeInstance", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.ConfusingToJackson\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson MakeInstance()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "makeStructInstance", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.ConfusingToJacksonStruct\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IConfusingToJacksonStruct MakeStructInstance()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IConfusingToJacksonStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IConfusingToJacksonStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConfusingToJackson), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiOptional]
@@ -19550,7 +19550,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut), fullyQualifiedName: "jsii-calc.ConstructorPassesThisOut", parametersJson: "[{\\"name\\":\\"consumer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.PartiallyInitializedThisConsumer\\"}}]")]
     public class ConstructorPassesThisOut : DeputyBase
     {
-        public ConstructorPassesThisOut(Amazon.JSII.Tests.CalculatorNamespace.PartiallyInitializedThisConsumer consumer): base(new DeputyProps(new object[]{consumer}))
+        public ConstructorPassesThisOut(Amazon.JSII.Tests.CalculatorNamespace.PartiallyInitializedThisConsumer consumer): base(new DeputyProps(new object?[]{consumer}))
         {
         }
 
@@ -19582,7 +19582,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), fullyQualifiedName: "jsii-calc.Constructors")]
     public class Constructors : DeputyBase
     {
-        public Constructors(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Constructors(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19603,43 +19603,43 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "hiddenInterface", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface HiddenInterface()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "hiddenInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"},\\"kind\\":\\"array\\"}}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[] HiddenInterfaces()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "hiddenSubInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"},\\"kind\\":\\"array\\"}}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[] HiddenSubInterfaces()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "makeClass", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.PublicClass\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.PublicClass MakeClass()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.PublicClass>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.PublicClass>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "makeInterface", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface MakeInterface()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "makeInterface2", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface2\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface2 MakeInterface2()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface2>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface2>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "makeInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"},\\"kind\\":\\"array\\"}}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[] MakeInterfaces()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Constructors), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -19656,7 +19656,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumePureInterface), fullyQualifiedName: "jsii-calc.ConsumePureInterface", parametersJson: "[{\\"name\\":\\"delegate\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IStructReturningDelegate\\"}}]")]
     public class ConsumePureInterface : DeputyBase
     {
-        public ConsumePureInterface(Amazon.JSII.Tests.CalculatorNamespace.IStructReturningDelegate @delegate): base(new DeputyProps(new object[]{@delegate}))
+        public ConsumePureInterface(Amazon.JSII.Tests.CalculatorNamespace.IStructReturningDelegate @delegate): base(new DeputyProps(new object?[]{@delegate}))
         {
         }
 
@@ -19677,7 +19677,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "workItBaby", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.StructB\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IStructB WorkItBaby()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructB>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructB>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -19699,7 +19699,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), fullyQualifiedName: "jsii-calc.ConsumerCanRingBell")]
     public class ConsumerCanRingBell : DeputyBase
     {
-        public ConsumerCanRingBell(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ConsumerCanRingBell(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19724,7 +19724,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "staticImplementedByObjectLiteral", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public static bool StaticImplementedByObjectLiteral(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>...if the interface is implemented using a private class.</summary>
@@ -19734,7 +19734,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "staticImplementedByPrivateClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public static bool StaticImplementedByPrivateClass(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>...if the interface is implemented using a public class.</summary>
@@ -19744,7 +19744,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "staticImplementedByPublicClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public static bool StaticImplementedByPublicClass(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>If the parameter is a concrete class instead of an interface.</summary>
@@ -19754,7 +19754,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "staticWhenTypedAsClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IConcreteBellRinger\\"}}]")]
         public static bool StaticWhenTypedAsClass(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger ringer)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger)}, new object[]{ringer});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumerCanRingBell), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>...if the interface is implemented using an object literal.</summary>
@@ -19764,7 +19764,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "implementedByObjectLiteral", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public virtual bool ImplementedByObjectLiteral(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>...if the interface is implemented using a private class.</summary>
@@ -19774,7 +19774,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "implementedByPrivateClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public virtual bool ImplementedByPrivateClass(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>...if the interface is implemented using a public class.</summary>
@@ -19784,7 +19784,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "implementedByPublicClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IBellRinger\\"}}]")]
         public virtual bool ImplementedByPublicClass(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger ringer)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IBellRinger)}, new object[]{ringer})!;
         }
 
         /// <summary>If the parameter is a concrete class instead of an interface.</summary>
@@ -19794,7 +19794,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "whenTypedAsClass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"ringer\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IConcreteBellRinger\\"}}]")]
         public virtual bool WhenTypedAsClass(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger ringer)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger)}, new object[]{ringer});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IConcreteBellRinger)}, new object[]{ringer})!;
         }
     }
 }
@@ -19811,7 +19811,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ConsumersOfThisCrazyTypeSystem), fullyQualifiedName: "jsii-calc.ConsumersOfThisCrazyTypeSystem")]
     public class ConsumersOfThisCrazyTypeSystem : DeputyBase
     {
-        public ConsumersOfThisCrazyTypeSystem(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ConsumersOfThisCrazyTypeSystem(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19832,13 +19832,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "consumeAnotherPublicInterface", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"obj\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IAnotherPublicInterface\\"}}]")]
         public virtual string ConsumeAnotherPublicInterface(Amazon.JSII.Tests.CalculatorNamespace.IAnotherPublicInterface obj)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IAnotherPublicInterface)}, new object[]{obj});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IAnotherPublicInterface)}, new object[]{obj})!;
         }
 
         [JsiiMethod(name: "consumeNonInternalInterface", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}", parametersJson: "[{\\"name\\":\\"obj\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.INonInternalInterface\\"}}]")]
         public virtual object ConsumeNonInternalInterface(Amazon.JSII.Tests.CalculatorNamespace.INonInternalInterface obj)
         {
-            return InvokeInstanceMethod<object>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.INonInternalInterface)}, new object[]{obj});
+            return InvokeInstanceMethod<object>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.INonInternalInterface)}, new object[]{obj})!;
         }
     }
 }
@@ -19856,7 +19856,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DataRenderer), fullyQualifiedName: "jsii-calc.DataRenderer")]
     public class DataRenderer : DeputyBase
     {
-        public DataRenderer(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DataRenderer(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19877,19 +19877,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "render", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"data\\",\\"optional\\":true,\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.MyFirstStruct\\"}}]")]
         public virtual string Render(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct? data = null)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct)}, new object?[]{data});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct)}, new object?[]{data})!;
         }
 
         [JsiiMethod(name: "renderArbitrary", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"data\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}}]")]
         public virtual string RenderArbitrary(System.Collections.Generic.IDictionary<string, object> data)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, object>)}, new object[]{data});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, object>)}, new object[]{data})!;
         }
 
         [JsiiMethod(name: "renderMap", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"map\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}}]")]
         public virtual string RenderMap(System.Collections.Generic.IDictionary<string, object> map)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, object>)}, new object[]{map});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, object>)}, new object[]{map})!;
         }
     }
 }
@@ -19927,13 +19927,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "arg1", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Arg1
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiProperty(name: "arg3", typeJson: "{\\"primitive\\":\\"date\\"}")]
         public virtual System.DateTime Arg3
         {
-            get => GetInstanceProperty<System.DateTime>();
+            get => GetInstanceProperty<System.DateTime>()!;
         }
 
         [JsiiOptional]
@@ -19962,7 +19962,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Demonstrate982), fullyQualifiedName: "jsii-calc.Demonstrate982")]
     public class Demonstrate982 : DeputyBase
     {
-        public Demonstrate982(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Demonstrate982(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -19984,14 +19984,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "takeThis", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.ChildStruct982\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IChildStruct982 TakeThis()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IChildStruct982>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Demonstrate982), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IChildStruct982>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Demonstrate982), new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>It's dangerous to go alone!</summary>
         [JsiiMethod(name: "takeThisToo", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.ParentStruct982\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IParentStruct982 TakeThisToo()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IParentStruct982>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Demonstrate982), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IParentStruct982>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Demonstrate982), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -20053,7 +20053,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete("this is not always \\"wazoo\\", be ready to be disappointed")]
         public virtual string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -20159,7 +20159,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete("well, yeah")]
         public string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -20176,7 +20176,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties.Base), fullyQualifiedName: "jsii-calc.DerivedClassHasNoProperties.Base")]
     public class Base : DeputyBase
     {
-        public Base(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Base(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20197,7 +20197,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
         [JsiiProperty(name: "prop", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Prop
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -20215,7 +20215,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties.Derived), fullyQualifiedName: "jsii-calc.DerivedClassHasNoProperties.Derived")]
     public class Derived : Amazon.JSII.Tests.CalculatorNamespace.DerivedClassHasNoProperties.Base
     {
-        public Derived(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Derived(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20355,20 +20355,20 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "anotherRequired", typeJson: "{\\"primitive\\":\\"date\\"}")]
         public System.DateTime AnotherRequired
         {
-            get => GetInstanceProperty<System.DateTime>();
+            get => GetInstanceProperty<System.DateTime>()!;
         }
 
         [JsiiProperty(name: "bool", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool Bool
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
 
         /// <summary>An example of a non primitive property.</summary>
         [JsiiProperty(name: "nonPrimitive", typeJson: "{\\"fqn\\":\\"jsii-calc.DoubleTrouble\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble NonPrimitive
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>()!;
         }
 
         /// <summary>This is optional.</summary>
@@ -20401,7 +20401,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public double Anumber
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) A string value.</summary>
@@ -20412,7 +20412,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public string Astring
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -20470,7 +20470,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "baseLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string BaseLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -20524,13 +20524,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string FirstMidLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "baseLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string BaseLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -20584,13 +20584,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string SecondMidLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "baseLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string BaseLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -20658,25 +20658,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "topLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string TopLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "firstMidLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string FirstMidLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "baseLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string BaseLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "secondMidLevelProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string SecondMidLevelProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -20716,7 +20716,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// (Nah, just a billion dollars mistake!)
         /// </remarks>
         [JsiiProperty(name: "maybeList", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}", isOptional: true)]
-        public static string[] MaybeList
+        public static string[]? MaybeList
         {
             get;
         }
@@ -20727,7 +20727,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// (Nah, just a billion dollars mistake!)
         /// </remarks>
         [JsiiProperty(name: "maybeMap", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"number\\"},\\"kind\\":\\"map\\"}}", isOptional: true)]
-        public static System.Collections.Generic.IDictionary<string, double> MaybeMap
+        public static System.Collections.Generic.IDictionary<string, double>? MaybeMap
         {
             get;
         }
@@ -20747,7 +20747,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DoNotOverridePrivates), fullyQualifiedName: "jsii-calc.DoNotOverridePrivates")]
     public class DoNotOverridePrivates : DeputyBase
     {
-        public DoNotOverridePrivates(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DoNotOverridePrivates(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20774,13 +20774,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "privateMethodValue", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string PrivateMethodValue()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "privatePropertyValue", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string PrivatePropertyValue()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -20798,7 +20798,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DoNotRecognizeAnyAsOptional), fullyQualifiedName: "jsii-calc.DoNotRecognizeAnyAsOptional")]
     public class DoNotRecognizeAnyAsOptional : DeputyBase
     {
-        public DoNotRecognizeAnyAsOptional(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DoNotRecognizeAnyAsOptional(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20843,7 +20843,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DocumentedClass), fullyQualifiedName: "jsii-calc.DocumentedClass")]
     public class DocumentedClass : DeputyBase
     {
-        public DocumentedClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DocumentedClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20871,7 +20871,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "greet", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"The person to be greeted.\\"},\\"name\\":\\"greetee\\",\\"optional\\":true,\\"type\\":{\\"fqn\\":\\"jsii-calc.Greetee\\"}}]")]
         public virtual double Greet(Amazon.JSII.Tests.CalculatorNamespace.IGreetee? greetee = null)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IGreetee)}, new object?[]{greetee});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IGreetee)}, new object?[]{greetee})!;
         }
 
         /// <summary>(experimental) Say ¡Hola!</summary>
@@ -20898,7 +20898,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DontComplainAboutVariadicAfterOptional), fullyQualifiedName: "jsii-calc.DontComplainAboutVariadicAfterOptional")]
     public class DontComplainAboutVariadicAfterOptional : DeputyBase
     {
-        public DontComplainAboutVariadicAfterOptional(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DontComplainAboutVariadicAfterOptional(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20919,7 +20919,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "optionalAndVariadic", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"optional\\",\\"optional\\":true,\\"type\\":{\\"primitive\\":\\"string\\"}},{\\"name\\":\\"things\\",\\"type\\":{\\"primitive\\":\\"string\\"},\\"variadic\\":true}]")]
         public virtual string OptionalAndVariadic(string? optional = null, params string[] things)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string), typeof(string[])}, new object?[]{optional, things});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string), typeof(string[])}, new object?[]{optional, things})!;
         }
     }
 }
@@ -20936,7 +20936,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble), fullyQualifiedName: "jsii-calc.DoubleTrouble")]
     public class DoubleTrouble : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IFriendlyRandomGenerator
     {
-        public DoubleTrouble(): base(new DeputyProps(System.Array.Empty<object>()))
+        public DoubleTrouble(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -20958,14 +20958,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "hello", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Returns another random number.</summary>
         [JsiiMethod(name: "next", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isOverride: true)]
         public virtual double Next()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -20983,7 +20983,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DynamicPropertyBearer), fullyQualifiedName: "jsii-calc.DynamicPropertyBearer", parametersJson: "[{\\"name\\":\\"valueStore\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class DynamicPropertyBearer : DeputyBase
     {
-        public DynamicPropertyBearer(string valueStore): base(new DeputyProps(new object[]{valueStore}))
+        public DynamicPropertyBearer(string valueStore): base(new DeputyProps(new object?[]{valueStore}))
         {
         }
 
@@ -21004,14 +21004,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "dynamicProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string DynamicProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "valueStore", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ValueStore
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -21029,7 +21029,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DynamicPropertyBearerChild), fullyQualifiedName: "jsii-calc.DynamicPropertyBearerChild", parametersJson: "[{\\"name\\":\\"originalValue\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class DynamicPropertyBearerChild : Amazon.JSII.Tests.CalculatorNamespace.DynamicPropertyBearer
     {
-        public DynamicPropertyBearerChild(string originalValue): base(new DeputyProps(new object[]{originalValue}))
+        public DynamicPropertyBearerChild(string originalValue): base(new DeputyProps(new object?[]{originalValue}))
         {
         }
 
@@ -21053,13 +21053,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "overrideValue", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the new value to be set.\\"},\\"name\\":\\"newValue\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual string OverrideValue(string newValue)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{newValue});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{newValue})!;
         }
 
         [JsiiProperty(name: "originalValue", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string OriginalValue
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -21079,7 +21079,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     {
         /// <summary>Creates a new instance of Entropy.</summary>
         /// <param name="clock">your implementation of \`WallClock\`.</param>
-        protected Entropy(Amazon.JSII.Tests.CalculatorNamespace.IWallClock clock): base(new DeputyProps(new object[]{clock}))
+        protected Entropy(Amazon.JSII.Tests.CalculatorNamespace.IWallClock clock): base(new DeputyProps(new object?[]{clock}))
         {
         }
 
@@ -21102,7 +21102,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "increase", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string Increase()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Implement this method such that it returns \`word\`.</summary>
@@ -21137,7 +21137,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "repeat", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the value to return.\\"},\\"name\\":\\"word\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public override string Repeat(string word)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{word});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{word})!;
         }
     }
 }
@@ -21171,13 +21171,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "randomIntegerLikeEnum", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.AllTypesEnum\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum RandomIntegerLikeEnum()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EnumDispenser), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EnumDispenser), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "randomStringLikeEnum", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.StringEnum\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.StringEnum RandomStringLikeEnum()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.StringEnum>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EnumDispenser), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.StringEnum>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EnumDispenser), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -21194,7 +21194,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), fullyQualifiedName: "jsii-calc.EraseUndefinedHashValues")]
     public class EraseUndefinedHashValues : DeputyBase
     {
-        public EraseUndefinedHashValues(): base(new DeputyProps(System.Array.Empty<object>()))
+        public EraseUndefinedHashValues(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -21220,21 +21220,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "doesKeyExist", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"opts\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.EraseUndefinedHashValuesOptions\\"}},{\\"name\\":\\"key\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public static bool DoesKeyExist(Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions opts, string key)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions), typeof(string)}, new object[]{opts, key});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IEraseUndefinedHashValuesOptions), typeof(string)}, new object[]{opts, key})!;
         }
 
         /// <summary>We expect "prop1" to be erased.</summary>
         [JsiiMethod(name: "prop1IsNull", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}}")]
         public static System.Collections.Generic.IDictionary<string, object> Prop1IsNull()
         {
-            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, object>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, object>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>We expect "prop2" to be erased.</summary>
         [JsiiMethod(name: "prop2IsUndefined", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}}")]
         public static System.Collections.Generic.IDictionary<string, object> Prop2IsUndefined()
         {
-            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, object>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, object>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.EraseUndefinedHashValues), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -21352,7 +21352,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -21451,7 +21451,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -21468,7 +21468,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ExportedBaseClass), fullyQualifiedName: "jsii-calc.ExportedBaseClass", parametersJson: "[{\\"name\\":\\"success\\",\\"type\\":{\\"primitive\\":\\"boolean\\"}}]")]
     public class ExportedBaseClass : DeputyBase
     {
-        public ExportedBaseClass(bool success): base(new DeputyProps(new object[]{success}))
+        public ExportedBaseClass(bool success): base(new DeputyProps(new object?[]{success}))
         {
         }
 
@@ -21489,7 +21489,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "success", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool Success
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -21543,13 +21543,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "boom", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool Boom
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
 
         [JsiiProperty(name: "prop", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Prop
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -21605,7 +21605,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <remarks>
@@ -21704,7 +21704,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -21721,7 +21721,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.GiveMeStructs), fullyQualifiedName: "jsii-calc.GiveMeStructs")]
     public class GiveMeStructs : DeputyBase
     {
-        public GiveMeStructs(): base(new DeputyProps(System.Array.Empty<object>()))
+        public GiveMeStructs(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -21743,27 +21743,27 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "derivedToFirst", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.MyFirstStruct\\"}}", parametersJson: "[{\\"name\\":\\"derived\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.DerivedStruct\\"}}]")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct DerivedToFirst(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct derived)
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct)}, new object[]{derived});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct)}, new object[]{derived})!;
         }
 
         /// <summary>Returns the boolean from a DerivedStruct struct.</summary>
         [JsiiMethod(name: "readDerivedNonPrimitive", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.DoubleTrouble\\"}}", parametersJson: "[{\\"name\\":\\"derived\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.DerivedStruct\\"}}]")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble ReadDerivedNonPrimitive(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct derived)
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct)}, new object[]{derived});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IDerivedStruct)}, new object[]{derived})!;
         }
 
         /// <summary>Returns the "anumber" from a MyFirstStruct struct;</summary>
         [JsiiMethod(name: "readFirstNumber", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"first\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.MyFirstStruct\\"}}]")]
         public virtual double ReadFirstNumber(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct first)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct)}, new object[]{first});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IMyFirstStruct)}, new object[]{first})!;
         }
 
         [JsiiProperty(name: "structLiteral", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.StructWithOnlyOptionals\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals StructLiteral
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IStructWithOnlyOptionals>()!;
         }
     }
 }
@@ -21837,7 +21837,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.GreetingAugmenter), fullyQualifiedName: "jsii-calc.GreetingAugmenter")]
     public class GreetingAugmenter : DeputyBase
     {
-        public GreetingAugmenter(): base(new DeputyProps(System.Array.Empty<object>()))
+        public GreetingAugmenter(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -21858,7 +21858,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "betterGreeting", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"friendly\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.IFriendly\\"}}]")]
         public virtual string BetterGreeting(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly friendly)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly)}, new object[]{friendly});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly)}, new object[]{friendly})!;
         }
     }
 }
@@ -21903,13 +21903,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "provideAsClass", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.Implementation\\"}}")]
         public Amazon.JSII.Tests.CalculatorNamespace.Implementation ProvideAsClass()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Implementation>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Implementation>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "provideAsInterface", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IAnonymouslyImplementMe\\"}}")]
         public Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe ProvideAsInterface()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -21955,13 +21955,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiMethod(name: "verb", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Verb()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -22006,7 +22006,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "a", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string A
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -22699,13 +22699,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "moreThings", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public string[] MoreThings
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
         }
 
         [JsiiProperty(name: "private", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Private
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -22861,7 +22861,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "farewell", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Farewell()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Say goodbye.</summary>
@@ -22869,7 +22869,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "goodbye", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Goodbye()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) Say hello!</summary>
@@ -22880,7 +22880,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -22921,7 +22921,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "next", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public double Next()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) Say hello!</summary>
@@ -22932,7 +22932,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -23027,7 +23027,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "propFromInterface", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string PropFromInterface
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -23073,13 +23073,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "otherValue", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string OtherValue
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Value
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiMethod(name: "doThings")]
@@ -23172,7 +23172,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Value
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiMethod(name: "doThings")]
@@ -23293,20 +23293,20 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Foo
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "readOnlyString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadOnlyString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "readWriteString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadWriteString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -23331,13 +23331,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readOnlyString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadOnlyString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "readWriteString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadWriteString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -23386,13 +23386,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "hasRoot", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool HasRoot
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
 
         [JsiiMethod(name: "bar")]
@@ -23456,7 +23456,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "hasRoot", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool HasRoot
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
 
         [JsiiMethod(name: "foo")]
@@ -23737,7 +23737,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Value
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -23811,21 +23811,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "b", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string B
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "c", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string C
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "a", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string A
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -23905,14 +23905,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiMethod(name: "wasSet", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}")]
         public bool WasSet()
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<bool>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24044,7 +24044,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "success", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool Success
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -24102,7 +24102,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "ciao", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Ciao()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24126,7 +24126,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "bye", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Bye()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24173,7 +24173,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "next", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public double Next()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24219,7 +24219,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Foo
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -24265,13 +24265,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "numberProp", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number NumberProp
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>()!;
         }
 
         [JsiiMethod(name: "obtainNumber", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.IDoublable\\"}}")]
         public Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable ObtainNumber()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24606,7 +24606,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "returnStruct", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.StructB\\"}}")]
         public Amazon.JSII.Tests.CalculatorNamespace.IStructB ReturnStruct()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructB>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructB>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24805,7 +24805,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "iso8601Now", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public string Iso8601Now()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -24822,7 +24822,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ImplementInternalInterface), fullyQualifiedName: "jsii-calc.ImplementInternalInterface")]
     public class ImplementInternalInterface : DeputyBase
     {
-        public ImplementInternalInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ImplementInternalInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -24843,7 +24843,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "prop", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Prop
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -24861,7 +24861,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Implementation), fullyQualifiedName: "jsii-calc.Implementation")]
     public class Implementation : DeputyBase
     {
-        public Implementation(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Implementation(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -24882,7 +24882,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -24899,7 +24899,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ImplementsInterfaceWithInternal), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternal")]
     public class ImplementsInterfaceWithInternal : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithInternal
     {
-        public ImplementsInterfaceWithInternal(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ImplementsInterfaceWithInternal(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -24937,7 +24937,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ImplementsInterfaceWithInternalSubclass), fullyQualifiedName: "jsii-calc.ImplementsInterfaceWithInternalSubclass")]
     public class ImplementsInterfaceWithInternalSubclass : Amazon.JSII.Tests.CalculatorNamespace.ImplementsInterfaceWithInternal
     {
-        public ImplementsInterfaceWithInternalSubclass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ImplementsInterfaceWithInternalSubclass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -24969,7 +24969,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ImplementsPrivateInterface), fullyQualifiedName: "jsii-calc.ImplementsPrivateInterface")]
     public class ImplementsPrivateInterface : DeputyBase
     {
-        public ImplementsPrivateInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ImplementsPrivateInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -24990,7 +24990,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "private", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Private
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -25052,19 +25052,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "goo", typeJson: "{\\"primitive\\":\\"date\\"}")]
         public System.DateTime Goo
         {
-            get => GetInstanceProperty<System.DateTime>();
+            get => GetInstanceProperty<System.DateTime>()!;
         }
 
         [JsiiProperty(name: "bar", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Bar
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "foo", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-base-of-base.Very\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very Foo
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace.Very>()!;
         }
     }
 }
@@ -25081,7 +25081,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass), fullyQualifiedName: "jsii-calc.InbetweenClass")]
     public class InbetweenClass : Amazon.JSII.Tests.CalculatorNamespace.PublicClass, Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface2
     {
-        public InbetweenClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public InbetweenClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25102,7 +25102,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "ciao", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Ciao()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -25140,25 +25140,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "listOfInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.IBell\\"},\\"kind\\":\\"array\\"}}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IBell[] ListOfInterfaces()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IBell[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IBell[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "listOfStructs", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.StructA\\"},\\"kind\\":\\"array\\"}}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IStructA[] ListOfStructs()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructA[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IStructA[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "mapOfInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.IBell\\"},\\"kind\\":\\"map\\"}}}")]
         public static System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IBell> MapOfInterfaces()
         {
-            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IBell>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IBell>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "mapOfStructs", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"jsii-calc.StructA\\"},\\"kind\\":\\"map\\"}}}")]
         public static System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IStructA> MapOfStructs()
         {
-            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IStructA>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.IStructA>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceCollections), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -25175,7 +25175,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClas
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClasses.Foo), fullyQualifiedName: "jsii-calc.InterfaceInNamespaceIncludesClasses.Foo")]
     public class Foo : DeputyBase
     {
-        public Foo(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Foo(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25245,7 +25245,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceIncludesClas
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Foo
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -25312,7 +25312,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.InterfaceInNamespaceOnlyInterfac
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Foo
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -25367,7 +25367,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "makeInterfaces", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.IDoublable\\"},\\"kind\\":\\"array\\"}}}", parametersJson: "[{\\"name\\":\\"count\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public static Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable[] MakeInterfaces(double count)
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfacesMaker), new System.Type[]{typeof(double)}, new object[]{count});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IDoublable[]>(typeof(Amazon.JSII.Tests.CalculatorNamespace.InterfacesMaker), new System.Type[]{typeof(double)}, new object[]{count})!;
         }
     }
 }
@@ -25407,7 +25407,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Isomorphism), fullyQualifiedName: "jsii-calc.Isomorphism")]
     public abstract class Isomorphism : DeputyBase
     {
-        protected Isomorphism(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected Isomorphism(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25428,7 +25428,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "myself", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.Isomorphism\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Isomorphism Myself()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Isomorphism>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.Isomorphism>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -25468,7 +25468,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JSII417Derived), fullyQualifiedName: "jsii-calc.JSII417Derived", parametersJson: "[{\\"name\\":\\"property\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class JSII417Derived : Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase
     {
-        public JSII417Derived(string property): base(new DeputyProps(new object[]{property}))
+        public JSII417Derived(string property): base(new DeputyProps(new object?[]{property}))
         {
         }
 
@@ -25501,7 +25501,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         protected virtual string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -25518,7 +25518,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase), fullyQualifiedName: "jsii-calc.JSII417PublicBaseOfBase")]
     public class JSII417PublicBaseOfBase : DeputyBase
     {
-        public JSII417PublicBaseOfBase(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JSII417PublicBaseOfBase(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25539,7 +25539,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "makeInstance", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.JSII417PublicBaseOfBase\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase MakeInstance()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JSII417PublicBaseOfBase), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "foo")]
@@ -25551,7 +25551,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "hasRoot", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool HasRoot
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -25568,7 +25568,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralForInterface), fullyQualifiedName: "jsii-calc.JSObjectLiteralForInterface")]
     public class JSObjectLiteralForInterface : DeputyBase
     {
-        public JSObjectLiteralForInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JSObjectLiteralForInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25589,13 +25589,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "giveMeFriendly", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.IFriendly\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly GiveMeFriendly()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "giveMeFriendlyGenerator", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IFriendlyRandomGenerator\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IFriendlyRandomGenerator GiveMeFriendlyGenerator()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IFriendlyRandomGenerator>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IFriendlyRandomGenerator>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -25612,7 +25612,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNative), fullyQualifiedName: "jsii-calc.JSObjectLiteralToNative")]
     public class JSObjectLiteralToNative : DeputyBase
     {
-        public JSObjectLiteralToNative(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JSObjectLiteralToNative(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25633,7 +25633,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "returnLiteral", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.JSObjectLiteralToNativeClass\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass ReturnLiteral()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -25650,7 +25650,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JSObjectLiteralToNativeClass), fullyQualifiedName: "jsii-calc.JSObjectLiteralToNativeClass")]
     public class JSObjectLiteralToNativeClass : DeputyBase
     {
-        public JSObjectLiteralToNativeClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JSObjectLiteralToNativeClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -25671,14 +25671,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "propA", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string PropA
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "propB", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double PropB
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -25696,7 +25696,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JavaReservedWords), fullyQualifiedName: "jsii-calc.JavaReservedWords")]
     public class JavaReservedWords : DeputyBase
     {
-        public JavaReservedWords(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JavaReservedWords(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26029,7 +26029,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "while", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string While
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -26047,7 +26047,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Jsii487Derived), fullyQualifiedName: "jsii-calc.Jsii487Derived")]
     public class Jsii487Derived : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IJsii487External2, Amazon.JSII.Tests.CalculatorNamespace.IJsii487External
     {
-        public Jsii487Derived(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Jsii487Derived(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26079,7 +26079,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Jsii496Derived), fullyQualifiedName: "jsii-calc.Jsii496Derived")]
     public class Jsii496Derived : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.IJsii496
     {
-        public Jsii496Derived(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Jsii496Derived(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26112,7 +26112,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.JsiiAgent), fullyQualifiedName: "jsii-calc.JsiiAgent")]
     public class JsiiAgent : DeputyBase
     {
-        public JsiiAgent(): base(new DeputyProps(System.Array.Empty<object>()))
+        public JsiiAgent(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26173,79 +26173,79 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "anyArray", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyArray()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyBooleanFalse", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyBooleanFalse()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyBooleanTrue", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyBooleanTrue()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyDate", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyDate()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyEmptyString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyEmptyString()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyFunction", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyFunction()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyHash", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyHash()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyNull", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyNull()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyNumber", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyNumber()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyRef", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyRef()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyString()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyUndefined", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyUndefined()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "anyZero", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object AnyZero()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.JsonFormatter), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "stringify", returnsJson: "{\\"optional\\":true,\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"value\\",\\"optional\\":true,\\"type\\":{\\"primitive\\":\\"any\\"}}]")]
@@ -26269,7 +26269,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.LevelOne), fullyQualifiedName: "jsii-calc.LevelOne", parametersJson: "[{\\"name\\":\\"props\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.LevelOneProps\\"}}]")]
     public class LevelOne : DeputyBase
     {
-        public LevelOne(Amazon.JSII.Tests.CalculatorNamespace.ILevelOneProps props): base(new DeputyProps(new object[]{props}))
+        public LevelOne(Amazon.JSII.Tests.CalculatorNamespace.ILevelOneProps props): base(new DeputyProps(new object?[]{props}))
         {
         }
 
@@ -26290,7 +26290,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "props", typeJson: "{\\"fqn\\":\\"jsii-calc.LevelOneProps\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.ILevelOneProps Props
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.ILevelOneProps>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.ILevelOneProps>()!;
         }
         [JsiiInterface(nativeType: typeof(IPropBooleanValue), fullyQualifiedName: "jsii-calc.LevelOne.PropBooleanValue")]
         public interface IPropBooleanValue
@@ -26311,7 +26311,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
             public bool Value
             {
-                get => GetInstanceProperty<bool>();
+                get => GetInstanceProperty<bool>()!;
             }
         }
         #pragma warning disable CS8618
@@ -26345,7 +26345,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             [JsiiProperty(name: "prop", typeJson: "{\\"fqn\\":\\"jsii-calc.LevelOne.PropBooleanValue\\"}")]
             public Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropBooleanValue Prop
             {
-                get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropBooleanValue>();
+                get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropBooleanValue>()!;
             }
         }
         #pragma warning disable CS8618
@@ -26405,7 +26405,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "prop", typeJson: "{\\"fqn\\":\\"jsii-calc.LevelOne.PropProperty\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropProperty Prop
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropProperty>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LevelOne.IPropProperty>()!;
         }
     }
 }
@@ -26623,7 +26623,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.MethodNamedProperty), fullyQualifiedName: "jsii-calc.MethodNamedProperty")]
     public class MethodNamedProperty : DeputyBase
     {
-        public MethodNamedProperty(): base(new DeputyProps(System.Array.Empty<object>()))
+        public MethodNamedProperty(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26644,13 +26644,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "property", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string Property()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "elite", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Elite
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -26671,7 +26671,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Creates a BinaryOperation.</summary>
         /// <param name="lhs">Left-hand side operand.</param>
         /// <param name="rhs">Right-hand side operand.</param>
-        public Multiply(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object[]{lhs, rhs}))
+        public Multiply(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue lhs, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue rhs): base(new DeputyProps(new object?[]{lhs, rhs}))
         {
         }
 
@@ -26693,35 +26693,35 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "farewell", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Farewell()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Say goodbye.</summary>
         [JsiiMethod(name: "goodbye", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Goodbye()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Returns another random number.</summary>
         [JsiiMethod(name: "next", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isOverride: true)]
         public virtual double Next()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) String representation of the value.</summary>
         [JsiiMethod(name: "toString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) The value.</summary>
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -26781,7 +26781,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Negate), fullyQualifiedName: "jsii-calc.Negate", parametersJson: "[{\\"name\\":\\"operand\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}}]")]
     public class Negate : Amazon.JSII.Tests.CalculatorNamespace.UnaryOperation, Amazon.JSII.Tests.CalculatorNamespace.IFriendlier
     {
-        public Negate(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue operand): base(new DeputyProps(new object[]{operand}))
+        public Negate(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue operand): base(new DeputyProps(new object?[]{operand}))
         {
         }
 
@@ -26803,35 +26803,35 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "farewell", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Farewell()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Say goodbye.</summary>
         [JsiiMethod(name: "goodbye", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Goodbye()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) Say hello!</summary>
         [JsiiMethod(name: "hello", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public virtual string Hello()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) String representation of the value.</summary>
         [JsiiMethod(name: "toString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>(deprecated) The value.</summary>
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -26865,7 +26865,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "makeInstance", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass\\"}}")]
         public static Amazon.JSII.Tests.CustomSubmoduleName.NestingClass.NestedClass MakeInstance()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CustomSubmoduleName.NestingClass.NestedClass>(typeof(Amazon.JSII.Tests.CalculatorNamespace.NestedClassInstance), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CustomSubmoduleName.NestingClass.NestedClass>(typeof(Amazon.JSII.Tests.CalculatorNamespace.NestedClassInstance), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -26914,7 +26914,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "numberProp", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double NumberProp
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
     }
 }
@@ -26932,7 +26932,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.NodeStandardLibrary), fullyQualifiedName: "jsii-calc.NodeStandardLibrary")]
     public class NodeStandardLibrary : DeputyBase
     {
-        public NodeStandardLibrary(): base(new DeputyProps(System.Array.Empty<object>()))
+        public NodeStandardLibrary(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -26955,7 +26955,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "cryptoSha256", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string CryptoSha256()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Reads a local resource file (resource.txt) asynchronously.</summary>
@@ -26963,7 +26963,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "fsReadFile", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isAsync: true)]
         public virtual string FsReadFile()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Sync version of fsReadFile.</summary>
@@ -26971,14 +26971,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "fsReadFileSync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string FsReadFileSync()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Returns the current os.platform() from the "os" node module.</summary>
         [JsiiProperty(name: "osPlatform", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string OsPlatform
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -27092,7 +27092,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "arrayWithThreeElementsAndUndefinedAsSecondArgument", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"array\\"}}")]
         public object[] ArrayWithThreeElementsAndUndefinedAsSecondArgument
         {
-            get => GetInstanceProperty<object[]>();
+            get => GetInstanceProperty<object[]>()!;
         }
 
         [JsiiOptional]
@@ -27117,7 +27117,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.NumberGenerator), fullyQualifiedName: "jsii-calc.NumberGenerator", parametersJson: "[{\\"name\\":\\"generator\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IRandomNumberGenerator\\"}}]")]
     public class NumberGenerator : DeputyBase
     {
-        public NumberGenerator(Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator generator): base(new DeputyProps(new object[]{generator}))
+        public NumberGenerator(Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator generator): base(new DeputyProps(new object?[]{generator}))
         {
         }
 
@@ -27138,19 +27138,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "isSameGenerator", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"gen\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IRandomNumberGenerator\\"}}]")]
         public virtual bool IsSameGenerator(Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator gen)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator)}, new object[]{gen});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator)}, new object[]{gen})!;
         }
 
         [JsiiMethod(name: "nextTimes100", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double NextTimes100()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "generator", typeJson: "{\\"fqn\\":\\"jsii-calc.IRandomNumberGenerator\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator Generator
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IRandomNumberGenerator>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -27169,7 +27169,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ObjectRefsInCollections), fullyQualifiedName: "jsii-calc.ObjectRefsInCollections")]
     public class ObjectRefsInCollections : DeputyBase
     {
-        public ObjectRefsInCollections(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ObjectRefsInCollections(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27191,14 +27191,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "sumFromArray", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"values\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"},\\"kind\\":\\"array\\"}}}]")]
         public virtual double SumFromArray(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[] values)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[])}, new object[]{values});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[])}, new object[]{values})!;
         }
 
         /// <summary>Returns the sum of all values in a map.</summary>
         [JsiiMethod(name: "sumFromMap", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"values\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"},\\"kind\\":\\"map\\"}}}]")]
         public virtual double SumFromMap(System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue> values)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>)}, new object[]{values});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(System.Collections.Generic.IDictionary<string, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>)}, new object[]{values})!;
         }
     }
 }
@@ -27232,7 +27232,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "provide", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IObjectWithProperty\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IObjectWithProperty Provide()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IObjectWithProperty>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ObjectWithPropertyProvider), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IObjectWithProperty>(typeof(Amazon.JSII.Tests.CalculatorNamespace.ObjectWithPropertyProvider), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -27254,7 +27254,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [System.Obsolete("Use the new class")]
     public class Old : DeputyBase
     {
-        public Old(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Old(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27297,7 +27297,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.OptionalArgumentInvoker), fullyQualifiedName: "jsii-calc.OptionalArgumentInvoker", parametersJson: "[{\\"name\\":\\"delegate\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IInterfaceWithOptionalMethodArguments\\"}}]")]
     public class OptionalArgumentInvoker : DeputyBase
     {
-        public OptionalArgumentInvoker(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithOptionalMethodArguments @delegate): base(new DeputyProps(new object[]{@delegate}))
+        public OptionalArgumentInvoker(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithOptionalMethodArguments @delegate): base(new DeputyProps(new object?[]{@delegate}))
         {
         }
 
@@ -27362,13 +27362,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "arg1", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Arg1
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiProperty(name: "arg2", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Arg2
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -27435,7 +27435,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "parameterWasUndefined", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool ParameterWasUndefined
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
 
         [JsiiOptional]
@@ -27487,7 +27487,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.OverridableProtectedMember), fullyQualifiedName: "jsii-calc.OverridableProtectedMember")]
     public class OverridableProtectedMember : DeputyBase
     {
-        public OverridableProtectedMember(): base(new DeputyProps(System.Array.Empty<object>()))
+        public OverridableProtectedMember(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27508,7 +27508,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "overrideMe", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         protected virtual string OverrideMe()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "switchModes")]
@@ -27520,19 +27520,19 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "valueFromProtected", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string ValueFromProtected()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "overrideReadOnly", typeJson: "{\\"primitive\\":\\"string\\"}")]
         protected virtual string OverrideReadOnly
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "overrideReadWrite", typeJson: "{\\"primitive\\":\\"string\\"}")]
         protected virtual string OverrideReadWrite
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -27550,7 +27550,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.OverrideReturnsObject), fullyQualifiedName: "jsii-calc.OverrideReturnsObject")]
     public class OverrideReturnsObject : DeputyBase
     {
-        public OverrideReturnsObject(): base(new DeputyProps(System.Array.Empty<object>()))
+        public OverrideReturnsObject(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27571,7 +27571,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "test", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"obj\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IReturnsNumber\\"}}]")]
         public virtual double Test(Amazon.JSII.Tests.CalculatorNamespace.IReturnsNumber obj)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IReturnsNumber)}, new object[]{obj});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IReturnsNumber)}, new object[]{obj})!;
         }
     }
 }
@@ -27620,7 +27620,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "foo", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Foo
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -27637,7 +27637,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PartiallyInitializedThisConsumer), fullyQualifiedName: "jsii-calc.PartiallyInitializedThisConsumer")]
     public abstract class PartiallyInitializedThisConsumer : DeputyBase
     {
-        protected PartiallyInitializedThisConsumer(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected PartiallyInitializedThisConsumer(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27680,7 +27680,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "consumePartiallyInitializedThis", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"obj\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.ConstructorPassesThisOut\\"}},{\\"name\\":\\"dt\\",\\"type\\":{\\"primitive\\":\\"date\\"}},{\\"name\\":\\"ev\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.AllTypesEnum\\"}}]")]
         public override string ConsumePartiallyInitializedThis(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut obj, System.DateTime dt, Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum ev)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut), typeof(System.DateTime), typeof(Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum)}, new object[]{obj, dt, ev});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut), typeof(System.DateTime), typeof(Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum)}, new object[]{obj, dt, ev})!;
         }
     }
 }
@@ -27697,7 +27697,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Polymorphism), fullyQualifiedName: "jsii-calc.Polymorphism")]
     public class Polymorphism : DeputyBase
     {
-        public Polymorphism(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Polymorphism(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27718,7 +27718,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "sayHello", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"friendly\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.IFriendly\\"}}]")]
         public virtual string SayHello(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly friendly)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly)}, new object[]{friendly});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.IFriendly)}, new object[]{friendly})!;
         }
     }
 }
@@ -27739,7 +27739,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         /// <summary>Creates a Power operation.</summary>
         /// <param name="base">The base of the power.</param>
         /// <param name="pow">The number of times to multiply.</param>
-        public Power(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue @base, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue pow): base(new DeputyProps(new object[]{@base, pow}))
+        public Power(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue @base, Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue pow): base(new DeputyProps(new object?[]{@base, pow}))
         {
         }
 
@@ -27761,7 +27761,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "base", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Base
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
 
         /// <summary>The expression that this operation consists of.</summary>
@@ -27771,14 +27771,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "expression", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Expression
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
 
         /// <summary>The number of times to multiply.</summary>
         [JsiiProperty(name: "pow", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Pow
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
     }
 }
@@ -27796,7 +27796,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PropertyNamedProperty), fullyQualifiedName: "jsii-calc.PropertyNamedProperty")]
     public class PropertyNamedProperty : DeputyBase
     {
-        public PropertyNamedProperty(): base(new DeputyProps(System.Array.Empty<object>()))
+        public PropertyNamedProperty(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27817,13 +27817,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "yetAnoterOne", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool YetAnoterOne
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -27840,7 +27840,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PublicClass), fullyQualifiedName: "jsii-calc.PublicClass")]
     public class PublicClass : DeputyBase
     {
-        public PublicClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public PublicClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -27878,7 +27878,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PythonReservedWords), fullyQualifiedName: "jsii-calc.PythonReservedWords")]
     public class PythonReservedWords : DeputyBase
     {
-        public PythonReservedWords(): base(new DeputyProps(System.Array.Empty<object>()))
+        public PythonReservedWords(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28102,7 +28102,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.ClassWithSelf), fullyQualifiedName: "jsii-calc.PythonSelf.ClassWithSelf", parametersJson: "[{\\"name\\":\\"self\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class ClassWithSelf : DeputyBase
     {
-        public ClassWithSelf(string self): base(new DeputyProps(new object[]{self}))
+        public ClassWithSelf(string self): base(new DeputyProps(new object?[]{self}))
         {
         }
 
@@ -28123,13 +28123,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
         [JsiiMethod(name: "method", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"self\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public virtual string Method(double self)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(double)}, new object[]{self});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(double)}, new object[]{self})!;
         }
 
         [JsiiProperty(name: "self", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Self
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -28146,7 +28146,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.ClassWithSelfKwarg), fullyQualifiedName: "jsii-calc.PythonSelf.ClassWithSelfKwarg", parametersJson: "[{\\"name\\":\\"props\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.PythonSelf.StructWithSelf\\"}}]")]
     public class ClassWithSelfKwarg : DeputyBase
     {
-        public ClassWithSelfKwarg(Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.IStructWithSelf props): base(new DeputyProps(new object[]{props}))
+        public ClassWithSelfKwarg(Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.IStructWithSelf props): base(new DeputyProps(new object?[]{props}))
         {
         }
 
@@ -28167,7 +28167,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
         [JsiiProperty(name: "props", typeJson: "{\\"fqn\\":\\"jsii-calc.PythonSelf.StructWithSelf\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.IStructWithSelf Props
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.IStructWithSelf>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.PythonSelf.IStructWithSelf>()!;
         }
     }
 }
@@ -28208,7 +28208,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
         [JsiiMethod(name: "method", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"self\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public string Method(double self)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(double)}, new object[]{self});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(double)}, new object[]{self})!;
         }
     }
 }
@@ -28275,7 +28275,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.PythonSelf
         [JsiiProperty(name: "self", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Self
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -28293,7 +28293,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ReferenceEnumFromScopedPackage), fullyQualifiedName: "jsii-calc.ReferenceEnumFromScopedPackage")]
     public class ReferenceEnumFromScopedPackage : DeputyBase
     {
-        public ReferenceEnumFromScopedPackage(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ReferenceEnumFromScopedPackage(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28350,7 +28350,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ReturnsPrivateImplementationOfInterface), fullyQualifiedName: "jsii-calc.ReturnsPrivateImplementationOfInterface")]
     public class ReturnsPrivateImplementationOfInterface : DeputyBase
     {
-        public ReturnsPrivateImplementationOfInterface(): base(new DeputyProps(System.Array.Empty<object>()))
+        public ReturnsPrivateImplementationOfInterface(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28371,7 +28371,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "privateImplementation", typeJson: "{\\"fqn\\":\\"jsii-calc.IPrivatelyImplemented\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IPrivatelyImplemented PrivateImplementation
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IPrivatelyImplemented>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IPrivatelyImplemented>()!;
         }
     }
 }
@@ -28438,7 +28438,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "stringProp", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string StringProp
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -28496,7 +28496,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.RuntimeTypeChecking), fullyQualifiedName: "jsii-calc.RuntimeTypeChecking")]
     public class RuntimeTypeChecking : DeputyBase
     {
-        public RuntimeTypeChecking(): base(new DeputyProps(System.Array.Empty<object>()))
+        public RuntimeTypeChecking(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28588,7 +28588,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "deeperRequiredProp", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string DeeperRequiredProp
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <summary>It's long, but you'll almost never pass it.</summary>
@@ -28619,7 +28619,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.SingleInstanceTwoTypes), fullyQualifiedName: "jsii-calc.SingleInstanceTwoTypes")]
     public class SingleInstanceTwoTypes : DeputyBase
     {
-        public SingleInstanceTwoTypes(): base(new DeputyProps(System.Array.Empty<object>()))
+        public SingleInstanceTwoTypes(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28640,13 +28640,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "interface1", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.InbetweenClass\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass Interface1()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.InbetweenClass>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "interface2", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IPublicInterface\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface Interface2()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IPublicInterface>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -28684,7 +28684,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "isSingletonInt", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public virtual bool IsSingletonInt(double @value)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(double)}, new object[]{@value});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(double)}, new object[]{@value})!;
         }
     }
 }
@@ -28742,7 +28742,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "isSingletonString", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual bool IsSingletonString(string @value)
         {
-            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(string)}, new object[]{@value});
+            return InvokeInstanceMethod<bool>(new System.Type[]{typeof(string)}, new object[]{@value})!;
         }
     }
 }
@@ -28816,13 +28816,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "property", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Property
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "yetAnoterOne", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool YetAnoterOne
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -28839,7 +28839,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.SomeTypeJsii976), fullyQualifiedName: "jsii-calc.SomeTypeJsii976")]
     public class SomeTypeJsii976 : DeputyBase
     {
-        public SomeTypeJsii976(): base(new DeputyProps(System.Array.Empty<object>()))
+        public SomeTypeJsii976(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -28860,13 +28860,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "returnAnonymous", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public static object ReturnAnonymous()
         {
-            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.SomeTypeJsii976), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<object>(typeof(Amazon.JSII.Tests.CalculatorNamespace.SomeTypeJsii976), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "returnReturn", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.IReturnJsii976\\"}}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.IReturnJsii976 ReturnReturn()
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IReturnJsii976>(typeof(Amazon.JSII.Tests.CalculatorNamespace.SomeTypeJsii976), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.IReturnJsii976>(typeof(Amazon.JSII.Tests.CalculatorNamespace.SomeTypeJsii976), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -28910,7 +28910,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -28985,7 +28985,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -29023,13 +29023,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "canAccessStaticContext", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}")]
         public static bool CanAccessStaticContext()
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StaticContext), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StaticContext), new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiProperty(name: "staticVariable", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public static bool StaticVariable
         {
-            get => GetStaticProperty<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StaticContext));
+            get => GetStaticProperty<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StaticContext))!;
             set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.StaticContext), value);
         }
     }
@@ -29047,7 +29047,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics), fullyQualifiedName: "jsii-calc.Statics", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
     public class Statics : DeputyBase
     {
-        public Statics(string @value): base(new DeputyProps(new object[]{@value}))
+        public Statics(string @value): base(new DeputyProps(new object?[]{@value}))
         {
         }
 
@@ -29070,13 +29070,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "staticMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"The name of the person to say hello to.\\"},\\"name\\":\\"name\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public static string StaticMethod(string name)
         {
-            return InvokeStaticMethod<string>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics), new System.Type[]{typeof(string)}, new object[]{name});
+            return InvokeStaticMethod<string>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics), new System.Type[]{typeof(string)}, new object[]{name})!;
         }
 
         [JsiiMethod(name: "justMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string JustMethod()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         /// <summary>Constants may also use all-caps.</summary>
@@ -29085,14 +29085,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
             get;
         }
-        = GetStaticProperty<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+        = GetStaticProperty<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
 
         [JsiiProperty(name: "ConstObj", typeJson: "{\\"fqn\\":\\"jsii-calc.DoubleTrouble\\"}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble ConstObj
         {
             get;
         }
-        = GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+        = GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.DoubleTrouble>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
 
         /// <summary>Jsdocs for static property.</summary>
         [JsiiProperty(name: "Foo", typeJson: "{\\"primitive\\":\\"string\\"}")]
@@ -29100,7 +29100,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
             get;
         }
-        = GetStaticProperty<string>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+        = GetStaticProperty<string>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
 
         /// <summary>Constants can also use camelCase.</summary>
         [JsiiProperty(name: "zooBar", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"map\\"}}")]
@@ -29108,7 +29108,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
             get;
         }
-        = GetStaticProperty<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+        = GetStaticProperty<System.Collections.Generic.IDictionary<string, string>>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
 
         /// <summary>Jsdocs for static getter.</summary>
         /// <remarks>
@@ -29117,21 +29117,21 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "instance", typeJson: "{\\"fqn\\":\\"jsii-calc.Statics\\"}")]
         public static Amazon.JSII.Tests.CalculatorNamespace.Statics Instance
         {
-            get => GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.Statics>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+            get => GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.Statics>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
             set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics), value);
         }
 
         [JsiiProperty(name: "nonConstStatic", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public static double NonConstStatic
         {
-            get => GetStaticProperty<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics));
+            get => GetStaticProperty<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics))!;
             set => SetStaticProperty(typeof(Amazon.JSII.Tests.CalculatorNamespace.Statics), value);
         }
 
         [JsiiProperty(name: "value", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string Value
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -29170,7 +29170,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.StripInternal), fullyQualifiedName: "jsii-calc.StripInternal")]
     public class StripInternal : DeputyBase
     {
-        public StripInternal(): base(new DeputyProps(System.Array.Empty<object>()))
+        public StripInternal(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -29191,7 +29191,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "youSeeMe", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string YouSeeMe
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -29257,7 +29257,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "requiredString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string RequiredString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -29336,7 +29336,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "requiredString", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string RequiredString
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -29413,7 +29413,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "scope", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Scope
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -29438,7 +29438,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.StructPassing), fullyQualifiedName: "jsii-calc.StructPassing")]
     public class StructPassing : DeputyBase
     {
-        public StructPassing(): base(new DeputyProps(System.Array.Empty<object>()))
+        public StructPassing(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -29459,13 +29459,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "howManyVarArgsDidIPass", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"_positional\\",\\"type\\":{\\"primitive\\":\\"number\\"}},{\\"name\\":\\"inputs\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.TopLevelStruct\\"},\\"variadic\\":true}]")]
         public static double HowManyVarArgsDidIPass(double positional, params Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct[] inputs)
         {
-            return InvokeStaticMethod<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructPassing), new System.Type[]{typeof(double), typeof(Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct[])}, new object[]{positional, inputs});
+            return InvokeStaticMethod<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructPassing), new System.Type[]{typeof(double), typeof(Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct[])}, new object[]{positional, inputs})!;
         }
 
         [JsiiMethod(name: "roundTrip", returnsJson: "{\\"type\\":{\\"fqn\\":\\"jsii-calc.TopLevelStruct\\"}}", parametersJson: "[{\\"name\\":\\"_positional\\",\\"type\\":{\\"primitive\\":\\"number\\"}},{\\"name\\":\\"input\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.TopLevelStruct\\"}}]")]
         public static Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct RoundTrip(double positional, Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct input)
         {
-            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructPassing), new System.Type[]{typeof(double), typeof(Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct)}, new object[]{positional, input});
+            return InvokeStaticMethod<Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructPassing), new System.Type[]{typeof(double), typeof(Amazon.JSII.Tests.CalculatorNamespace.ITopLevelStruct)}, new object[]{positional, input})!;
         }
     }
 }
@@ -29499,13 +29499,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "isStructA", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"struct\\",\\"type\\":{\\"union\\":{\\"types\\":[{\\"fqn\\":\\"jsii-calc.StructA\\"},{\\"fqn\\":\\"jsii-calc.StructB\\"}]}}}]")]
         public static bool IsStructA(object @struct)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct})!;
         }
 
         [JsiiMethod(name: "isStructB", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"struct\\",\\"type\\":{\\"union\\":{\\"types\\":[{\\"fqn\\":\\"jsii-calc.StructA\\"},{\\"fqn\\":\\"jsii-calc.StructB\\"}]}}}]")]
         public static bool IsStructB(object @struct)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.StructUnionConsumer), new System.Type[]{typeof(object)}, new object[]{@struct})!;
         }
     }
 }
@@ -29576,7 +29576,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "default", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Default
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiOptional]
@@ -29664,7 +29664,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.BackReferences
         [JsiiProperty(name: "reference", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.MyClass\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.Submodule.MyClass Reference
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.MyClass>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.MyClass>()!;
         }
     }
 }
@@ -29789,7 +29789,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass), fullyQualifiedName: "jsii-calc.submodule.child.InnerClass")]
     public class InnerClass : DeputyBase
     {
-        public InnerClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public InnerClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -29812,7 +29812,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
         {
             get;
         }
-        = GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass));
+        = GetStaticProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass))!;
     }
 }
 
@@ -29871,7 +29871,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
         [JsiiProperty(name: "prop", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.SomeEnum\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum Prop
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum>()!;
         }
     }
 }
@@ -29892,7 +29892,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.OuterClass), fullyQualifiedName: "jsii-calc.submodule.child.OuterClass")]
     public class OuterClass : DeputyBase
     {
-        public OuterClass(): base(new DeputyProps(System.Array.Empty<object>()))
+        public OuterClass(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -29913,7 +29913,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
         [JsiiProperty(name: "innerClass", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.InnerClass\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass InnerClass
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.InnerClass>()!;
         }
     }
 }
@@ -29978,7 +29978,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
         [JsiiProperty(name: "prop", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.SomeEnum\\"}")]
         public Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum Prop
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.SomeEnum>()!;
         }
     }
 }
@@ -30025,7 +30025,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child
         [JsiiProperty(name: "bool", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public bool Bool
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -30060,7 +30060,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.Isolated
         [JsiiMethod(name: "method", returnsJson: "{\\"type\\":{\\"primitive\\":\\"boolean\\"}}", parametersJson: "[{\\"name\\":\\"props\\",\\"optional\\":true,\\"type\\":{\\"fqn\\":\\"jsii-calc.submodule.child.KwargsProps\\"}}]")]
         public static bool Method(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.IKwargsProps? props = null)
         {
-            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Isolated.Kwargs), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.IKwargsProps)}, new object?[]{props});
+            return InvokeStaticMethod<bool>(typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Isolated.Kwargs), new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.IKwargsProps)}, new object?[]{props})!;
         }
     }
 }
@@ -30077,7 +30077,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Submodule.MyClass), fullyQualifiedName: "jsii-calc.submodule.MyClass", parametersJson: "[{\\"name\\":\\"props\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.submodule.child.SomeStruct\\"}}]")]
     public class MyClass : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.Submodule.NestedSubmodule.DeeplyNested.INamespaced
     {
-        public MyClass(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct props): base(new DeputyProps(new object[]{props}))
+        public MyClass(Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct props): base(new DeputyProps(new object?[]{props}))
         {
         }
 
@@ -30098,25 +30098,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule
         [JsiiProperty(name: "awesomeness", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.Awesomeness\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Awesomeness Awesomeness
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Awesomeness>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Awesomeness>()!;
         }
 
         [JsiiProperty(name: "definedAt", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string DefinedAt
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "goodness", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.Goodness\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness Goodness
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness>()!;
         }
 
         [JsiiProperty(name: "props", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.SomeStruct\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct Props
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.ISomeStruct>()!;
         }
 
         [JsiiOptional]
@@ -30168,7 +30168,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.NestedSubmodule.Deeply
         [JsiiProperty(name: "definedAt", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string DefinedAt
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
     }
 }
@@ -30202,7 +30202,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.NestedSubmodule
         [JsiiProperty(name: "definedAt", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string DefinedAt
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "goodness", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.Goodness\\"}")]
@@ -30232,7 +30232,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Submodule.NestedSubmodule
         [JsiiProperty(name: "goodness", typeJson: "{\\"fqn\\":\\"jsii-calc.submodule.child.Goodness\\"}")]
         public override Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness Goodness
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.Submodule.Child.Goodness>()!;
         }
     }
 }
@@ -30250,7 +30250,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Sum), fullyQualifiedName: "jsii-calc.Sum")]
     public class Sum : Amazon.JSII.Tests.CalculatorNamespace.Composition.CompositeOperation
     {
-        public Sum(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Sum(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -30275,14 +30275,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "expression", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public override Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Expression
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
 
         /// <summary>The parts to sum.</summary>
         [JsiiProperty(name: "parts", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"},\\"kind\\":\\"array\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[] Parts
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue[]>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -30326,13 +30326,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "id", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public override double Id
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiProperty(name: "rest", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"string\\"},\\"kind\\":\\"array\\"}}")]
         public virtual string[] Rest
         {
-            get => GetInstanceProperty<string[]>();
+            get => GetInstanceProperty<string[]>()!;
         }
     }
 }
@@ -30393,7 +30393,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "bar", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public double Bar
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>An \`id\` field here is terrible API design, because the constructor of \`SupportsNiceJavaBuilder\` already has a parameter named \`id\`.</summary>
@@ -30424,7 +30424,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     {
         /// <param name="id">some identifier of your choice.</param>
         /// <param name="props">some properties.</param>
-        public SupportsNiceJavaBuilderWithRequiredProps(double id, Amazon.JSII.Tests.CalculatorNamespace.ISupportsNiceJavaBuilderProps props): base(new DeputyProps(new object[]{id, props}))
+        public SupportsNiceJavaBuilderWithRequiredProps(double id, Amazon.JSII.Tests.CalculatorNamespace.ISupportsNiceJavaBuilderProps props): base(new DeputyProps(new object?[]{id, props}))
         {
         }
 
@@ -30445,14 +30445,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "bar", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Bar
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>some identifier of your choice.</summary>
         [JsiiProperty(name: "id", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double Id
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         [JsiiOptional]
@@ -30476,7 +30476,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.SyncVirtualMethods), fullyQualifiedName: "jsii-calc.SyncVirtualMethods")]
     public class SyncVirtualMethods : DeputyBase
     {
-        public SyncVirtualMethods(): base(new DeputyProps(System.Array.Empty<object>()))
+        public SyncVirtualMethods(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -30497,13 +30497,13 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "callerIsAsync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", isAsync: true)]
         public virtual double CallerIsAsync()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "callerIsMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double CallerIsMethod()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "modifyOtherProperty", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
@@ -30521,31 +30521,31 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "readA", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public virtual double ReadA()
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<double>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "retrieveOtherProperty", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string RetrieveOtherProperty()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "retrieveReadOnlyProperty", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string RetrieveReadOnlyProperty()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "retrieveValueOfTheProperty", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string RetrieveValueOfTheProperty()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "virtualMethod", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"n\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public virtual double VirtualMethod(double n)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{n});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{n})!;
         }
 
         [JsiiMethod(name: "writeA", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
@@ -30557,41 +30557,41 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "readonlyProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ReadonlyProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         [JsiiProperty(name: "a", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double A
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "callerIsProperty", typeJson: "{\\"primitive\\":\\"number\\"}")]
         public virtual double CallerIsProperty
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "otherProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string OtherProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "theProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string TheProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
 
         [JsiiProperty(name: "valueOfOtherProperty", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public virtual string ValueOfOtherProperty
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
             set => SetInstanceProperty(value);
         }
     }
@@ -30609,7 +30609,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Thrower), fullyQualifiedName: "jsii-calc.Thrower")]
     public class Thrower : DeputyBase
     {
-        public Thrower(): base(new DeputyProps(System.Array.Empty<object>()))
+        public Thrower(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -30696,14 +30696,14 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "required", typeJson: "{\\"primitive\\":\\"string\\"}")]
         public string Required
         {
-            get => GetInstanceProperty<string>();
+            get => GetInstanceProperty<string>()!;
         }
 
         /// <summary>A union to really stress test our serialization.</summary>
         [JsiiProperty(name: "secondLevel", typeJson: "{\\"union\\":{\\"types\\":[{\\"primitive\\":\\"number\\"},{\\"fqn\\":\\"jsii-calc.SecondLevelStruct\\"}]}}")]
         public object SecondLevel
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
         }
 
         /// <summary>You don't have to pass this.</summary>
@@ -30750,7 +30750,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "mode", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}")]
         public static double Mode()
         {
-            return InvokeStaticMethod<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.UmaskCheck), new System.Type[]{}, new object[]{});
+            return InvokeStaticMethod<double>(typeof(Amazon.JSII.Tests.CalculatorNamespace.UmaskCheck), new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -30768,7 +30768,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UnaryOperation), fullyQualifiedName: "jsii-calc.UnaryOperation", parametersJson: "[{\\"name\\":\\"operand\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}}]")]
     public abstract class UnaryOperation : Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Operation
     {
-        protected UnaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue operand): base(new DeputyProps(new object[]{operand}))
+        protected UnaryOperation(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue operand): base(new DeputyProps(new object?[]{operand}))
         {
         }
 
@@ -30789,7 +30789,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "operand", typeJson: "{\\"fqn\\":\\"@scope/jsii-calc-lib.NumericValue\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue Operand
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.NumericValue>()!;
         }
     }
 }
@@ -30819,7 +30819,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public override double Value
         {
-            get => GetInstanceProperty<double>();
+            get => GetInstanceProperty<double>()!;
         }
 
         /// <summary>(deprecated) String representation of the value.</summary>
@@ -30830,7 +30830,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [System.Obsolete()]
         public override string ToString()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -30885,7 +30885,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "bar", typeJson: "{\\"union\\":{\\"types\\":[{\\"primitive\\":\\"string\\"},{\\"primitive\\":\\"number\\"},{\\"fqn\\":\\"jsii-calc.AllTypes\\"}]}}")]
         public object Bar
         {
-            get => GetInstanceProperty<object>();
+            get => GetInstanceProperty<object>()!;
         }
 
         [JsiiOptional]
@@ -30910,7 +30910,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UpcasingReflectable), fullyQualifiedName: "jsii-calc.UpcasingReflectable", parametersJson: "[{\\"name\\":\\"delegate\\",\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"any\\"},\\"kind\\":\\"map\\"}}}]")]
     public class UpcasingReflectable : DeputyBase, Amazon.JSII.Tests.CustomSubmoduleName.IReflectable
     {
-        public UpcasingReflectable(System.Collections.Generic.IDictionary<string, object> @delegate): base(new DeputyProps(new object[]{@delegate}))
+        public UpcasingReflectable(System.Collections.Generic.IDictionary<string, object> @delegate): base(new DeputyProps(new object?[]{@delegate}))
         {
         }
 
@@ -30933,12 +30933,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
             get;
         }
-        = GetStaticProperty<Amazon.JSII.Tests.CustomSubmoduleName.Reflector>(typeof(Amazon.JSII.Tests.CalculatorNamespace.UpcasingReflectable));
+        = GetStaticProperty<Amazon.JSII.Tests.CustomSubmoduleName.Reflector>(typeof(Amazon.JSII.Tests.CalculatorNamespace.UpcasingReflectable))!;
 
         [JsiiProperty(name: "entries", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.submodule.ReflectableEntry\\"},\\"kind\\":\\"array\\"}}")]
         public virtual Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[] Entries
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[]>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CustomSubmoduleName.IReflectableEntry[]>()!;
         }
     }
 }
@@ -30955,7 +30955,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UseBundledDependency), fullyQualifiedName: "jsii-calc.UseBundledDependency")]
     public class UseBundledDependency : DeputyBase
     {
-        public UseBundledDependency(): base(new DeputyProps(System.Array.Empty<object>()))
+        public UseBundledDependency(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -30976,7 +30976,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "value", returnsJson: "{\\"type\\":{\\"primitive\\":\\"any\\"}}")]
         public virtual object Value()
         {
-            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<object>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -30994,7 +30994,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UseCalcBase), fullyQualifiedName: "jsii-calc.UseCalcBase")]
     public class UseCalcBase : DeputyBase
     {
-        public UseCalcBase(): base(new DeputyProps(System.Array.Empty<object>()))
+        public UseCalcBase(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -31015,7 +31015,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "hello", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-base.Base\\"}}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base Hello()
         {
-            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.BaseNamespace.Base>(new System.Type[]{}, new object[]{})!;
         }
     }
 }
@@ -31032,7 +31032,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.UsesInterfaceWithProperties), fullyQualifiedName: "jsii-calc.UsesInterfaceWithProperties", parametersJson: "[{\\"name\\":\\"obj\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IInterfaceWithProperties\\"}}]")]
     public class UsesInterfaceWithProperties : DeputyBase
     {
-        public UsesInterfaceWithProperties(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithProperties obj): base(new DeputyProps(new object[]{obj}))
+        public UsesInterfaceWithProperties(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithProperties obj): base(new DeputyProps(new object?[]{obj}))
         {
         }
 
@@ -31053,25 +31053,25 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "justRead", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
         public virtual string JustRead()
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{});
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
         }
 
         [JsiiMethod(name: "readStringAndNumber", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"ext\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.IInterfaceWithPropertiesExtension\\"}}]")]
         public virtual string ReadStringAndNumber(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithPropertiesExtension ext)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithPropertiesExtension)}, new object[]{ext});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithPropertiesExtension)}, new object[]{ext})!;
         }
 
         [JsiiMethod(name: "writeAndRead", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", parametersJson: "[{\\"name\\":\\"value\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
         public virtual string WriteAndRead(string @value)
         {
-            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{@value});
+            return InvokeInstanceMethod<string>(new System.Type[]{typeof(string)}, new object[]{@value})!;
         }
 
         [JsiiProperty(name: "obj", typeJson: "{\\"fqn\\":\\"jsii-calc.IInterfaceWithProperties\\"}")]
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithProperties Obj
         {
-            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithProperties>();
+            get => GetInstanceProperty<Amazon.JSII.Tests.CalculatorNamespace.IInterfaceWithProperties>()!;
         }
     }
 }
@@ -31088,7 +31088,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.VariadicInvoker), fullyQualifiedName: "jsii-calc.VariadicInvoker", parametersJson: "[{\\"name\\":\\"method\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.VariadicMethod\\"}}]")]
     public class VariadicInvoker : DeputyBase
     {
-        public VariadicInvoker(Amazon.JSII.Tests.CalculatorNamespace.VariadicMethod method): base(new DeputyProps(new object[]{method}))
+        public VariadicInvoker(Amazon.JSII.Tests.CalculatorNamespace.VariadicMethod method): base(new DeputyProps(new object?[]{method}))
         {
         }
 
@@ -31109,7 +31109,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "asArray", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"number\\"},\\"kind\\":\\"array\\"}}}", parametersJson: "[{\\"name\\":\\"values\\",\\"type\\":{\\"primitive\\":\\"number\\"},\\"variadic\\":true}]")]
         public virtual double[] AsArray(params double[] values)
         {
-            return InvokeInstanceMethod<double[]>(new System.Type[]{typeof(double[])}, new object[]{values});
+            return InvokeInstanceMethod<double[]>(new System.Type[]{typeof(double[])}, new object[]{values})!;
         }
     }
 }
@@ -31127,7 +31127,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     public class VariadicMethod : DeputyBase
     {
         /// <param name="prefix">a prefix that will be use for all values returned by \`#asArray\`.</param>
-        public VariadicMethod(params double[] prefix): base(new DeputyProps(new object[]{prefix}))
+        public VariadicMethod(params double[] prefix): base(new DeputyProps(new object?[]{prefix}))
         {
         }
 
@@ -31150,7 +31150,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "asArray", returnsJson: "{\\"type\\":{\\"collection\\":{\\"elementtype\\":{\\"primitive\\":\\"number\\"},\\"kind\\":\\"array\\"}}}", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the first element of the array to be returned (after the \`prefix\` provided at construction time).\\"},\\"name\\":\\"first\\",\\"type\\":{\\"primitive\\":\\"number\\"}},{\\"docs\\":{\\"summary\\":\\"other elements to be included in the array.\\"},\\"name\\":\\"others\\",\\"type\\":{\\"primitive\\":\\"number\\"},\\"variadic\\":true}]")]
         public virtual double[] AsArray(double first, params double[] others)
         {
-            return InvokeInstanceMethod<double[]>(new System.Type[]{typeof(double), typeof(double[])}, new object[]{first, others});
+            return InvokeInstanceMethod<double[]>(new System.Type[]{typeof(double), typeof(double[])}, new object[]{first, others})!;
         }
     }
 }
@@ -31167,7 +31167,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.VirtualMethodPlayground), fullyQualifiedName: "jsii-calc.VirtualMethodPlayground")]
     public class VirtualMethodPlayground : DeputyBase
     {
-        public VirtualMethodPlayground(): base(new DeputyProps(System.Array.Empty<object>()))
+        public VirtualMethodPlayground(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -31188,31 +31188,31 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiMethod(name: "overrideMeAsync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"index\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]", isAsync: true)]
         public virtual double OverrideMeAsync(double index)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{index});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{index})!;
         }
 
         [JsiiMethod(name: "overrideMeSync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"index\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public virtual double OverrideMeSync(double index)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{index});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{index})!;
         }
 
         [JsiiMethod(name: "parallelSumAsync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"count\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]", isAsync: true)]
         public virtual double ParallelSumAsync(double count)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count})!;
         }
 
         [JsiiMethod(name: "serialSumAsync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"count\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]", isAsync: true)]
         public virtual double SerialSumAsync(double count)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count})!;
         }
 
         [JsiiMethod(name: "sumSync", returnsJson: "{\\"type\\":{\\"primitive\\":\\"number\\"}}", parametersJson: "[{\\"name\\":\\"count\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
         public virtual double SumSync(double count)
         {
-            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count});
+            return InvokeInstanceMethod<double>(new System.Type[]{typeof(double)}, new object[]{count})!;
         }
     }
 }
@@ -31237,7 +31237,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.VoidCallback), fullyQualifiedName: "jsii-calc.VoidCallback")]
     public abstract class VoidCallback : DeputyBase
     {
-        protected VoidCallback(): base(new DeputyProps(System.Array.Empty<object>()))
+        protected VoidCallback(): base(new DeputyProps(System.Array.Empty<object?>()))
         {
         }
 
@@ -31268,7 +31268,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "methodWasCalled", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool MethodWasCalled
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }
@@ -31339,7 +31339,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         [JsiiProperty(name: "success", typeJson: "{\\"primitive\\":\\"boolean\\"}")]
         public virtual bool Success
         {
-            get => GetInstanceProperty<bool>();
+            get => GetInstanceProperty<bool>()!;
         }
     }
 }


### PR DESCRIPTION
The generated code had a number of quirks related to nullability
annotations (`?` and `!`) that resulted in sometimes abundant warnings
emitted during the compilation of the generated code. This makes the
necessary changes to correctly reflect that method arguments can be
`null` in the `DeptyBase` methods; and adds the necessary `?` and `!`
where they were previously missing.

This results in much fewer compilation warnings being emitted while
compiling `jsii-calc` and dependencies (the remaining warnings are
actually "legitimate" in the sense that they are the result of
us/users making questionable naming choices).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
