### PR TITLE
fix(rosetta): duplicated problem markers

### DIFF
--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -13,7 +13,9 @@ export function printDiagnostics(
   diags: ts.Diagnostic[],
   stream: NodeJS.WritableStream,
 ) {
-  diags.forEach((d) => printDiagnostic(d, stream));
+  ts.sortAndDeduplicateDiagnostics(diags).forEach((d) =>
+    printDiagnostic(d, stream),
+  );
 }
 
 export function printDiagnostic(


### PR DESCRIPTION
When running with `--compile`, problem markers could end up duplicated.
This particularly affected problem markers reporting use of unsupported
language features in examples, which would have been repeated once per
target language.

This adds the necessary hook to de-duplicate diagnostics before
rendering them to the user interface.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
