### PR TITLE
feat(go): embed jsii runtime application

### DIFF
--- a/packages/@jsii/go-runtime/.gitignore
+++ b/packages/@jsii/go-runtime/.gitignore
@@ -1,4 +1,2 @@
-jsii-experimental/embedded/*
-jsii-calc
-
-!jsii-experimental/embedded/.gitkeep
+/jsii-calc/
+*.generated.go

--- a/packages/@jsii/go-runtime/build-tools/gen.ts
+++ b/packages/@jsii/go-runtime/build-tools/gen.ts
@@ -1,14 +1,73 @@
 #!/usr/bin/env npx ts-node
 
-import { copyFileSync, readdirSync } from 'fs';
-import { join, resolve } from 'path';
+import { CodeMaker } from 'codemaker';
+import { readdirSync, readFileSync } from 'fs';
+import { resolve } from 'path';
 
-const EMBEDDED_SOURCE = resolve(__dirname, '..', '..', 'runtime', 'webpack');
+const EMBEDDED_RUNTIME_ROOT = resolve(
+  __dirname,
+  '..',
+  '..',
+  'runtime',
+  'webpack',
+);
 
-for (const filename of readdirSync(EMBEDDED_SOURCE)) {
-  const filepath = join(EMBEDDED_SOURCE, filename);
-  copyFileSync(
-    filepath,
-    resolve(__dirname, '..', 'jsii-experimental', 'embedded', filename),
+const OUTPUT_DIR = resolve(__dirname, '..', 'jsii-experimental');
+
+const RUNTIME_FILE = 'embeddedruntime.generated.go';
+const VERSION_FILE = 'version.generated.go';
+
+const code = new CodeMaker();
+
+code.openFile(RUNTIME_FILE);
+code.line('package jsii');
+code.line();
+code.open('var embeddedruntime = map[string][]byte{');
+const bytesPerLine = 16;
+const files = readdirSync(EMBEDDED_RUNTIME_ROOT);
+const fileSize: Record<string, number> = {};
+for (const file of files) {
+  const byteSlice = getByteSlice(resolve(EMBEDDED_RUNTIME_ROOT, file));
+  fileSize[file] = byteSlice.length;
+  code.open(`${JSON.stringify(file)}: []byte{`);
+  for (let i = 0; i < byteSlice.length; i += bytesPerLine) {
+    const line = byteSlice.slice(i, i + bytesPerLine);
+    code.line(`${line.join(', ')},`);
+  }
+  code.close('},');
+}
+code.close('}');
+code.line();
+const mainKey = JSON.stringify(files.find((f) => f.endsWith('.js')))!;
+code.line(`const embeddedruntimeMain = ${mainKey}`);
+code.line();
+// This performs sanity tests upon initialization
+code.open('func init() {');
+for (const [file, size] of Object.entries(fileSize)) {
+  code.open(`if len(embeddedruntime[${JSON.stringify(file)}]) != ${size} {`);
+  code.line(
+    `panic("Embedded runtime file ${file} does not have expected size of ${size} bytes!")`,
   );
+  code.close('}');
+}
+code.close('}');
+code.closeFile(RUNTIME_FILE);
+
+code.openFile(VERSION_FILE);
+code.line('package jsii');
+code.line();
+const thisVersion = require('../package.json').version;
+code.line(`const version = ${JSON.stringify(thisVersion)}`);
+code.closeFile(VERSION_FILE);
+
+code.save(OUTPUT_DIR);
+
+function getByteSlice(path: string) {
+  const fileData = readFileSync(path).toString('hex');
+  const result = [];
+  for (let i = 0; i < fileData.length; i += 2) {
+    result.push(`0x${fileData[i]}${fileData[i + 1]}`);
+  }
+
+  return result;
 }

--- a/packages/@jsii/go-runtime/jsii-calc-test/main.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main.go
@@ -1,21 +1,21 @@
 package main
 
 import (
-	// "log"
-	"fmt"
-	jsiicalc "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
+	// "fmt"
+	calc "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
 	"github.com/aws-cdk/jsii/jsii-experimental"
+	"math"
 )
 
 func main() {
-	fmt.Println("Hello, JSII")
-	// client, err := jsii.InitClient()
+	defer jsii.Close()
 
-	// if err !=nil {
-	//   log.Fatal(err)
-	// }
-	fmt.Print(jsii.Client{RuntimeVersion: "100.100.100"})
+	calculator := calc.NewCalculator(calc.CalculatorProps{InitialValue: 0, MaximumValue: math.MaxFloat64})
+	calculator.Add(1337)
+	calculator.Mul(42)
 
-	// fmt.Printf("Client init successful\nRuntime version: %s", client.RuntimeVersion)
-	fmt.Println(jsiicalc.AbstractClass{})
+	if calculator.GetValue() != 1337.*42. {
+		// TODO: right now implementations are just NOOP.
+		// panic(fmt.Sprintf("Unexpected calculator value: expected %f, but received %f", 1337.*42., calculator.GetValue()))
+	}
 }

--- a/packages/@jsii/go-runtime/jsii-experimental/client_test.go
+++ b/packages/@jsii/go-runtime/jsii-experimental/client_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	client, err := InitClient()
+	client, err := newClient()
 	if err != nil {
 		t.Log(err)
 		t.Errorf(fmt.Sprintf("Client init error: %s", err.Error()))
 	}
+	defer client.close()
 
 	if client.RuntimeVersion == "" {
 		clientstr, _ := json.Marshal(&client)

--- a/packages/@jsii/go-runtime/jsii-experimental/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-experimental/runtime.go
@@ -1,34 +1,5 @@
 package jsii
 
-import (
-	"sync"
-)
-
-var (
-	clientInstance      *client
-	clientInstanceMutex sync.Mutex
-	once                sync.Once
-)
-
-// getClient returns a singleton client instance, initializing one the first
-// time it is called.
-func getClient() *client {
-	once.Do(func() {
-		// Locking early to be safe with a concurrent Close execution
-		clientInstanceMutex.Lock()
-		defer clientInstanceMutex.Unlock()
-
-		client, err := newClient()
-		if err != nil {
-			panic(err)
-		}
-
-		clientInstance = client
-	})
-
-	return clientInstance
-}
-
 // Close finalizes the runtime process, signalling the end of the execution to
 // the jsii kernel process, and waiting for graceful termination. The best
 // practice is to defer call thins at the beginning of the "main" function.
@@ -37,16 +8,5 @@ func getClient() *client {
 // will be initialized, and Close should be called again to correctly finalize
 // that, too. This behavior is intended for use in unit/integration tests.
 func Close() {
-	// Locking early to be safe with a concurrent getClient execution
-	clientInstanceMutex.Lock()
-	defer clientInstanceMutex.Unlock()
-
-	// Reset the "once" so a new client would get initialized next time around
-	once = sync.Once{}
-
-	if clientInstance != nil {
-		// Close the client & reset it
-		clientInstance.close()
-		clientInstance = nil
-	}
+	closeClient()
 }

--- a/packages/@jsii/go-runtime/jsii-experimental/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-experimental/runtime.go
@@ -1,0 +1,52 @@
+package jsii
+
+import (
+	"sync"
+)
+
+var (
+	clientInstance      *client
+	clientInstanceMutex sync.Mutex
+	once                sync.Once
+)
+
+// getClient returns a singleton client instance, initializing one the first
+// time it is called.
+func getClient() *client {
+	once.Do(func() {
+		// Locking early to be safe with a concurrent Close execution
+		clientInstanceMutex.Lock()
+		defer clientInstanceMutex.Unlock()
+
+		client, err := newClient()
+		if err != nil {
+			panic(err)
+		}
+
+		clientInstance = client
+	})
+
+	return clientInstance
+}
+
+// Close finalizes the runtime process, signalling the end of the execution to
+// the jsii kernel process, and waiting for graceful termination. The best
+// practice is to defer call thins at the beginning of the "main" function.
+//
+// If a jsii client is used *after* Close was called, a new jsii kernel process
+// will be initialized, and Close should be called again to correctly finalize
+// that, too. This behavior is intended for use in unit/integration tests.
+func Close() {
+	// Locking early to be safe with a concurrent getClient execution
+	clientInstanceMutex.Lock()
+	defer clientInstanceMutex.Unlock()
+
+	// Reset the "once" so a new client would get initialized next time around
+	once = sync.Once{}
+
+	if clientInstance != nil {
+		// Close the client & reset it
+		clientInstance.close()
+		clientInstance = nil
+	}
+}

--- a/packages/@jsii/go-runtime/package.json
+++ b/packages/@jsii/go-runtime/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/fs-extra": "^8.1.1",
     "@types/node": "^10.17.35",
+    "codemaker": "^0.0.0",
     "fs-extra": "^9.0.1",
     "jsii-calc": "^0.0.0",
     "jsii-pacmak": "^0.0.0",


### PR DESCRIPTION
Bundles the `@jsii/runtime` application within the go runtime library.
This ships the necessary files as byte slices in
`embeddedruntime.generated.go`. The `client` initializer will un-pack
this into a temporary directory (cleaned up by `client.Close()`) and run
that, unless the user specified the `JSII_RUNTIME` environment variable
(in which case, that command is used instead).

The `client` also assigns `JSII_AGENT` to a string representing the `go`
stack version used during build (`runtime.Version()`), the operating
system under which the application is running and the CPU architecture.
The string is formatted as `VERSION/OS/ARCH`.

A new `runtime.go` was introduced that manages a singleton `client`
instance and exports a `Close` function that can be invoked to
gracefully clean up the child process.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
