### PR TITLE
chore(runtime/java): apply tighter pin on Jackson

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -59,11 +59,11 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions of the dependencies -->
-        <hamcrest.version>[1.3,1.4)</hamcrest.version>
-        <jackson.version>[2.11.3,2.12)</jackson.version>
-        <jetbrains-annotations.version>[13.0.0,20.0)</jetbrains-annotations.version>
-        <junit.version>[5.7.0,5.8)</junit.version>
-        <mockito.version>[3.5.13,4.0)</mockito.version>
+        <hamcrest.version>[1.3,1.4-a0)</hamcrest.version>
+        <jackson.version>[2.11.3,2.12-a0)</jackson.version>
+        <jetbrains-annotations.version>[13.0.0,20.0-a0)</jetbrains-annotations.version>
+        <junit.version>[5.7.0,5.8-a0)</junit.version>
+        <mockito.version>[3.5.13,4.0-a0)</mockito.version>
     </properties>
 
     <dependencies>

--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -60,11 +60,10 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions of the dependencies -->
         <hamcrest.version>[1.3,1.4)</hamcrest.version>
-        <jackson-core.version>[2.11.3,3.0.0)</jackson-core.version>
-        <jackson-databind.version>[2.11.3,3.0.0)</jackson-databind.version>
-        <jetbrains-annotations.version>[13.0.0,20.0.0)</jetbrains-annotations.version>
-        <junit.version>[5.6.1,5.7.0)</junit.version>
-        <mockito.version>[3.5.13,4.0.0)</mockito.version>
+        <jackson.version>[2.11.3,2.12)</jackson.version>
+        <jetbrains-annotations.version>[13.0.0,20.0)</jetbrains-annotations.version>
+        <junit.version>[5.7.0,5.8)</junit.version>
+        <mockito.version>[3.5.13,4.0)</mockito.version>
     </properties>
 
     <dependencies>
@@ -72,14 +71,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>\${jackson-core.version}</version>
+            <version>\${jackson.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>\${jackson-databind.version}</version>
+            <version>\${jackson.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->


### PR DESCRIPTION
Current `2.12.0-rc1` is breaking source compatibility due to the removal of a checked
exception from `ObjectMapper#treeToValue()`.

See: FasterXML/jackson-databind#2878.

---

Took the opportunity to also tidy up other version constraints (simplifying the
right hand side of the ranges to the shorter form while making them prerelease-safe),
and upgraded `junit.version` while I was there).

The Jackson version for `core` and `databind` where unified as they ought to
always match and previously were separated only because a security patch
was released to one but not the other (and we wanted to mandate it was present).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
