### PR TITLE
chore(pacmak/go): indent using tabs instead of spaces

### DIFF
--- a/packages/codemaker/lib/codemaker.ts
+++ b/packages/codemaker/lib/codemaker.ts
@@ -9,12 +9,29 @@ export class CodeMaker {
   /**
    * The indentation level of the file.
    */
-  public indentation = 4;
+  public indentation: number;
+
+  /**
+   * The character to use for indentation. When setting this to `\t`, consider
+   * also setting `indentation` to `1`.
+   */
+  public indentCharacter: ' ' | '\t';
 
   private currIndent = 0;
   private currentFile?: FileBuffer;
   private readonly files = new Array<FileBuffer>();
   private readonly excludes = new Array<string>();
+
+  public constructor({
+    indentationLevel = 4,
+    indentCharacter = ' ',
+  }: {
+    indentationLevel?: CodeMaker['indentation'];
+    indentCharacter?: CodeMaker['indentCharacter'];
+  } = {}) {
+    this.indentation = indentationLevel;
+    this.indentCharacter = indentCharacter;
+  }
 
   public get currentIndentLength(): number {
     return this.currIndent * this.indentation;
@@ -183,6 +200,6 @@ export class CodeMaker {
     if (length <= 0) {
       return '';
     }
-    return ' '.repeat(length);
+    return this.indentCharacter.repeat(length);
   }
 }

--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -31,7 +31,10 @@ export class Golang extends Target {
 
 class GoGenerator implements IGenerator {
   private assembly!: Assembly;
-  private readonly code = new CodeMaker();
+  private readonly code = new CodeMaker({
+    indentCharacter: '\t',
+    indentationLevel: 1,
+  });
   private readonly documenter: Documentation;
 
   public constructor(private readonly rosetta: Rosetta) {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -16,13 +16,13 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/golang/scopejsiica
 package scopejsiicalcbase
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
 )
 
 // Class interface
 type BaseIface interface {
-    TypeName() jsii.Any
+	TypeName() jsii.Any
 }
 
 // A base class.
@@ -31,47 +31,47 @@ type Base struct {
 }
 
 func NewBase() BaseIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Base",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Base{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Base",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Base{}
 }
 
 func (b *Base) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Base",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Base",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 // BasePropsIface is the public interface for the custom type BaseProps
 type BasePropsIface interface {
-    GetFoo() scopejsiicalcbaseofbase.Very
-    GetBar() string
+	GetFoo() scopejsiicalcbaseofbase.Very
+	GetBar() string
 }
 
 // Struct proxy
 type BaseProps struct {
-    Foo scopejsiicalcbaseofbase.Very
-    Bar string
+	Foo scopejsiicalcbaseofbase.Very
+	Bar string
 }
 
 func (b *BaseProps) GetFoo() scopejsiicalcbaseofbase.Very {
-    return b.Foo
+	return b.Foo
 }
 
 func (b *BaseProps) GetBar() string {
-    return b.Bar
+	return b.Bar
 }
 
 
 type IBaseInterface interface {
-    scopejsiicalcbaseofbase.IVeryBaseInterface
-    Bar()
+	scopejsiicalcbaseofbase.IVeryBaseInterface
+	Bar()
 }
 
 
@@ -93,11 +93,11 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/golang/sco
 package scopejsiicalcbaseofbase
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 type IVeryBaseInterface interface {
-    Foo()
+	Foo()
 }
 
 // Class interface
@@ -109,16 +109,16 @@ type StaticConsumer struct {
 }
 
 func StaticConsumer_Consume(_args jsii.Any) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StaticConsumer",
-        Method: "Consume",
-        Args: []string{"any",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StaticConsumer",
+		Method: "Consume",
+		Args: []string{"any",},
+	})
 }
 
 // Class interface
 type VeryIface interface {
-    Hey() float64
+	Hey() float64
 }
 
 // Something here.
@@ -128,35 +128,35 @@ type Very struct {
 }
 
 func NewVery() VeryIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Very",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Very{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Very",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Very{}
 }
 
 func (v *Very) Hey() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Very",
-        Method: "Hey",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Very",
+		Method: "Hey",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // VeryBasePropsIface is the public interface for the custom type VeryBaseProps
 type VeryBasePropsIface interface {
-    GetFoo() Very
+	GetFoo() Very
 }
 
 // Struct proxy
 type VeryBaseProps struct {
-    Foo Very
+	Foo Very
 }
 
 func (v *VeryBaseProps) GetFoo() Very {
-    return v.Foo
+	return v.Foo
 }
 
 
@@ -181,9 +181,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/golang/scopejsiical
 package scopejsiicalclib
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbase"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbase"
 )
 
 // Check that enums from \\@scoped packages can be references.
@@ -193,15 +193,15 @@ import (
 type EnumFromScopedModule string
 
 const (
-    EnumFromScopedModuleValue1 EnumFromScopedModule = "VALUE1"
-    EnumFromScopedModuleValue2 EnumFromScopedModule = "VALUE2"
+	EnumFromScopedModuleValue1 EnumFromScopedModule = "VALUE1"
+	EnumFromScopedModuleValue2 EnumFromScopedModule = "VALUE2"
 )
 
 // The general contract for a concrete number.
 // Deprecated.
 type IDoublable interface {
-    // Deprecated.
-    GetDoubleValue() float64
+	// Deprecated.
+	GetDoubleValue() float64
 }
 
 // Applies to classes that are considered friendly.
@@ -210,9 +210,9 @@ type IDoublable interface {
 // a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
 // Deprecated.
 type IFriendly interface {
-    // Say hello!
-    // Deprecated.
-    Hello() string
+	// Say hello!
+	// Deprecated.
+	Hello() string
 }
 
 // Interface that inherits from packages 2 levels up the tree.
@@ -221,252 +221,252 @@ type IFriendly interface {
 // far enough up the tree.
 // Deprecated.
 type IThreeLevelsInterface interface {
-    scopejsiicalcbaseofbase.IVeryBaseInterface
-    scopejsiicalcbase.IBaseInterface
-    // Deprecated.
-    Baz()
+	scopejsiicalcbaseofbase.IVeryBaseInterface
+	scopejsiicalcbase.IBaseInterface
+	// Deprecated.
+	Baz()
 }
 
 // MyFirstStructIface is the public interface for the custom type MyFirstStruct
 // Deprecated.
 type MyFirstStructIface interface {
-    GetAnumber() float64
-    GetAstring() string
-    GetFirstOptional() []string
+	GetAnumber() float64
+	GetAstring() string
+	GetFirstOptional() []string
 }
 
 // This is the first struct we have created in jsii.
 // Deprecated.
 // Struct proxy
 type MyFirstStruct struct {
-    // An awesome number value.
-    // Deprecated.
-    Anumber float64
-    // A string value.
-    // Deprecated.
-    Astring string
-    // Deprecated.
-    FirstOptional []string
+	// An awesome number value.
+	// Deprecated.
+	Anumber float64
+	// A string value.
+	// Deprecated.
+	Astring string
+	// Deprecated.
+	FirstOptional []string
 }
 
 func (m *MyFirstStruct) GetAnumber() float64 {
-    return m.Anumber
+	return m.Anumber
 }
 
 func (m *MyFirstStruct) GetAstring() string {
-    return m.Astring
+	return m.Astring
 }
 
 func (m *MyFirstStruct) GetFirstOptional() []string {
-    return m.FirstOptional
+	return m.FirstOptional
 }
 
 
 // Class interface
 type NumberIface interface {
-    IDoublable
-    GetValue() float64
-    SetValue(val float64)
-    GetDoubleValue() float64
-    SetDoubleValue(val float64)
-    TypeName() jsii.Any
-    ToString() string
+	IDoublable
+	GetValue() float64
+	SetValue(val float64)
+	GetDoubleValue() float64
+	SetDoubleValue(val float64)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // Represents a concrete number.
 // Deprecated.
 // Struct proxy
 type Number struct {
-    // The number.
-    // Deprecated.
-    Value float64
-    // The number multiplied by 2.
-    // Deprecated.
-    DoubleValue float64
+	// The number.
+	// Deprecated.
+	Value float64
+	// The number multiplied by 2.
+	// Deprecated.
+	DoubleValue float64
 }
 
 func (n *Number) GetValue() float64 {
-    return n.Value
+	return n.Value
 }
 
 func (n *Number) GetDoubleValue() float64 {
-    return n.DoubleValue
+	return n.DoubleValue
 }
 
 
 // Creates a Number object.
 func NewNumber(value float64) NumberIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Number",
-        Method: "Constructor",
-        Args: []string{"number",},
-    })
-    return &Number{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Number",
+		Method: "Constructor",
+		Args: []string{"number",},
+	})
+	return &Number{}
 }
 
 func (n *Number) SetValue(val float64) {
-    n.Value = val
+	n.Value = val
 }
 
 func (n *Number) SetDoubleValue(val float64) {
-    n.DoubleValue = val
+	n.DoubleValue = val
 }
 
 func (n *Number) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Number",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Number",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (n *Number) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Number",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Number",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type NumericValueIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // Abstract class which represents a numeric value.
 // Deprecated.
 // Struct proxy
 type NumericValue struct {
-    // The value.
-    // Deprecated.
-    Value float64
+	// The value.
+	// Deprecated.
+	Value float64
 }
 
 func (n *NumericValue) GetValue() float64 {
-    return n.Value
+	return n.Value
 }
 
 
 func NewNumericValue() NumericValueIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumericValue",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &NumericValue{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumericValue",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &NumericValue{}
 }
 
 func (n *NumericValue) SetValue(val float64) {
-    n.Value = val
+	n.Value = val
 }
 
 func (n *NumericValue) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumericValue",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumericValue",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (n *NumericValue) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumericValue",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumericValue",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type OperationIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // Represents an operation on values.
 // Deprecated.
 // Struct proxy
 type Operation struct {
-    // The value.
-    // Deprecated.
-    Value float64
+	// The value.
+	// Deprecated.
+	Value float64
 }
 
 func (o *Operation) GetValue() float64 {
-    return o.Value
+	return o.Value
 }
 
 
 func NewOperation() OperationIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Operation",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Operation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Operation",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Operation{}
 }
 
 func (o *Operation) SetValue(val float64) {
-    o.Value = val
+	o.Value = val
 }
 
 func (o *Operation) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Operation",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Operation",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (o *Operation) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Operation",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Operation",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // StructWithOnlyOptionalsIface is the public interface for the custom type StructWithOnlyOptionals
 // Deprecated.
 type StructWithOnlyOptionalsIface interface {
-    GetOptional1() string
-    GetOptional2() float64
-    GetOptional3() bool
+	GetOptional1() string
+	GetOptional2() float64
+	GetOptional3() bool
 }
 
 // This is a struct with only optional properties.
 // Deprecated.
 // Struct proxy
 type StructWithOnlyOptionals struct {
-    // The first optional!
-    // Deprecated.
-    Optional1 string
-    // Deprecated.
-    Optional2 float64
-    // Deprecated.
-    Optional3 bool
+	// The first optional!
+	// Deprecated.
+	Optional1 string
+	// Deprecated.
+	Optional2 float64
+	// Deprecated.
+	Optional3 bool
 }
 
 func (s *StructWithOnlyOptionals) GetOptional1() string {
-    return s.Optional1
+	return s.Optional1
 }
 
 func (s *StructWithOnlyOptionals) GetOptional2() float64 {
-    return s.Optional2
+	return s.Optional2
 }
 
 func (s *StructWithOnlyOptionals) GetOptional3() bool {
-    return s.Optional3
+	return s.Optional3
 }
 
 
@@ -477,13 +477,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/golang/scopejsiical
 package submodule
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // Deprecated.
 type IReflectable interface {
-    // Deprecated.
-    GetEntries() []ReflectableEntry
+	// Deprecated.
+	GetEntries() []ReflectableEntry
 }
 
 // Class interface
@@ -498,40 +498,40 @@ type NestingClass struct {
 
 // Class interface
 type NestedClassIface interface {
-    GetProperty() string
-    SetProperty(val string)
+	GetProperty() string
+	SetProperty(val string)
 }
 
 // This class is here to show we can use nested classes across module boundaries.
 // Deprecated.
 // Struct proxy
 type NestedClass struct {
-    // Deprecated.
-    Property string
+	// Deprecated.
+	Property string
 }
 
 func (n *NestedClass) GetProperty() string {
-    return n.Property
+	return n.Property
 }
 
 
 func NewNestedClass() NestedClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NestedClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &NestedClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NestedClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &NestedClass{}
 }
 
 func (n *NestedClass) SetProperty(val string) {
-    n.Property = val
+	n.Property = val
 }
 
 // NestedStructIface is the public interface for the custom type NestedStruct
 // Deprecated.
 type NestedStructIface interface {
-    GetName() string
+	GetName() string
 }
 
 // This is a struct, nested within a class.
@@ -540,43 +540,43 @@ type NestedStructIface interface {
 // Deprecated.
 // Struct proxy
 type NestedStruct struct {
-    // Deprecated.
-    Name string
+	// Deprecated.
+	Name string
 }
 
 func (n *NestedStruct) GetName() string {
-    return n.Name
+	return n.Name
 }
 
 
 // ReflectableEntryIface is the public interface for the custom type ReflectableEntry
 // Deprecated.
 type ReflectableEntryIface interface {
-    GetKey() string
-    GetValue() jsii.Any
+	GetKey() string
+	GetValue() jsii.Any
 }
 
 // Deprecated.
 // Struct proxy
 type ReflectableEntry struct {
-    // Deprecated.
-    Key string
-    // Deprecated.
-    Value jsii.Any
+	// Deprecated.
+	Key string
+	// Deprecated.
+	Value jsii.Any
 }
 
 func (r *ReflectableEntry) GetKey() string {
-    return r.Key
+	return r.Key
 }
 
 func (r *ReflectableEntry) GetValue() jsii.Any {
-    return r.Value
+	return r.Value
 }
 
 
 // Class interface
 type ReflectorIface interface {
-    AsMap(reflectable IReflectable) map[string]jsii.Any
+	AsMap(reflectable IReflectable) map[string]jsii.Any
 }
 
 // Deprecated.
@@ -585,21 +585,21 @@ type Reflector struct {
 }
 
 func NewReflector() ReflectorIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Reflector",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Reflector{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Reflector",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Reflector{}
 }
 
 func (r *Reflector) AsMap(reflectable IReflectable) map[string]jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Reflector",
-        Method: "AsMap",
-        Args: []string{"@scope/jsii-calc-lib.submodule.IReflectable",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Reflector",
+		Method: "AsMap",
+		Args: []string{"@scope/jsii-calc-lib.submodule.IReflectable",},
+	})
+	return nil
 }
 
 
@@ -668,117 +668,117 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/composition/co
 package composition
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib"
 )
 
 // Class interface
 type CompositeOperationIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    GetExpression() scopejsiicalclib.NumericValue
-    SetExpression(val scopejsiicalclib.NumericValue)
-    GetDecorationPostfixes() []string
-    SetDecorationPostfixes(val []string)
-    GetDecorationPrefixes() []string
-    SetDecorationPrefixes(val []string)
-    GetStringStyle() CompositionStringStyle
-    SetStringStyle(val CompositionStringStyle)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	GetExpression() scopejsiicalclib.NumericValue
+	SetExpression(val scopejsiicalclib.NumericValue)
+	GetDecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	GetDecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
+	GetStringStyle() CompositionStringStyle
+	SetStringStyle(val CompositionStringStyle)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // Abstract operation composed from an expression of other operations.
 // Struct proxy
 type CompositeOperation struct {
-    // (deprecated) The value.
-    Value float64
-    // The expression that this operation consists of.
-    // 
-    // Must be implemented by derived classes.
-    Expression scopejsiicalclib.NumericValue
-    // A set of postfixes to include in a decorated .toString().
-    DecorationPostfixes []string
-    // A set of prefixes to include in a decorated .toString().
-    DecorationPrefixes []string
-    // The .toString() style.
-    StringStyle CompositionStringStyle
+	// (deprecated) The value.
+	Value float64
+	// The expression that this operation consists of.
+	// 
+	// Must be implemented by derived classes.
+	Expression scopejsiicalclib.NumericValue
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes []string
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes []string
+	// The .toString() style.
+	StringStyle CompositionStringStyle
 }
 
 func (c *CompositeOperation) GetValue() float64 {
-    return c.Value
+	return c.Value
 }
 
 func (c *CompositeOperation) GetExpression() scopejsiicalclib.NumericValue {
-    return c.Expression
+	return c.Expression
 }
 
 func (c *CompositeOperation) GetDecorationPostfixes() []string {
-    return c.DecorationPostfixes
+	return c.DecorationPostfixes
 }
 
 func (c *CompositeOperation) GetDecorationPrefixes() []string {
-    return c.DecorationPrefixes
+	return c.DecorationPrefixes
 }
 
 func (c *CompositeOperation) GetStringStyle() CompositionStringStyle {
-    return c.StringStyle
+	return c.StringStyle
 }
 
 
 func NewCompositeOperation() CompositeOperationIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "CompositeOperation",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &CompositeOperation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "CompositeOperation",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &CompositeOperation{}
 }
 
 func (c *CompositeOperation) SetValue(val float64) {
-    c.Value = val
+	c.Value = val
 }
 
 func (c *CompositeOperation) SetExpression(val scopejsiicalclib.NumericValue) {
-    c.Expression = val
+	c.Expression = val
 }
 
 func (c *CompositeOperation) SetDecorationPostfixes(val []string) {
-    c.DecorationPostfixes = val
+	c.DecorationPostfixes = val
 }
 
 func (c *CompositeOperation) SetDecorationPrefixes(val []string) {
-    c.DecorationPrefixes = val
+	c.DecorationPrefixes = val
 }
 
 func (c *CompositeOperation) SetStringStyle(val CompositionStringStyle) {
-    c.StringStyle = val
+	c.StringStyle = val
 }
 
 func (c *CompositeOperation) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "CompositeOperation",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "CompositeOperation",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (c *CompositeOperation) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "CompositeOperation",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "CompositeOperation",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Style of .toString() output for CompositeOperation.
 type CompositionStringStyle string
 
 const (
-    CompositionStringStyleNormal CompositionStringStyle = "NORMAL"
-    CompositionStringStyleDecorated CompositionStringStyle = "DECORATED"
+	CompositionStringStyleNormal CompositionStringStyle = "NORMAL"
+	CompositionStringStyleDecorated CompositionStringStyle = "DECORATED"
 )
 
 
@@ -788,65 +788,65 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/derivedclassha
 package derivedclasshasnoproperties
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // Class interface
 type BaseIface interface {
-    GetProp() string
-    SetProp(val string)
+	GetProp() string
+	SetProp(val string)
 }
 
 // Struct proxy
 type Base struct {
-    Prop string
+	Prop string
 }
 
 func (b *Base) GetProp() string {
-    return b.Prop
+	return b.Prop
 }
 
 
 func NewBase() BaseIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Base",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Base{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Base",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Base{}
 }
 
 func (b *Base) SetProp(val string) {
-    b.Prop = val
+	b.Prop = val
 }
 
 // Class interface
 type DerivedIface interface {
-    GetProp() string
-    SetProp(val string)
+	GetProp() string
+	SetProp(val string)
 }
 
 // Struct proxy
 type Derived struct {
-    Prop string
+	Prop string
 }
 
 func (d *Derived) GetProp() string {
-    return d.Prop
+	return d.Prop
 }
 
 
 func NewDerived() DerivedIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Derived",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Derived{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Derived",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Derived{}
 }
 
 func (d *Derived) SetProp(val string) {
-    d.Prop = val
+	d.Prop = val
 }
 
 
@@ -856,50 +856,50 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/interfaceinnam
 package interfaceinnamespaceincludesclasses
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // Class interface
 type FooIface interface {
-    GetBar() string
-    SetBar(val string)
+	GetBar() string
+	SetBar(val string)
 }
 
 // Struct proxy
 type Foo struct {
-    Bar string
+	Bar string
 }
 
 func (f *Foo) GetBar() string {
-    return f.Bar
+	return f.Bar
 }
 
 
 func NewFoo() FooIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Foo",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Foo{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Foo",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Foo{}
 }
 
 func (f *Foo) SetBar(val string) {
-    f.Bar = val
+	f.Bar = val
 }
 
 // HelloIface is the public interface for the custom type Hello
 type HelloIface interface {
-    GetFoo() float64
+	GetFoo() float64
 }
 
 // Struct proxy
 type Hello struct {
-    Foo float64
+	Foo float64
 }
 
 func (h *Hello) GetFoo() float64 {
-    return h.Foo
+	return h.Foo
 }
 
 
@@ -910,21 +910,21 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/interfaceinnam
 package interfaceinnamespaceonlyinterface
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // HelloIface is the public interface for the custom type Hello
 type HelloIface interface {
-    GetFoo() float64
+	GetFoo() float64
 }
 
 // Struct proxy
 type Hello struct {
-    Foo float64
+	Foo float64
 }
 
 func (h *Hello) GetFoo() float64 {
-    return h.Foo
+	return h.Foo
 }
 
 
@@ -936,332 +936,332 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/jsiicalc.go 1`
 package jsiicalc
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/composition"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbase"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib/submodule"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/composition"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbaseofbase"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalcbase"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/scopejsiicalclib/submodule"
 )
 
 // Class interface
 type AbstractClassIface interface {
-    IInterfaceImplementedByAbstractClass
-    GetAbstractProperty() string
-    SetAbstractProperty(val string)
-    GetPropFromInterface() string
-    SetPropFromInterface(val string)
-    AbstractMethod(name string) string
-    NonAbstractMethod() float64
+	IInterfaceImplementedByAbstractClass
+	GetAbstractProperty() string
+	SetAbstractProperty(val string)
+	GetPropFromInterface() string
+	SetPropFromInterface(val string)
+	AbstractMethod(name string) string
+	NonAbstractMethod() float64
 }
 
 // Struct proxy
 type AbstractClass struct {
-    AbstractProperty string
-    PropFromInterface string
+	AbstractProperty string
+	PropFromInterface string
 }
 
 func (a *AbstractClass) GetAbstractProperty() string {
-    return a.AbstractProperty
+	return a.AbstractProperty
 }
 
 func (a *AbstractClass) GetPropFromInterface() string {
-    return a.PropFromInterface
+	return a.PropFromInterface
 }
 
 
 func NewAbstractClass() AbstractClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AbstractClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AbstractClass{}
 }
 
 func (a *AbstractClass) SetAbstractProperty(val string) {
-    a.AbstractProperty = val
+	a.AbstractProperty = val
 }
 
 func (a *AbstractClass) SetPropFromInterface(val string) {
-    a.PropFromInterface = val
+	a.PropFromInterface = val
 }
 
 func (a *AbstractClass) AbstractMethod(name string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClass",
-        Method: "AbstractMethod",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClass",
+		Method: "AbstractMethod",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (a *AbstractClass) NonAbstractMethod() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClass",
-        Method: "NonAbstractMethod",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClass",
+		Method: "NonAbstractMethod",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type AbstractClassBaseIface interface {
-    GetAbstractProperty() string
-    SetAbstractProperty(val string)
+	GetAbstractProperty() string
+	SetAbstractProperty(val string)
 }
 
 // Struct proxy
 type AbstractClassBase struct {
-    AbstractProperty string
+	AbstractProperty string
 }
 
 func (a *AbstractClassBase) GetAbstractProperty() string {
-    return a.AbstractProperty
+	return a.AbstractProperty
 }
 
 
 func NewAbstractClassBase() AbstractClassBaseIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClassBase",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AbstractClassBase{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClassBase",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AbstractClassBase{}
 }
 
 func (a *AbstractClassBase) SetAbstractProperty(val string) {
-    a.AbstractProperty = val
+	a.AbstractProperty = val
 }
 
 // Class interface
 type AbstractClassReturnerIface interface {
-    GetReturnAbstractFromProperty() AbstractClassBase
-    SetReturnAbstractFromProperty(val AbstractClassBase)
-    GiveMeAbstract() AbstractClass
-    GiveMeInterface() IInterfaceImplementedByAbstractClass
+	GetReturnAbstractFromProperty() AbstractClassBase
+	SetReturnAbstractFromProperty(val AbstractClassBase)
+	GiveMeAbstract() AbstractClass
+	GiveMeInterface() IInterfaceImplementedByAbstractClass
 }
 
 // Struct proxy
 type AbstractClassReturner struct {
-    ReturnAbstractFromProperty AbstractClassBase
+	ReturnAbstractFromProperty AbstractClassBase
 }
 
 func (a *AbstractClassReturner) GetReturnAbstractFromProperty() AbstractClassBase {
-    return a.ReturnAbstractFromProperty
+	return a.ReturnAbstractFromProperty
 }
 
 
 func NewAbstractClassReturner() AbstractClassReturnerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClassReturner",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AbstractClassReturner{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClassReturner",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AbstractClassReturner{}
 }
 
 func (a *AbstractClassReturner) SetReturnAbstractFromProperty(val AbstractClassBase) {
-    a.ReturnAbstractFromProperty = val
+	a.ReturnAbstractFromProperty = val
 }
 
 func (a *AbstractClassReturner) GiveMeAbstract() AbstractClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClassReturner",
-        Method: "GiveMeAbstract",
-        Args: []string{},
-    })
-    return AbstractClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClassReturner",
+		Method: "GiveMeAbstract",
+		Args: []string{},
+	})
+	return AbstractClass{}
 }
 
 func (a *AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstractClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractClassReturner",
-        Method: "GiveMeInterface",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractClassReturner",
+		Method: "GiveMeInterface",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type AbstractSuiteIface interface {
-    GetProperty() string
-    SomeMethod(str string) string
-    WorkItAll(seed string) string
+	GetProperty() string
+	SomeMethod(str string) string
+	WorkItAll(seed string) string
 }
 
 // Ensures abstract members implementations correctly register overrides in various languages.
 // Struct proxy
 type AbstractSuite struct {
-    Property string
+	Property string
 }
 
 func (a *AbstractSuite) GetProperty() string {
-    return a.Property
+	return a.Property
 }
 
 
 func NewAbstractSuite() AbstractSuiteIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractSuite",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AbstractSuite{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractSuite",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AbstractSuite{}
 }
 
 func (a *AbstractSuite) SetProperty(val string) {
-    a.Property = val
+	a.Property = val
 }
 
 func (a *AbstractSuite) SomeMethod(str string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractSuite",
-        Method: "SomeMethod",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractSuite",
+		Method: "SomeMethod",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (a *AbstractSuite) WorkItAll(seed string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AbstractSuite",
-        Method: "WorkItAll",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AbstractSuite",
+		Method: "WorkItAll",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type AddIface interface {
-    scopejsiicalclib.IFriendly
-    GetValue() float64
-    SetValue(val float64)
-    GetLhs() scopejsiicalclib.NumericValue
-    SetLhs(val scopejsiicalclib.NumericValue)
-    GetRhs() scopejsiicalclib.NumericValue
-    SetRhs(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
-    Hello() string
+	scopejsiicalclib.IFriendly
+	GetValue() float64
+	SetValue(val float64)
+	GetLhs() scopejsiicalclib.NumericValue
+	SetLhs(val scopejsiicalclib.NumericValue)
+	GetRhs() scopejsiicalclib.NumericValue
+	SetRhs(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
+	Hello() string
 }
 
 // The "+" binary operation.
 // Struct proxy
 type Add struct {
-    // (deprecated) The value.
-    Value float64
-    // Left-hand side operand.
-    Lhs scopejsiicalclib.NumericValue
-    // Right-hand side operand.
-    Rhs scopejsiicalclib.NumericValue
+	// (deprecated) The value.
+	Value float64
+	// Left-hand side operand.
+	Lhs scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs scopejsiicalclib.NumericValue
 }
 
 func (a *Add) GetValue() float64 {
-    return a.Value
+	return a.Value
 }
 
 func (a *Add) GetLhs() scopejsiicalclib.NumericValue {
-    return a.Lhs
+	return a.Lhs
 }
 
 func (a *Add) GetRhs() scopejsiicalclib.NumericValue {
-    return a.Rhs
+	return a.Rhs
 }
 
 
 // Creates a BinaryOperation.
 func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) AddIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Add",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &Add{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Add",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &Add{}
 }
 
 func (a *Add) SetValue(val float64) {
-    a.Value = val
+	a.Value = val
 }
 
 func (a *Add) SetLhs(val scopejsiicalclib.NumericValue) {
-    a.Lhs = val
+	a.Lhs = val
 }
 
 func (a *Add) SetRhs(val scopejsiicalclib.NumericValue) {
-    a.Rhs = val
+	a.Rhs = val
 }
 
 func (a *Add) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Add",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Add",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (a *Add) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Add",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Add",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (a *Add) Hello() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Add",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Add",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type AllTypesIface interface {
-    GetEnumPropertyValue() float64
-    SetEnumPropertyValue(val float64)
-    GetAnyArrayProperty() []jsii.Any
-    SetAnyArrayProperty(val []jsii.Any)
-    GetAnyMapProperty() map[string]jsii.Any
-    SetAnyMapProperty(val map[string]jsii.Any)
-    GetAnyProperty() jsii.Any
-    SetAnyProperty(val jsii.Any)
-    GetArrayProperty() []string
-    SetArrayProperty(val []string)
-    GetBooleanProperty() bool
-    SetBooleanProperty(val bool)
-    GetDateProperty() string
-    SetDateProperty(val string)
-    GetEnumProperty() AllTypesEnum
-    SetEnumProperty(val AllTypesEnum)
-    GetJsonProperty() map[string]jsii.Any
-    SetJsonProperty(val map[string]jsii.Any)
-    GetMapProperty() map[string]scopejsiicalclib.Number
-    SetMapProperty(val map[string]scopejsiicalclib.Number)
-    GetNumberProperty() float64
-    SetNumberProperty(val float64)
-    GetStringProperty() string
-    SetStringProperty(val string)
-    GetUnionArrayProperty() []jsii.Any
-    SetUnionArrayProperty(val []jsii.Any)
-    GetUnionMapProperty() map[string]jsii.Any
-    SetUnionMapProperty(val map[string]jsii.Any)
-    GetUnionProperty() jsii.Any
-    SetUnionProperty(val jsii.Any)
-    GetUnknownArrayProperty() []jsii.Any
-    SetUnknownArrayProperty(val []jsii.Any)
-    GetUnknownMapProperty() map[string]jsii.Any
-    SetUnknownMapProperty(val map[string]jsii.Any)
-    GetUnknownProperty() jsii.Any
-    SetUnknownProperty(val jsii.Any)
-    GetOptionalEnumValue() StringEnum
-    SetOptionalEnumValue(val StringEnum)
-    AnyIn(inp jsii.Any)
-    AnyOut() jsii.Any
-    EnumMethod(value StringEnum) StringEnum
+	GetEnumPropertyValue() float64
+	SetEnumPropertyValue(val float64)
+	GetAnyArrayProperty() []jsii.Any
+	SetAnyArrayProperty(val []jsii.Any)
+	GetAnyMapProperty() map[string]jsii.Any
+	SetAnyMapProperty(val map[string]jsii.Any)
+	GetAnyProperty() jsii.Any
+	SetAnyProperty(val jsii.Any)
+	GetArrayProperty() []string
+	SetArrayProperty(val []string)
+	GetBooleanProperty() bool
+	SetBooleanProperty(val bool)
+	GetDateProperty() string
+	SetDateProperty(val string)
+	GetEnumProperty() AllTypesEnum
+	SetEnumProperty(val AllTypesEnum)
+	GetJsonProperty() map[string]jsii.Any
+	SetJsonProperty(val map[string]jsii.Any)
+	GetMapProperty() map[string]scopejsiicalclib.Number
+	SetMapProperty(val map[string]scopejsiicalclib.Number)
+	GetNumberProperty() float64
+	SetNumberProperty(val float64)
+	GetStringProperty() string
+	SetStringProperty(val string)
+	GetUnionArrayProperty() []jsii.Any
+	SetUnionArrayProperty(val []jsii.Any)
+	GetUnionMapProperty() map[string]jsii.Any
+	SetUnionMapProperty(val map[string]jsii.Any)
+	GetUnionProperty() jsii.Any
+	SetUnionProperty(val jsii.Any)
+	GetUnknownArrayProperty() []jsii.Any
+	SetUnknownArrayProperty(val []jsii.Any)
+	GetUnknownMapProperty() map[string]jsii.Any
+	SetUnknownMapProperty(val map[string]jsii.Any)
+	GetUnknownProperty() jsii.Any
+	SetUnknownProperty(val jsii.Any)
+	GetOptionalEnumValue() StringEnum
+	SetOptionalEnumValue(val StringEnum)
+	AnyIn(inp jsii.Any)
+	AnyOut() jsii.Any
+	EnumMethod(value StringEnum) StringEnum
 }
 
 // This class includes property for all types supported by jsii.
@@ -1270,229 +1270,229 @@ type AllTypesIface interface {
 // that the value set is of the expected type and throw otherwise.
 // Struct proxy
 type AllTypes struct {
-    EnumPropertyValue float64
-    AnyArrayProperty []jsii.Any
-    AnyMapProperty map[string]jsii.Any
-    AnyProperty jsii.Any
-    ArrayProperty []string
-    BooleanProperty bool
-    DateProperty string
-    EnumProperty AllTypesEnum
-    JsonProperty map[string]jsii.Any
-    MapProperty map[string]scopejsiicalclib.Number
-    NumberProperty float64
-    StringProperty string
-    UnionArrayProperty []jsii.Any
-    UnionMapProperty map[string]jsii.Any
-    UnionProperty jsii.Any
-    UnknownArrayProperty []jsii.Any
-    UnknownMapProperty map[string]jsii.Any
-    UnknownProperty jsii.Any
-    OptionalEnumValue StringEnum
+	EnumPropertyValue float64
+	AnyArrayProperty []jsii.Any
+	AnyMapProperty map[string]jsii.Any
+	AnyProperty jsii.Any
+	ArrayProperty []string
+	BooleanProperty bool
+	DateProperty string
+	EnumProperty AllTypesEnum
+	JsonProperty map[string]jsii.Any
+	MapProperty map[string]scopejsiicalclib.Number
+	NumberProperty float64
+	StringProperty string
+	UnionArrayProperty []jsii.Any
+	UnionMapProperty map[string]jsii.Any
+	UnionProperty jsii.Any
+	UnknownArrayProperty []jsii.Any
+	UnknownMapProperty map[string]jsii.Any
+	UnknownProperty jsii.Any
+	OptionalEnumValue StringEnum
 }
 
 func (a *AllTypes) GetEnumPropertyValue() float64 {
-    return a.EnumPropertyValue
+	return a.EnumPropertyValue
 }
 
 func (a *AllTypes) GetAnyArrayProperty() []jsii.Any {
-    return a.AnyArrayProperty
+	return a.AnyArrayProperty
 }
 
 func (a *AllTypes) GetAnyMapProperty() map[string]jsii.Any {
-    return a.AnyMapProperty
+	return a.AnyMapProperty
 }
 
 func (a *AllTypes) GetAnyProperty() jsii.Any {
-    return a.AnyProperty
+	return a.AnyProperty
 }
 
 func (a *AllTypes) GetArrayProperty() []string {
-    return a.ArrayProperty
+	return a.ArrayProperty
 }
 
 func (a *AllTypes) GetBooleanProperty() bool {
-    return a.BooleanProperty
+	return a.BooleanProperty
 }
 
 func (a *AllTypes) GetDateProperty() string {
-    return a.DateProperty
+	return a.DateProperty
 }
 
 func (a *AllTypes) GetEnumProperty() AllTypesEnum {
-    return a.EnumProperty
+	return a.EnumProperty
 }
 
 func (a *AllTypes) GetJsonProperty() map[string]jsii.Any {
-    return a.JsonProperty
+	return a.JsonProperty
 }
 
 func (a *AllTypes) GetMapProperty() map[string]scopejsiicalclib.Number {
-    return a.MapProperty
+	return a.MapProperty
 }
 
 func (a *AllTypes) GetNumberProperty() float64 {
-    return a.NumberProperty
+	return a.NumberProperty
 }
 
 func (a *AllTypes) GetStringProperty() string {
-    return a.StringProperty
+	return a.StringProperty
 }
 
 func (a *AllTypes) GetUnionArrayProperty() []jsii.Any {
-    return a.UnionArrayProperty
+	return a.UnionArrayProperty
 }
 
 func (a *AllTypes) GetUnionMapProperty() map[string]jsii.Any {
-    return a.UnionMapProperty
+	return a.UnionMapProperty
 }
 
 func (a *AllTypes) GetUnionProperty() jsii.Any {
-    return a.UnionProperty
+	return a.UnionProperty
 }
 
 func (a *AllTypes) GetUnknownArrayProperty() []jsii.Any {
-    return a.UnknownArrayProperty
+	return a.UnknownArrayProperty
 }
 
 func (a *AllTypes) GetUnknownMapProperty() map[string]jsii.Any {
-    return a.UnknownMapProperty
+	return a.UnknownMapProperty
 }
 
 func (a *AllTypes) GetUnknownProperty() jsii.Any {
-    return a.UnknownProperty
+	return a.UnknownProperty
 }
 
 func (a *AllTypes) GetOptionalEnumValue() StringEnum {
-    return a.OptionalEnumValue
+	return a.OptionalEnumValue
 }
 
 
 func NewAllTypes() AllTypesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllTypes",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AllTypes{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllTypes",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AllTypes{}
 }
 
 func (a *AllTypes) SetEnumPropertyValue(val float64) {
-    a.EnumPropertyValue = val
+	a.EnumPropertyValue = val
 }
 
 func (a *AllTypes) SetAnyArrayProperty(val []jsii.Any) {
-    a.AnyArrayProperty = val
+	a.AnyArrayProperty = val
 }
 
 func (a *AllTypes) SetAnyMapProperty(val map[string]jsii.Any) {
-    a.AnyMapProperty = val
+	a.AnyMapProperty = val
 }
 
 func (a *AllTypes) SetAnyProperty(val jsii.Any) {
-    a.AnyProperty = val
+	a.AnyProperty = val
 }
 
 func (a *AllTypes) SetArrayProperty(val []string) {
-    a.ArrayProperty = val
+	a.ArrayProperty = val
 }
 
 func (a *AllTypes) SetBooleanProperty(val bool) {
-    a.BooleanProperty = val
+	a.BooleanProperty = val
 }
 
 func (a *AllTypes) SetDateProperty(val string) {
-    a.DateProperty = val
+	a.DateProperty = val
 }
 
 func (a *AllTypes) SetEnumProperty(val AllTypesEnum) {
-    a.EnumProperty = val
+	a.EnumProperty = val
 }
 
 func (a *AllTypes) SetJsonProperty(val map[string]jsii.Any) {
-    a.JsonProperty = val
+	a.JsonProperty = val
 }
 
 func (a *AllTypes) SetMapProperty(val map[string]scopejsiicalclib.Number) {
-    a.MapProperty = val
+	a.MapProperty = val
 }
 
 func (a *AllTypes) SetNumberProperty(val float64) {
-    a.NumberProperty = val
+	a.NumberProperty = val
 }
 
 func (a *AllTypes) SetStringProperty(val string) {
-    a.StringProperty = val
+	a.StringProperty = val
 }
 
 func (a *AllTypes) SetUnionArrayProperty(val []jsii.Any) {
-    a.UnionArrayProperty = val
+	a.UnionArrayProperty = val
 }
 
 func (a *AllTypes) SetUnionMapProperty(val map[string]jsii.Any) {
-    a.UnionMapProperty = val
+	a.UnionMapProperty = val
 }
 
 func (a *AllTypes) SetUnionProperty(val jsii.Any) {
-    a.UnionProperty = val
+	a.UnionProperty = val
 }
 
 func (a *AllTypes) SetUnknownArrayProperty(val []jsii.Any) {
-    a.UnknownArrayProperty = val
+	a.UnknownArrayProperty = val
 }
 
 func (a *AllTypes) SetUnknownMapProperty(val map[string]jsii.Any) {
-    a.UnknownMapProperty = val
+	a.UnknownMapProperty = val
 }
 
 func (a *AllTypes) SetUnknownProperty(val jsii.Any) {
-    a.UnknownProperty = val
+	a.UnknownProperty = val
 }
 
 func (a *AllTypes) SetOptionalEnumValue(val StringEnum) {
-    a.OptionalEnumValue = val
+	a.OptionalEnumValue = val
 }
 
 func (a *AllTypes) AnyIn(inp jsii.Any) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllTypes",
-        Method: "AnyIn",
-        Args: []string{"any",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllTypes",
+		Method: "AnyIn",
+		Args: []string{"any",},
+	})
 }
 
 func (a *AllTypes) AnyOut() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllTypes",
-        Method: "AnyOut",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllTypes",
+		Method: "AnyOut",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (a *AllTypes) EnumMethod(value StringEnum) StringEnum {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllTypes",
-        Method: "EnumMethod",
-        Args: []string{"jsii-calc.StringEnum",},
-    })
-    return "ENUM_DUMMY"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllTypes",
+		Method: "EnumMethod",
+		Args: []string{"jsii-calc.StringEnum",},
+	})
+	return "ENUM_DUMMY"
 }
 
 type AllTypesEnum string
 
 const (
-    AllTypesEnumMyEnumValue AllTypesEnum = "MY_ENUM_VALUE"
-    AllTypesEnumYourEnumValue AllTypesEnum = "YOUR_ENUM_VALUE"
-    AllTypesEnumThisIsGreat AllTypesEnum = "THIS_IS_GREAT"
+	AllTypesEnumMyEnumValue AllTypesEnum = "MY_ENUM_VALUE"
+	AllTypesEnumYourEnumValue AllTypesEnum = "YOUR_ENUM_VALUE"
+	AllTypesEnumThisIsGreat AllTypesEnum = "THIS_IS_GREAT"
 )
 
 // Class interface
 type AllowedMethodNamesIface interface {
-    GetBar(_p1 string, _p2 float64)
-    GetFoo(withParam string) string
-    SetBar(_x string, _y float64, _z bool)
-    SetFoo(_x string, _y float64)
+	GetBar(_p1 string, _p2 float64)
+	GetFoo(withParam string) string
+	SetBar(_x string, _y float64, _z bool)
+	SetFoo(_x string, _y float64)
 }
 
 // Struct proxy
@@ -1500,92 +1500,92 @@ type AllowedMethodNames struct {
 }
 
 func NewAllowedMethodNames() AllowedMethodNamesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllowedMethodNames",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AllowedMethodNames{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllowedMethodNames",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AllowedMethodNames{}
 }
 
 func (a *AllowedMethodNames) GetBar(_p1 string, _p2 float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllowedMethodNames",
-        Method: "GetBar",
-        Args: []string{"string", "number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllowedMethodNames",
+		Method: "GetBar",
+		Args: []string{"string", "number",},
+	})
 }
 
 func (a *AllowedMethodNames) GetFoo(withParam string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllowedMethodNames",
-        Method: "GetFoo",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllowedMethodNames",
+		Method: "GetFoo",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (a *AllowedMethodNames) SetBar(_x string, _y float64, _z bool) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllowedMethodNames",
-        Method: "SetBar",
-        Args: []string{"string", "number", "boolean",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllowedMethodNames",
+		Method: "SetBar",
+		Args: []string{"string", "number", "boolean",},
+	})
 }
 
 func (a *AllowedMethodNames) SetFoo(_x string, _y float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AllowedMethodNames",
-        Method: "SetFoo",
-        Args: []string{"string", "number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AllowedMethodNames",
+		Method: "SetFoo",
+		Args: []string{"string", "number",},
+	})
 }
 
 // Class interface
 type AmbiguousParametersIface interface {
-    GetProps() StructParameterType
-    SetProps(val StructParameterType)
-    GetScope() Bell
-    SetScope(val Bell)
+	GetProps() StructParameterType
+	SetProps(val StructParameterType)
+	GetScope() Bell
+	SetScope(val Bell)
 }
 
 // Struct proxy
 type AmbiguousParameters struct {
-    Props StructParameterType
-    Scope Bell
+	Props StructParameterType
+	Scope Bell
 }
 
 func (a *AmbiguousParameters) GetProps() StructParameterType {
-    return a.Props
+	return a.Props
 }
 
 func (a *AmbiguousParameters) GetScope() Bell {
-    return a.Scope
+	return a.Scope
 }
 
 
 func NewAmbiguousParameters(scope Bell, props StructParameterType) AmbiguousParametersIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AmbiguousParameters",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.Bell", "jsii-calc.StructParameterType",},
-    })
-    return &AmbiguousParameters{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AmbiguousParameters",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.Bell", "jsii-calc.StructParameterType",},
+	})
+	return &AmbiguousParameters{}
 }
 
 func (a *AmbiguousParameters) SetProps(val StructParameterType) {
-    a.Props = val
+	a.Props = val
 }
 
 func (a *AmbiguousParameters) SetScope(val Bell) {
-    a.Scope = val
+	a.Scope = val
 }
 
 // Class interface
 type AnonymousImplementationProviderIface interface {
-    IAnonymousImplementationProvider
-    ProvideAsClass() Implementation
-    ProvideAsInterface() IAnonymouslyImplementMe
+	IAnonymousImplementationProvider
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
 }
 
 // Struct proxy
@@ -1593,40 +1593,40 @@ type AnonymousImplementationProvider struct {
 }
 
 func NewAnonymousImplementationProvider() AnonymousImplementationProviderIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AnonymousImplementationProvider",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AnonymousImplementationProvider{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AnonymousImplementationProvider",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AnonymousImplementationProvider{}
 }
 
 func (a *AnonymousImplementationProvider) ProvideAsClass() Implementation {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AnonymousImplementationProvider",
-        Method: "ProvideAsClass",
-        Args: []string{},
-    })
-    return Implementation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AnonymousImplementationProvider",
+		Method: "ProvideAsClass",
+		Args: []string{},
+	})
+	return Implementation{}
 }
 
 func (a *AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AnonymousImplementationProvider",
-        Method: "ProvideAsInterface",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AnonymousImplementationProvider",
+		Method: "ProvideAsInterface",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type AsyncVirtualMethodsIface interface {
-    CallMe() float64
-    CallMe2() float64
-    CallMeDoublePromise() float64
-    DontOverrideMe() float64
-    OverrideMe(mult float64) float64
-    OverrideMeToo() float64
+	CallMe() float64
+	CallMe2() float64
+	CallMeDoublePromise() float64
+	DontOverrideMe() float64
+	OverrideMe(mult float64) float64
+	OverrideMeToo() float64
 }
 
 // Struct proxy
@@ -1634,72 +1634,72 @@ type AsyncVirtualMethods struct {
 }
 
 func NewAsyncVirtualMethods() AsyncVirtualMethodsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AsyncVirtualMethods{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AsyncVirtualMethods{}
 }
 
 func (a *AsyncVirtualMethods) CallMe() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "CallMe",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "CallMe",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (a *AsyncVirtualMethods) CallMe2() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "CallMe2",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "CallMe2",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (a *AsyncVirtualMethods) CallMeDoublePromise() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "CallMeDoublePromise",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "CallMeDoublePromise",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (a *AsyncVirtualMethods) DontOverrideMe() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "DontOverrideMe",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "DontOverrideMe",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (a *AsyncVirtualMethods) OverrideMe(mult float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "OverrideMe",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "OverrideMe",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (a *AsyncVirtualMethods) OverrideMeToo() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AsyncVirtualMethods",
-        Method: "OverrideMeToo",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AsyncVirtualMethods",
+		Method: "OverrideMeToo",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type AugmentableClassIface interface {
-    MethodOne()
-    MethodTwo()
+	MethodOne()
+	MethodTwo()
 }
 
 // Struct proxy
@@ -1707,28 +1707,28 @@ type AugmentableClass struct {
 }
 
 func NewAugmentableClass() AugmentableClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AugmentableClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &AugmentableClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AugmentableClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &AugmentableClass{}
 }
 
 func (a *AugmentableClass) MethodOne() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AugmentableClass",
-        Method: "MethodOne",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AugmentableClass",
+		Method: "MethodOne",
+		Args: []string{},
+	})
 }
 
 func (a *AugmentableClass) MethodTwo() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "AugmentableClass",
-        Method: "MethodTwo",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "AugmentableClass",
+		Method: "MethodTwo",
+		Args: []string{},
+	})
 }
 
 // Class interface
@@ -1740,145 +1740,145 @@ type BaseJsii976 struct {
 }
 
 func NewBaseJsii976() BaseJsii976Iface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BaseJsii976",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &BaseJsii976{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BaseJsii976",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &BaseJsii976{}
 }
 
 // Class interface
 type BellIface interface {
-    IBell
-    GetRung() bool
-    SetRung(val bool)
-    Ring()
+	IBell
+	GetRung() bool
+	SetRung(val bool)
+	Ring()
 }
 
 // Struct proxy
 type Bell struct {
-    Rung bool
+	Rung bool
 }
 
 func (b *Bell) GetRung() bool {
-    return b.Rung
+	return b.Rung
 }
 
 
 func NewBell() BellIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Bell",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Bell{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Bell",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Bell{}
 }
 
 func (b *Bell) SetRung(val bool) {
-    b.Rung = val
+	b.Rung = val
 }
 
 func (b *Bell) Ring() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Bell",
-        Method: "Ring",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Bell",
+		Method: "Ring",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type BinaryOperationIface interface {
-    scopejsiicalclib.IFriendly
-    GetValue() float64
-    SetValue(val float64)
-    GetLhs() scopejsiicalclib.NumericValue
-    SetLhs(val scopejsiicalclib.NumericValue)
-    GetRhs() scopejsiicalclib.NumericValue
-    SetRhs(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
-    Hello() string
+	scopejsiicalclib.IFriendly
+	GetValue() float64
+	SetValue(val float64)
+	GetLhs() scopejsiicalclib.NumericValue
+	SetLhs(val scopejsiicalclib.NumericValue)
+	GetRhs() scopejsiicalclib.NumericValue
+	SetRhs(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
+	Hello() string
 }
 
 // Represents an operation with two operands.
 // Struct proxy
 type BinaryOperation struct {
-    // The value.
-    // Deprecated.
-    Value float64
-    // Left-hand side operand.
-    Lhs scopejsiicalclib.NumericValue
-    // Right-hand side operand.
-    Rhs scopejsiicalclib.NumericValue
+	// The value.
+	// Deprecated.
+	Value float64
+	// Left-hand side operand.
+	Lhs scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs scopejsiicalclib.NumericValue
 }
 
 func (b *BinaryOperation) GetValue() float64 {
-    return b.Value
+	return b.Value
 }
 
 func (b *BinaryOperation) GetLhs() scopejsiicalclib.NumericValue {
-    return b.Lhs
+	return b.Lhs
 }
 
 func (b *BinaryOperation) GetRhs() scopejsiicalclib.NumericValue {
-    return b.Rhs
+	return b.Rhs
 }
 
 
 // Creates a BinaryOperation.
 func NewBinaryOperation(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) BinaryOperationIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BinaryOperation",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &BinaryOperation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BinaryOperation",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &BinaryOperation{}
 }
 
 func (b *BinaryOperation) SetValue(val float64) {
-    b.Value = val
+	b.Value = val
 }
 
 func (b *BinaryOperation) SetLhs(val scopejsiicalclib.NumericValue) {
-    b.Lhs = val
+	b.Lhs = val
 }
 
 func (b *BinaryOperation) SetRhs(val scopejsiicalclib.NumericValue) {
-    b.Rhs = val
+	b.Rhs = val
 }
 
 func (b *BinaryOperation) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BinaryOperation",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BinaryOperation",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (b *BinaryOperation) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BinaryOperation",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BinaryOperation",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (b *BinaryOperation) Hello() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BinaryOperation",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BinaryOperation",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type BurriedAnonymousObjectIface interface {
-    Check() bool
-    GiveItBack(value jsii.Any) jsii.Any
+	Check() bool
+	GiveItBack(value jsii.Any) jsii.Any
 }
 
 // See https://github.com/aws/aws-cdk/issues/7977.
@@ -1887,61 +1887,61 @@ type BurriedAnonymousObject struct {
 }
 
 func NewBurriedAnonymousObject() BurriedAnonymousObjectIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BurriedAnonymousObject",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &BurriedAnonymousObject{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BurriedAnonymousObject",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &BurriedAnonymousObject{}
 }
 
 func (b *BurriedAnonymousObject) Check() bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BurriedAnonymousObject",
-        Method: "Check",
-        Args: []string{},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BurriedAnonymousObject",
+		Method: "Check",
+		Args: []string{},
+	})
+	return true
 }
 
 func (b *BurriedAnonymousObject) GiveItBack(value jsii.Any) jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "BurriedAnonymousObject",
-        Method: "GiveItBack",
-        Args: []string{"any",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "BurriedAnonymousObject",
+		Method: "GiveItBack",
+		Args: []string{"any",},
+	})
+	return nil
 }
 
 // Class interface
 type CalculatorIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    GetExpression() scopejsiicalclib.NumericValue
-    SetExpression(val scopejsiicalclib.NumericValue)
-    GetDecorationPostfixes() []string
-    SetDecorationPostfixes(val []string)
-    GetDecorationPrefixes() []string
-    SetDecorationPrefixes(val []string)
-    GetStringStyle() composition.CompositionStringStyle
-    SetStringStyle(val composition.CompositionStringStyle)
-    GetOperationsLog() []scopejsiicalclib.NumericValue
-    SetOperationsLog(val []scopejsiicalclib.NumericValue)
-    GetOperationsMap() map[string][]scopejsiicalclib.NumericValue
-    SetOperationsMap(val map[string][]scopejsiicalclib.NumericValue)
-    GetCurr() scopejsiicalclib.NumericValue
-    SetCurr(val scopejsiicalclib.NumericValue)
-    GetMaxValue() float64
-    SetMaxValue(val float64)
-    GetUnionProperty() jsii.Any
-    SetUnionProperty(val jsii.Any)
-    TypeName() jsii.Any
-    ToString() string
-    Add(value float64)
-    Mul(value float64)
-    Neg()
-    Pow(value float64)
-    ReadUnionValue() float64
+	GetValue() float64
+	SetValue(val float64)
+	GetExpression() scopejsiicalclib.NumericValue
+	SetExpression(val scopejsiicalclib.NumericValue)
+	GetDecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	GetDecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
+	GetStringStyle() composition.CompositionStringStyle
+	SetStringStyle(val composition.CompositionStringStyle)
+	GetOperationsLog() []scopejsiicalclib.NumericValue
+	SetOperationsLog(val []scopejsiicalclib.NumericValue)
+	GetOperationsMap() map[string][]scopejsiicalclib.NumericValue
+	SetOperationsMap(val map[string][]scopejsiicalclib.NumericValue)
+	GetCurr() scopejsiicalclib.NumericValue
+	SetCurr(val scopejsiicalclib.NumericValue)
+	GetMaxValue() float64
+	SetMaxValue(val float64)
+	GetUnionProperty() jsii.Any
+	SetUnionProperty(val jsii.Any)
+	TypeName() jsii.Any
+	ToString() string
+	Add(value float64)
+	Mul(value float64)
+	Neg()
+	Pow(value float64)
+	ReadUnionValue() float64
 }
 
 // A calculator which maintains a current value and allows adding operations.
@@ -1961,431 +1961,431 @@ type CalculatorIface interface {
 //
 // Struct proxy
 type Calculator struct {
-    // (deprecated) The value.
-    Value float64
-    // Returns the expression.
-    Expression scopejsiicalclib.NumericValue
-    // A set of postfixes to include in a decorated .toString().
-    DecorationPostfixes []string
-    // A set of prefixes to include in a decorated .toString().
-    DecorationPrefixes []string
-    // The .toString() style.
-    StringStyle composition.CompositionStringStyle
-    // A log of all operations.
-    OperationsLog []scopejsiicalclib.NumericValue
-    // A map of per operation name of all operations performed.
-    OperationsMap map[string][]scopejsiicalclib.NumericValue
-    // The current value.
-    Curr scopejsiicalclib.NumericValue
-    // The maximum value allows in this calculator.
-    MaxValue float64
-    // Example of a property that accepts a union of types.
-    UnionProperty jsii.Any
+	// (deprecated) The value.
+	Value float64
+	// Returns the expression.
+	Expression scopejsiicalclib.NumericValue
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes []string
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes []string
+	// The .toString() style.
+	StringStyle composition.CompositionStringStyle
+	// A log of all operations.
+	OperationsLog []scopejsiicalclib.NumericValue
+	// A map of per operation name of all operations performed.
+	OperationsMap map[string][]scopejsiicalclib.NumericValue
+	// The current value.
+	Curr scopejsiicalclib.NumericValue
+	// The maximum value allows in this calculator.
+	MaxValue float64
+	// Example of a property that accepts a union of types.
+	UnionProperty jsii.Any
 }
 
 func (c *Calculator) GetValue() float64 {
-    return c.Value
+	return c.Value
 }
 
 func (c *Calculator) GetExpression() scopejsiicalclib.NumericValue {
-    return c.Expression
+	return c.Expression
 }
 
 func (c *Calculator) GetDecorationPostfixes() []string {
-    return c.DecorationPostfixes
+	return c.DecorationPostfixes
 }
 
 func (c *Calculator) GetDecorationPrefixes() []string {
-    return c.DecorationPrefixes
+	return c.DecorationPrefixes
 }
 
 func (c *Calculator) GetStringStyle() composition.CompositionStringStyle {
-    return c.StringStyle
+	return c.StringStyle
 }
 
 func (c *Calculator) GetOperationsLog() []scopejsiicalclib.NumericValue {
-    return c.OperationsLog
+	return c.OperationsLog
 }
 
 func (c *Calculator) GetOperationsMap() map[string][]scopejsiicalclib.NumericValue {
-    return c.OperationsMap
+	return c.OperationsMap
 }
 
 func (c *Calculator) GetCurr() scopejsiicalclib.NumericValue {
-    return c.Curr
+	return c.Curr
 }
 
 func (c *Calculator) GetMaxValue() float64 {
-    return c.MaxValue
+	return c.MaxValue
 }
 
 func (c *Calculator) GetUnionProperty() jsii.Any {
-    return c.UnionProperty
+	return c.UnionProperty
 }
 
 
 // Creates a Calculator object.
 func NewCalculator(props CalculatorProps) CalculatorIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.CalculatorProps",},
-    })
-    return &Calculator{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.CalculatorProps",},
+	})
+	return &Calculator{}
 }
 
 func (c *Calculator) SetValue(val float64) {
-    c.Value = val
+	c.Value = val
 }
 
 func (c *Calculator) SetExpression(val scopejsiicalclib.NumericValue) {
-    c.Expression = val
+	c.Expression = val
 }
 
 func (c *Calculator) SetDecorationPostfixes(val []string) {
-    c.DecorationPostfixes = val
+	c.DecorationPostfixes = val
 }
 
 func (c *Calculator) SetDecorationPrefixes(val []string) {
-    c.DecorationPrefixes = val
+	c.DecorationPrefixes = val
 }
 
 func (c *Calculator) SetStringStyle(val composition.CompositionStringStyle) {
-    c.StringStyle = val
+	c.StringStyle = val
 }
 
 func (c *Calculator) SetOperationsLog(val []scopejsiicalclib.NumericValue) {
-    c.OperationsLog = val
+	c.OperationsLog = val
 }
 
 func (c *Calculator) SetOperationsMap(val map[string][]scopejsiicalclib.NumericValue) {
-    c.OperationsMap = val
+	c.OperationsMap = val
 }
 
 func (c *Calculator) SetCurr(val scopejsiicalclib.NumericValue) {
-    c.Curr = val
+	c.Curr = val
 }
 
 func (c *Calculator) SetMaxValue(val float64) {
-    c.MaxValue = val
+	c.MaxValue = val
 }
 
 func (c *Calculator) SetUnionProperty(val jsii.Any) {
-    c.UnionProperty = val
+	c.UnionProperty = val
 }
 
 func (c *Calculator) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (c *Calculator) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (c *Calculator) Add(value float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "Add",
-        Args: []string{"number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "Add",
+		Args: []string{"number",},
+	})
 }
 
 func (c *Calculator) Mul(value float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "Mul",
-        Args: []string{"number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "Mul",
+		Args: []string{"number",},
+	})
 }
 
 func (c *Calculator) Neg() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "Neg",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "Neg",
+		Args: []string{},
+	})
 }
 
 func (c *Calculator) Pow(value float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "Pow",
-        Args: []string{"number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "Pow",
+		Args: []string{"number",},
+	})
 }
 
 func (c *Calculator) ReadUnionValue() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Calculator",
-        Method: "ReadUnionValue",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Calculator",
+		Method: "ReadUnionValue",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // CalculatorPropsIface is the public interface for the custom type CalculatorProps
 type CalculatorPropsIface interface {
-    GetInitialValue() float64
-    GetMaximumValue() float64
+	GetInitialValue() float64
+	GetMaximumValue() float64
 }
 
 // Properties for Calculator.
 // Struct proxy
 type CalculatorProps struct {
-    // The initial value of the calculator.
-    // 
-    // NOTE: Any number works here, it's fine.
-    InitialValue float64
-    // The maximum value the calculator can store.
-    MaximumValue float64
+	// The initial value of the calculator.
+	// 
+	// NOTE: Any number works here, it's fine.
+	InitialValue float64
+	// The maximum value the calculator can store.
+	MaximumValue float64
 }
 
 func (c *CalculatorProps) GetInitialValue() float64 {
-    return c.InitialValue
+	return c.InitialValue
 }
 
 func (c *CalculatorProps) GetMaximumValue() float64 {
-    return c.MaximumValue
+	return c.MaximumValue
 }
 
 
 // ChildStruct982Iface is the public interface for the custom type ChildStruct982
 type ChildStruct982Iface interface {
-    GetFoo() string
-    GetBar() float64
+	GetFoo() string
+	GetBar() float64
 }
 
 // Struct proxy
 type ChildStruct982 struct {
-    Foo string
-    Bar float64
+	Foo string
+	Bar float64
 }
 
 func (c *ChildStruct982) GetFoo() string {
-    return c.Foo
+	return c.Foo
 }
 
 func (c *ChildStruct982) GetBar() float64 {
-    return c.Bar
+	return c.Bar
 }
 
 
 // Class interface
 type ClassThatImplementsTheInternalInterfaceIface interface {
-    INonInternalInterface
-    IAnotherPublicInterface
-    GetA() string
-    SetA(val string)
-    GetB() string
-    SetB(val string)
-    GetC() string
-    SetC(val string)
-    GetD() string
-    SetD(val string)
+	INonInternalInterface
+	IAnotherPublicInterface
+	GetA() string
+	SetA(val string)
+	GetB() string
+	SetB(val string)
+	GetC() string
+	SetC(val string)
+	GetD() string
+	SetD(val string)
 }
 
 // Struct proxy
 type ClassThatImplementsTheInternalInterface struct {
-    A string
-    B string
-    C string
-    D string
+	A string
+	B string
+	C string
+	D string
 }
 
 func (c *ClassThatImplementsTheInternalInterface) GetA() string {
-    return c.A
+	return c.A
 }
 
 func (c *ClassThatImplementsTheInternalInterface) GetB() string {
-    return c.B
+	return c.B
 }
 
 func (c *ClassThatImplementsTheInternalInterface) GetC() string {
-    return c.C
+	return c.C
 }
 
 func (c *ClassThatImplementsTheInternalInterface) GetD() string {
-    return c.D
+	return c.D
 }
 
 
 func NewClassThatImplementsTheInternalInterface() ClassThatImplementsTheInternalInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassThatImplementsTheInternalInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ClassThatImplementsTheInternalInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassThatImplementsTheInternalInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ClassThatImplementsTheInternalInterface{}
 }
 
 func (c *ClassThatImplementsTheInternalInterface) SetA(val string) {
-    c.A = val
+	c.A = val
 }
 
 func (c *ClassThatImplementsTheInternalInterface) SetB(val string) {
-    c.B = val
+	c.B = val
 }
 
 func (c *ClassThatImplementsTheInternalInterface) SetC(val string) {
-    c.C = val
+	c.C = val
 }
 
 func (c *ClassThatImplementsTheInternalInterface) SetD(val string) {
-    c.D = val
+	c.D = val
 }
 
 // Class interface
 type ClassThatImplementsThePrivateInterfaceIface interface {
-    INonInternalInterface
-    IAnotherPublicInterface
-    GetA() string
-    SetA(val string)
-    GetB() string
-    SetB(val string)
-    GetC() string
-    SetC(val string)
-    GetE() string
-    SetE(val string)
+	INonInternalInterface
+	IAnotherPublicInterface
+	GetA() string
+	SetA(val string)
+	GetB() string
+	SetB(val string)
+	GetC() string
+	SetC(val string)
+	GetE() string
+	SetE(val string)
 }
 
 // Struct proxy
 type ClassThatImplementsThePrivateInterface struct {
-    A string
-    B string
-    C string
-    E string
+	A string
+	B string
+	C string
+	E string
 }
 
 func (c *ClassThatImplementsThePrivateInterface) GetA() string {
-    return c.A
+	return c.A
 }
 
 func (c *ClassThatImplementsThePrivateInterface) GetB() string {
-    return c.B
+	return c.B
 }
 
 func (c *ClassThatImplementsThePrivateInterface) GetC() string {
-    return c.C
+	return c.C
 }
 
 func (c *ClassThatImplementsThePrivateInterface) GetE() string {
-    return c.E
+	return c.E
 }
 
 
 func NewClassThatImplementsThePrivateInterface() ClassThatImplementsThePrivateInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassThatImplementsThePrivateInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ClassThatImplementsThePrivateInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassThatImplementsThePrivateInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ClassThatImplementsThePrivateInterface{}
 }
 
 func (c *ClassThatImplementsThePrivateInterface) SetA(val string) {
-    c.A = val
+	c.A = val
 }
 
 func (c *ClassThatImplementsThePrivateInterface) SetB(val string) {
-    c.B = val
+	c.B = val
 }
 
 func (c *ClassThatImplementsThePrivateInterface) SetC(val string) {
-    c.C = val
+	c.C = val
 }
 
 func (c *ClassThatImplementsThePrivateInterface) SetE(val string) {
-    c.E = val
+	c.E = val
 }
 
 // Class interface
 type ClassWithCollectionsIface interface {
-    GetStaticArray() []string
-    SetStaticArray(val []string)
-    GetStaticMap() map[string]string
-    SetStaticMap(val map[string]string)
-    GetArray() []string
-    SetArray(val []string)
-    GetMap() map[string]string
-    SetMap(val map[string]string)
+	GetStaticArray() []string
+	SetStaticArray(val []string)
+	GetStaticMap() map[string]string
+	SetStaticMap(val map[string]string)
+	GetArray() []string
+	SetArray(val []string)
+	GetMap() map[string]string
+	SetMap(val map[string]string)
 }
 
 // Struct proxy
 type ClassWithCollections struct {
-    StaticArray []string
-    StaticMap map[string]string
-    Array []string
-    Map map[string]string
+	StaticArray []string
+	StaticMap map[string]string
+	Array []string
+	Map map[string]string
 }
 
 func (c *ClassWithCollections) GetStaticArray() []string {
-    return c.StaticArray
+	return c.StaticArray
 }
 
 func (c *ClassWithCollections) GetStaticMap() map[string]string {
-    return c.StaticMap
+	return c.StaticMap
 }
 
 func (c *ClassWithCollections) GetArray() []string {
-    return c.Array
+	return c.Array
 }
 
 func (c *ClassWithCollections) GetMap() map[string]string {
-    return c.Map
+	return c.Map
 }
 
 
 func NewClassWithCollections(map_ map[string]string, array []string) ClassWithCollectionsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithCollections",
-        Method: "Constructor",
-        Args: []string{"Map<string => string>", "Array<string>",},
-    })
-    return &ClassWithCollections{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithCollections",
+		Method: "Constructor",
+		Args: []string{"Map<string => string>", "Array<string>",},
+	})
+	return &ClassWithCollections{}
 }
 
 func (c *ClassWithCollections) SetStaticArray(val []string) {
-    c.StaticArray = val
+	c.StaticArray = val
 }
 
 func (c *ClassWithCollections) SetStaticMap(val map[string]string) {
-    c.StaticMap = val
+	c.StaticMap = val
 }
 
 func (c *ClassWithCollections) SetArray(val []string) {
-    c.Array = val
+	c.Array = val
 }
 
 func (c *ClassWithCollections) SetMap(val map[string]string) {
-    c.Map = val
+	c.Map = val
 }
 
 func ClassWithCollections_CreateAList() []string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithCollections",
-        Method: "CreateAList",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithCollections",
+		Method: "CreateAList",
+		Args: []string{},
+	})
+	return nil
 }
 
 func ClassWithCollections_CreateAMap() map[string]string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithCollections",
-        Method: "CreateAMap",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithCollections",
+		Method: "CreateAMap",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
@@ -2405,128 +2405,128 @@ type ClassWithDocs struct {
 }
 
 func NewClassWithDocs() ClassWithDocsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithDocs",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ClassWithDocs{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithDocs",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ClassWithDocs{}
 }
 
 // Class interface
 type ClassWithJavaReservedWordsIface interface {
-    GetInt() string
-    SetInt(val string)
-    Import(assert string) string
+	GetInt() string
+	SetInt(val string)
+	Import(assert string) string
 }
 
 // Struct proxy
 type ClassWithJavaReservedWords struct {
-    Int string
+	Int string
 }
 
 func (c *ClassWithJavaReservedWords) GetInt() string {
-    return c.Int
+	return c.Int
 }
 
 
 func NewClassWithJavaReservedWords(int string) ClassWithJavaReservedWordsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithJavaReservedWords",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &ClassWithJavaReservedWords{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithJavaReservedWords",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &ClassWithJavaReservedWords{}
 }
 
 func (c *ClassWithJavaReservedWords) SetInt(val string) {
-    c.Int = val
+	c.Int = val
 }
 
 func (c *ClassWithJavaReservedWords) Import(assert string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithJavaReservedWords",
-        Method: "Import",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithJavaReservedWords",
+		Method: "Import",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type ClassWithMutableObjectLiteralPropertyIface interface {
-    GetMutableObject() IMutableObjectLiteral
-    SetMutableObject(val IMutableObjectLiteral)
+	GetMutableObject() IMutableObjectLiteral
+	SetMutableObject(val IMutableObjectLiteral)
 }
 
 // Struct proxy
 type ClassWithMutableObjectLiteralProperty struct {
-    MutableObject IMutableObjectLiteral
+	MutableObject IMutableObjectLiteral
 }
 
 func (c *ClassWithMutableObjectLiteralProperty) GetMutableObject() IMutableObjectLiteral {
-    return c.MutableObject
+	return c.MutableObject
 }
 
 
 func NewClassWithMutableObjectLiteralProperty() ClassWithMutableObjectLiteralPropertyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithMutableObjectLiteralProperty",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ClassWithMutableObjectLiteralProperty{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithMutableObjectLiteralProperty",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ClassWithMutableObjectLiteralProperty{}
 }
 
 func (c *ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObjectLiteral) {
-    c.MutableObject = val
+	c.MutableObject = val
 }
 
 // Class interface
 type ClassWithPrivateConstructorAndAutomaticPropertiesIface interface {
-    IInterfaceWithProperties
-    GetReadOnlyString() string
-    SetReadOnlyString(val string)
-    GetReadWriteString() string
-    SetReadWriteString(val string)
+	IInterfaceWithProperties
+	GetReadOnlyString() string
+	SetReadOnlyString(val string)
+	GetReadWriteString() string
+	SetReadWriteString(val string)
 }
 
 // Class that implements interface properties automatically, but using a private constructor.
 // Struct proxy
 type ClassWithPrivateConstructorAndAutomaticProperties struct {
-    ReadOnlyString string
-    ReadWriteString string
+	ReadOnlyString string
+	ReadWriteString string
 }
 
 func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadOnlyString() string {
-    return c.ReadOnlyString
+	return c.ReadOnlyString
 }
 
 func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadWriteString() string {
-    return c.ReadWriteString
+	return c.ReadWriteString
 }
 
 
 func (c *ClassWithPrivateConstructorAndAutomaticProperties) SetReadOnlyString(val string) {
-    c.ReadOnlyString = val
+	c.ReadOnlyString = val
 }
 
 func (c *ClassWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(val string) {
-    c.ReadWriteString = val
+	c.ReadWriteString = val
 }
 
 func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString string, readWriteString string) ClassWithPrivateConstructorAndAutomaticProperties {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithPrivateConstructorAndAutomaticProperties",
-        Method: "Create",
-        Args: []string{"string", "string",},
-    })
-    return ClassWithPrivateConstructorAndAutomaticProperties{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithPrivateConstructorAndAutomaticProperties",
+		Method: "Create",
+		Args: []string{"string", "string",},
+	})
+	return ClassWithPrivateConstructorAndAutomaticProperties{}
 }
 
 // Class interface
 type ConfusingToJacksonIface interface {
-    GetUnionProperty() jsii.Any
-    SetUnionProperty(val jsii.Any)
+	GetUnionProperty() jsii.Any
+	SetUnionProperty(val jsii.Any)
 }
 
 // This tries to confuse Jackson by having overloaded property setters.
@@ -2534,48 +2534,48 @@ type ConfusingToJacksonIface interface {
 //
 // Struct proxy
 type ConfusingToJackson struct {
-    UnionProperty jsii.Any
+	UnionProperty jsii.Any
 }
 
 func (c *ConfusingToJackson) GetUnionProperty() jsii.Any {
-    return c.UnionProperty
+	return c.UnionProperty
 }
 
 
 func (c *ConfusingToJackson) SetUnionProperty(val jsii.Any) {
-    c.UnionProperty = val
+	c.UnionProperty = val
 }
 
 func ConfusingToJackson_MakeInstance() ConfusingToJackson {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConfusingToJackson",
-        Method: "MakeInstance",
-        Args: []string{},
-    })
-    return ConfusingToJackson{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConfusingToJackson",
+		Method: "MakeInstance",
+		Args: []string{},
+	})
+	return ConfusingToJackson{}
 }
 
 func ConfusingToJackson_MakeStructInstance() ConfusingToJacksonStruct {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConfusingToJackson",
-        Method: "MakeStructInstance",
-        Args: []string{},
-    })
-    return ConfusingToJacksonStruct{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConfusingToJackson",
+		Method: "MakeStructInstance",
+		Args: []string{},
+	})
+	return ConfusingToJacksonStruct{}
 }
 
 // ConfusingToJacksonStructIface is the public interface for the custom type ConfusingToJacksonStruct
 type ConfusingToJacksonStructIface interface {
-    GetUnionProperty() jsii.Any
+	GetUnionProperty() jsii.Any
 }
 
 // Struct proxy
 type ConfusingToJacksonStruct struct {
-    UnionProperty jsii.Any
+	UnionProperty jsii.Any
 }
 
 func (c *ConfusingToJacksonStruct) GetUnionProperty() jsii.Any {
-    return c.UnionProperty
+	return c.UnionProperty
 }
 
 
@@ -2588,12 +2588,12 @@ type ConstructorPassesThisOut struct {
 }
 
 func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumer) ConstructorPassesThisOutIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConstructorPassesThisOut",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.PartiallyInitializedThisConsumer",},
-    })
-    return &ConstructorPassesThisOut{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConstructorPassesThisOut",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.PartiallyInitializedThisConsumer",},
+	})
+	return &ConstructorPassesThisOut{}
 }
 
 // Class interface
@@ -2605,80 +2605,80 @@ type Constructors struct {
 }
 
 func NewConstructors() ConstructorsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Constructors{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Constructors{}
 }
 
 func Constructors_HiddenInterface() IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "HiddenInterface",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "HiddenInterface",
+		Args: []string{},
+	})
+	return nil
 }
 
 func Constructors_HiddenInterfaces() []IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "HiddenInterfaces",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "HiddenInterfaces",
+		Args: []string{},
+	})
+	return nil
 }
 
 func Constructors_HiddenSubInterfaces() []IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "HiddenSubInterfaces",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "HiddenSubInterfaces",
+		Args: []string{},
+	})
+	return nil
 }
 
 func Constructors_MakeClass() PublicClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "MakeClass",
-        Args: []string{},
-    })
-    return PublicClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "MakeClass",
+		Args: []string{},
+	})
+	return PublicClass{}
 }
 
 func Constructors_MakeInterface() IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "MakeInterface",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "MakeInterface",
+		Args: []string{},
+	})
+	return nil
 }
 
 func Constructors_MakeInterface2() IPublicInterface2 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "MakeInterface2",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "MakeInterface2",
+		Args: []string{},
+	})
+	return nil
 }
 
 func Constructors_MakeInterfaces() []IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Constructors",
-        Method: "MakeInterfaces",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Constructors",
+		Method: "MakeInterfaces",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type ConsumePureInterfaceIface interface {
-    WorkItBaby() StructB
+	WorkItBaby() StructB
 }
 
 // Struct proxy
@@ -2686,29 +2686,29 @@ type ConsumePureInterface struct {
 }
 
 func NewConsumePureInterface(delegate IStructReturningDelegate) ConsumePureInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumePureInterface",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.IStructReturningDelegate",},
-    })
-    return &ConsumePureInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumePureInterface",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.IStructReturningDelegate",},
+	})
+	return &ConsumePureInterface{}
 }
 
 func (c *ConsumePureInterface) WorkItBaby() StructB {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumePureInterface",
-        Method: "WorkItBaby",
-        Args: []string{},
-    })
-    return StructB{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumePureInterface",
+		Method: "WorkItBaby",
+		Args: []string{},
+	})
+	return StructB{}
 }
 
 // Class interface
 type ConsumerCanRingBellIface interface {
-    ImplementedByObjectLiteral(ringer IBellRinger) bool
-    ImplementedByPrivateClass(ringer IBellRinger) bool
-    ImplementedByPublicClass(ringer IBellRinger) bool
-    WhenTypedAsClass(ringer IConcreteBellRinger) bool
+	ImplementedByObjectLiteral(ringer IBellRinger) bool
+	ImplementedByPrivateClass(ringer IBellRinger) bool
+	ImplementedByPublicClass(ringer IBellRinger) bool
+	WhenTypedAsClass(ringer IConcreteBellRinger) bool
 }
 
 // Test calling back to consumers that implement interfaces.
@@ -2720,90 +2720,90 @@ type ConsumerCanRingBell struct {
 }
 
 func NewConsumerCanRingBell() ConsumerCanRingBellIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ConsumerCanRingBell{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ConsumerCanRingBell{}
 }
 
 func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "StaticImplementedByObjectLiteral",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "StaticImplementedByObjectLiteral",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "StaticImplementedByPrivateClass",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "StaticImplementedByPrivateClass",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "StaticImplementedByPublicClass",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "StaticImplementedByPublicClass",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "StaticWhenTypedAsClass",
-        Args: []string{"jsii-calc.IConcreteBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "StaticWhenTypedAsClass",
+		Args: []string{"jsii-calc.IConcreteBellRinger",},
+	})
+	return true
 }
 
 func (c *ConsumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "ImplementedByObjectLiteral",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "ImplementedByObjectLiteral",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func (c *ConsumerCanRingBell) ImplementedByPrivateClass(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "ImplementedByPrivateClass",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "ImplementedByPrivateClass",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func (c *ConsumerCanRingBell) ImplementedByPublicClass(ringer IBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "ImplementedByPublicClass",
-        Args: []string{"jsii-calc.IBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "ImplementedByPublicClass",
+		Args: []string{"jsii-calc.IBellRinger",},
+	})
+	return true
 }
 
 func (c *ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRinger) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumerCanRingBell",
-        Method: "WhenTypedAsClass",
-        Args: []string{"jsii-calc.IConcreteBellRinger",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumerCanRingBell",
+		Method: "WhenTypedAsClass",
+		Args: []string{"jsii-calc.IConcreteBellRinger",},
+	})
+	return true
 }
 
 // Class interface
 type ConsumersOfThisCrazyTypeSystemIface interface {
-    ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) string
-    ConsumeNonInternalInterface(obj INonInternalInterface) jsii.Any
+	ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) string
+	ConsumeNonInternalInterface(obj INonInternalInterface) jsii.Any
 }
 
 // Struct proxy
@@ -2811,37 +2811,37 @@ type ConsumersOfThisCrazyTypeSystem struct {
 }
 
 func NewConsumersOfThisCrazyTypeSystem() ConsumersOfThisCrazyTypeSystemIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumersOfThisCrazyTypeSystem",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ConsumersOfThisCrazyTypeSystem{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumersOfThisCrazyTypeSystem",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ConsumersOfThisCrazyTypeSystem{}
 }
 
 func (c *ConsumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumersOfThisCrazyTypeSystem",
-        Method: "ConsumeAnotherPublicInterface",
-        Args: []string{"jsii-calc.IAnotherPublicInterface",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumersOfThisCrazyTypeSystem",
+		Method: "ConsumeAnotherPublicInterface",
+		Args: []string{"jsii-calc.IAnotherPublicInterface",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (c *ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInternalInterface) jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ConsumersOfThisCrazyTypeSystem",
-        Method: "ConsumeNonInternalInterface",
-        Args: []string{"jsii-calc.INonInternalInterface",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ConsumersOfThisCrazyTypeSystem",
+		Method: "ConsumeNonInternalInterface",
+		Args: []string{"jsii-calc.INonInternalInterface",},
+	})
+	return nil
 }
 
 // Class interface
 type DataRendererIface interface {
-    Render(data scopejsiicalclib.MyFirstStruct) string
-    RenderArbitrary(data map[string]jsii.Any) string
-    RenderMap(map_ map[string]jsii.Any) string
+	Render(data scopejsiicalclib.MyFirstStruct) string
+	RenderArbitrary(data map[string]jsii.Any) string
+	RenderMap(map_ map[string]jsii.Any) string
 }
 
 // Verifies proper type handling through dynamic overrides.
@@ -2850,90 +2850,90 @@ type DataRenderer struct {
 }
 
 func NewDataRenderer() DataRendererIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DataRenderer",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DataRenderer{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DataRenderer",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DataRenderer{}
 }
 
 func (d *DataRenderer) Render(data scopejsiicalclib.MyFirstStruct) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DataRenderer",
-        Method: "Render",
-        Args: []string{"@scope/jsii-calc-lib.MyFirstStruct",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DataRenderer",
+		Method: "Render",
+		Args: []string{"@scope/jsii-calc-lib.MyFirstStruct",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (d *DataRenderer) RenderArbitrary(data map[string]jsii.Any) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DataRenderer",
-        Method: "RenderArbitrary",
-        Args: []string{"Map<string => any>",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DataRenderer",
+		Method: "RenderArbitrary",
+		Args: []string{"Map<string => any>",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (d *DataRenderer) RenderMap(map_ map[string]jsii.Any) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DataRenderer",
-        Method: "RenderMap",
-        Args: []string{"Map<string => any>",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DataRenderer",
+		Method: "RenderMap",
+		Args: []string{"Map<string => any>",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type DefaultedConstructorArgumentIface interface {
-    GetArg1() float64
-    SetArg1(val float64)
-    GetArg3() string
-    SetArg3(val string)
-    GetArg2() string
-    SetArg2(val string)
+	GetArg1() float64
+	SetArg1(val float64)
+	GetArg3() string
+	SetArg3(val string)
+	GetArg2() string
+	SetArg2(val string)
 }
 
 // Struct proxy
 type DefaultedConstructorArgument struct {
-    Arg1 float64
-    Arg3 string
-    Arg2 string
+	Arg1 float64
+	Arg3 string
+	Arg2 string
 }
 
 func (d *DefaultedConstructorArgument) GetArg1() float64 {
-    return d.Arg1
+	return d.Arg1
 }
 
 func (d *DefaultedConstructorArgument) GetArg3() string {
-    return d.Arg3
+	return d.Arg3
 }
 
 func (d *DefaultedConstructorArgument) GetArg2() string {
-    return d.Arg2
+	return d.Arg2
 }
 
 
 func NewDefaultedConstructorArgument(arg1 float64, arg2 string, arg3 string) DefaultedConstructorArgumentIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DefaultedConstructorArgument",
-        Method: "Constructor",
-        Args: []string{"number", "string", "date",},
-    })
-    return &DefaultedConstructorArgument{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DefaultedConstructorArgument",
+		Method: "Constructor",
+		Args: []string{"number", "string", "date",},
+	})
+	return &DefaultedConstructorArgument{}
 }
 
 func (d *DefaultedConstructorArgument) SetArg1(val float64) {
-    d.Arg1 = val
+	d.Arg1 = val
 }
 
 func (d *DefaultedConstructorArgument) SetArg3(val string) {
-    d.Arg3 = val
+	d.Arg3 = val
 }
 
 func (d *DefaultedConstructorArgument) SetArg2(val string) {
-    d.Arg2 = val
+	d.Arg2 = val
 }
 
 // Class interface
@@ -2949,277 +2949,277 @@ type Demonstrate982 struct {
 }
 
 func NewDemonstrate982() Demonstrate982Iface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Demonstrate982",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Demonstrate982{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Demonstrate982",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Demonstrate982{}
 }
 
 func Demonstrate982_TakeThis() ChildStruct982 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Demonstrate982",
-        Method: "TakeThis",
-        Args: []string{},
-    })
-    return ChildStruct982{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Demonstrate982",
+		Method: "TakeThis",
+		Args: []string{},
+	})
+	return ChildStruct982{}
 }
 
 func Demonstrate982_TakeThisToo() ParentStruct982 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Demonstrate982",
-        Method: "TakeThisToo",
-        Args: []string{},
-    })
-    return ParentStruct982{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Demonstrate982",
+		Method: "TakeThisToo",
+		Args: []string{},
+	})
+	return ParentStruct982{}
 }
 
 // Class interface
 type DeprecatedClassIface interface {
-    GetReadonlyProperty() string
-    SetReadonlyProperty(val string)
-    GetMutableProperty() float64
-    SetMutableProperty(val float64)
-    Method()
+	GetReadonlyProperty() string
+	SetReadonlyProperty(val string)
+	GetMutableProperty() float64
+	SetMutableProperty(val float64)
+	Method()
 }
 
 // Deprecated: a pretty boring class
 // Struct proxy
 type DeprecatedClass struct {
-    // Deprecated: this is not always "wazoo", be ready to be disappointed
-    ReadonlyProperty string
-    // Deprecated: shouldn't have been mutable
-    MutableProperty float64
+	// Deprecated: this is not always "wazoo", be ready to be disappointed
+	ReadonlyProperty string
+	// Deprecated: shouldn't have been mutable
+	MutableProperty float64
 }
 
 func (d *DeprecatedClass) GetReadonlyProperty() string {
-    return d.ReadonlyProperty
+	return d.ReadonlyProperty
 }
 
 func (d *DeprecatedClass) GetMutableProperty() float64 {
-    return d.MutableProperty
+	return d.MutableProperty
 }
 
 
 func NewDeprecatedClass(readonlyString string, mutableNumber float64) DeprecatedClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DeprecatedClass",
-        Method: "Constructor",
-        Args: []string{"string", "number",},
-    })
-    return &DeprecatedClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DeprecatedClass",
+		Method: "Constructor",
+		Args: []string{"string", "number",},
+	})
+	return &DeprecatedClass{}
 }
 
 func (d *DeprecatedClass) SetReadonlyProperty(val string) {
-    d.ReadonlyProperty = val
+	d.ReadonlyProperty = val
 }
 
 func (d *DeprecatedClass) SetMutableProperty(val float64) {
-    d.MutableProperty = val
+	d.MutableProperty = val
 }
 
 func (d *DeprecatedClass) Method() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DeprecatedClass",
-        Method: "Method",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DeprecatedClass",
+		Method: "Method",
+		Args: []string{},
+	})
 }
 
 // Deprecated: your deprecated selection of bad options
 type DeprecatedEnum string
 
 const (
-    DeprecatedEnumOptionA DeprecatedEnum = "OPTION_A"
-    DeprecatedEnumOptionB DeprecatedEnum = "OPTION_B"
+	DeprecatedEnumOptionA DeprecatedEnum = "OPTION_A"
+	DeprecatedEnumOptionB DeprecatedEnum = "OPTION_B"
 )
 
 // DeprecatedStructIface is the public interface for the custom type DeprecatedStruct
 // Deprecated: it just wraps a string
 type DeprecatedStructIface interface {
-    GetReadonlyProperty() string
+	GetReadonlyProperty() string
 }
 
 // Deprecated: it just wraps a string
 // Struct proxy
 type DeprecatedStruct struct {
-    // Deprecated: well, yeah
-    ReadonlyProperty string
+	// Deprecated: well, yeah
+	ReadonlyProperty string
 }
 
 func (d *DeprecatedStruct) GetReadonlyProperty() string {
-    return d.ReadonlyProperty
+	return d.ReadonlyProperty
 }
 
 
 // DerivedStructIface is the public interface for the custom type DerivedStruct
 type DerivedStructIface interface {
-    GetAnumber() float64
-    GetAstring() string
-    GetFirstOptional() []string
-    GetAnotherRequired() string
-    GetBool() bool
-    GetNonPrimitive() DoubleTrouble
-    GetAnotherOptional() map[string]scopejsiicalclib.NumericValue
-    GetOptionalAny() jsii.Any
-    GetOptionalArray() []string
+	GetAnumber() float64
+	GetAstring() string
+	GetFirstOptional() []string
+	GetAnotherRequired() string
+	GetBool() bool
+	GetNonPrimitive() DoubleTrouble
+	GetAnotherOptional() map[string]scopejsiicalclib.NumericValue
+	GetOptionalAny() jsii.Any
+	GetOptionalArray() []string
 }
 
 // A struct which derives from another struct.
 // Struct proxy
 type DerivedStruct struct {
-    // An awesome number value.
-    // Deprecated.
-    Anumber float64
-    // A string value.
-    // Deprecated.
-    Astring string
-    // Deprecated.
-    FirstOptional []string
-    AnotherRequired string
-    Bool bool
-    // An example of a non primitive property.
-    NonPrimitive DoubleTrouble
-    // This is optional.
-    AnotherOptional map[string]scopejsiicalclib.NumericValue
-    OptionalAny jsii.Any
-    OptionalArray []string
+	// An awesome number value.
+	// Deprecated.
+	Anumber float64
+	// A string value.
+	// Deprecated.
+	Astring string
+	// Deprecated.
+	FirstOptional []string
+	AnotherRequired string
+	Bool bool
+	// An example of a non primitive property.
+	NonPrimitive DoubleTrouble
+	// This is optional.
+	AnotherOptional map[string]scopejsiicalclib.NumericValue
+	OptionalAny jsii.Any
+	OptionalArray []string
 }
 
 func (d *DerivedStruct) GetAnumber() float64 {
-    return d.Anumber
+	return d.Anumber
 }
 
 func (d *DerivedStruct) GetAstring() string {
-    return d.Astring
+	return d.Astring
 }
 
 func (d *DerivedStruct) GetFirstOptional() []string {
-    return d.FirstOptional
+	return d.FirstOptional
 }
 
 func (d *DerivedStruct) GetAnotherRequired() string {
-    return d.AnotherRequired
+	return d.AnotherRequired
 }
 
 func (d *DerivedStruct) GetBool() bool {
-    return d.Bool
+	return d.Bool
 }
 
 func (d *DerivedStruct) GetNonPrimitive() DoubleTrouble {
-    return d.NonPrimitive
+	return d.NonPrimitive
 }
 
 func (d *DerivedStruct) GetAnotherOptional() map[string]scopejsiicalclib.NumericValue {
-    return d.AnotherOptional
+	return d.AnotherOptional
 }
 
 func (d *DerivedStruct) GetOptionalAny() jsii.Any {
-    return d.OptionalAny
+	return d.OptionalAny
 }
 
 func (d *DerivedStruct) GetOptionalArray() []string {
-    return d.OptionalArray
+	return d.OptionalArray
 }
 
 
 // DiamondInheritanceBaseLevelStructIface is the public interface for the custom type DiamondInheritanceBaseLevelStruct
 type DiamondInheritanceBaseLevelStructIface interface {
-    GetBaseLevelProperty() string
+	GetBaseLevelProperty() string
 }
 
 // Struct proxy
 type DiamondInheritanceBaseLevelStruct struct {
-    BaseLevelProperty string
+	BaseLevelProperty string
 }
 
 func (d *DiamondInheritanceBaseLevelStruct) GetBaseLevelProperty() string {
-    return d.BaseLevelProperty
+	return d.BaseLevelProperty
 }
 
 
 // DiamondInheritanceFirstMidLevelStructIface is the public interface for the custom type DiamondInheritanceFirstMidLevelStruct
 type DiamondInheritanceFirstMidLevelStructIface interface {
-    GetBaseLevelProperty() string
-    GetFirstMidLevelProperty() string
+	GetBaseLevelProperty() string
+	GetFirstMidLevelProperty() string
 }
 
 // Struct proxy
 type DiamondInheritanceFirstMidLevelStruct struct {
-    BaseLevelProperty string
-    FirstMidLevelProperty string
+	BaseLevelProperty string
+	FirstMidLevelProperty string
 }
 
 func (d *DiamondInheritanceFirstMidLevelStruct) GetBaseLevelProperty() string {
-    return d.BaseLevelProperty
+	return d.BaseLevelProperty
 }
 
 func (d *DiamondInheritanceFirstMidLevelStruct) GetFirstMidLevelProperty() string {
-    return d.FirstMidLevelProperty
+	return d.FirstMidLevelProperty
 }
 
 
 // DiamondInheritanceSecondMidLevelStructIface is the public interface for the custom type DiamondInheritanceSecondMidLevelStruct
 type DiamondInheritanceSecondMidLevelStructIface interface {
-    GetBaseLevelProperty() string
-    GetSecondMidLevelProperty() string
+	GetBaseLevelProperty() string
+	GetSecondMidLevelProperty() string
 }
 
 // Struct proxy
 type DiamondInheritanceSecondMidLevelStruct struct {
-    BaseLevelProperty string
-    SecondMidLevelProperty string
+	BaseLevelProperty string
+	SecondMidLevelProperty string
 }
 
 func (d *DiamondInheritanceSecondMidLevelStruct) GetBaseLevelProperty() string {
-    return d.BaseLevelProperty
+	return d.BaseLevelProperty
 }
 
 func (d *DiamondInheritanceSecondMidLevelStruct) GetSecondMidLevelProperty() string {
-    return d.SecondMidLevelProperty
+	return d.SecondMidLevelProperty
 }
 
 
 // DiamondInheritanceTopLevelStructIface is the public interface for the custom type DiamondInheritanceTopLevelStruct
 type DiamondInheritanceTopLevelStructIface interface {
-    GetBaseLevelProperty() string
-    GetFirstMidLevelProperty() string
-    GetSecondMidLevelProperty() string
-    GetTopLevelProperty() string
+	GetBaseLevelProperty() string
+	GetFirstMidLevelProperty() string
+	GetSecondMidLevelProperty() string
+	GetTopLevelProperty() string
 }
 
 // Struct proxy
 type DiamondInheritanceTopLevelStruct struct {
-    BaseLevelProperty string
-    FirstMidLevelProperty string
-    SecondMidLevelProperty string
-    TopLevelProperty string
+	BaseLevelProperty string
+	FirstMidLevelProperty string
+	SecondMidLevelProperty string
+	TopLevelProperty string
 }
 
 func (d *DiamondInheritanceTopLevelStruct) GetBaseLevelProperty() string {
-    return d.BaseLevelProperty
+	return d.BaseLevelProperty
 }
 
 func (d *DiamondInheritanceTopLevelStruct) GetFirstMidLevelProperty() string {
-    return d.FirstMidLevelProperty
+	return d.FirstMidLevelProperty
 }
 
 func (d *DiamondInheritanceTopLevelStruct) GetSecondMidLevelProperty() string {
-    return d.SecondMidLevelProperty
+	return d.SecondMidLevelProperty
 }
 
 func (d *DiamondInheritanceTopLevelStruct) GetTopLevelProperty() string {
-    return d.TopLevelProperty
+	return d.TopLevelProperty
 }
 
 
 // Class interface
 type DisappointingCollectionSourceIface interface {
-    GetMaybeList() []string
-    SetMaybeList(val []string)
-    GetMaybeMap() map[string]float64
-    SetMaybeMap(val map[string]float64)
+	GetMaybeList() []string
+	SetMaybeList(val []string)
+	GetMaybeMap() map[string]float64
+	SetMaybeMap(val map[string]float64)
 }
 
 // Verifies that null/undefined can be returned for optional collections.
@@ -3227,38 +3227,38 @@ type DisappointingCollectionSourceIface interface {
 // This source of collections is disappointing - it'll always give you nothing :(
 // Struct proxy
 type DisappointingCollectionSource struct {
-    // Some List of strings, maybe?
-    // 
-    // (Nah, just a billion dollars mistake!)
-    MaybeList []string
-    // Some Map of strings to numbers, maybe?
-    // 
-    // (Nah, just a billion dollars mistake!)
-    MaybeMap map[string]float64
+	// Some List of strings, maybe?
+	// 
+	// (Nah, just a billion dollars mistake!)
+	MaybeList []string
+	// Some Map of strings to numbers, maybe?
+	// 
+	// (Nah, just a billion dollars mistake!)
+	MaybeMap map[string]float64
 }
 
 func (d *DisappointingCollectionSource) GetMaybeList() []string {
-    return d.MaybeList
+	return d.MaybeList
 }
 
 func (d *DisappointingCollectionSource) GetMaybeMap() map[string]float64 {
-    return d.MaybeMap
+	return d.MaybeMap
 }
 
 
 func (d *DisappointingCollectionSource) SetMaybeList(val []string) {
-    d.MaybeList = val
+	d.MaybeList = val
 }
 
 func (d *DisappointingCollectionSource) SetMaybeMap(val map[string]float64) {
-    d.MaybeMap = val
+	d.MaybeMap = val
 }
 
 // Class interface
 type DoNotOverridePrivatesIface interface {
-    ChangePrivatePropertyValue(newValue string)
-    PrivateMethodValue() string
-    PrivatePropertyValue() string
+	ChangePrivatePropertyValue(newValue string)
+	PrivateMethodValue() string
+	PrivatePropertyValue() string
 }
 
 // Struct proxy
@@ -3266,43 +3266,43 @@ type DoNotOverridePrivates struct {
 }
 
 func NewDoNotOverridePrivates() DoNotOverridePrivatesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotOverridePrivates",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DoNotOverridePrivates{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotOverridePrivates",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DoNotOverridePrivates{}
 }
 
 func (d *DoNotOverridePrivates) ChangePrivatePropertyValue(newValue string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotOverridePrivates",
-        Method: "ChangePrivatePropertyValue",
-        Args: []string{"string",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotOverridePrivates",
+		Method: "ChangePrivatePropertyValue",
+		Args: []string{"string",},
+	})
 }
 
 func (d *DoNotOverridePrivates) PrivateMethodValue() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotOverridePrivates",
-        Method: "PrivateMethodValue",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotOverridePrivates",
+		Method: "PrivateMethodValue",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (d *DoNotOverridePrivates) PrivatePropertyValue() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotOverridePrivates",
-        Method: "PrivatePropertyValue",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotOverridePrivates",
+		Method: "PrivatePropertyValue",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type DoNotRecognizeAnyAsOptionalIface interface {
-    Method(_requiredAny jsii.Any, _optionalAny jsii.Any, _optionalString string)
+	Method(_requiredAny jsii.Any, _optionalAny jsii.Any, _optionalString string)
 }
 
 // jsii#284: do not recognize "any" as an optional argument.
@@ -3311,26 +3311,26 @@ type DoNotRecognizeAnyAsOptional struct {
 }
 
 func NewDoNotRecognizeAnyAsOptional() DoNotRecognizeAnyAsOptionalIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotRecognizeAnyAsOptional",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DoNotRecognizeAnyAsOptional{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotRecognizeAnyAsOptional",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DoNotRecognizeAnyAsOptional{}
 }
 
 func (d *DoNotRecognizeAnyAsOptional) Method(_requiredAny jsii.Any, _optionalAny jsii.Any, _optionalString string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoNotRecognizeAnyAsOptional",
-        Method: "Method",
-        Args: []string{"any", "any", "string",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoNotRecognizeAnyAsOptional",
+		Method: "Method",
+		Args: []string{"any", "any", "string",},
+	})
 }
 
 // Class interface
 type DocumentedClassIface interface {
-    Greet(greetee Greetee) float64
-    Hola()
+	Greet(greetee Greetee) float64
+	Hola()
 }
 
 // Here's the first line of the TSDoc comment.
@@ -3344,34 +3344,34 @@ type DocumentedClass struct {
 }
 
 func NewDocumentedClass() DocumentedClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DocumentedClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DocumentedClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DocumentedClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DocumentedClass{}
 }
 
 func (d *DocumentedClass) Greet(greetee Greetee) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DocumentedClass",
-        Method: "Greet",
-        Args: []string{"jsii-calc.Greetee",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DocumentedClass",
+		Method: "Greet",
+		Args: []string{"jsii-calc.Greetee",},
+	})
+	return 0.0
 }
 
 func (d *DocumentedClass) Hola() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DocumentedClass",
-        Method: "Hola",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DocumentedClass",
+		Method: "Hola",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type DontComplainAboutVariadicAfterOptionalIface interface {
-    OptionalAndVariadic(optional string, things string) string
+	OptionalAndVariadic(optional string, things string) string
 }
 
 // Struct proxy
@@ -3379,30 +3379,30 @@ type DontComplainAboutVariadicAfterOptional struct {
 }
 
 func NewDontComplainAboutVariadicAfterOptional() DontComplainAboutVariadicAfterOptionalIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DontComplainAboutVariadicAfterOptional",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DontComplainAboutVariadicAfterOptional{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DontComplainAboutVariadicAfterOptional",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DontComplainAboutVariadicAfterOptional{}
 }
 
 func (d *DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional string, things string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DontComplainAboutVariadicAfterOptional",
-        Method: "OptionalAndVariadic",
-        Args: []string{"string", "string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DontComplainAboutVariadicAfterOptional",
+		Method: "OptionalAndVariadic",
+		Args: []string{"string", "string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type DoubleTroubleIface interface {
-    IFriendlyRandomGenerator
-    IRandomNumberGenerator
-    scopejsiicalclib.IFriendly
-    Hello() string
-    Next() float64
+	IFriendlyRandomGenerator
+	IRandomNumberGenerator
+	scopejsiicalclib.IFriendly
+	Hello() string
+	Next() float64
 }
 
 // Struct proxy
@@ -3410,138 +3410,138 @@ type DoubleTrouble struct {
 }
 
 func NewDoubleTrouble() DoubleTroubleIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoubleTrouble",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &DoubleTrouble{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoubleTrouble",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &DoubleTrouble{}
 }
 
 func (d *DoubleTrouble) Hello() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoubleTrouble",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoubleTrouble",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (d *DoubleTrouble) Next() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DoubleTrouble",
-        Method: "Next",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DoubleTrouble",
+		Method: "Next",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type DynamicPropertyBearerIface interface {
-    GetDynamicProperty() string
-    SetDynamicProperty(val string)
-    GetValueStore() string
-    SetValueStore(val string)
+	GetDynamicProperty() string
+	SetDynamicProperty(val string)
+	GetValueStore() string
+	SetValueStore(val string)
 }
 
 // Ensures we can override a dynamic property that was inherited.
 // Struct proxy
 type DynamicPropertyBearer struct {
-    DynamicProperty string
-    ValueStore string
+	DynamicProperty string
+	ValueStore string
 }
 
 func (d *DynamicPropertyBearer) GetDynamicProperty() string {
-    return d.DynamicProperty
+	return d.DynamicProperty
 }
 
 func (d *DynamicPropertyBearer) GetValueStore() string {
-    return d.ValueStore
+	return d.ValueStore
 }
 
 
 func NewDynamicPropertyBearer(valueStore string) DynamicPropertyBearerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DynamicPropertyBearer",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &DynamicPropertyBearer{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DynamicPropertyBearer",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &DynamicPropertyBearer{}
 }
 
 func (d *DynamicPropertyBearer) SetDynamicProperty(val string) {
-    d.DynamicProperty = val
+	d.DynamicProperty = val
 }
 
 func (d *DynamicPropertyBearer) SetValueStore(val string) {
-    d.ValueStore = val
+	d.ValueStore = val
 }
 
 // Class interface
 type DynamicPropertyBearerChildIface interface {
-    GetDynamicProperty() string
-    SetDynamicProperty(val string)
-    GetValueStore() string
-    SetValueStore(val string)
-    GetOriginalValue() string
-    SetOriginalValue(val string)
-    OverrideValue(newValue string) string
+	GetDynamicProperty() string
+	SetDynamicProperty(val string)
+	GetValueStore() string
+	SetValueStore(val string)
+	GetOriginalValue() string
+	SetOriginalValue(val string)
+	OverrideValue(newValue string) string
 }
 
 // Struct proxy
 type DynamicPropertyBearerChild struct {
-    DynamicProperty string
-    ValueStore string
-    OriginalValue string
+	DynamicProperty string
+	ValueStore string
+	OriginalValue string
 }
 
 func (d *DynamicPropertyBearerChild) GetDynamicProperty() string {
-    return d.DynamicProperty
+	return d.DynamicProperty
 }
 
 func (d *DynamicPropertyBearerChild) GetValueStore() string {
-    return d.ValueStore
+	return d.ValueStore
 }
 
 func (d *DynamicPropertyBearerChild) GetOriginalValue() string {
-    return d.OriginalValue
+	return d.OriginalValue
 }
 
 
 func NewDynamicPropertyBearerChild(originalValue string) DynamicPropertyBearerChildIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DynamicPropertyBearerChild",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &DynamicPropertyBearerChild{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DynamicPropertyBearerChild",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &DynamicPropertyBearerChild{}
 }
 
 func (d *DynamicPropertyBearerChild) SetDynamicProperty(val string) {
-    d.DynamicProperty = val
+	d.DynamicProperty = val
 }
 
 func (d *DynamicPropertyBearerChild) SetValueStore(val string) {
-    d.ValueStore = val
+	d.ValueStore = val
 }
 
 func (d *DynamicPropertyBearerChild) SetOriginalValue(val string) {
-    d.OriginalValue = val
+	d.OriginalValue = val
 }
 
 func (d *DynamicPropertyBearerChild) OverrideValue(newValue string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "DynamicPropertyBearerChild",
-        Method: "OverrideValue",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "DynamicPropertyBearerChild",
+		Method: "OverrideValue",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type EntropyIface interface {
-    Increase() string
-    Repeat(word string) string
+	Increase() string
+	Repeat(word string) string
 }
 
 // This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
@@ -3551,30 +3551,30 @@ type Entropy struct {
 
 // Creates a new instance of Entropy.
 func NewEntropy(clock IWallClock) EntropyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Entropy",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.IWallClock",},
-    })
-    return &Entropy{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Entropy",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.IWallClock",},
+	})
+	return &Entropy{}
 }
 
 func (e *Entropy) Increase() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Entropy",
-        Method: "Increase",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Entropy",
+		Method: "Increase",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (e *Entropy) Repeat(word string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Entropy",
-        Method: "Repeat",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Entropy",
+		Method: "Repeat",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
@@ -3586,21 +3586,21 @@ type EnumDispenser struct {
 }
 
 func EnumDispenser_RandomIntegerLikeEnum() AllTypesEnum {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EnumDispenser",
-        Method: "RandomIntegerLikeEnum",
-        Args: []string{},
-    })
-    return "ENUM_DUMMY"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EnumDispenser",
+		Method: "RandomIntegerLikeEnum",
+		Args: []string{},
+	})
+	return "ENUM_DUMMY"
 }
 
 func EnumDispenser_RandomStringLikeEnum() StringEnum {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EnumDispenser",
-        Method: "RandomStringLikeEnum",
-        Args: []string{},
-    })
-    return "ENUM_DUMMY"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EnumDispenser",
+		Method: "RandomStringLikeEnum",
+		Args: []string{},
+	})
+	return "ENUM_DUMMY"
 }
 
 // Class interface
@@ -3612,340 +3612,340 @@ type EraseUndefinedHashValues struct {
 }
 
 func NewEraseUndefinedHashValues() EraseUndefinedHashValuesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EraseUndefinedHashValues",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &EraseUndefinedHashValues{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EraseUndefinedHashValues",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &EraseUndefinedHashValues{}
 }
 
 func EraseUndefinedHashValues_DoesKeyExist(opts EraseUndefinedHashValuesOptions, key string) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EraseUndefinedHashValues",
-        Method: "DoesKeyExist",
-        Args: []string{"jsii-calc.EraseUndefinedHashValuesOptions", "string",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EraseUndefinedHashValues",
+		Method: "DoesKeyExist",
+		Args: []string{"jsii-calc.EraseUndefinedHashValuesOptions", "string",},
+	})
+	return true
 }
 
 func EraseUndefinedHashValues_Prop1IsNull() map[string]jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EraseUndefinedHashValues",
-        Method: "Prop1IsNull",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EraseUndefinedHashValues",
+		Method: "Prop1IsNull",
+		Args: []string{},
+	})
+	return nil
 }
 
 func EraseUndefinedHashValues_Prop2IsUndefined() map[string]jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "EraseUndefinedHashValues",
-        Method: "Prop2IsUndefined",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "EraseUndefinedHashValues",
+		Method: "Prop2IsUndefined",
+		Args: []string{},
+	})
+	return nil
 }
 
 // EraseUndefinedHashValuesOptionsIface is the public interface for the custom type EraseUndefinedHashValuesOptions
 type EraseUndefinedHashValuesOptionsIface interface {
-    GetOption1() string
-    GetOption2() string
+	GetOption1() string
+	GetOption2() string
 }
 
 // Struct proxy
 type EraseUndefinedHashValuesOptions struct {
-    Option1 string
-    Option2 string
+	Option1 string
+	Option2 string
 }
 
 func (e *EraseUndefinedHashValuesOptions) GetOption1() string {
-    return e.Option1
+	return e.Option1
 }
 
 func (e *EraseUndefinedHashValuesOptions) GetOption2() string {
-    return e.Option2
+	return e.Option2
 }
 
 
 // Class interface
 type ExperimentalClassIface interface {
-    GetReadonlyProperty() string
-    SetReadonlyProperty(val string)
-    GetMutableProperty() float64
-    SetMutableProperty(val float64)
-    Method()
+	GetReadonlyProperty() string
+	SetReadonlyProperty(val string)
+	GetMutableProperty() float64
+	SetMutableProperty(val float64)
+	Method()
 }
 
 // Experimental.
 // Struct proxy
 type ExperimentalClass struct {
-    // Experimental.
-    ReadonlyProperty string
-    // Experimental.
-    MutableProperty float64
+	// Experimental.
+	ReadonlyProperty string
+	// Experimental.
+	MutableProperty float64
 }
 
 func (e *ExperimentalClass) GetReadonlyProperty() string {
-    return e.ReadonlyProperty
+	return e.ReadonlyProperty
 }
 
 func (e *ExperimentalClass) GetMutableProperty() float64 {
-    return e.MutableProperty
+	return e.MutableProperty
 }
 
 
 func NewExperimentalClass(readonlyString string, mutableNumber float64) ExperimentalClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ExperimentalClass",
-        Method: "Constructor",
-        Args: []string{"string", "number",},
-    })
-    return &ExperimentalClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ExperimentalClass",
+		Method: "Constructor",
+		Args: []string{"string", "number",},
+	})
+	return &ExperimentalClass{}
 }
 
 func (e *ExperimentalClass) SetReadonlyProperty(val string) {
-    e.ReadonlyProperty = val
+	e.ReadonlyProperty = val
 }
 
 func (e *ExperimentalClass) SetMutableProperty(val float64) {
-    e.MutableProperty = val
+	e.MutableProperty = val
 }
 
 func (e *ExperimentalClass) Method() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ExperimentalClass",
-        Method: "Method",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ExperimentalClass",
+		Method: "Method",
+		Args: []string{},
+	})
 }
 
 // Experimental.
 type ExperimentalEnum string
 
 const (
-    ExperimentalEnumOptionA ExperimentalEnum = "OPTION_A"
-    ExperimentalEnumOptionB ExperimentalEnum = "OPTION_B"
+	ExperimentalEnumOptionA ExperimentalEnum = "OPTION_A"
+	ExperimentalEnumOptionB ExperimentalEnum = "OPTION_B"
 )
 
 // ExperimentalStructIface is the public interface for the custom type ExperimentalStruct
 // Experimental.
 type ExperimentalStructIface interface {
-    GetReadonlyProperty() string
+	GetReadonlyProperty() string
 }
 
 // Experimental.
 // Struct proxy
 type ExperimentalStruct struct {
-    // Experimental.
-    ReadonlyProperty string
+	// Experimental.
+	ReadonlyProperty string
 }
 
 func (e *ExperimentalStruct) GetReadonlyProperty() string {
-    return e.ReadonlyProperty
+	return e.ReadonlyProperty
 }
 
 
 // Class interface
 type ExportedBaseClassIface interface {
-    GetSuccess() bool
-    SetSuccess(val bool)
+	GetSuccess() bool
+	SetSuccess(val bool)
 }
 
 // Struct proxy
 type ExportedBaseClass struct {
-    Success bool
+	Success bool
 }
 
 func (e *ExportedBaseClass) GetSuccess() bool {
-    return e.Success
+	return e.Success
 }
 
 
 func NewExportedBaseClass(success bool) ExportedBaseClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ExportedBaseClass",
-        Method: "Constructor",
-        Args: []string{"boolean",},
-    })
-    return &ExportedBaseClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ExportedBaseClass",
+		Method: "Constructor",
+		Args: []string{"boolean",},
+	})
+	return &ExportedBaseClass{}
 }
 
 func (e *ExportedBaseClass) SetSuccess(val bool) {
-    e.Success = val
+	e.Success = val
 }
 
 // ExtendsInternalInterfaceIface is the public interface for the custom type ExtendsInternalInterface
 type ExtendsInternalInterfaceIface interface {
-    GetBoom() bool
-    GetProp() string
+	GetBoom() bool
+	GetProp() string
 }
 
 // Struct proxy
 type ExtendsInternalInterface struct {
-    Boom bool
-    Prop string
+	Boom bool
+	Prop string
 }
 
 func (e *ExtendsInternalInterface) GetBoom() bool {
-    return e.Boom
+	return e.Boom
 }
 
 func (e *ExtendsInternalInterface) GetProp() string {
-    return e.Prop
+	return e.Prop
 }
 
 
 // Class interface
 type ExternalClassIface interface {
-    GetReadonlyProperty() string
-    SetReadonlyProperty(val string)
-    GetMutableProperty() float64
-    SetMutableProperty(val float64)
-    Method()
+	GetReadonlyProperty() string
+	SetReadonlyProperty(val string)
+	GetMutableProperty() float64
+	SetMutableProperty(val float64)
+	Method()
 }
 
 // Struct proxy
 type ExternalClass struct {
-    ReadonlyProperty string
-    MutableProperty float64
+	ReadonlyProperty string
+	MutableProperty float64
 }
 
 func (e *ExternalClass) GetReadonlyProperty() string {
-    return e.ReadonlyProperty
+	return e.ReadonlyProperty
 }
 
 func (e *ExternalClass) GetMutableProperty() float64 {
-    return e.MutableProperty
+	return e.MutableProperty
 }
 
 
 func NewExternalClass(readonlyString string, mutableNumber float64) ExternalClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ExternalClass",
-        Method: "Constructor",
-        Args: []string{"string", "number",},
-    })
-    return &ExternalClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ExternalClass",
+		Method: "Constructor",
+		Args: []string{"string", "number",},
+	})
+	return &ExternalClass{}
 }
 
 func (e *ExternalClass) SetReadonlyProperty(val string) {
-    e.ReadonlyProperty = val
+	e.ReadonlyProperty = val
 }
 
 func (e *ExternalClass) SetMutableProperty(val float64) {
-    e.MutableProperty = val
+	e.MutableProperty = val
 }
 
 func (e *ExternalClass) Method() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ExternalClass",
-        Method: "Method",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ExternalClass",
+		Method: "Method",
+		Args: []string{},
+	})
 }
 
 type ExternalEnum string
 
 const (
-    ExternalEnumOptionA ExternalEnum = "OPTION_A"
-    ExternalEnumOptionB ExternalEnum = "OPTION_B"
+	ExternalEnumOptionA ExternalEnum = "OPTION_A"
+	ExternalEnumOptionB ExternalEnum = "OPTION_B"
 )
 
 // ExternalStructIface is the public interface for the custom type ExternalStruct
 type ExternalStructIface interface {
-    GetReadonlyProperty() string
+	GetReadonlyProperty() string
 }
 
 // Struct proxy
 type ExternalStruct struct {
-    ReadonlyProperty string
+	ReadonlyProperty string
 }
 
 func (e *ExternalStruct) GetReadonlyProperty() string {
-    return e.ReadonlyProperty
+	return e.ReadonlyProperty
 }
 
 
 // Class interface
 type GiveMeStructsIface interface {
-    GetStructLiteral() scopejsiicalclib.StructWithOnlyOptionals
-    SetStructLiteral(val scopejsiicalclib.StructWithOnlyOptionals)
-    DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct
-    ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTrouble
-    ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64
+	GetStructLiteral() scopejsiicalclib.StructWithOnlyOptionals
+	SetStructLiteral(val scopejsiicalclib.StructWithOnlyOptionals)
+	DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct
+	ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTrouble
+	ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64
 }
 
 // Struct proxy
 type GiveMeStructs struct {
-    StructLiteral scopejsiicalclib.StructWithOnlyOptionals
+	StructLiteral scopejsiicalclib.StructWithOnlyOptionals
 }
 
 func (g *GiveMeStructs) GetStructLiteral() scopejsiicalclib.StructWithOnlyOptionals {
-    return g.StructLiteral
+	return g.StructLiteral
 }
 
 
 func NewGiveMeStructs() GiveMeStructsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GiveMeStructs",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &GiveMeStructs{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GiveMeStructs",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &GiveMeStructs{}
 }
 
 func (g *GiveMeStructs) SetStructLiteral(val scopejsiicalclib.StructWithOnlyOptionals) {
-    g.StructLiteral = val
+	g.StructLiteral = val
 }
 
 func (g *GiveMeStructs) DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GiveMeStructs",
-        Method: "DerivedToFirst",
-        Args: []string{"jsii-calc.DerivedStruct",},
-    })
-    return scopejsiicalclib.MyFirstStruct{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GiveMeStructs",
+		Method: "DerivedToFirst",
+		Args: []string{"jsii-calc.DerivedStruct",},
+	})
+	return scopejsiicalclib.MyFirstStruct{}
 }
 
 func (g *GiveMeStructs) ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTrouble {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GiveMeStructs",
-        Method: "ReadDerivedNonPrimitive",
-        Args: []string{"jsii-calc.DerivedStruct",},
-    })
-    return DoubleTrouble{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GiveMeStructs",
+		Method: "ReadDerivedNonPrimitive",
+		Args: []string{"jsii-calc.DerivedStruct",},
+	})
+	return DoubleTrouble{}
 }
 
 func (g *GiveMeStructs) ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GiveMeStructs",
-        Method: "ReadFirstNumber",
-        Args: []string{"@scope/jsii-calc-lib.MyFirstStruct",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GiveMeStructs",
+		Method: "ReadFirstNumber",
+		Args: []string{"@scope/jsii-calc-lib.MyFirstStruct",},
+	})
+	return 0.0
 }
 
 // GreeteeIface is the public interface for the custom type Greetee
 type GreeteeIface interface {
-    GetName() string
+	GetName() string
 }
 
 // These are some arguments you can pass to a method.
 // Struct proxy
 type Greetee struct {
-    // The name of the greetee.
-    Name string
+	// The name of the greetee.
+	Name string
 }
 
 func (g *Greetee) GetName() string {
-    return g.Name
+	return g.Name
 }
 
 
 // Class interface
 type GreetingAugmenterIface interface {
-    BetterGreeting(friendly scopejsiicalclib.IFriendly) string
+	BetterGreeting(friendly scopejsiicalclib.IFriendly) string
 }
 
 // Struct proxy
@@ -3953,139 +3953,139 @@ type GreetingAugmenter struct {
 }
 
 func NewGreetingAugmenter() GreetingAugmenterIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GreetingAugmenter",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &GreetingAugmenter{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GreetingAugmenter",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &GreetingAugmenter{}
 }
 
 func (g *GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendly) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "GreetingAugmenter",
-        Method: "BetterGreeting",
-        Args: []string{"@scope/jsii-calc-lib.IFriendly",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "GreetingAugmenter",
+		Method: "BetterGreeting",
+		Args: []string{"@scope/jsii-calc-lib.IFriendly",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // We can return an anonymous interface implementation from an override without losing the interface declarations.
 type IAnonymousImplementationProvider interface {
-    ProvideAsClass() Implementation
-    ProvideAsInterface() IAnonymouslyImplementMe
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
 }
 
 type IAnonymouslyImplementMe interface {
-    Verb() string
-    GetValue() float64
+	Verb() string
+	GetValue() float64
 }
 
 type IAnotherPublicInterface interface {
-    GetA() string
+	GetA() string
 }
 
 type IBell interface {
-    Ring()
+	Ring()
 }
 
 // Takes the object parameter as an interface.
 type IBellRinger interface {
-    YourTurn(bell IBell)
+	YourTurn(bell IBell)
 }
 
 // Takes the object parameter as a calss.
 type IConcreteBellRinger interface {
-    YourTurn(bell Bell)
+	YourTurn(bell Bell)
 }
 
 // Deprecated: useless interface
 type IDeprecatedInterface interface {
-    // Deprecated: services no purpose
-    Method()
-    // Deprecated: could be better
-    GetMutableProperty() float64
+	// Deprecated: services no purpose
+	Method()
+	// Deprecated: could be better
+	GetMutableProperty() float64
 }
 
 // Experimental.
 type IExperimentalInterface interface {
-    // Experimental.
-    Method()
-    // Experimental.
-    GetMutableProperty() float64
+	// Experimental.
+	Method()
+	// Experimental.
+	GetMutableProperty() float64
 }
 
 type IExtendsPrivateInterface interface {
-    GetMoreThings() []string
-    GetPrivate() string
+	GetMoreThings() []string
+	GetPrivate() string
 }
 
 type IExternalInterface interface {
-    Method()
-    GetMutableProperty() float64
+	Method()
+	GetMutableProperty() float64
 }
 
 // Even friendlier classes can implement this interface.
 type IFriendlier interface {
-    scopejsiicalclib.IFriendly
-    // Say farewell.
-    Farewell() string
-    // Say goodbye.
-    //
-    // Returns: A goodbye blessing.
-    Goodbye() string
+	scopejsiicalclib.IFriendly
+	// Say farewell.
+	Farewell() string
+	// Say goodbye.
+	//
+	// Returns: A goodbye blessing.
+	Goodbye() string
 }
 
 type IFriendlyRandomGenerator interface {
-    IRandomNumberGenerator
-    scopejsiicalclib.IFriendly
+	IRandomNumberGenerator
+	scopejsiicalclib.IFriendly
 }
 
 // awslabs/jsii#220 Abstract return type.
 type IInterfaceImplementedByAbstractClass interface {
-    GetPropFromInterface() string
+	GetPropFromInterface() string
 }
 
 // Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
 type IInterfaceThatShouldNotBeADataType interface {
-    IInterfaceWithMethods
-    GetOtherValue() string
+	IInterfaceWithMethods
+	GetOtherValue() string
 }
 
 type IInterfaceWithInternal interface {
-    Visible()
+	Visible()
 }
 
 type IInterfaceWithMethods interface {
-    DoThings()
-    GetValue() string
+	DoThings()
+	GetValue() string
 }
 
 // awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
 type IInterfaceWithOptionalMethodArguments interface {
-    Hello(arg1 string, arg2 float64)
+	Hello(arg1 string, arg2 float64)
 }
 
 type IInterfaceWithProperties interface {
-    GetReadOnlyString() string
-    GetReadWriteString() string
+	GetReadOnlyString() string
+	GetReadWriteString() string
 }
 
 type IInterfaceWithPropertiesExtension interface {
-    IInterfaceWithProperties
-    GetFoo() float64
+	IInterfaceWithProperties
+	GetFoo() float64
 }
 
 type Ijsii417Derived interface {
-    Ijsii417PublicBaseOfBase
-    Bar()
-    Baz()
-    GetProperty() string
+	Ijsii417PublicBaseOfBase
+	Bar()
+	Baz()
+	GetProperty() string
 }
 
 type Ijsii417PublicBaseOfBase interface {
-    Foo()
-    GetHasRoot() bool
+	Foo()
+	GetHasRoot() bool
 }
 
 type IJsii487External interface {
@@ -4098,134 +4098,134 @@ type IJsii496 interface {
 }
 
 type IMutableObjectLiteral interface {
-    GetValue() string
+	GetValue() string
 }
 
 type INonInternalInterface interface {
-    IAnotherPublicInterface
-    GetB() string
-    GetC() string
+	IAnotherPublicInterface
+	GetB() string
+	GetC() string
 }
 
 // Make sure that setters are properly called on objects with interfaces.
 type IObjectWithProperty interface {
-    WasSet() bool
-    GetProperty() string
+	WasSet() bool
+	GetProperty() string
 }
 
 // Checks that optional result from interface method code generates correctly.
 type IOptionalMethod interface {
-    Optional() string
+	Optional() string
 }
 
 type IPrivatelyImplemented interface {
-    GetSuccess() bool
+	GetSuccess() bool
 }
 
 type IPublicInterface interface {
-    Bye() string
+	Bye() string
 }
 
 type IPublicInterface2 interface {
-    Ciao() string
+	Ciao() string
 }
 
 // Generates random numbers.
 type IRandomNumberGenerator interface {
-    // Returns another random number.
-    //
-    // Returns: A random number.
-    Next() float64
+	// Returns another random number.
+	//
+	// Returns: A random number.
+	Next() float64
 }
 
 // Returns a subclass of a known class which implements an interface.
 type IReturnJsii976 interface {
-    GetFoo() float64
+	GetFoo() float64
 }
 
 type IReturnsNumber interface {
-    ObtainNumber() scopejsiicalclib.IDoublable
-    GetNumberProp() scopejsiicalclib.Number
+	ObtainNumber() scopejsiicalclib.IDoublable
+	GetNumberProp() scopejsiicalclib.Number
 }
 
 type IStableInterface interface {
-    Method()
-    GetMutableProperty() float64
+	Method()
+	GetMutableProperty() float64
 }
 
 // Verifies that a "pure" implementation of an interface works correctly.
 type IStructReturningDelegate interface {
-    ReturnStruct() StructB
+	ReturnStruct() StructB
 }
 
 // Implement this interface.
 type IWallClock interface {
-    // Returns the current time, formatted as an ISO-8601 string.
-    Iso8601Now() string
+	// Returns the current time, formatted as an ISO-8601 string.
+	Iso8601Now() string
 }
 
 // Class interface
 type ImplementInternalInterfaceIface interface {
-    GetProp() string
-    SetProp(val string)
+	GetProp() string
+	SetProp(val string)
 }
 
 // Struct proxy
 type ImplementInternalInterface struct {
-    Prop string
+	Prop string
 }
 
 func (i *ImplementInternalInterface) GetProp() string {
-    return i.Prop
+	return i.Prop
 }
 
 
 func NewImplementInternalInterface() ImplementInternalInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementInternalInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ImplementInternalInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementInternalInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ImplementInternalInterface{}
 }
 
 func (i *ImplementInternalInterface) SetProp(val string) {
-    i.Prop = val
+	i.Prop = val
 }
 
 // Class interface
 type ImplementationIface interface {
-    GetValue() float64
-    SetValue(val float64)
+	GetValue() float64
+	SetValue(val float64)
 }
 
 // Struct proxy
 type Implementation struct {
-    Value float64
+	Value float64
 }
 
 func (i *Implementation) GetValue() float64 {
-    return i.Value
+	return i.Value
 }
 
 
 func NewImplementation() ImplementationIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Implementation",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Implementation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Implementation",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Implementation{}
 }
 
 func (i *Implementation) SetValue(val float64) {
-    i.Value = val
+	i.Value = val
 }
 
 // Class interface
 type ImplementsInterfaceWithInternalIface interface {
-    IInterfaceWithInternal
-    Visible()
+	IInterfaceWithInternal
+	Visible()
 }
 
 // Struct proxy
@@ -4233,26 +4233,26 @@ type ImplementsInterfaceWithInternal struct {
 }
 
 func NewImplementsInterfaceWithInternal() ImplementsInterfaceWithInternalIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementsInterfaceWithInternal",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ImplementsInterfaceWithInternal{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementsInterfaceWithInternal",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ImplementsInterfaceWithInternal{}
 }
 
 func (i *ImplementsInterfaceWithInternal) Visible() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementsInterfaceWithInternal",
-        Method: "Visible",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementsInterfaceWithInternal",
+		Method: "Visible",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type ImplementsInterfaceWithInternalSubclassIface interface {
-    IInterfaceWithInternal
-    Visible()
+	IInterfaceWithInternal
+	Visible()
 }
 
 // Struct proxy
@@ -4260,83 +4260,83 @@ type ImplementsInterfaceWithInternalSubclass struct {
 }
 
 func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInternalSubclassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementsInterfaceWithInternalSubclass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ImplementsInterfaceWithInternalSubclass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementsInterfaceWithInternalSubclass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ImplementsInterfaceWithInternalSubclass{}
 }
 
 func (i *ImplementsInterfaceWithInternalSubclass) Visible() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementsInterfaceWithInternalSubclass",
-        Method: "Visible",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementsInterfaceWithInternalSubclass",
+		Method: "Visible",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type ImplementsPrivateInterfaceIface interface {
-    GetPrivate() string
-    SetPrivate(val string)
+	GetPrivate() string
+	SetPrivate(val string)
 }
 
 // Struct proxy
 type ImplementsPrivateInterface struct {
-    Private string
+	Private string
 }
 
 func (i *ImplementsPrivateInterface) GetPrivate() string {
-    return i.Private
+	return i.Private
 }
 
 
 func NewImplementsPrivateInterface() ImplementsPrivateInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ImplementsPrivateInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ImplementsPrivateInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ImplementsPrivateInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ImplementsPrivateInterface{}
 }
 
 func (i *ImplementsPrivateInterface) SetPrivate(val string) {
-    i.Private = val
+	i.Private = val
 }
 
 // ImplictBaseOfBaseIface is the public interface for the custom type ImplictBaseOfBase
 type ImplictBaseOfBaseIface interface {
-    GetFoo() scopejsiicalcbaseofbase.Very
-    GetBar() string
-    GetGoo() string
+	GetFoo() scopejsiicalcbaseofbase.Very
+	GetBar() string
+	GetGoo() string
 }
 
 // Struct proxy
 type ImplictBaseOfBase struct {
-    Foo scopejsiicalcbaseofbase.Very
-    Bar string
-    Goo string
+	Foo scopejsiicalcbaseofbase.Very
+	Bar string
+	Goo string
 }
 
 func (i *ImplictBaseOfBase) GetFoo() scopejsiicalcbaseofbase.Very {
-    return i.Foo
+	return i.Foo
 }
 
 func (i *ImplictBaseOfBase) GetBar() string {
-    return i.Bar
+	return i.Bar
 }
 
 func (i *ImplictBaseOfBase) GetGoo() string {
-    return i.Goo
+	return i.Goo
 }
 
 
 // Class interface
 type InbetweenClassIface interface {
-    IPublicInterface2
-    Hello()
-    Ciao() string
+	IPublicInterface2
+	Hello()
+	Ciao() string
 }
 
 // Struct proxy
@@ -4344,29 +4344,29 @@ type InbetweenClass struct {
 }
 
 func NewInbetweenClass() InbetweenClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InbetweenClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &InbetweenClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InbetweenClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &InbetweenClass{}
 }
 
 func (i *InbetweenClass) Hello() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InbetweenClass",
-        Method: "Hello",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InbetweenClass",
+		Method: "Hello",
+		Args: []string{},
+	})
 }
 
 func (i *InbetweenClass) Ciao() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InbetweenClass",
-        Method: "Ciao",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InbetweenClass",
+		Method: "Ciao",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
@@ -4381,39 +4381,39 @@ type InterfaceCollections struct {
 }
 
 func InterfaceCollections_ListOfInterfaces() []IBell {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InterfaceCollections",
-        Method: "ListOfInterfaces",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InterfaceCollections",
+		Method: "ListOfInterfaces",
+		Args: []string{},
+	})
+	return nil
 }
 
 func InterfaceCollections_ListOfStructs() []StructA {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InterfaceCollections",
-        Method: "ListOfStructs",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InterfaceCollections",
+		Method: "ListOfStructs",
+		Args: []string{},
+	})
+	return nil
 }
 
 func InterfaceCollections_MapOfInterfaces() map[string]IBell {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InterfaceCollections",
-        Method: "MapOfInterfaces",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InterfaceCollections",
+		Method: "MapOfInterfaces",
+		Args: []string{},
+	})
+	return nil
 }
 
 func InterfaceCollections_MapOfStructs() map[string]StructA {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InterfaceCollections",
-        Method: "MapOfStructs",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InterfaceCollections",
+		Method: "MapOfStructs",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
@@ -4426,17 +4426,17 @@ type InterfacesMaker struct {
 }
 
 func InterfacesMaker_MakeInterfaces(count float64) []scopejsiicalclib.IDoublable {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InterfacesMaker",
-        Method: "MakeInterfaces",
-        Args: []string{"number",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InterfacesMaker",
+		Method: "MakeInterfaces",
+		Args: []string{"number",},
+	})
+	return nil
 }
 
 // Class interface
 type IsomorphismIface interface {
-    Myself() Isomorphism
+	Myself() Isomorphism
 }
 
 // Checks the "same instance" isomorphism is preserved within the constructor.
@@ -4448,149 +4448,149 @@ type Isomorphism struct {
 }
 
 func NewIsomorphism() IsomorphismIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Isomorphism",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Isomorphism{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Isomorphism",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Isomorphism{}
 }
 
 func (i *Isomorphism) Myself() Isomorphism {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Isomorphism",
-        Method: "Myself",
-        Args: []string{},
-    })
-    return Isomorphism{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Isomorphism",
+		Method: "Myself",
+		Args: []string{},
+	})
+	return Isomorphism{}
 }
 
 // Class interface
 type Jsii417DerivedIface interface {
-    GetHasRoot() bool
-    SetHasRoot(val bool)
-    GetProperty() string
-    Foo()
-    Bar()
-    Baz()
+	GetHasRoot() bool
+	SetHasRoot(val bool)
+	GetProperty() string
+	Foo()
+	Bar()
+	Baz()
 }
 
 // Struct proxy
 type Jsii417Derived struct {
-    HasRoot bool
-    Property string
+	HasRoot bool
+	Property string
 }
 
 func (j *Jsii417Derived) GetHasRoot() bool {
-    return j.HasRoot
+	return j.HasRoot
 }
 
 func (j *Jsii417Derived) GetProperty() string {
-    return j.Property
+	return j.Property
 }
 
 
 func NewJsii417Derived(property string) Jsii417DerivedIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417Derived",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &Jsii417Derived{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417Derived",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &Jsii417Derived{}
 }
 
 func (j *Jsii417Derived) SetHasRoot(val bool) {
-    j.HasRoot = val
+	j.HasRoot = val
 }
 
 func (j *Jsii417Derived) SetProperty(val string) {
-    j.Property = val
+	j.Property = val
 }
 
 func Jsii417Derived_MakeInstance() Jsii417PublicBaseOfBase {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417Derived",
-        Method: "MakeInstance",
-        Args: []string{},
-    })
-    return Jsii417PublicBaseOfBase{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417Derived",
+		Method: "MakeInstance",
+		Args: []string{},
+	})
+	return Jsii417PublicBaseOfBase{}
 }
 
 func (j *Jsii417Derived) Foo() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417Derived",
-        Method: "Foo",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417Derived",
+		Method: "Foo",
+		Args: []string{},
+	})
 }
 
 func (j *Jsii417Derived) Bar() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417Derived",
-        Method: "Bar",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417Derived",
+		Method: "Bar",
+		Args: []string{},
+	})
 }
 
 func (j *Jsii417Derived) Baz() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417Derived",
-        Method: "Baz",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417Derived",
+		Method: "Baz",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type Jsii417PublicBaseOfBaseIface interface {
-    GetHasRoot() bool
-    SetHasRoot(val bool)
-    Foo()
+	GetHasRoot() bool
+	SetHasRoot(val bool)
+	Foo()
 }
 
 // Struct proxy
 type Jsii417PublicBaseOfBase struct {
-    HasRoot bool
+	HasRoot bool
 }
 
 func (j *Jsii417PublicBaseOfBase) GetHasRoot() bool {
-    return j.HasRoot
+	return j.HasRoot
 }
 
 
 func NewJsii417PublicBaseOfBase() Jsii417PublicBaseOfBaseIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417PublicBaseOfBase",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Jsii417PublicBaseOfBase{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417PublicBaseOfBase",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Jsii417PublicBaseOfBase{}
 }
 
 func (j *Jsii417PublicBaseOfBase) SetHasRoot(val bool) {
-    j.HasRoot = val
+	j.HasRoot = val
 }
 
 func Jsii417PublicBaseOfBase_MakeInstance() Jsii417PublicBaseOfBase {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417PublicBaseOfBase",
-        Method: "MakeInstance",
-        Args: []string{},
-    })
-    return Jsii417PublicBaseOfBase{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417PublicBaseOfBase",
+		Method: "MakeInstance",
+		Args: []string{},
+	})
+	return Jsii417PublicBaseOfBase{}
 }
 
 func (j *Jsii417PublicBaseOfBase) Foo() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii417PublicBaseOfBase",
-        Method: "Foo",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii417PublicBaseOfBase",
+		Method: "Foo",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type JsObjectLiteralForInterfaceIface interface {
-    GiveMeFriendly() scopejsiicalclib.IFriendly
-    GiveMeFriendlyGenerator() IFriendlyRandomGenerator
+	GiveMeFriendly() scopejsiicalclib.IFriendly
+	GiveMeFriendlyGenerator() IFriendlyRandomGenerator
 }
 
 // Struct proxy
@@ -4598,35 +4598,35 @@ type JsObjectLiteralForInterface struct {
 }
 
 func NewJsObjectLiteralForInterface() JsObjectLiteralForInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralForInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &JsObjectLiteralForInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralForInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &JsObjectLiteralForInterface{}
 }
 
 func (j *JsObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendly {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralForInterface",
-        Method: "GiveMeFriendly",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralForInterface",
+		Method: "GiveMeFriendly",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (j *JsObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomGenerator {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralForInterface",
-        Method: "GiveMeFriendlyGenerator",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralForInterface",
+		Method: "GiveMeFriendlyGenerator",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type JsObjectLiteralToNativeIface interface {
-    ReturnLiteral() JsObjectLiteralToNativeClass
+	ReturnLiteral() JsObjectLiteralToNativeClass
 }
 
 // Struct proxy
@@ -4634,564 +4634,564 @@ type JsObjectLiteralToNative struct {
 }
 
 func NewJsObjectLiteralToNative() JsObjectLiteralToNativeIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralToNative",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &JsObjectLiteralToNative{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralToNative",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &JsObjectLiteralToNative{}
 }
 
 func (j *JsObjectLiteralToNative) ReturnLiteral() JsObjectLiteralToNativeClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralToNative",
-        Method: "ReturnLiteral",
-        Args: []string{},
-    })
-    return JsObjectLiteralToNativeClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralToNative",
+		Method: "ReturnLiteral",
+		Args: []string{},
+	})
+	return JsObjectLiteralToNativeClass{}
 }
 
 // Class interface
 type JsObjectLiteralToNativeClassIface interface {
-    GetPropA() string
-    SetPropA(val string)
-    GetPropB() float64
-    SetPropB(val float64)
+	GetPropA() string
+	SetPropA(val string)
+	GetPropB() float64
+	SetPropB(val float64)
 }
 
 // Struct proxy
 type JsObjectLiteralToNativeClass struct {
-    PropA string
-    PropB float64
+	PropA string
+	PropB float64
 }
 
 func (j *JsObjectLiteralToNativeClass) GetPropA() string {
-    return j.PropA
+	return j.PropA
 }
 
 func (j *JsObjectLiteralToNativeClass) GetPropB() float64 {
-    return j.PropB
+	return j.PropB
 }
 
 
 func NewJsObjectLiteralToNativeClass() JsObjectLiteralToNativeClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsObjectLiteralToNativeClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &JsObjectLiteralToNativeClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsObjectLiteralToNativeClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &JsObjectLiteralToNativeClass{}
 }
 
 func (j *JsObjectLiteralToNativeClass) SetPropA(val string) {
-    j.PropA = val
+	j.PropA = val
 }
 
 func (j *JsObjectLiteralToNativeClass) SetPropB(val float64) {
-    j.PropB = val
+	j.PropB = val
 }
 
 // Class interface
 type JavaReservedWordsIface interface {
-    GetWhile() string
-    SetWhile(val string)
-    Abstract()
-    Assert()
-    Boolean()
-    Break()
-    Byte()
-    Case()
-    Catch()
-    Char()
-    Class()
-    Const()
-    Continue()
-    Default()
-    Do()
-    Double()
-    Else()
-    Enum()
-    Extends()
-    False()
-    Final()
-    Finally()
-    Float()
-    For()
-    Goto()
-    If()
-    Implements()
-    Import()
-    Instanceof()
-    Int()
-    Interface()
-    Long()
-    Native()
-    New()
-    Null()
-    Package()
-    Private()
-    Protected()
-    Public()
-    Return()
-    Short()
-    Static()
-    Strictfp()
-    Super()
-    Switch()
-    Synchronized()
-    This()
-    Throw()
-    Throws()
-    Transient()
-    True()
-    Try()
-    Void()
-    Volatile()
+	GetWhile() string
+	SetWhile(val string)
+	Abstract()
+	Assert()
+	Boolean()
+	Break()
+	Byte()
+	Case()
+	Catch()
+	Char()
+	Class()
+	Const()
+	Continue()
+	Default()
+	Do()
+	Double()
+	Else()
+	Enum()
+	Extends()
+	False()
+	Final()
+	Finally()
+	Float()
+	For()
+	Goto()
+	If()
+	Implements()
+	Import()
+	Instanceof()
+	Int()
+	Interface()
+	Long()
+	Native()
+	New()
+	Null()
+	Package()
+	Private()
+	Protected()
+	Public()
+	Return()
+	Short()
+	Static()
+	Strictfp()
+	Super()
+	Switch()
+	Synchronized()
+	This()
+	Throw()
+	Throws()
+	Transient()
+	True()
+	Try()
+	Void()
+	Volatile()
 }
 
 // Struct proxy
 type JavaReservedWords struct {
-    While string
+	While string
 }
 
 func (j *JavaReservedWords) GetWhile() string {
-    return j.While
+	return j.While
 }
 
 
 func NewJavaReservedWords() JavaReservedWordsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &JavaReservedWords{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &JavaReservedWords{}
 }
 
 func (j *JavaReservedWords) SetWhile(val string) {
-    j.While = val
+	j.While = val
 }
 
 func (j *JavaReservedWords) Abstract() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Abstract",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Abstract",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Assert() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Assert",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Assert",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Boolean() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Boolean",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Boolean",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Break() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Break",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Break",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Byte() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Byte",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Byte",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Case() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Case",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Case",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Catch() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Catch",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Catch",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Char() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Char",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Char",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Class() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Class",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Class",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Const() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Const",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Const",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Continue() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Continue",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Continue",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Default() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Default",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Default",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Do() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Do",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Do",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Double() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Double",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Double",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Else() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Else",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Else",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Enum() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Enum",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Enum",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Extends() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Extends",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Extends",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) False() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "False",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "False",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Final() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Final",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Final",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Finally() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Finally",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Finally",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Float() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Float",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Float",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) For() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "For",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "For",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Goto() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Goto",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Goto",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) If() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "If",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "If",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Implements() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Implements",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Implements",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Import() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Import",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Import",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Instanceof() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Instanceof",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Instanceof",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Int() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Int",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Int",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Interface() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Interface",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Interface",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Long() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Long",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Long",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Native() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Native",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Native",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) New() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "New",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "New",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Null() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Null",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Null",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Package() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Package",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Package",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Private() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Private",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Private",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Protected() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Protected",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Protected",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Public() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Public",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Public",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Return() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Return",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Return",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Short() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Short",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Short",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Static() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Static",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Static",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Strictfp() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Strictfp",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Strictfp",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Super() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Super",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Super",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Switch() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Switch",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Switch",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Synchronized() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Synchronized",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Synchronized",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) This() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "This",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "This",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Throw() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Throw",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Throw",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Throws() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Throws",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Throws",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Transient() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Transient",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Transient",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) True() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "True",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "True",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Try() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Try",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Try",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Void() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Void",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Void",
+		Args: []string{},
+	})
 }
 
 func (j *JavaReservedWords) Volatile() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JavaReservedWords",
-        Method: "Volatile",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JavaReservedWords",
+		Method: "Volatile",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type Jsii487DerivedIface interface {
-    IJsii487External2
-    IJsii487External
+	IJsii487External2
+	IJsii487External
 }
 
 // Struct proxy
@@ -5199,17 +5199,17 @@ type Jsii487Derived struct {
 }
 
 func NewJsii487Derived() Jsii487DerivedIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii487Derived",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Jsii487Derived{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii487Derived",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Jsii487Derived{}
 }
 
 // Class interface
 type Jsii496DerivedIface interface {
-    IJsii496
+	IJsii496
 }
 
 // Struct proxy
@@ -5217,43 +5217,43 @@ type Jsii496Derived struct {
 }
 
 func NewJsii496Derived() Jsii496DerivedIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Jsii496Derived",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Jsii496Derived{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Jsii496Derived",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Jsii496Derived{}
 }
 
 // Class interface
 type JsiiAgentIface interface {
-    GetValue() string
-    SetValue(val string)
+	GetValue() string
+	SetValue(val string)
 }
 
 // Host runtime version should be set via JSII_AGENT.
 // Struct proxy
 type JsiiAgent struct {
-    // Returns the value of the JSII_AGENT environment variable.
-    Value string
+	// Returns the value of the JSII_AGENT environment variable.
+	Value string
 }
 
 func (j *JsiiAgent) GetValue() string {
-    return j.Value
+	return j.Value
 }
 
 
 func NewJsiiAgent() JsiiAgentIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsiiAgent",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &JsiiAgent{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsiiAgent",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &JsiiAgent{}
 }
 
 func (j *JsiiAgent) SetValue(val string) {
-    j.Value = val
+	j.Value = val
 }
 
 // Class interface
@@ -5268,528 +5268,528 @@ type JsonFormatter struct {
 }
 
 func JsonFormatter_AnyArray() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyArray",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyArray",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyBooleanFalse() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyBooleanFalse",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyBooleanFalse",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyBooleanTrue() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyBooleanTrue",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyBooleanTrue",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyDate() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyDate",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyDate",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyEmptyString() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyEmptyString",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyEmptyString",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyFunction() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyFunction",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyFunction",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyHash() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyHash",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyHash",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyNull() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyNull",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyNull",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyNumber() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyNumber",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyNumber",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyRef() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyRef",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyRef",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyString() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyString",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyString",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyUndefined() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyUndefined",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyUndefined",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_AnyZero() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "AnyZero",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "AnyZero",
+		Args: []string{},
+	})
+	return nil
 }
 
 func JsonFormatter_Stringify(value jsii.Any) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "JsonFormatter",
-        Method: "Stringify",
-        Args: []string{"any",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "JsonFormatter",
+		Method: "Stringify",
+		Args: []string{"any",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type LevelOneIface interface {
-    GetProps() LevelOneProps
-    SetProps(val LevelOneProps)
+	GetProps() LevelOneProps
+	SetProps(val LevelOneProps)
 }
 
 // Validates that nested classes get correct code generation for the occasional forward reference.
 // Struct proxy
 type LevelOne struct {
-    Props LevelOneProps
+	Props LevelOneProps
 }
 
 func (l *LevelOne) GetProps() LevelOneProps {
-    return l.Props
+	return l.Props
 }
 
 
 func NewLevelOne(props LevelOneProps) LevelOneIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "LevelOne",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.LevelOneProps",},
-    })
-    return &LevelOne{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "LevelOne",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.LevelOneProps",},
+	})
+	return &LevelOne{}
 }
 
 func (l *LevelOne) SetProps(val LevelOneProps) {
-    l.Props = val
+	l.Props = val
 }
 
 // PropBooleanValueIface is the public interface for the custom type PropBooleanValue
 type PropBooleanValueIface interface {
-    GetValue() bool
+	GetValue() bool
 }
 
 // Struct proxy
 type PropBooleanValue struct {
-    Value bool
+	Value bool
 }
 
 func (p *PropBooleanValue) GetValue() bool {
-    return p.Value
+	return p.Value
 }
 
 
 // PropPropertyIface is the public interface for the custom type PropProperty
 type PropPropertyIface interface {
-    GetProp() PropBooleanValue
+	GetProp() PropBooleanValue
 }
 
 // Struct proxy
 type PropProperty struct {
-    Prop PropBooleanValue
+	Prop PropBooleanValue
 }
 
 func (p *PropProperty) GetProp() PropBooleanValue {
-    return p.Prop
+	return p.Prop
 }
 
 
 // LevelOnePropsIface is the public interface for the custom type LevelOneProps
 type LevelOnePropsIface interface {
-    GetProp() PropProperty
+	GetProp() PropProperty
 }
 
 // Struct proxy
 type LevelOneProps struct {
-    Prop PropProperty
+	Prop PropProperty
 }
 
 func (l *LevelOneProps) GetProp() PropProperty {
-    return l.Prop
+	return l.Prop
 }
 
 
 // LoadBalancedFargateServicePropsIface is the public interface for the custom type LoadBalancedFargateServiceProps
 type LoadBalancedFargateServicePropsIface interface {
-    GetContainerPort() float64
-    GetCpu() string
-    GetMemoryMiB() string
-    GetPublicLoadBalancer() bool
-    GetPublicTasks() bool
+	GetContainerPort() float64
+	GetCpu() string
+	GetMemoryMiB() string
+	GetPublicLoadBalancer() bool
+	GetPublicTasks() bool
 }
 
 // jsii#298: show default values in sphinx documentation, and respect newlines.
 // Struct proxy
 type LoadBalancedFargateServiceProps struct {
-    // The container port of the application load balancer attached to your Fargate service.
-    // 
-    // Corresponds to container port mapping.
-    ContainerPort float64
-    // The number of cpu units used by the task.
-    // 
-    // Valid values, which determines your range of valid values for the memory parameter:
-    // 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
-    // 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
-    // 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
-    // 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
-    // 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
-    // 
-    // This default is set in the underlying FargateTaskDefinition construct.
-    Cpu string
-    // The amount (in MiB) of memory used by the task.
-    // 
-    // This field is required and you must use one of the following values, which determines your range of valid values
-    // for the cpu parameter:
-    // 
-    // 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
-    // 
-    // 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
-    // 
-    // 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
-    // 
-    // Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
-    // 
-    // Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
-    // 
-    // This default is set in the underlying FargateTaskDefinition construct.
-    MemoryMiB string
-    // Determines whether the Application Load Balancer will be internet-facing.
-    PublicLoadBalancer bool
-    // Determines whether your Fargate Service will be assigned a public IP address.
-    PublicTasks bool
+	// The container port of the application load balancer attached to your Fargate service.
+	// 
+	// Corresponds to container port mapping.
+	ContainerPort float64
+	// The number of cpu units used by the task.
+	// 
+	// Valid values, which determines your range of valid values for the memory parameter:
+	// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+	// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+	// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+	// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+	// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+	// 
+	// This default is set in the underlying FargateTaskDefinition construct.
+	Cpu string
+	// The amount (in MiB) of memory used by the task.
+	// 
+	// This field is required and you must use one of the following values, which determines your range of valid values
+	// for the cpu parameter:
+	// 
+	// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+	// 
+	// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+	// 
+	// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+	// 
+	// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+	// 
+	// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+	// 
+	// This default is set in the underlying FargateTaskDefinition construct.
+	MemoryMiB string
+	// Determines whether the Application Load Balancer will be internet-facing.
+	PublicLoadBalancer bool
+	// Determines whether your Fargate Service will be assigned a public IP address.
+	PublicTasks bool
 }
 
 func (l *LoadBalancedFargateServiceProps) GetContainerPort() float64 {
-    return l.ContainerPort
+	return l.ContainerPort
 }
 
 func (l *LoadBalancedFargateServiceProps) GetCpu() string {
-    return l.Cpu
+	return l.Cpu
 }
 
 func (l *LoadBalancedFargateServiceProps) GetMemoryMiB() string {
-    return l.MemoryMiB
+	return l.MemoryMiB
 }
 
 func (l *LoadBalancedFargateServiceProps) GetPublicLoadBalancer() bool {
-    return l.PublicLoadBalancer
+	return l.PublicLoadBalancer
 }
 
 func (l *LoadBalancedFargateServiceProps) GetPublicTasks() bool {
-    return l.PublicTasks
+	return l.PublicTasks
 }
 
 
 // Class interface
 type MethodNamedPropertyIface interface {
-    GetElite() float64
-    SetElite(val float64)
-    Property() string
+	GetElite() float64
+	SetElite(val float64)
+	Property() string
 }
 
 // Struct proxy
 type MethodNamedProperty struct {
-    Elite float64
+	Elite float64
 }
 
 func (m *MethodNamedProperty) GetElite() float64 {
-    return m.Elite
+	return m.Elite
 }
 
 
 func NewMethodNamedProperty() MethodNamedPropertyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "MethodNamedProperty",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &MethodNamedProperty{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "MethodNamedProperty",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &MethodNamedProperty{}
 }
 
 func (m *MethodNamedProperty) SetElite(val float64) {
-    m.Elite = val
+	m.Elite = val
 }
 
 func (m *MethodNamedProperty) Property() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "MethodNamedProperty",
-        Method: "Property",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "MethodNamedProperty",
+		Method: "Property",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type MultiplyIface interface {
-    scopejsiicalclib.IFriendly
-    IFriendlier
-    scopejsiicalclib.IFriendly
-    IRandomNumberGenerator
-    GetValue() float64
-    SetValue(val float64)
-    GetLhs() scopejsiicalclib.NumericValue
-    SetLhs(val scopejsiicalclib.NumericValue)
-    GetRhs() scopejsiicalclib.NumericValue
-    SetRhs(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
-    Hello() string
-    Farewell() string
-    Goodbye() string
-    Next() float64
+	scopejsiicalclib.IFriendly
+	IFriendlier
+	scopejsiicalclib.IFriendly
+	IRandomNumberGenerator
+	GetValue() float64
+	SetValue(val float64)
+	GetLhs() scopejsiicalclib.NumericValue
+	SetLhs(val scopejsiicalclib.NumericValue)
+	GetRhs() scopejsiicalclib.NumericValue
+	SetRhs(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
+	Hello() string
+	Farewell() string
+	Goodbye() string
+	Next() float64
 }
 
 // The "*" binary operation.
 // Struct proxy
 type Multiply struct {
-    // (deprecated) The value.
-    Value float64
-    // Left-hand side operand.
-    Lhs scopejsiicalclib.NumericValue
-    // Right-hand side operand.
-    Rhs scopejsiicalclib.NumericValue
+	// (deprecated) The value.
+	Value float64
+	// Left-hand side operand.
+	Lhs scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs scopejsiicalclib.NumericValue
 }
 
 func (m *Multiply) GetValue() float64 {
-    return m.Value
+	return m.Value
 }
 
 func (m *Multiply) GetLhs() scopejsiicalclib.NumericValue {
-    return m.Lhs
+	return m.Lhs
 }
 
 func (m *Multiply) GetRhs() scopejsiicalclib.NumericValue {
-    return m.Rhs
+	return m.Rhs
 }
 
 
 // Creates a BinaryOperation.
 func NewMultiply(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) MultiplyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &Multiply{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &Multiply{}
 }
 
 func (m *Multiply) SetValue(val float64) {
-    m.Value = val
+	m.Value = val
 }
 
 func (m *Multiply) SetLhs(val scopejsiicalclib.NumericValue) {
-    m.Lhs = val
+	m.Lhs = val
 }
 
 func (m *Multiply) SetRhs(val scopejsiicalclib.NumericValue) {
-    m.Rhs = val
+	m.Rhs = val
 }
 
 func (m *Multiply) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (m *Multiply) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (m *Multiply) Hello() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (m *Multiply) Farewell() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "Farewell",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "Farewell",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (m *Multiply) Goodbye() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "Goodbye",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "Goodbye",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (m *Multiply) Next() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Multiply",
-        Method: "Next",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Multiply",
+		Method: "Next",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type NegateIface interface {
-    IFriendlier
-    scopejsiicalclib.IFriendly
-    GetValue() float64
-    SetValue(val float64)
-    GetOperand() scopejsiicalclib.NumericValue
-    SetOperand(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
-    Farewell() string
-    Goodbye() string
-    Hello() string
+	IFriendlier
+	scopejsiicalclib.IFriendly
+	GetValue() float64
+	SetValue(val float64)
+	GetOperand() scopejsiicalclib.NumericValue
+	SetOperand(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
+	Farewell() string
+	Goodbye() string
+	Hello() string
 }
 
 // The negation operation ("-value").
 // Struct proxy
 type Negate struct {
-    // (deprecated) The value.
-    Value float64
-    Operand scopejsiicalclib.NumericValue
+	// (deprecated) The value.
+	Value float64
+	Operand scopejsiicalclib.NumericValue
 }
 
 func (n *Negate) GetValue() float64 {
-    return n.Value
+	return n.Value
 }
 
 func (n *Negate) GetOperand() scopejsiicalclib.NumericValue {
-    return n.Operand
+	return n.Operand
 }
 
 
 func NewNegate(operand scopejsiicalclib.NumericValue) NegateIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &Negate{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &Negate{}
 }
 
 func (n *Negate) SetValue(val float64) {
-    n.Value = val
+	n.Value = val
 }
 
 func (n *Negate) SetOperand(val scopejsiicalclib.NumericValue) {
-    n.Operand = val
+	n.Operand = val
 }
 
 func (n *Negate) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (n *Negate) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (n *Negate) Farewell() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "Farewell",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "Farewell",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (n *Negate) Goodbye() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "Goodbye",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "Goodbye",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (n *Negate) Hello() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Negate",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Negate",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
@@ -5801,223 +5801,223 @@ type NestedClassInstance struct {
 }
 
 func NestedClassInstance_MakeInstance() submodule.NestedClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NestedClassInstance",
-        Method: "MakeInstance",
-        Args: []string{},
-    })
-    return submodule.NestedClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NestedClassInstance",
+		Method: "MakeInstance",
+		Args: []string{},
+	})
+	return submodule.NestedClass{}
 }
 
 // NestedStructIface is the public interface for the custom type NestedStruct
 type NestedStructIface interface {
-    GetNumberProp() float64
+	GetNumberProp() float64
 }
 
 // Struct proxy
 type NestedStruct struct {
-    // When provided, must be > 0.
-    NumberProp float64
+	// When provided, must be > 0.
+	NumberProp float64
 }
 
 func (n *NestedStruct) GetNumberProp() float64 {
-    return n.NumberProp
+	return n.NumberProp
 }
 
 
 // Class interface
 type NodeStandardLibraryIface interface {
-    GetOsPlatform() string
-    SetOsPlatform(val string)
-    CryptoSha256() string
-    FsReadFile() string
-    FsReadFileSync() string
+	GetOsPlatform() string
+	SetOsPlatform(val string)
+	CryptoSha256() string
+	FsReadFile() string
+	FsReadFileSync() string
 }
 
 // Test fixture to verify that jsii modules can use the node standard library.
 // Struct proxy
 type NodeStandardLibrary struct {
-    // Returns the current os.platform() from the "os" node module.
-    OsPlatform string
+	// Returns the current os.platform() from the "os" node module.
+	OsPlatform string
 }
 
 func (n *NodeStandardLibrary) GetOsPlatform() string {
-    return n.OsPlatform
+	return n.OsPlatform
 }
 
 
 func NewNodeStandardLibrary() NodeStandardLibraryIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NodeStandardLibrary",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &NodeStandardLibrary{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NodeStandardLibrary",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &NodeStandardLibrary{}
 }
 
 func (n *NodeStandardLibrary) SetOsPlatform(val string) {
-    n.OsPlatform = val
+	n.OsPlatform = val
 }
 
 func (n *NodeStandardLibrary) CryptoSha256() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NodeStandardLibrary",
-        Method: "CryptoSha256",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NodeStandardLibrary",
+		Method: "CryptoSha256",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (n *NodeStandardLibrary) FsReadFile() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NodeStandardLibrary",
-        Method: "FsReadFile",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NodeStandardLibrary",
+		Method: "FsReadFile",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (n *NodeStandardLibrary) FsReadFileSync() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NodeStandardLibrary",
-        Method: "FsReadFileSync",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NodeStandardLibrary",
+		Method: "FsReadFileSync",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type NullShouldBeTreatedAsUndefinedIface interface {
-    GetChangeMeToUndefined() string
-    SetChangeMeToUndefined(val string)
-    GiveMeUndefined(value jsii.Any)
-    GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData)
-    VerifyPropertyIsUndefined()
+	GetChangeMeToUndefined() string
+	SetChangeMeToUndefined(val string)
+	GiveMeUndefined(value jsii.Any)
+	GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData)
+	VerifyPropertyIsUndefined()
 }
 
 // jsii#282, aws-cdk#157: null should be treated as "undefined".
 // Struct proxy
 type NullShouldBeTreatedAsUndefined struct {
-    ChangeMeToUndefined string
+	ChangeMeToUndefined string
 }
 
 func (n *NullShouldBeTreatedAsUndefined) GetChangeMeToUndefined() string {
-    return n.ChangeMeToUndefined
+	return n.ChangeMeToUndefined
 }
 
 
 func NewNullShouldBeTreatedAsUndefined(_param1 string, optional jsii.Any) NullShouldBeTreatedAsUndefinedIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NullShouldBeTreatedAsUndefined",
-        Method: "Constructor",
-        Args: []string{"string", "any",},
-    })
-    return &NullShouldBeTreatedAsUndefined{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NullShouldBeTreatedAsUndefined",
+		Method: "Constructor",
+		Args: []string{"string", "any",},
+	})
+	return &NullShouldBeTreatedAsUndefined{}
 }
 
 func (n *NullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val string) {
-    n.ChangeMeToUndefined = val
+	n.ChangeMeToUndefined = val
 }
 
 func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefined(value jsii.Any) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NullShouldBeTreatedAsUndefined",
-        Method: "GiveMeUndefined",
-        Args: []string{"any",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NullShouldBeTreatedAsUndefined",
+		Method: "GiveMeUndefined",
+		Args: []string{"any",},
+	})
 }
 
 func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NullShouldBeTreatedAsUndefined",
-        Method: "GiveMeUndefinedInsideAnObject",
-        Args: []string{"jsii-calc.NullShouldBeTreatedAsUndefinedData",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NullShouldBeTreatedAsUndefined",
+		Method: "GiveMeUndefinedInsideAnObject",
+		Args: []string{"jsii-calc.NullShouldBeTreatedAsUndefinedData",},
+	})
 }
 
 func (n *NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NullShouldBeTreatedAsUndefined",
-        Method: "VerifyPropertyIsUndefined",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NullShouldBeTreatedAsUndefined",
+		Method: "VerifyPropertyIsUndefined",
+		Args: []string{},
+	})
 }
 
 // NullShouldBeTreatedAsUndefinedDataIface is the public interface for the custom type NullShouldBeTreatedAsUndefinedData
 type NullShouldBeTreatedAsUndefinedDataIface interface {
-    GetArrayWithThreeElementsAndUndefinedAsSecondArgument() []jsii.Any
-    GetThisShouldBeUndefined() jsii.Any
+	GetArrayWithThreeElementsAndUndefinedAsSecondArgument() []jsii.Any
+	GetThisShouldBeUndefined() jsii.Any
 }
 
 // Struct proxy
 type NullShouldBeTreatedAsUndefinedData struct {
-    ArrayWithThreeElementsAndUndefinedAsSecondArgument []jsii.Any
-    ThisShouldBeUndefined jsii.Any
+	ArrayWithThreeElementsAndUndefinedAsSecondArgument []jsii.Any
+	ThisShouldBeUndefined jsii.Any
 }
 
 func (n *NullShouldBeTreatedAsUndefinedData) GetArrayWithThreeElementsAndUndefinedAsSecondArgument() []jsii.Any {
-    return n.ArrayWithThreeElementsAndUndefinedAsSecondArgument
+	return n.ArrayWithThreeElementsAndUndefinedAsSecondArgument
 }
 
 func (n *NullShouldBeTreatedAsUndefinedData) GetThisShouldBeUndefined() jsii.Any {
-    return n.ThisShouldBeUndefined
+	return n.ThisShouldBeUndefined
 }
 
 
 // Class interface
 type NumberGeneratorIface interface {
-    GetGenerator() IRandomNumberGenerator
-    SetGenerator(val IRandomNumberGenerator)
-    IsSameGenerator(gen IRandomNumberGenerator) bool
-    NextTimes100() float64
+	GetGenerator() IRandomNumberGenerator
+	SetGenerator(val IRandomNumberGenerator)
+	IsSameGenerator(gen IRandomNumberGenerator) bool
+	NextTimes100() float64
 }
 
 // This allows us to test that a reference can be stored for objects that implement interfaces.
 // Struct proxy
 type NumberGenerator struct {
-    Generator IRandomNumberGenerator
+	Generator IRandomNumberGenerator
 }
 
 func (n *NumberGenerator) GetGenerator() IRandomNumberGenerator {
-    return n.Generator
+	return n.Generator
 }
 
 
 func NewNumberGenerator(generator IRandomNumberGenerator) NumberGeneratorIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumberGenerator",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.IRandomNumberGenerator",},
-    })
-    return &NumberGenerator{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumberGenerator",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.IRandomNumberGenerator",},
+	})
+	return &NumberGenerator{}
 }
 
 func (n *NumberGenerator) SetGenerator(val IRandomNumberGenerator) {
-    n.Generator = val
+	n.Generator = val
 }
 
 func (n *NumberGenerator) IsSameGenerator(gen IRandomNumberGenerator) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumberGenerator",
-        Method: "IsSameGenerator",
-        Args: []string{"jsii-calc.IRandomNumberGenerator",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumberGenerator",
+		Method: "IsSameGenerator",
+		Args: []string{"jsii-calc.IRandomNumberGenerator",},
+	})
+	return true
 }
 
 func (n *NumberGenerator) NextTimes100() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "NumberGenerator",
-        Method: "NextTimes100",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "NumberGenerator",
+		Method: "NextTimes100",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type ObjectRefsInCollectionsIface interface {
-    SumFromArray(values []scopejsiicalclib.NumericValue) float64
-    SumFromMap(values map[string]scopejsiicalclib.NumericValue) float64
+	SumFromArray(values []scopejsiicalclib.NumericValue) float64
+	SumFromMap(values map[string]scopejsiicalclib.NumericValue) float64
 }
 
 // Verify that object references can be passed inside collections.
@@ -6026,30 +6026,30 @@ type ObjectRefsInCollections struct {
 }
 
 func NewObjectRefsInCollections() ObjectRefsInCollectionsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ObjectRefsInCollections",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ObjectRefsInCollections{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ObjectRefsInCollections",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ObjectRefsInCollections{}
 }
 
 func (o *ObjectRefsInCollections) SumFromArray(values []scopejsiicalclib.NumericValue) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ObjectRefsInCollections",
-        Method: "SumFromArray",
-        Args: []string{"Array<@scope/jsii-calc-lib.NumericValue>",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ObjectRefsInCollections",
+		Method: "SumFromArray",
+		Args: []string{"Array<@scope/jsii-calc-lib.NumericValue>",},
+	})
+	return 0.0
 }
 
 func (o *ObjectRefsInCollections) SumFromMap(values map[string]scopejsiicalclib.NumericValue) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ObjectRefsInCollections",
-        Method: "SumFromMap",
-        Args: []string{"Map<string => @scope/jsii-calc-lib.NumericValue>",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ObjectRefsInCollections",
+		Method: "SumFromMap",
+		Args: []string{"Map<string => @scope/jsii-calc-lib.NumericValue>",},
+	})
+	return 0.0
 }
 
 // Class interface
@@ -6061,17 +6061,17 @@ type ObjectWithPropertyProvider struct {
 }
 
 func ObjectWithPropertyProvider_Provide() IObjectWithProperty {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ObjectWithPropertyProvider",
-        Method: "Provide",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ObjectWithPropertyProvider",
+		Method: "Provide",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type OldIface interface {
-    DoAThing()
+	DoAThing()
 }
 
 // Old class.
@@ -6081,26 +6081,26 @@ type Old struct {
 }
 
 func NewOld() OldIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Old",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Old{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Old",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Old{}
 }
 
 func (o *Old) DoAThing() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Old",
-        Method: "DoAThing",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Old",
+		Method: "DoAThing",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type OptionalArgumentInvokerIface interface {
-    InvokeWithOptional()
-    InvokeWithoutOptional()
+	InvokeWithOptional()
+	InvokeWithoutOptional()
 }
 
 // Struct proxy
@@ -6108,208 +6108,208 @@ type OptionalArgumentInvoker struct {
 }
 
 func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArguments) OptionalArgumentInvokerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OptionalArgumentInvoker",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.IInterfaceWithOptionalMethodArguments",},
-    })
-    return &OptionalArgumentInvoker{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OptionalArgumentInvoker",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.IInterfaceWithOptionalMethodArguments",},
+	})
+	return &OptionalArgumentInvoker{}
 }
 
 func (o *OptionalArgumentInvoker) InvokeWithOptional() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OptionalArgumentInvoker",
-        Method: "InvokeWithOptional",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OptionalArgumentInvoker",
+		Method: "InvokeWithOptional",
+		Args: []string{},
+	})
 }
 
 func (o *OptionalArgumentInvoker) InvokeWithoutOptional() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OptionalArgumentInvoker",
-        Method: "InvokeWithoutOptional",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OptionalArgumentInvoker",
+		Method: "InvokeWithoutOptional",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type OptionalConstructorArgumentIface interface {
-    GetArg1() float64
-    SetArg1(val float64)
-    GetArg2() string
-    SetArg2(val string)
-    GetArg3() string
-    SetArg3(val string)
+	GetArg1() float64
+	SetArg1(val float64)
+	GetArg2() string
+	SetArg2(val string)
+	GetArg3() string
+	SetArg3(val string)
 }
 
 // Struct proxy
 type OptionalConstructorArgument struct {
-    Arg1 float64
-    Arg2 string
-    Arg3 string
+	Arg1 float64
+	Arg2 string
+	Arg3 string
 }
 
 func (o *OptionalConstructorArgument) GetArg1() float64 {
-    return o.Arg1
+	return o.Arg1
 }
 
 func (o *OptionalConstructorArgument) GetArg2() string {
-    return o.Arg2
+	return o.Arg2
 }
 
 func (o *OptionalConstructorArgument) GetArg3() string {
-    return o.Arg3
+	return o.Arg3
 }
 
 
 func NewOptionalConstructorArgument(arg1 float64, arg2 string, arg3 string) OptionalConstructorArgumentIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OptionalConstructorArgument",
-        Method: "Constructor",
-        Args: []string{"number", "string", "date",},
-    })
-    return &OptionalConstructorArgument{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OptionalConstructorArgument",
+		Method: "Constructor",
+		Args: []string{"number", "string", "date",},
+	})
+	return &OptionalConstructorArgument{}
 }
 
 func (o *OptionalConstructorArgument) SetArg1(val float64) {
-    o.Arg1 = val
+	o.Arg1 = val
 }
 
 func (o *OptionalConstructorArgument) SetArg2(val string) {
-    o.Arg2 = val
+	o.Arg2 = val
 }
 
 func (o *OptionalConstructorArgument) SetArg3(val string) {
-    o.Arg3 = val
+	o.Arg3 = val
 }
 
 // OptionalStructIface is the public interface for the custom type OptionalStruct
 type OptionalStructIface interface {
-    GetField() string
+	GetField() string
 }
 
 // Struct proxy
 type OptionalStruct struct {
-    Field string
+	Field string
 }
 
 func (o *OptionalStruct) GetField() string {
-    return o.Field
+	return o.Field
 }
 
 
 // Class interface
 type OptionalStructConsumerIface interface {
-    GetParameterWasUndefined() bool
-    SetParameterWasUndefined(val bool)
-    GetFieldValue() string
-    SetFieldValue(val string)
+	GetParameterWasUndefined() bool
+	SetParameterWasUndefined(val bool)
+	GetFieldValue() string
+	SetFieldValue(val string)
 }
 
 // Struct proxy
 type OptionalStructConsumer struct {
-    ParameterWasUndefined bool
-    FieldValue string
+	ParameterWasUndefined bool
+	FieldValue string
 }
 
 func (o *OptionalStructConsumer) GetParameterWasUndefined() bool {
-    return o.ParameterWasUndefined
+	return o.ParameterWasUndefined
 }
 
 func (o *OptionalStructConsumer) GetFieldValue() string {
-    return o.FieldValue
+	return o.FieldValue
 }
 
 
 func NewOptionalStructConsumer(optionalStruct OptionalStruct) OptionalStructConsumerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OptionalStructConsumer",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.OptionalStruct",},
-    })
-    return &OptionalStructConsumer{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OptionalStructConsumer",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.OptionalStruct",},
+	})
+	return &OptionalStructConsumer{}
 }
 
 func (o *OptionalStructConsumer) SetParameterWasUndefined(val bool) {
-    o.ParameterWasUndefined = val
+	o.ParameterWasUndefined = val
 }
 
 func (o *OptionalStructConsumer) SetFieldValue(val string) {
-    o.FieldValue = val
+	o.FieldValue = val
 }
 
 // Class interface
 type OverridableProtectedMemberIface interface {
-    GetOverrideReadOnly() string
-    GetOverrideReadWrite() string
-    OverrideMe() string
-    SwitchModes()
-    ValueFromProtected() string
+	GetOverrideReadOnly() string
+	GetOverrideReadWrite() string
+	OverrideMe() string
+	SwitchModes()
+	ValueFromProtected() string
 }
 
 // See: https://github.com/aws/jsii/issues/903
 //
 // Struct proxy
 type OverridableProtectedMember struct {
-    OverrideReadOnly string
-    OverrideReadWrite string
+	OverrideReadOnly string
+	OverrideReadWrite string
 }
 
 func (o *OverridableProtectedMember) GetOverrideReadOnly() string {
-    return o.OverrideReadOnly
+	return o.OverrideReadOnly
 }
 
 func (o *OverridableProtectedMember) GetOverrideReadWrite() string {
-    return o.OverrideReadWrite
+	return o.OverrideReadWrite
 }
 
 
 func NewOverridableProtectedMember() OverridableProtectedMemberIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverridableProtectedMember",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &OverridableProtectedMember{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverridableProtectedMember",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &OverridableProtectedMember{}
 }
 
 func (o *OverridableProtectedMember) SetOverrideReadOnly(val string) {
-    o.OverrideReadOnly = val
+	o.OverrideReadOnly = val
 }
 
 func (o *OverridableProtectedMember) SetOverrideReadWrite(val string) {
-    o.OverrideReadWrite = val
+	o.OverrideReadWrite = val
 }
 
 func (o *OverridableProtectedMember) OverrideMe() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverridableProtectedMember",
-        Method: "OverrideMe",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverridableProtectedMember",
+		Method: "OverrideMe",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (o *OverridableProtectedMember) SwitchModes() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverridableProtectedMember",
-        Method: "SwitchModes",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverridableProtectedMember",
+		Method: "SwitchModes",
+		Args: []string{},
+	})
 }
 
 func (o *OverridableProtectedMember) ValueFromProtected() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverridableProtectedMember",
-        Method: "ValueFromProtected",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverridableProtectedMember",
+		Method: "ValueFromProtected",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type OverrideReturnsObjectIface interface {
-    Test(obj IReturnsNumber) float64
+	Test(obj IReturnsNumber) float64
 }
 
 // Struct proxy
@@ -6317,42 +6317,42 @@ type OverrideReturnsObject struct {
 }
 
 func NewOverrideReturnsObject() OverrideReturnsObjectIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverrideReturnsObject",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &OverrideReturnsObject{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverrideReturnsObject",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &OverrideReturnsObject{}
 }
 
 func (o *OverrideReturnsObject) Test(obj IReturnsNumber) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OverrideReturnsObject",
-        Method: "Test",
-        Args: []string{"jsii-calc.IReturnsNumber",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OverrideReturnsObject",
+		Method: "Test",
+		Args: []string{"jsii-calc.IReturnsNumber",},
+	})
+	return 0.0
 }
 
 // ParentStruct982Iface is the public interface for the custom type ParentStruct982
 type ParentStruct982Iface interface {
-    GetFoo() string
+	GetFoo() string
 }
 
 // https://github.com/aws/jsii/issues/982.
 // Struct proxy
 type ParentStruct982 struct {
-    Foo string
+	Foo string
 }
 
 func (p *ParentStruct982) GetFoo() string {
-    return p.Foo
+	return p.Foo
 }
 
 
 // Class interface
 type PartiallyInitializedThisConsumerIface interface {
-    ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt string, ev AllTypesEnum) string
+	ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt string, ev AllTypesEnum) string
 }
 
 // Struct proxy
@@ -6360,26 +6360,26 @@ type PartiallyInitializedThisConsumer struct {
 }
 
 func NewPartiallyInitializedThisConsumer() PartiallyInitializedThisConsumerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PartiallyInitializedThisConsumer",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &PartiallyInitializedThisConsumer{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PartiallyInitializedThisConsumer",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &PartiallyInitializedThisConsumer{}
 }
 
 func (p *PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt string, ev AllTypesEnum) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PartiallyInitializedThisConsumer",
-        Method: "ConsumePartiallyInitializedThis",
-        Args: []string{"jsii-calc.ConstructorPassesThisOut", "date", "jsii-calc.AllTypesEnum",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PartiallyInitializedThisConsumer",
+		Method: "ConsumePartiallyInitializedThis",
+		Args: []string{"jsii-calc.ConstructorPassesThisOut", "date", "jsii-calc.AllTypesEnum",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type PolymorphismIface interface {
-    SayHello(friendly scopejsiicalclib.IFriendly) string
+	SayHello(friendly scopejsiicalclib.IFriendly) string
 }
 
 // Struct proxy
@@ -6387,193 +6387,193 @@ type Polymorphism struct {
 }
 
 func NewPolymorphism() PolymorphismIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Polymorphism",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Polymorphism{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Polymorphism",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Polymorphism{}
 }
 
 func (p *Polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Polymorphism",
-        Method: "SayHello",
-        Args: []string{"@scope/jsii-calc-lib.IFriendly",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Polymorphism",
+		Method: "SayHello",
+		Args: []string{"@scope/jsii-calc-lib.IFriendly",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type PowerIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    GetExpression() scopejsiicalclib.NumericValue
-    SetExpression(val scopejsiicalclib.NumericValue)
-    GetDecorationPostfixes() []string
-    SetDecorationPostfixes(val []string)
-    GetDecorationPrefixes() []string
-    SetDecorationPrefixes(val []string)
-    GetStringStyle() composition.CompositionStringStyle
-    SetStringStyle(val composition.CompositionStringStyle)
-    GetBase() scopejsiicalclib.NumericValue
-    SetBase(val scopejsiicalclib.NumericValue)
-    GetPow() scopejsiicalclib.NumericValue
-    SetPow(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	GetExpression() scopejsiicalclib.NumericValue
+	SetExpression(val scopejsiicalclib.NumericValue)
+	GetDecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	GetDecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
+	GetStringStyle() composition.CompositionStringStyle
+	SetStringStyle(val composition.CompositionStringStyle)
+	GetBase() scopejsiicalclib.NumericValue
+	SetBase(val scopejsiicalclib.NumericValue)
+	GetPow() scopejsiicalclib.NumericValue
+	SetPow(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // The power operation.
 // Struct proxy
 type Power struct {
-    // (deprecated) The value.
-    Value float64
-    // The expression that this operation consists of.
-    // 
-    // Must be implemented by derived classes.
-    Expression scopejsiicalclib.NumericValue
-    // A set of postfixes to include in a decorated .toString().
-    DecorationPostfixes []string
-    // A set of prefixes to include in a decorated .toString().
-    DecorationPrefixes []string
-    // The .toString() style.
-    StringStyle composition.CompositionStringStyle
-    // The base of the power.
-    Base scopejsiicalclib.NumericValue
-    // The number of times to multiply.
-    Pow scopejsiicalclib.NumericValue
+	// (deprecated) The value.
+	Value float64
+	// The expression that this operation consists of.
+	// 
+	// Must be implemented by derived classes.
+	Expression scopejsiicalclib.NumericValue
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes []string
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes []string
+	// The .toString() style.
+	StringStyle composition.CompositionStringStyle
+	// The base of the power.
+	Base scopejsiicalclib.NumericValue
+	// The number of times to multiply.
+	Pow scopejsiicalclib.NumericValue
 }
 
 func (p *Power) GetValue() float64 {
-    return p.Value
+	return p.Value
 }
 
 func (p *Power) GetExpression() scopejsiicalclib.NumericValue {
-    return p.Expression
+	return p.Expression
 }
 
 func (p *Power) GetDecorationPostfixes() []string {
-    return p.DecorationPostfixes
+	return p.DecorationPostfixes
 }
 
 func (p *Power) GetDecorationPrefixes() []string {
-    return p.DecorationPrefixes
+	return p.DecorationPrefixes
 }
 
 func (p *Power) GetStringStyle() composition.CompositionStringStyle {
-    return p.StringStyle
+	return p.StringStyle
 }
 
 func (p *Power) GetBase() scopejsiicalclib.NumericValue {
-    return p.Base
+	return p.Base
 }
 
 func (p *Power) GetPow() scopejsiicalclib.NumericValue {
-    return p.Pow
+	return p.Pow
 }
 
 
 // Creates a Power operation.
 func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) PowerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Power",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &Power{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Power",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue", "@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &Power{}
 }
 
 func (p *Power) SetValue(val float64) {
-    p.Value = val
+	p.Value = val
 }
 
 func (p *Power) SetExpression(val scopejsiicalclib.NumericValue) {
-    p.Expression = val
+	p.Expression = val
 }
 
 func (p *Power) SetDecorationPostfixes(val []string) {
-    p.DecorationPostfixes = val
+	p.DecorationPostfixes = val
 }
 
 func (p *Power) SetDecorationPrefixes(val []string) {
-    p.DecorationPrefixes = val
+	p.DecorationPrefixes = val
 }
 
 func (p *Power) SetStringStyle(val composition.CompositionStringStyle) {
-    p.StringStyle = val
+	p.StringStyle = val
 }
 
 func (p *Power) SetBase(val scopejsiicalclib.NumericValue) {
-    p.Base = val
+	p.Base = val
 }
 
 func (p *Power) SetPow(val scopejsiicalclib.NumericValue) {
-    p.Pow = val
+	p.Pow = val
 }
 
 func (p *Power) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Power",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Power",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (p *Power) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Power",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Power",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type PropertyNamedPropertyIface interface {
-    GetProperty() string
-    SetProperty(val string)
-    GetYetAnoterOne() bool
-    SetYetAnoterOne(val bool)
+	GetProperty() string
+	SetProperty(val string)
+	GetYetAnoterOne() bool
+	SetYetAnoterOne(val bool)
 }
 
 // Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.
 // Struct proxy
 type PropertyNamedProperty struct {
-    Property string
-    YetAnoterOne bool
+	Property string
+	YetAnoterOne bool
 }
 
 func (p *PropertyNamedProperty) GetProperty() string {
-    return p.Property
+	return p.Property
 }
 
 func (p *PropertyNamedProperty) GetYetAnoterOne() bool {
-    return p.YetAnoterOne
+	return p.YetAnoterOne
 }
 
 
 func NewPropertyNamedProperty() PropertyNamedPropertyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PropertyNamedProperty",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &PropertyNamedProperty{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PropertyNamedProperty",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &PropertyNamedProperty{}
 }
 
 func (p *PropertyNamedProperty) SetProperty(val string) {
-    p.Property = val
+	p.Property = val
 }
 
 func (p *PropertyNamedProperty) SetYetAnoterOne(val bool) {
-    p.YetAnoterOne = val
+	p.YetAnoterOne = val
 }
 
 // Class interface
 type PublicClassIface interface {
-    Hello()
+	Hello()
 }
 
 // Struct proxy
@@ -6581,56 +6581,56 @@ type PublicClass struct {
 }
 
 func NewPublicClass() PublicClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PublicClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &PublicClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PublicClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &PublicClass{}
 }
 
 func (p *PublicClass) Hello() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PublicClass",
-        Method: "Hello",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PublicClass",
+		Method: "Hello",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type PythonReservedWordsIface interface {
-    And()
-    As()
-    Assert()
-    Async()
-    Await()
-    Break()
-    Class()
-    Continue()
-    Def()
-    Del()
-    Elif()
-    Else()
-    Except()
-    Finally()
-    For()
-    From()
-    Global()
-    If()
-    Import()
-    In()
-    Is()
-    Lambda()
-    Nonlocal()
-    Not()
-    Or()
-    Pass()
-    Raise()
-    Return()
-    Try()
-    While()
-    With()
-    Yield()
+	And()
+	As()
+	Assert()
+	Async()
+	Await()
+	Break()
+	Class()
+	Continue()
+	Def()
+	Del()
+	Elif()
+	Else()
+	Except()
+	Finally()
+	For()
+	From()
+	Global()
+	If()
+	Import()
+	In()
+	Is()
+	Lambda()
+	Nonlocal()
+	Not()
+	Or()
+	Pass()
+	Raise()
+	Return()
+	Try()
+	While()
+	With()
+	Yield()
 }
 
 // Struct proxy
@@ -6638,323 +6638,323 @@ type PythonReservedWords struct {
 }
 
 func NewPythonReservedWords() PythonReservedWordsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &PythonReservedWords{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &PythonReservedWords{}
 }
 
 func (p *PythonReservedWords) And() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "And",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "And",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) As() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "As",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "As",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Assert() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Assert",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Assert",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Async() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Async",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Async",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Await() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Await",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Await",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Break() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Break",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Break",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Class() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Class",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Class",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Continue() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Continue",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Continue",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Def() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Def",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Def",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Del() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Del",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Del",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Elif() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Elif",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Elif",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Else() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Else",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Else",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Except() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Except",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Except",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Finally() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Finally",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Finally",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) For() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "For",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "For",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) From() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "From",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "From",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Global() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Global",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Global",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) If() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "If",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "If",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Import() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Import",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Import",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) In() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "In",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "In",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Is() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Is",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Is",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Lambda() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Lambda",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Lambda",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Nonlocal() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Nonlocal",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Nonlocal",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Not() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Not",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Not",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Or() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Or",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Or",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Pass() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Pass",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Pass",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Raise() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Raise",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Raise",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Return() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Return",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Return",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Try() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Try",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Try",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) While() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "While",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "While",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) With() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "With",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "With",
+		Args: []string{},
+	})
 }
 
 func (p *PythonReservedWords) Yield() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "PythonReservedWords",
-        Method: "Yield",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "PythonReservedWords",
+		Method: "Yield",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type ReferenceEnumFromScopedPackageIface interface {
-    GetFoo() scopejsiicalclib.EnumFromScopedModule
-    SetFoo(val scopejsiicalclib.EnumFromScopedModule)
-    LoadFoo() scopejsiicalclib.EnumFromScopedModule
-    SaveFoo(value scopejsiicalclib.EnumFromScopedModule)
+	GetFoo() scopejsiicalclib.EnumFromScopedModule
+	SetFoo(val scopejsiicalclib.EnumFromScopedModule)
+	LoadFoo() scopejsiicalclib.EnumFromScopedModule
+	SaveFoo(value scopejsiicalclib.EnumFromScopedModule)
 }
 
 // See awslabs/jsii#138.
 // Struct proxy
 type ReferenceEnumFromScopedPackage struct {
-    Foo scopejsiicalclib.EnumFromScopedModule
+	Foo scopejsiicalclib.EnumFromScopedModule
 }
 
 func (r *ReferenceEnumFromScopedPackage) GetFoo() scopejsiicalclib.EnumFromScopedModule {
-    return r.Foo
+	return r.Foo
 }
 
 
 func NewReferenceEnumFromScopedPackage() ReferenceEnumFromScopedPackageIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ReferenceEnumFromScopedPackage",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ReferenceEnumFromScopedPackage{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ReferenceEnumFromScopedPackage",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ReferenceEnumFromScopedPackage{}
 }
 
 func (r *ReferenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromScopedModule) {
-    r.Foo = val
+	r.Foo = val
 }
 
 func (r *ReferenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScopedModule {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ReferenceEnumFromScopedPackage",
-        Method: "LoadFoo",
-        Args: []string{},
-    })
-    return "ENUM_DUMMY"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ReferenceEnumFromScopedPackage",
+		Method: "LoadFoo",
+		Args: []string{},
+	})
+	return "ENUM_DUMMY"
 }
 
 func (r *ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFromScopedModule) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ReferenceEnumFromScopedPackage",
-        Method: "SaveFoo",
-        Args: []string{"@scope/jsii-calc-lib.EnumFromScopedModule",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ReferenceEnumFromScopedPackage",
+		Method: "SaveFoo",
+		Args: []string{"@scope/jsii-calc-lib.EnumFromScopedModule",},
+	})
 }
 
 // Class interface
 type ReturnsPrivateImplementationOfInterfaceIface interface {
-    GetPrivateImplementation() IPrivatelyImplemented
-    SetPrivateImplementation(val IPrivatelyImplemented)
+	GetPrivateImplementation() IPrivatelyImplemented
+	SetPrivateImplementation(val IPrivatelyImplemented)
 }
 
 // Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
@@ -6964,31 +6964,31 @@ type ReturnsPrivateImplementationOfInterfaceIface interface {
 //
 // Struct proxy
 type ReturnsPrivateImplementationOfInterface struct {
-    PrivateImplementation IPrivatelyImplemented
+	PrivateImplementation IPrivatelyImplemented
 }
 
 func (r *ReturnsPrivateImplementationOfInterface) GetPrivateImplementation() IPrivatelyImplemented {
-    return r.PrivateImplementation
+	return r.PrivateImplementation
 }
 
 
 func NewReturnsPrivateImplementationOfInterface() ReturnsPrivateImplementationOfInterfaceIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ReturnsPrivateImplementationOfInterface",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &ReturnsPrivateImplementationOfInterface{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ReturnsPrivateImplementationOfInterface",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &ReturnsPrivateImplementationOfInterface{}
 }
 
 func (r *ReturnsPrivateImplementationOfInterface) SetPrivateImplementation(val IPrivatelyImplemented) {
-    r.PrivateImplementation = val
+	r.PrivateImplementation = val
 }
 
 // RootStructIface is the public interface for the custom type RootStruct
 type RootStructIface interface {
-    GetStringProp() string
-    GetNestedStruct() NestedStruct
+	GetStringProp() string
+	GetNestedStruct() NestedStruct
 }
 
 // This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
@@ -6997,17 +6997,17 @@ type RootStructIface interface {
 // idiomatic" way for Pythonists.
 // Struct proxy
 type RootStruct struct {
-    // May not be empty.
-    StringProp string
-    NestedStruct NestedStruct
+	// May not be empty.
+	StringProp string
+	NestedStruct NestedStruct
 }
 
 func (r *RootStruct) GetStringProp() string {
-    return r.StringProp
+	return r.StringProp
 }
 
 func (r *RootStruct) GetNestedStruct() NestedStruct {
-    return r.NestedStruct
+	return r.NestedStruct
 }
 
 
@@ -7020,18 +7020,18 @@ type RootStructValidator struct {
 }
 
 func RootStructValidator_Validate(struct_ RootStruct) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "RootStructValidator",
-        Method: "Validate",
-        Args: []string{"jsii-calc.RootStruct",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "RootStructValidator",
+		Method: "Validate",
+		Args: []string{"jsii-calc.RootStruct",},
+	})
 }
 
 // Class interface
 type RuntimeTypeCheckingIface interface {
-    MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string)
-    MethodWithOptionalAnyArgument(arg jsii.Any)
-    MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string)
+	MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string)
+	MethodWithOptionalAnyArgument(arg jsii.Any)
+	MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string)
 }
 
 // Struct proxy
@@ -7039,65 +7039,65 @@ type RuntimeTypeChecking struct {
 }
 
 func NewRuntimeTypeChecking() RuntimeTypeCheckingIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "RuntimeTypeChecking",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &RuntimeTypeChecking{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "RuntimeTypeChecking",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &RuntimeTypeChecking{}
 }
 
 func (r *RuntimeTypeChecking) MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "RuntimeTypeChecking",
-        Method: "MethodWithDefaultedArguments",
-        Args: []string{"number", "string", "date",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "RuntimeTypeChecking",
+		Method: "MethodWithDefaultedArguments",
+		Args: []string{"number", "string", "date",},
+	})
 }
 
 func (r *RuntimeTypeChecking) MethodWithOptionalAnyArgument(arg jsii.Any) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "RuntimeTypeChecking",
-        Method: "MethodWithOptionalAnyArgument",
-        Args: []string{"any",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "RuntimeTypeChecking",
+		Method: "MethodWithOptionalAnyArgument",
+		Args: []string{"any",},
+	})
 }
 
 func (r *RuntimeTypeChecking) MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "RuntimeTypeChecking",
-        Method: "MethodWithOptionalArguments",
-        Args: []string{"number", "string", "date",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "RuntimeTypeChecking",
+		Method: "MethodWithOptionalArguments",
+		Args: []string{"number", "string", "date",},
+	})
 }
 
 // SecondLevelStructIface is the public interface for the custom type SecondLevelStruct
 type SecondLevelStructIface interface {
-    GetDeeperRequiredProp() string
-    GetDeeperOptionalProp() string
+	GetDeeperRequiredProp() string
+	GetDeeperOptionalProp() string
 }
 
 // Struct proxy
 type SecondLevelStruct struct {
-    // It's long and required.
-    DeeperRequiredProp string
-    // It's long, but you'll almost never pass it.
-    DeeperOptionalProp string
+	// It's long and required.
+	DeeperRequiredProp string
+	// It's long, but you'll almost never pass it.
+	DeeperOptionalProp string
 }
 
 func (s *SecondLevelStruct) GetDeeperRequiredProp() string {
-    return s.DeeperRequiredProp
+	return s.DeeperRequiredProp
 }
 
 func (s *SecondLevelStruct) GetDeeperOptionalProp() string {
-    return s.DeeperOptionalProp
+	return s.DeeperOptionalProp
 }
 
 
 // Class interface
 type SingleInstanceTwoTypesIface interface {
-    Interface1() InbetweenClass
-    Interface2() IPublicInterface
+	Interface1() InbetweenClass
+	Interface2() IPublicInterface
 }
 
 // Test that a single instance can be returned under two different FQNs.
@@ -7110,35 +7110,35 @@ type SingleInstanceTwoTypes struct {
 }
 
 func NewSingleInstanceTwoTypes() SingleInstanceTwoTypesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SingleInstanceTwoTypes",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &SingleInstanceTwoTypes{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SingleInstanceTwoTypes",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &SingleInstanceTwoTypes{}
 }
 
 func (s *SingleInstanceTwoTypes) Interface1() InbetweenClass {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SingleInstanceTwoTypes",
-        Method: "Interface1",
-        Args: []string{},
-    })
-    return InbetweenClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SingleInstanceTwoTypes",
+		Method: "Interface1",
+		Args: []string{},
+	})
+	return InbetweenClass{}
 }
 
 func (s *SingleInstanceTwoTypes) Interface2() IPublicInterface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SingleInstanceTwoTypes",
-        Method: "Interface2",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SingleInstanceTwoTypes",
+		Method: "Interface2",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type SingletonIntIface interface {
-    IsSingletonInt(value float64) bool
+	IsSingletonInt(value float64) bool
 }
 
 // Verifies that singleton enums are handled correctly.
@@ -7149,24 +7149,24 @@ type SingletonInt struct {
 }
 
 func (s *SingletonInt) IsSingletonInt(value float64) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SingletonInt",
-        Method: "IsSingletonInt",
-        Args: []string{"number",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SingletonInt",
+		Method: "IsSingletonInt",
+		Args: []string{"number",},
+	})
+	return true
 }
 
 // A singleton integer.
 type SingletonIntEnum string
 
 const (
-    SingletonIntEnumSingletonInt SingletonIntEnum = "SINGLETON_INT"
+	SingletonIntEnumSingletonInt SingletonIntEnum = "SINGLETON_INT"
 )
 
 // Class interface
 type SingletonStringIface interface {
-    IsSingletonString(value string) bool
+	IsSingletonString(value string) bool
 }
 
 // Verifies that singleton enums are handled correctly.
@@ -7177,39 +7177,39 @@ type SingletonString struct {
 }
 
 func (s *SingletonString) IsSingletonString(value string) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SingletonString",
-        Method: "IsSingletonString",
-        Args: []string{"string",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SingletonString",
+		Method: "IsSingletonString",
+		Args: []string{"string",},
+	})
+	return true
 }
 
 // A singleton string.
 type SingletonStringEnum string
 
 const (
-    SingletonStringEnumSingletonString SingletonStringEnum = "SINGLETON_STRING"
+	SingletonStringEnumSingletonString SingletonStringEnum = "SINGLETON_STRING"
 )
 
 // SmellyStructIface is the public interface for the custom type SmellyStruct
 type SmellyStructIface interface {
-    GetProperty() string
-    GetYetAnoterOne() bool
+	GetProperty() string
+	GetYetAnoterOne() bool
 }
 
 // Struct proxy
 type SmellyStruct struct {
-    Property string
-    YetAnoterOne bool
+	Property string
+	YetAnoterOne bool
 }
 
 func (s *SmellyStruct) GetProperty() string {
-    return s.Property
+	return s.Property
 }
 
 func (s *SmellyStruct) GetYetAnoterOne() bool {
-    return s.YetAnoterOne
+	return s.YetAnoterOne
 }
 
 
@@ -7222,107 +7222,107 @@ type SomeTypeJsii976 struct {
 }
 
 func NewSomeTypeJsii976() SomeTypeJsii976Iface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SomeTypeJsii976",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &SomeTypeJsii976{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SomeTypeJsii976",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &SomeTypeJsii976{}
 }
 
 func SomeTypeJsii976_ReturnAnonymous() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SomeTypeJsii976",
-        Method: "ReturnAnonymous",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SomeTypeJsii976",
+		Method: "ReturnAnonymous",
+		Args: []string{},
+	})
+	return nil
 }
 
 func SomeTypeJsii976_ReturnReturn() IReturnJsii976 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SomeTypeJsii976",
-        Method: "ReturnReturn",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SomeTypeJsii976",
+		Method: "ReturnReturn",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type StableClassIface interface {
-    GetReadonlyProperty() string
-    SetReadonlyProperty(val string)
-    GetMutableProperty() float64
-    SetMutableProperty(val float64)
-    Method()
+	GetReadonlyProperty() string
+	SetReadonlyProperty(val string)
+	GetMutableProperty() float64
+	SetMutableProperty(val float64)
+	Method()
 }
 
 // Struct proxy
 type StableClass struct {
-    ReadonlyProperty string
-    MutableProperty float64
+	ReadonlyProperty string
+	MutableProperty float64
 }
 
 func (s *StableClass) GetReadonlyProperty() string {
-    return s.ReadonlyProperty
+	return s.ReadonlyProperty
 }
 
 func (s *StableClass) GetMutableProperty() float64 {
-    return s.MutableProperty
+	return s.MutableProperty
 }
 
 
 func NewStableClass(readonlyString string, mutableNumber float64) StableClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StableClass",
-        Method: "Constructor",
-        Args: []string{"string", "number",},
-    })
-    return &StableClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StableClass",
+		Method: "Constructor",
+		Args: []string{"string", "number",},
+	})
+	return &StableClass{}
 }
 
 func (s *StableClass) SetReadonlyProperty(val string) {
-    s.ReadonlyProperty = val
+	s.ReadonlyProperty = val
 }
 
 func (s *StableClass) SetMutableProperty(val float64) {
-    s.MutableProperty = val
+	s.MutableProperty = val
 }
 
 func (s *StableClass) Method() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StableClass",
-        Method: "Method",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StableClass",
+		Method: "Method",
+		Args: []string{},
+	})
 }
 
 type StableEnum string
 
 const (
-    StableEnumOptionA StableEnum = "OPTION_A"
-    StableEnumOptionB StableEnum = "OPTION_B"
+	StableEnumOptionA StableEnum = "OPTION_A"
+	StableEnumOptionB StableEnum = "OPTION_B"
 )
 
 // StableStructIface is the public interface for the custom type StableStruct
 type StableStructIface interface {
-    GetReadonlyProperty() string
+	GetReadonlyProperty() string
 }
 
 // Struct proxy
 type StableStruct struct {
-    ReadonlyProperty string
+	ReadonlyProperty string
 }
 
 func (s *StableStruct) GetReadonlyProperty() string {
-    return s.ReadonlyProperty
+	return s.ReadonlyProperty
 }
 
 
 // Class interface
 type StaticContextIface interface {
-    GetStaticVariable() bool
-    SetStaticVariable(val bool)
+	GetStaticVariable() bool
+	SetStaticVariable(val bool)
 }
 
 // This is used to validate the ability to use \`this\` from within a static context.
@@ -7330,244 +7330,244 @@ type StaticContextIface interface {
 // https://github.com/awslabs/aws-cdk/issues/2304
 // Struct proxy
 type StaticContext struct {
-    StaticVariable bool
+	StaticVariable bool
 }
 
 func (s *StaticContext) GetStaticVariable() bool {
-    return s.StaticVariable
+	return s.StaticVariable
 }
 
 
 func (s *StaticContext) SetStaticVariable(val bool) {
-    s.StaticVariable = val
+	s.StaticVariable = val
 }
 
 func StaticContext_CanAccessStaticContext() bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StaticContext",
-        Method: "CanAccessStaticContext",
-        Args: []string{},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StaticContext",
+		Method: "CanAccessStaticContext",
+		Args: []string{},
+	})
+	return true
 }
 
 // Class interface
 type StaticsIface interface {
-    GetBar() float64
-    SetBar(val float64)
-    GetConstObj() DoubleTrouble
-    SetConstObj(val DoubleTrouble)
-    GetFoo() string
-    SetFoo(val string)
-    GetZooBar() map[string]string
-    SetZooBar(val map[string]string)
-    GetInstance() Statics
-    SetInstance(val Statics)
-    GetNonConstStatic() float64
-    SetNonConstStatic(val float64)
-    GetValue() string
-    SetValue(val string)
-    JustMethod() string
+	GetBar() float64
+	SetBar(val float64)
+	GetConstObj() DoubleTrouble
+	SetConstObj(val DoubleTrouble)
+	GetFoo() string
+	SetFoo(val string)
+	GetZooBar() map[string]string
+	SetZooBar(val map[string]string)
+	GetInstance() Statics
+	SetInstance(val Statics)
+	GetNonConstStatic() float64
+	SetNonConstStatic(val float64)
+	GetValue() string
+	SetValue(val string)
+	JustMethod() string
 }
 
 // Struct proxy
 type Statics struct {
-    // Constants may also use all-caps.
-    Bar float64
-    ConstObj DoubleTrouble
-    // Jsdocs for static property.
-    Foo string
-    // Constants can also use camelCase.
-    ZooBar map[string]string
-    // Jsdocs for static getter.
-    // 
-    // Jsdocs for static setter.
-    Instance *Statics
-    NonConstStatic float64
-    Value string
+	// Constants may also use all-caps.
+	Bar float64
+	ConstObj DoubleTrouble
+	// Jsdocs for static property.
+	Foo string
+	// Constants can also use camelCase.
+	ZooBar map[string]string
+	// Jsdocs for static getter.
+	// 
+	// Jsdocs for static setter.
+	Instance *Statics
+	NonConstStatic float64
+	Value string
 }
 
 func (s *Statics) GetBar() float64 {
-    return s.Bar
+	return s.Bar
 }
 
 func (s *Statics) GetConstObj() DoubleTrouble {
-    return s.ConstObj
+	return s.ConstObj
 }
 
 func (s *Statics) GetFoo() string {
-    return s.Foo
+	return s.Foo
 }
 
 func (s *Statics) GetZooBar() map[string]string {
-    return s.ZooBar
+	return s.ZooBar
 }
 
 func (s *Statics) GetInstance() Statics {
-    return *s.Instance
+	return *s.Instance
 }
 
 func (s *Statics) GetNonConstStatic() float64 {
-    return s.NonConstStatic
+	return s.NonConstStatic
 }
 
 func (s *Statics) GetValue() string {
-    return s.Value
+	return s.Value
 }
 
 
 func NewStatics(value string) StaticsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Statics",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &Statics{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Statics",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &Statics{}
 }
 
 func (s *Statics) SetBar(val float64) {
-    s.Bar = val
+	s.Bar = val
 }
 
 func (s *Statics) SetConstObj(val DoubleTrouble) {
-    s.ConstObj = val
+	s.ConstObj = val
 }
 
 func (s *Statics) SetFoo(val string) {
-    s.Foo = val
+	s.Foo = val
 }
 
 func (s *Statics) SetZooBar(val map[string]string) {
-    s.ZooBar = val
+	s.ZooBar = val
 }
 
 func (s *Statics) SetInstance(val Statics) {
-    s.Instance = &val
+	s.Instance = &val
 }
 
 func (s *Statics) SetNonConstStatic(val float64) {
-    s.NonConstStatic = val
+	s.NonConstStatic = val
 }
 
 func (s *Statics) SetValue(val string) {
-    s.Value = val
+	s.Value = val
 }
 
 func Statics_StaticMethod(name string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Statics",
-        Method: "StaticMethod",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Statics",
+		Method: "StaticMethod",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (s *Statics) JustMethod() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Statics",
-        Method: "JustMethod",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Statics",
+		Method: "JustMethod",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 type StringEnum string
 
 const (
-    StringEnumA StringEnum = "A"
-    StringEnumB StringEnum = "B"
-    StringEnumC StringEnum = "C"
+	StringEnumA StringEnum = "A"
+	StringEnumB StringEnum = "B"
+	StringEnumC StringEnum = "C"
 )
 
 // Class interface
 type StripInternalIface interface {
-    GetYouSeeMe() string
-    SetYouSeeMe(val string)
+	GetYouSeeMe() string
+	SetYouSeeMe(val string)
 }
 
 // Struct proxy
 type StripInternal struct {
-    YouSeeMe string
+	YouSeeMe string
 }
 
 func (s *StripInternal) GetYouSeeMe() string {
-    return s.YouSeeMe
+	return s.YouSeeMe
 }
 
 
 func NewStripInternal() StripInternalIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StripInternal",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &StripInternal{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StripInternal",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &StripInternal{}
 }
 
 func (s *StripInternal) SetYouSeeMe(val string) {
-    s.YouSeeMe = val
+	s.YouSeeMe = val
 }
 
 // StructAIface is the public interface for the custom type StructA
 type StructAIface interface {
-    GetRequiredString() string
-    GetOptionalNumber() float64
-    GetOptionalString() string
+	GetRequiredString() string
+	GetOptionalNumber() float64
+	GetOptionalString() string
 }
 
 // We can serialize and deserialize structs without silently ignoring optional fields.
 // Struct proxy
 type StructA struct {
-    RequiredString string
-    OptionalNumber float64
-    OptionalString string
+	RequiredString string
+	OptionalNumber float64
+	OptionalString string
 }
 
 func (s *StructA) GetRequiredString() string {
-    return s.RequiredString
+	return s.RequiredString
 }
 
 func (s *StructA) GetOptionalNumber() float64 {
-    return s.OptionalNumber
+	return s.OptionalNumber
 }
 
 func (s *StructA) GetOptionalString() string {
-    return s.OptionalString
+	return s.OptionalString
 }
 
 
 // StructBIface is the public interface for the custom type StructB
 type StructBIface interface {
-    GetRequiredString() string
-    GetOptionalBoolean() bool
-    GetOptionalStructA() StructA
+	GetRequiredString() string
+	GetOptionalBoolean() bool
+	GetOptionalStructA() StructA
 }
 
 // This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
 // Struct proxy
 type StructB struct {
-    RequiredString string
-    OptionalBoolean bool
-    OptionalStructA StructA
+	RequiredString string
+	OptionalBoolean bool
+	OptionalStructA StructA
 }
 
 func (s *StructB) GetRequiredString() string {
-    return s.RequiredString
+	return s.RequiredString
 }
 
 func (s *StructB) GetOptionalBoolean() bool {
-    return s.OptionalBoolean
+	return s.OptionalBoolean
 }
 
 func (s *StructB) GetOptionalStructA() StructA {
-    return s.OptionalStructA
+	return s.OptionalStructA
 }
 
 
 // StructParameterTypeIface is the public interface for the custom type StructParameterType
 type StructParameterTypeIface interface {
-    GetScope() string
-    GetProps() bool
+	GetScope() string
+	GetProps() bool
 }
 
 // Verifies that, in languages that do keyword lifting (e.g: Python), having a struct member with the same name as a positional parameter results in the correct code being emitted.
@@ -7575,16 +7575,16 @@ type StructParameterTypeIface interface {
 // See: https://github.com/aws/aws-cdk/issues/4302
 // Struct proxy
 type StructParameterType struct {
-    Scope string
-    Props bool
+	Scope string
+	Props bool
 }
 
 func (s *StructParameterType) GetScope() string {
-    return s.Scope
+	return s.Scope
 }
 
 func (s *StructParameterType) GetProps() bool {
-    return s.Props
+	return s.Props
 }
 
 
@@ -7598,30 +7598,30 @@ type StructPassing struct {
 }
 
 func NewStructPassing() StructPassingIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StructPassing",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &StructPassing{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StructPassing",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &StructPassing{}
 }
 
 func StructPassing_HowManyVarArgsDidIPass(_positional float64, inputs TopLevelStruct) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StructPassing",
-        Method: "HowManyVarArgsDidIPass",
-        Args: []string{"number", "jsii-calc.TopLevelStruct",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StructPassing",
+		Method: "HowManyVarArgsDidIPass",
+		Args: []string{"number", "jsii-calc.TopLevelStruct",},
+	})
+	return 0.0
 }
 
 func StructPassing_RoundTrip(_positional float64, input TopLevelStruct) TopLevelStruct {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StructPassing",
-        Method: "RoundTrip",
-        Args: []string{"number", "jsii-calc.TopLevelStruct",},
-    })
-    return TopLevelStruct{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StructPassing",
+		Method: "RoundTrip",
+		Args: []string{"number", "jsii-calc.TopLevelStruct",},
+	})
+	return TopLevelStruct{}
 }
 
 // Class interface
@@ -7633,494 +7633,494 @@ type StructUnionConsumer struct {
 }
 
 func StructUnionConsumer_IsStructA(struct_ jsii.Any) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StructUnionConsumer",
-        Method: "IsStructA",
-        Args: []string{"jsii-calc.StructA | jsii-calc.StructB",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StructUnionConsumer",
+		Method: "IsStructA",
+		Args: []string{"jsii-calc.StructA | jsii-calc.StructB",},
+	})
+	return true
 }
 
 func StructUnionConsumer_IsStructB(struct_ jsii.Any) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "StructUnionConsumer",
-        Method: "IsStructB",
-        Args: []string{"jsii-calc.StructA | jsii-calc.StructB",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "StructUnionConsumer",
+		Method: "IsStructB",
+		Args: []string{"jsii-calc.StructA | jsii-calc.StructB",},
+	})
+	return true
 }
 
 // StructWithJavaReservedWordsIface is the public interface for the custom type StructWithJavaReservedWords
 type StructWithJavaReservedWordsIface interface {
-    GetDefault() string
-    GetAssert() string
-    GetResult() string
-    GetThat() string
+	GetDefault() string
+	GetAssert() string
+	GetResult() string
+	GetThat() string
 }
 
 // Struct proxy
 type StructWithJavaReservedWords struct {
-    Default string
-    Assert string
-    Result string
-    That string
+	Default string
+	Assert string
+	Result string
+	That string
 }
 
 func (s *StructWithJavaReservedWords) GetDefault() string {
-    return s.Default
+	return s.Default
 }
 
 func (s *StructWithJavaReservedWords) GetAssert() string {
-    return s.Assert
+	return s.Assert
 }
 
 func (s *StructWithJavaReservedWords) GetResult() string {
-    return s.Result
+	return s.Result
 }
 
 func (s *StructWithJavaReservedWords) GetThat() string {
-    return s.That
+	return s.That
 }
 
 
 // Class interface
 type SumIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    GetExpression() scopejsiicalclib.NumericValue
-    SetExpression(val scopejsiicalclib.NumericValue)
-    GetDecorationPostfixes() []string
-    SetDecorationPostfixes(val []string)
-    GetDecorationPrefixes() []string
-    SetDecorationPrefixes(val []string)
-    GetStringStyle() composition.CompositionStringStyle
-    SetStringStyle(val composition.CompositionStringStyle)
-    GetParts() []scopejsiicalclib.NumericValue
-    SetParts(val []scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	GetExpression() scopejsiicalclib.NumericValue
+	SetExpression(val scopejsiicalclib.NumericValue)
+	GetDecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	GetDecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
+	GetStringStyle() composition.CompositionStringStyle
+	SetStringStyle(val composition.CompositionStringStyle)
+	GetParts() []scopejsiicalclib.NumericValue
+	SetParts(val []scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // An operation that sums multiple values.
 // Struct proxy
 type Sum struct {
-    // (deprecated) The value.
-    Value float64
-    // The expression that this operation consists of.
-    // 
-    // Must be implemented by derived classes.
-    Expression scopejsiicalclib.NumericValue
-    // A set of postfixes to include in a decorated .toString().
-    DecorationPostfixes []string
-    // A set of prefixes to include in a decorated .toString().
-    DecorationPrefixes []string
-    // The .toString() style.
-    StringStyle composition.CompositionStringStyle
-    // The parts to sum.
-    Parts []scopejsiicalclib.NumericValue
+	// (deprecated) The value.
+	Value float64
+	// The expression that this operation consists of.
+	// 
+	// Must be implemented by derived classes.
+	Expression scopejsiicalclib.NumericValue
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes []string
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes []string
+	// The .toString() style.
+	StringStyle composition.CompositionStringStyle
+	// The parts to sum.
+	Parts []scopejsiicalclib.NumericValue
 }
 
 func (s *Sum) GetValue() float64 {
-    return s.Value
+	return s.Value
 }
 
 func (s *Sum) GetExpression() scopejsiicalclib.NumericValue {
-    return s.Expression
+	return s.Expression
 }
 
 func (s *Sum) GetDecorationPostfixes() []string {
-    return s.DecorationPostfixes
+	return s.DecorationPostfixes
 }
 
 func (s *Sum) GetDecorationPrefixes() []string {
-    return s.DecorationPrefixes
+	return s.DecorationPrefixes
 }
 
 func (s *Sum) GetStringStyle() composition.CompositionStringStyle {
-    return s.StringStyle
+	return s.StringStyle
 }
 
 func (s *Sum) GetParts() []scopejsiicalclib.NumericValue {
-    return s.Parts
+	return s.Parts
 }
 
 
 func NewSum() SumIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Sum",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Sum{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Sum",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Sum{}
 }
 
 func (s *Sum) SetValue(val float64) {
-    s.Value = val
+	s.Value = val
 }
 
 func (s *Sum) SetExpression(val scopejsiicalclib.NumericValue) {
-    s.Expression = val
+	s.Expression = val
 }
 
 func (s *Sum) SetDecorationPostfixes(val []string) {
-    s.DecorationPostfixes = val
+	s.DecorationPostfixes = val
 }
 
 func (s *Sum) SetDecorationPrefixes(val []string) {
-    s.DecorationPrefixes = val
+	s.DecorationPrefixes = val
 }
 
 func (s *Sum) SetStringStyle(val composition.CompositionStringStyle) {
-    s.StringStyle = val
+	s.StringStyle = val
 }
 
 func (s *Sum) SetParts(val []scopejsiicalclib.NumericValue) {
-    s.Parts = val
+	s.Parts = val
 }
 
 func (s *Sum) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Sum",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Sum",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (s *Sum) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Sum",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Sum",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type SupportsNiceJavaBuilderIface interface {
-    GetBar() float64
-    SetBar(val float64)
-    GetId() float64
-    SetId(val float64)
-    GetPropId() string
-    SetPropId(val string)
-    GetRest() []string
-    SetRest(val []string)
+	GetBar() float64
+	SetBar(val float64)
+	GetId() float64
+	SetId(val float64)
+	GetPropId() string
+	SetPropId(val string)
+	GetRest() []string
+	SetRest(val []string)
 }
 
 // Struct proxy
 type SupportsNiceJavaBuilder struct {
-    Bar float64
-    // some identifier.
-    Id float64
-    PropId string
-    Rest []string
+	Bar float64
+	// some identifier.
+	Id float64
+	PropId string
+	Rest []string
 }
 
 func (s *SupportsNiceJavaBuilder) GetBar() float64 {
-    return s.Bar
+	return s.Bar
 }
 
 func (s *SupportsNiceJavaBuilder) GetId() float64 {
-    return s.Id
+	return s.Id
 }
 
 func (s *SupportsNiceJavaBuilder) GetPropId() string {
-    return s.PropId
+	return s.PropId
 }
 
 func (s *SupportsNiceJavaBuilder) GetRest() []string {
-    return s.Rest
+	return s.Rest
 }
 
 
 func NewSupportsNiceJavaBuilder(id float64, defaultBar float64, props SupportsNiceJavaBuilderProps, rest string) SupportsNiceJavaBuilderIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SupportsNiceJavaBuilder",
-        Method: "Constructor",
-        Args: []string{"number", "number", "jsii-calc.SupportsNiceJavaBuilderProps", "string",},
-    })
-    return &SupportsNiceJavaBuilder{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SupportsNiceJavaBuilder",
+		Method: "Constructor",
+		Args: []string{"number", "number", "jsii-calc.SupportsNiceJavaBuilderProps", "string",},
+	})
+	return &SupportsNiceJavaBuilder{}
 }
 
 func (s *SupportsNiceJavaBuilder) SetBar(val float64) {
-    s.Bar = val
+	s.Bar = val
 }
 
 func (s *SupportsNiceJavaBuilder) SetId(val float64) {
-    s.Id = val
+	s.Id = val
 }
 
 func (s *SupportsNiceJavaBuilder) SetPropId(val string) {
-    s.PropId = val
+	s.PropId = val
 }
 
 func (s *SupportsNiceJavaBuilder) SetRest(val []string) {
-    s.Rest = val
+	s.Rest = val
 }
 
 // SupportsNiceJavaBuilderPropsIface is the public interface for the custom type SupportsNiceJavaBuilderProps
 type SupportsNiceJavaBuilderPropsIface interface {
-    GetBar() float64
-    GetId() string
+	GetBar() float64
+	GetId() string
 }
 
 // Struct proxy
 type SupportsNiceJavaBuilderProps struct {
-    // Some number, like 42.
-    Bar float64
-    // An \`id\` field here is terrible API design, because the constructor of \`SupportsNiceJavaBuilder\` already has a parameter named \`id\`.
-    // 
-    // But here we are, doing it like we didn't care.
-    Id string
+	// Some number, like 42.
+	Bar float64
+	// An \`id\` field here is terrible API design, because the constructor of \`SupportsNiceJavaBuilder\` already has a parameter named \`id\`.
+	// 
+	// But here we are, doing it like we didn't care.
+	Id string
 }
 
 func (s *SupportsNiceJavaBuilderProps) GetBar() float64 {
-    return s.Bar
+	return s.Bar
 }
 
 func (s *SupportsNiceJavaBuilderProps) GetId() string {
-    return s.Id
+	return s.Id
 }
 
 
 // Class interface
 type SupportsNiceJavaBuilderWithRequiredPropsIface interface {
-    GetBar() float64
-    SetBar(val float64)
-    GetId() float64
-    SetId(val float64)
-    GetPropId() string
-    SetPropId(val string)
+	GetBar() float64
+	SetBar(val float64)
+	GetId() float64
+	SetId(val float64)
+	GetPropId() string
+	SetPropId(val string)
 }
 
 // We can generate fancy builders in Java for classes which take a mix of positional & struct parameters.
 // Struct proxy
 type SupportsNiceJavaBuilderWithRequiredProps struct {
-    Bar float64
-    // some identifier of your choice.
-    Id float64
-    PropId string
+	Bar float64
+	// some identifier of your choice.
+	Id float64
+	PropId string
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) GetBar() float64 {
-    return s.Bar
+	return s.Bar
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) GetId() float64 {
-    return s.Id
+	return s.Id
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) GetPropId() string {
-    return s.PropId
+	return s.PropId
 }
 
 
 func NewSupportsNiceJavaBuilderWithRequiredProps(id float64, props SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredPropsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SupportsNiceJavaBuilderWithRequiredProps",
-        Method: "Constructor",
-        Args: []string{"number", "jsii-calc.SupportsNiceJavaBuilderProps",},
-    })
-    return &SupportsNiceJavaBuilderWithRequiredProps{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SupportsNiceJavaBuilderWithRequiredProps",
+		Method: "Constructor",
+		Args: []string{"number", "jsii-calc.SupportsNiceJavaBuilderProps",},
+	})
+	return &SupportsNiceJavaBuilderWithRequiredProps{}
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) SetBar(val float64) {
-    s.Bar = val
+	s.Bar = val
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) SetId(val float64) {
-    s.Id = val
+	s.Id = val
 }
 
 func (s *SupportsNiceJavaBuilderWithRequiredProps) SetPropId(val string) {
-    s.PropId = val
+	s.PropId = val
 }
 
 // Class interface
 type SyncVirtualMethodsIface interface {
-    GetReadonlyProperty() string
-    SetReadonlyProperty(val string)
-    GetA() float64
-    SetA(val float64)
-    GetCallerIsProperty() float64
-    SetCallerIsProperty(val float64)
-    GetOtherProperty() string
-    SetOtherProperty(val string)
-    GetTheProperty() string
-    SetTheProperty(val string)
-    GetValueOfOtherProperty() string
-    SetValueOfOtherProperty(val string)
-    CallerIsAsync() float64
-    CallerIsMethod() float64
-    ModifyOtherProperty(value string)
-    ModifyValueOfTheProperty(value string)
-    ReadA() float64
-    RetrieveOtherProperty() string
-    RetrieveReadOnlyProperty() string
-    RetrieveValueOfTheProperty() string
-    VirtualMethod(n float64) float64
-    WriteA(value float64)
+	GetReadonlyProperty() string
+	SetReadonlyProperty(val string)
+	GetA() float64
+	SetA(val float64)
+	GetCallerIsProperty() float64
+	SetCallerIsProperty(val float64)
+	GetOtherProperty() string
+	SetOtherProperty(val string)
+	GetTheProperty() string
+	SetTheProperty(val string)
+	GetValueOfOtherProperty() string
+	SetValueOfOtherProperty(val string)
+	CallerIsAsync() float64
+	CallerIsMethod() float64
+	ModifyOtherProperty(value string)
+	ModifyValueOfTheProperty(value string)
+	ReadA() float64
+	RetrieveOtherProperty() string
+	RetrieveReadOnlyProperty() string
+	RetrieveValueOfTheProperty() string
+	VirtualMethod(n float64) float64
+	WriteA(value float64)
 }
 
 // Struct proxy
 type SyncVirtualMethods struct {
-    ReadonlyProperty string
-    A float64
-    CallerIsProperty float64
-    OtherProperty string
-    TheProperty string
-    ValueOfOtherProperty string
+	ReadonlyProperty string
+	A float64
+	CallerIsProperty float64
+	OtherProperty string
+	TheProperty string
+	ValueOfOtherProperty string
 }
 
 func (s *SyncVirtualMethods) GetReadonlyProperty() string {
-    return s.ReadonlyProperty
+	return s.ReadonlyProperty
 }
 
 func (s *SyncVirtualMethods) GetA() float64 {
-    return s.A
+	return s.A
 }
 
 func (s *SyncVirtualMethods) GetCallerIsProperty() float64 {
-    return s.CallerIsProperty
+	return s.CallerIsProperty
 }
 
 func (s *SyncVirtualMethods) GetOtherProperty() string {
-    return s.OtherProperty
+	return s.OtherProperty
 }
 
 func (s *SyncVirtualMethods) GetTheProperty() string {
-    return s.TheProperty
+	return s.TheProperty
 }
 
 func (s *SyncVirtualMethods) GetValueOfOtherProperty() string {
-    return s.ValueOfOtherProperty
+	return s.ValueOfOtherProperty
 }
 
 
 func NewSyncVirtualMethods() SyncVirtualMethodsIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &SyncVirtualMethods{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &SyncVirtualMethods{}
 }
 
 func (s *SyncVirtualMethods) SetReadonlyProperty(val string) {
-    s.ReadonlyProperty = val
+	s.ReadonlyProperty = val
 }
 
 func (s *SyncVirtualMethods) SetA(val float64) {
-    s.A = val
+	s.A = val
 }
 
 func (s *SyncVirtualMethods) SetCallerIsProperty(val float64) {
-    s.CallerIsProperty = val
+	s.CallerIsProperty = val
 }
 
 func (s *SyncVirtualMethods) SetOtherProperty(val string) {
-    s.OtherProperty = val
+	s.OtherProperty = val
 }
 
 func (s *SyncVirtualMethods) SetTheProperty(val string) {
-    s.TheProperty = val
+	s.TheProperty = val
 }
 
 func (s *SyncVirtualMethods) SetValueOfOtherProperty(val string) {
-    s.ValueOfOtherProperty = val
+	s.ValueOfOtherProperty = val
 }
 
 func (s *SyncVirtualMethods) CallerIsAsync() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "CallerIsAsync",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "CallerIsAsync",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (s *SyncVirtualMethods) CallerIsMethod() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "CallerIsMethod",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "CallerIsMethod",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (s *SyncVirtualMethods) ModifyOtherProperty(value string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "ModifyOtherProperty",
-        Args: []string{"string",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "ModifyOtherProperty",
+		Args: []string{"string",},
+	})
 }
 
 func (s *SyncVirtualMethods) ModifyValueOfTheProperty(value string) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "ModifyValueOfTheProperty",
-        Args: []string{"string",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "ModifyValueOfTheProperty",
+		Args: []string{"string",},
+	})
 }
 
 func (s *SyncVirtualMethods) ReadA() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "ReadA",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "ReadA",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 func (s *SyncVirtualMethods) RetrieveOtherProperty() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "RetrieveOtherProperty",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "RetrieveOtherProperty",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (s *SyncVirtualMethods) RetrieveReadOnlyProperty() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "RetrieveReadOnlyProperty",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "RetrieveReadOnlyProperty",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (s *SyncVirtualMethods) RetrieveValueOfTheProperty() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "RetrieveValueOfTheProperty",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "RetrieveValueOfTheProperty",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (s *SyncVirtualMethods) VirtualMethod(n float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "VirtualMethod",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "VirtualMethod",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (s *SyncVirtualMethods) WriteA(value float64) {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "SyncVirtualMethods",
-        Method: "WriteA",
-        Args: []string{"number",},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "SyncVirtualMethods",
+		Method: "WriteA",
+		Args: []string{"number",},
+	})
 }
 
 // Class interface
 type ThrowerIface interface {
-    ThrowError()
+	ThrowError()
 }
 
 // Struct proxy
@@ -8128,49 +8128,49 @@ type Thrower struct {
 }
 
 func NewThrower() ThrowerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Thrower",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &Thrower{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Thrower",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &Thrower{}
 }
 
 func (t *Thrower) ThrowError() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Thrower",
-        Method: "ThrowError",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Thrower",
+		Method: "ThrowError",
+		Args: []string{},
+	})
 }
 
 // TopLevelStructIface is the public interface for the custom type TopLevelStruct
 type TopLevelStructIface interface {
-    GetRequired() string
-    GetSecondLevel() jsii.Any
-    GetOptional() string
+	GetRequired() string
+	GetSecondLevel() jsii.Any
+	GetOptional() string
 }
 
 // Struct proxy
 type TopLevelStruct struct {
-    // This is a required field.
-    Required string
-    // A union to really stress test our serialization.
-    SecondLevel jsii.Any
-    // You don't have to pass this.
-    Optional string
+	// This is a required field.
+	Required string
+	// A union to really stress test our serialization.
+	SecondLevel jsii.Any
+	// You don't have to pass this.
+	Optional string
 }
 
 func (t *TopLevelStruct) GetRequired() string {
-    return t.Required
+	return t.Required
 }
 
 func (t *TopLevelStruct) GetSecondLevel() jsii.Any {
-    return t.SecondLevel
+	return t.SecondLevel
 }
 
 func (t *TopLevelStruct) GetOptional() string {
-    return t.Optional
+	return t.Optional
 }
 
 
@@ -8186,143 +8186,143 @@ type UmaskCheck struct {
 }
 
 func UmaskCheck_Mode() float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UmaskCheck",
-        Method: "Mode",
-        Args: []string{},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UmaskCheck",
+		Method: "Mode",
+		Args: []string{},
+	})
+	return 0.0
 }
 
 // Class interface
 type UnaryOperationIface interface {
-    GetValue() float64
-    SetValue(val float64)
-    GetOperand() scopejsiicalclib.NumericValue
-    SetOperand(val scopejsiicalclib.NumericValue)
-    TypeName() jsii.Any
-    ToString() string
+	GetValue() float64
+	SetValue(val float64)
+	GetOperand() scopejsiicalclib.NumericValue
+	SetOperand(val scopejsiicalclib.NumericValue)
+	TypeName() jsii.Any
+	ToString() string
 }
 
 // An operation on a single operand.
 // Struct proxy
 type UnaryOperation struct {
-    // The value.
-    // Deprecated.
-    Value float64
-    Operand scopejsiicalclib.NumericValue
+	// The value.
+	// Deprecated.
+	Value float64
+	Operand scopejsiicalclib.NumericValue
 }
 
 func (u *UnaryOperation) GetValue() float64 {
-    return u.Value
+	return u.Value
 }
 
 func (u *UnaryOperation) GetOperand() scopejsiicalclib.NumericValue {
-    return u.Operand
+	return u.Operand
 }
 
 
 func NewUnaryOperation(operand scopejsiicalclib.NumericValue) UnaryOperationIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UnaryOperation",
-        Method: "Constructor",
-        Args: []string{"@scope/jsii-calc-lib.NumericValue",},
-    })
-    return &UnaryOperation{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UnaryOperation",
+		Method: "Constructor",
+		Args: []string{"@scope/jsii-calc-lib.NumericValue",},
+	})
+	return &UnaryOperation{}
 }
 
 func (u *UnaryOperation) SetValue(val float64) {
-    u.Value = val
+	u.Value = val
 }
 
 func (u *UnaryOperation) SetOperand(val scopejsiicalclib.NumericValue) {
-    u.Operand = val
+	u.Operand = val
 }
 
 func (u *UnaryOperation) TypeName() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UnaryOperation",
-        Method: "TypeName",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UnaryOperation",
+		Method: "TypeName",
+		Args: []string{},
+	})
+	return nil
 }
 
 func (u *UnaryOperation) ToString() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UnaryOperation",
-        Method: "ToString",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UnaryOperation",
+		Method: "ToString",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // UnionPropertiesIface is the public interface for the custom type UnionProperties
 type UnionPropertiesIface interface {
-    GetBar() jsii.Any
-    GetFoo() jsii.Any
+	GetBar() jsii.Any
+	GetFoo() jsii.Any
 }
 
 // Struct proxy
 type UnionProperties struct {
-    Bar jsii.Any
-    Foo jsii.Any
+	Bar jsii.Any
+	Foo jsii.Any
 }
 
 func (u *UnionProperties) GetBar() jsii.Any {
-    return u.Bar
+	return u.Bar
 }
 
 func (u *UnionProperties) GetFoo() jsii.Any {
-    return u.Foo
+	return u.Foo
 }
 
 
 // Class interface
 type UpcasingReflectableIface interface {
-    submodule.IReflectable
-    GetReflector() submodule.Reflector
-    SetReflector(val submodule.Reflector)
-    GetEntries() []submodule.ReflectableEntry
-    SetEntries(val []submodule.ReflectableEntry)
+	submodule.IReflectable
+	GetReflector() submodule.Reflector
+	SetReflector(val submodule.Reflector)
+	GetEntries() []submodule.ReflectableEntry
+	SetEntries(val []submodule.ReflectableEntry)
 }
 
 // Ensures submodule-imported types from dependencies can be used correctly.
 // Struct proxy
 type UpcasingReflectable struct {
-    Reflector submodule.Reflector
-    Entries []submodule.ReflectableEntry
+	Reflector submodule.Reflector
+	Entries []submodule.ReflectableEntry
 }
 
 func (u *UpcasingReflectable) GetReflector() submodule.Reflector {
-    return u.Reflector
+	return u.Reflector
 }
 
 func (u *UpcasingReflectable) GetEntries() []submodule.ReflectableEntry {
-    return u.Entries
+	return u.Entries
 }
 
 
 func NewUpcasingReflectable(delegate map[string]jsii.Any) UpcasingReflectableIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UpcasingReflectable",
-        Method: "Constructor",
-        Args: []string{"Map<string => any>",},
-    })
-    return &UpcasingReflectable{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UpcasingReflectable",
+		Method: "Constructor",
+		Args: []string{"Map<string => any>",},
+	})
+	return &UpcasingReflectable{}
 }
 
 func (u *UpcasingReflectable) SetReflector(val submodule.Reflector) {
-    u.Reflector = val
+	u.Reflector = val
 }
 
 func (u *UpcasingReflectable) SetEntries(val []submodule.ReflectableEntry) {
-    u.Entries = val
+	u.Entries = val
 }
 
 // Class interface
 type UseBundledDependencyIface interface {
-    Value() jsii.Any
+	Value() jsii.Any
 }
 
 // Struct proxy
@@ -8330,26 +8330,26 @@ type UseBundledDependency struct {
 }
 
 func NewUseBundledDependency() UseBundledDependencyIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UseBundledDependency",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &UseBundledDependency{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UseBundledDependency",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &UseBundledDependency{}
 }
 
 func (u *UseBundledDependency) Value() jsii.Any {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UseBundledDependency",
-        Method: "Value",
-        Args: []string{},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UseBundledDependency",
+		Method: "Value",
+		Args: []string{},
+	})
+	return nil
 }
 
 // Class interface
 type UseCalcBaseIface interface {
-    Hello() scopejsiicalcbase.Base
+	Hello() scopejsiicalcbase.Base
 }
 
 // Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
@@ -8358,85 +8358,85 @@ type UseCalcBase struct {
 }
 
 func NewUseCalcBase() UseCalcBaseIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UseCalcBase",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &UseCalcBase{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UseCalcBase",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &UseCalcBase{}
 }
 
 func (u *UseCalcBase) Hello() scopejsiicalcbase.Base {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UseCalcBase",
-        Method: "Hello",
-        Args: []string{},
-    })
-    return scopejsiicalcbase.Base{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UseCalcBase",
+		Method: "Hello",
+		Args: []string{},
+	})
+	return scopejsiicalcbase.Base{}
 }
 
 // Class interface
 type UsesInterfaceWithPropertiesIface interface {
-    GetObj() IInterfaceWithProperties
-    SetObj(val IInterfaceWithProperties)
-    JustRead() string
-    ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) string
-    WriteAndRead(value string) string
+	GetObj() IInterfaceWithProperties
+	SetObj(val IInterfaceWithProperties)
+	JustRead() string
+	ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) string
+	WriteAndRead(value string) string
 }
 
 // Struct proxy
 type UsesInterfaceWithProperties struct {
-    Obj IInterfaceWithProperties
+	Obj IInterfaceWithProperties
 }
 
 func (u *UsesInterfaceWithProperties) GetObj() IInterfaceWithProperties {
-    return u.Obj
+	return u.Obj
 }
 
 
 func NewUsesInterfaceWithProperties(obj IInterfaceWithProperties) UsesInterfaceWithPropertiesIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UsesInterfaceWithProperties",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.IInterfaceWithProperties",},
-    })
-    return &UsesInterfaceWithProperties{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UsesInterfaceWithProperties",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.IInterfaceWithProperties",},
+	})
+	return &UsesInterfaceWithProperties{}
 }
 
 func (u *UsesInterfaceWithProperties) SetObj(val IInterfaceWithProperties) {
-    u.Obj = val
+	u.Obj = val
 }
 
 func (u *UsesInterfaceWithProperties) JustRead() string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UsesInterfaceWithProperties",
-        Method: "JustRead",
-        Args: []string{},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UsesInterfaceWithProperties",
+		Method: "JustRead",
+		Args: []string{},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (u *UsesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UsesInterfaceWithProperties",
-        Method: "ReadStringAndNumber",
-        Args: []string{"jsii-calc.IInterfaceWithPropertiesExtension",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UsesInterfaceWithProperties",
+		Method: "ReadStringAndNumber",
+		Args: []string{"jsii-calc.IInterfaceWithPropertiesExtension",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 func (u *UsesInterfaceWithProperties) WriteAndRead(value string) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "UsesInterfaceWithProperties",
-        Method: "WriteAndRead",
-        Args: []string{"string",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "UsesInterfaceWithProperties",
+		Method: "WriteAndRead",
+		Args: []string{"string",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type VariadicInvokerIface interface {
-    AsArray(values float64) []float64
+	AsArray(values float64) []float64
 }
 
 // Struct proxy
@@ -8444,26 +8444,26 @@ type VariadicInvoker struct {
 }
 
 func NewVariadicInvoker(method VariadicMethod) VariadicInvokerIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VariadicInvoker",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.VariadicMethod",},
-    })
-    return &VariadicInvoker{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VariadicInvoker",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.VariadicMethod",},
+	})
+	return &VariadicInvoker{}
 }
 
 func (v *VariadicInvoker) AsArray(values float64) []float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VariadicInvoker",
-        Method: "AsArray",
-        Args: []string{"number",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VariadicInvoker",
+		Method: "AsArray",
+		Args: []string{"number",},
+	})
+	return nil
 }
 
 // Class interface
 type VariadicMethodIface interface {
-    AsArray(first float64, others float64) []float64
+	AsArray(first float64, others float64) []float64
 }
 
 // Struct proxy
@@ -8471,30 +8471,30 @@ type VariadicMethod struct {
 }
 
 func NewVariadicMethod(prefix float64) VariadicMethodIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VariadicMethod",
-        Method: "Constructor",
-        Args: []string{"number",},
-    })
-    return &VariadicMethod{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VariadicMethod",
+		Method: "Constructor",
+		Args: []string{"number",},
+	})
+	return &VariadicMethod{}
 }
 
 func (v *VariadicMethod) AsArray(first float64, others float64) []float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VariadicMethod",
-        Method: "AsArray",
-        Args: []string{"number", "number",},
-    })
-    return nil
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VariadicMethod",
+		Method: "AsArray",
+		Args: []string{"number", "number",},
+	})
+	return nil
 }
 
 // Class interface
 type VirtualMethodPlaygroundIface interface {
-    OverrideMeAsync(index float64) float64
-    OverrideMeSync(index float64) float64
-    ParallelSumAsync(count float64) float64
-    SerialSumAsync(count float64) float64
-    SumSync(count float64) float64
+	OverrideMeAsync(index float64) float64
+	OverrideMeSync(index float64) float64
+	ParallelSumAsync(count float64) float64
+	SerialSumAsync(count float64) float64
+	SumSync(count float64) float64
 }
 
 // Struct proxy
@@ -8502,65 +8502,65 @@ type VirtualMethodPlayground struct {
 }
 
 func NewVirtualMethodPlayground() VirtualMethodPlaygroundIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &VirtualMethodPlayground{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &VirtualMethodPlayground{}
 }
 
 func (v *VirtualMethodPlayground) OverrideMeAsync(index float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "OverrideMeAsync",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "OverrideMeAsync",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (v *VirtualMethodPlayground) OverrideMeSync(index float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "OverrideMeSync",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "OverrideMeSync",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (v *VirtualMethodPlayground) ParallelSumAsync(count float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "ParallelSumAsync",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "ParallelSumAsync",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (v *VirtualMethodPlayground) SerialSumAsync(count float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "SerialSumAsync",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "SerialSumAsync",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 func (v *VirtualMethodPlayground) SumSync(count float64) float64 {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VirtualMethodPlayground",
-        Method: "SumSync",
-        Args: []string{"number",},
-    })
-    return 0.0
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VirtualMethodPlayground",
+		Method: "SumSync",
+		Args: []string{"number",},
+	})
+	return 0.0
 }
 
 // Class interface
 type VoidCallbackIface interface {
-    GetMethodWasCalled() bool
-    SetMethodWasCalled(val bool)
-    CallMe()
-    OverrideMe()
+	GetMethodWasCalled() bool
+	SetMethodWasCalled(val bool)
+	CallMe()
+	OverrideMe()
 }
 
 // This test is used to validate the runtimes can return correctly from a void callback.
@@ -8570,71 +8570,71 @@ type VoidCallbackIface interface {
 // - Verify that \`methodWasCalled\` is \`true\`.
 // Struct proxy
 type VoidCallback struct {
-    MethodWasCalled bool
+	MethodWasCalled bool
 }
 
 func (v *VoidCallback) GetMethodWasCalled() bool {
-    return v.MethodWasCalled
+	return v.MethodWasCalled
 }
 
 
 func NewVoidCallback() VoidCallbackIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VoidCallback",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &VoidCallback{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VoidCallback",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &VoidCallback{}
 }
 
 func (v *VoidCallback) SetMethodWasCalled(val bool) {
-    v.MethodWasCalled = val
+	v.MethodWasCalled = val
 }
 
 func (v *VoidCallback) CallMe() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VoidCallback",
-        Method: "CallMe",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VoidCallback",
+		Method: "CallMe",
+		Args: []string{},
+	})
 }
 
 func (v *VoidCallback) OverrideMe() {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "VoidCallback",
-        Method: "OverrideMe",
-        Args: []string{},
-    })
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "VoidCallback",
+		Method: "OverrideMe",
+		Args: []string{},
+	})
 }
 
 // Class interface
 type WithPrivatePropertyInConstructorIface interface {
-    GetSuccess() bool
-    SetSuccess(val bool)
+	GetSuccess() bool
+	SetSuccess(val bool)
 }
 
 // Verifies that private property declarations in constructor arguments are hidden.
 // Struct proxy
 type WithPrivatePropertyInConstructor struct {
-    Success bool
+	Success bool
 }
 
 func (w *WithPrivatePropertyInConstructor) GetSuccess() bool {
-    return w.Success
+	return w.Success
 }
 
 
 func NewWithPrivatePropertyInConstructor(privateField string) WithPrivatePropertyInConstructorIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "WithPrivatePropertyInConstructor",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &WithPrivatePropertyInConstructor{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "WithPrivatePropertyInConstructor",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &WithPrivatePropertyInConstructor{}
 }
 
 func (w *WithPrivatePropertyInConstructor) SetSuccess(val bool) {
-    w.Success = val
+	w.Success = val
 }
 
 
@@ -8644,93 +8644,93 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/pythonself/pyt
 package pythonself
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // Class interface
 type ClassWithSelfIface interface {
-    GetSelf() string
-    SetSelf(val string)
-    Method(self float64) string
+	GetSelf() string
+	SetSelf(val string)
+	Method(self float64) string
 }
 
 // Struct proxy
 type ClassWithSelf struct {
-    Self string
+	Self string
 }
 
 func (c *ClassWithSelf) GetSelf() string {
-    return c.Self
+	return c.Self
 }
 
 
 func NewClassWithSelf(self string) ClassWithSelfIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithSelf",
-        Method: "Constructor",
-        Args: []string{"string",},
-    })
-    return &ClassWithSelf{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithSelf",
+		Method: "Constructor",
+		Args: []string{"string",},
+	})
+	return &ClassWithSelf{}
 }
 
 func (c *ClassWithSelf) SetSelf(val string) {
-    c.Self = val
+	c.Self = val
 }
 
 func (c *ClassWithSelf) Method(self float64) string {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithSelf",
-        Method: "Method",
-        Args: []string{"number",},
-    })
-    return "NOOP_RETURN_STRING"
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithSelf",
+		Method: "Method",
+		Args: []string{"number",},
+	})
+	return "NOOP_RETURN_STRING"
 }
 
 // Class interface
 type ClassWithSelfKwargIface interface {
-    GetProps() StructWithSelf
-    SetProps(val StructWithSelf)
+	GetProps() StructWithSelf
+	SetProps(val StructWithSelf)
 }
 
 // Struct proxy
 type ClassWithSelfKwarg struct {
-    Props StructWithSelf
+	Props StructWithSelf
 }
 
 func (c *ClassWithSelfKwarg) GetProps() StructWithSelf {
-    return c.Props
+	return c.Props
 }
 
 
 func NewClassWithSelfKwarg(props StructWithSelf) ClassWithSelfKwargIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "ClassWithSelfKwarg",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.PythonSelf.StructWithSelf",},
-    })
-    return &ClassWithSelfKwarg{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "ClassWithSelfKwarg",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.PythonSelf.StructWithSelf",},
+	})
+	return &ClassWithSelfKwarg{}
 }
 
 func (c *ClassWithSelfKwarg) SetProps(val StructWithSelf) {
-    c.Props = val
+	c.Props = val
 }
 
 type IInterfaceWithSelf interface {
-    Method(self float64) string
+	Method(self float64) string
 }
 
 // StructWithSelfIface is the public interface for the custom type StructWithSelf
 type StructWithSelfIface interface {
-    GetSelf() string
+	GetSelf() string
 }
 
 // Struct proxy
 type StructWithSelf struct {
-    Self string
+	Self string
 }
 
 func (s *StructWithSelf) GetSelf() string {
-    return s.Self
+	return s.Self
 }
 
 
@@ -8741,22 +8741,22 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/back
 package backreferences
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
 )
 
 // MyClassReferenceIface is the public interface for the custom type MyClassReference
 type MyClassReferenceIface interface {
-    GetReference() submodule.MyClass
+	GetReference() submodule.MyClass
 }
 
 // Struct proxy
 type MyClassReference struct {
-    Reference submodule.MyClass
+	Reference submodule.MyClass
 }
 
 func (m *MyClassReference) GetReference() submodule.MyClass {
-    return m.Reference
+	return m.Reference
 }
 
 
@@ -8767,77 +8767,77 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/chil
 package child
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 type Awesomeness string
 
 const (
-    AwesomenessAwesome Awesomeness = "AWESOME"
+	AwesomenessAwesome Awesomeness = "AWESOME"
 )
 
 type Goodness string
 
 const (
-    GoodnessPrettyGood Goodness = "PRETTY_GOOD"
-    GoodnessReallyGood Goodness = "REALLY_GOOD"
-    GoodnessAmazinglyGood Goodness = "AMAZINGLY_GOOD"
+	GoodnessPrettyGood Goodness = "PRETTY_GOOD"
+	GoodnessReallyGood Goodness = "REALLY_GOOD"
+	GoodnessAmazinglyGood Goodness = "AMAZINGLY_GOOD"
 )
 
 // Class interface
 type InnerClassIface interface {
-    GetStaticProp() SomeStruct
-    SetStaticProp(val SomeStruct)
+	GetStaticProp() SomeStruct
+	SetStaticProp(val SomeStruct)
 }
 
 // Struct proxy
 type InnerClass struct {
-    StaticProp SomeStruct
+	StaticProp SomeStruct
 }
 
 func (i *InnerClass) GetStaticProp() SomeStruct {
-    return i.StaticProp
+	return i.StaticProp
 }
 
 
 func NewInnerClass() InnerClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "InnerClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &InnerClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "InnerClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &InnerClass{}
 }
 
 func (i *InnerClass) SetStaticProp(val SomeStruct) {
-    i.StaticProp = val
+	i.StaticProp = val
 }
 
 // KwargsPropsIface is the public interface for the custom type KwargsProps
 type KwargsPropsIface interface {
-    GetProp() SomeEnum
-    GetExtra() string
+	GetProp() SomeEnum
+	GetExtra() string
 }
 
 // Struct proxy
 type KwargsProps struct {
-    Prop SomeEnum
-    Extra string
+	Prop SomeEnum
+	Extra string
 }
 
 func (k *KwargsProps) GetProp() SomeEnum {
-    return k.Prop
+	return k.Prop
 }
 
 func (k *KwargsProps) GetExtra() string {
-    return k.Extra
+	return k.Extra
 }
 
 
 // Class interface
 type OuterClassIface interface {
-    GetInnerClass() InnerClass
-    SetInnerClass(val InnerClass)
+	GetInnerClass() InnerClass
+	SetInnerClass(val InnerClass)
 }
 
 // Checks that classes can self-reference during initialization.
@@ -8845,60 +8845,60 @@ type OuterClassIface interface {
 //
 // Struct proxy
 type OuterClass struct {
-    InnerClass InnerClass
+	InnerClass InnerClass
 }
 
 func (o *OuterClass) GetInnerClass() InnerClass {
-    return o.InnerClass
+	return o.InnerClass
 }
 
 
 func NewOuterClass() OuterClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "OuterClass",
-        Method: "Constructor",
-        Args: []string{},
-    })
-    return &OuterClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "OuterClass",
+		Method: "Constructor",
+		Args: []string{},
+	})
+	return &OuterClass{}
 }
 
 func (o *OuterClass) SetInnerClass(val InnerClass) {
-    o.InnerClass = val
+	o.InnerClass = val
 }
 
 type SomeEnum string
 
 const (
-    SomeEnumSome SomeEnum = "SOME"
+	SomeEnumSome SomeEnum = "SOME"
 )
 
 // SomeStructIface is the public interface for the custom type SomeStruct
 type SomeStructIface interface {
-    GetProp() SomeEnum
+	GetProp() SomeEnum
 }
 
 // Struct proxy
 type SomeStruct struct {
-    Prop SomeEnum
+	Prop SomeEnum
 }
 
 func (s *SomeStruct) GetProp() SomeEnum {
-    return s.Prop
+	return s.Prop
 }
 
 
 // StructureIface is the public interface for the custom type Structure
 type StructureIface interface {
-    GetBool() bool
+	GetBool() bool
 }
 
 // Struct proxy
 type Structure struct {
-    Bool bool
+	Bool bool
 }
 
 func (s *Structure) GetBool() bool {
-    return s.Bool
+	return s.Bool
 }
 
 
@@ -8909,11 +8909,11 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/deep
 package deeplynested
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 type INamespaced interface {
-    GetDefinedAt() string
+	GetDefinedAt() string
 }
 
 
@@ -8923,7 +8923,7 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/isol
 package isolated
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-experimental"
 )
 
 // Class interface
@@ -8936,12 +8936,12 @@ type Kwargs struct {
 }
 
 func Kwargs_Method(props child.KwargsProps) bool {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "Kwargs",
-        Method: "Method",
-        Args: []string{"jsii-calc.submodule.child.KwargsProps",},
-    })
-    return true
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "Kwargs",
+		Method: "Method",
+		Args: []string{"jsii-calc.submodule.child.KwargsProps",},
+	})
+	return true
 }
 
 
@@ -8951,40 +8951,40 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/nest
 package nestedsubmodule
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
 )
 
 // Class interface
 type NamespacedIface interface {
-    deeplynested.INamespaced
-    GetDefinedAt() string
-    SetDefinedAt(val string)
-    GetGoodness() child.Goodness
-    SetGoodness(val child.Goodness)
+	deeplynested.INamespaced
+	GetDefinedAt() string
+	SetDefinedAt(val string)
+	GetGoodness() child.Goodness
+	SetGoodness(val child.Goodness)
 }
 
 // Struct proxy
 type Namespaced struct {
-    DefinedAt string
-    Goodness child.Goodness
+	DefinedAt string
+	Goodness child.Goodness
 }
 
 func (n *Namespaced) GetDefinedAt() string {
-    return n.DefinedAt
+	return n.DefinedAt
 }
 
 func (n *Namespaced) GetGoodness() child.Goodness {
-    return n.Goodness
+	return n.Goodness
 }
 
 
 func (n *Namespaced) SetDefinedAt(val string) {
-    n.DefinedAt = val
+	n.DefinedAt = val
 }
 
 func (n *Namespaced) SetGoodness(val child.Goodness) {
-    n.Goodness = val
+	n.Goodness = val
 }
 
 
@@ -8994,83 +8994,83 @@ exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/subm
 package submodule
 
 import (
-    "github.com/aws-cdk/jsii/jsii-experimental"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
-    "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
+	"github.com/aws-cdk/jsii/jsii-experimental"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
 )
 
 // Class interface
 type MyClassIface interface {
-    deeplynested.INamespaced
-    GetAwesomeness() child.Awesomeness
-    SetAwesomeness(val child.Awesomeness)
-    GetDefinedAt() string
-    SetDefinedAt(val string)
-    GetGoodness() child.Goodness
-    SetGoodness(val child.Goodness)
-    GetProps() child.SomeStruct
-    SetProps(val child.SomeStruct)
-    GetAllTypes() jsiicalc.AllTypes
-    SetAllTypes(val jsiicalc.AllTypes)
+	deeplynested.INamespaced
+	GetAwesomeness() child.Awesomeness
+	SetAwesomeness(val child.Awesomeness)
+	GetDefinedAt() string
+	SetDefinedAt(val string)
+	GetGoodness() child.Goodness
+	SetGoodness(val child.Goodness)
+	GetProps() child.SomeStruct
+	SetProps(val child.SomeStruct)
+	GetAllTypes() jsiicalc.AllTypes
+	SetAllTypes(val jsiicalc.AllTypes)
 }
 
 // Struct proxy
 type MyClass struct {
-    Awesomeness child.Awesomeness
-    DefinedAt string
-    Goodness child.Goodness
-    Props child.SomeStruct
-    AllTypes jsiicalc.AllTypes
+	Awesomeness child.Awesomeness
+	DefinedAt string
+	Goodness child.Goodness
+	Props child.SomeStruct
+	AllTypes jsiicalc.AllTypes
 }
 
 func (m *MyClass) GetAwesomeness() child.Awesomeness {
-    return m.Awesomeness
+	return m.Awesomeness
 }
 
 func (m *MyClass) GetDefinedAt() string {
-    return m.DefinedAt
+	return m.DefinedAt
 }
 
 func (m *MyClass) GetGoodness() child.Goodness {
-    return m.Goodness
+	return m.Goodness
 }
 
 func (m *MyClass) GetProps() child.SomeStruct {
-    return m.Props
+	return m.Props
 }
 
 func (m *MyClass) GetAllTypes() jsiicalc.AllTypes {
-    return m.AllTypes
+	return m.AllTypes
 }
 
 
 func NewMyClass(props child.SomeStruct) MyClassIface {
-    jsii.NoOpRequest(jsii.NoOpApiRequest {
-        Class: "MyClass",
-        Method: "Constructor",
-        Args: []string{"jsii-calc.submodule.child.SomeStruct",},
-    })
-    return &MyClass{}
+	jsii.NoOpRequest(jsii.NoOpApiRequest {
+		Class: "MyClass",
+		Method: "Constructor",
+		Args: []string{"jsii-calc.submodule.child.SomeStruct",},
+	})
+	return &MyClass{}
 }
 
 func (m *MyClass) SetAwesomeness(val child.Awesomeness) {
-    m.Awesomeness = val
+	m.Awesomeness = val
 }
 
 func (m *MyClass) SetDefinedAt(val string) {
-    m.DefinedAt = val
+	m.DefinedAt = val
 }
 
 func (m *MyClass) SetGoodness(val child.Goodness) {
-    m.Goodness = val
+	m.Goodness = val
 }
 
 func (m *MyClass) SetProps(val child.SomeStruct) {
-    m.Props = val
+	m.Props = val
 }
 
 func (m *MyClass) SetAllTypes(val jsiicalc.AllTypes) {
-    m.AllTypes = val
+	m.AllTypes = val
 }
 
 


### PR DESCRIPTION
Since `gofmt` indents using tabulations, reproduce this behvaior on
generated code so it looks more idiomatic.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
