### PR TITLE
chore(rosetta): streamline TypeScript compiler API usage

### DIFF
--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -141,9 +141,9 @@ export class SnippetTranslator {
       const program = this.compilation.program;
       this.compileDiagnostics.push(
         ...program.getGlobalDiagnostics(),
-        ...program.getSyntacticDiagnostics(),
-        ...program.getDeclarationDiagnostics(),
-        ...program.getSemanticDiagnostics(),
+        ...program.getSyntacticDiagnostics(this.compilation.rootFile),
+        ...program.getDeclarationDiagnostics(this.compilation.rootFile),
+        ...program.getSemanticDiagnostics(this.compilation.rootFile),
       );
     }
   }

--- a/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
+++ b/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
@@ -1,11 +1,10 @@
 import * as ts from 'typescript';
 
 export class TypeScriptCompiler {
-  private readonly realHost: ts.CompilerHost;
-
-  public constructor() {
-    this.realHost = ts.createCompilerHost(STANDARD_COMPILER_OPTIONS, true);
-  }
+  private readonly realHost = ts.createCompilerHost(
+    STANDARD_COMPILER_OPTIONS,
+    true,
+  );
 
   public createInMemoryCompilerHost(
     sourcePath: string,
@@ -20,16 +19,13 @@ export class TypeScriptCompiler {
     );
 
     return {
+      ...realHost,
       fileExists: (filePath) =>
         filePath === sourcePath || realHost.fileExists(filePath),
-      directoryExists: realHost.directoryExists?.bind(realHost),
-      getCurrentDirectory: () =>
-        currentDirectory || realHost.getCurrentDirectory(),
-      getDirectories: realHost.getDirectories?.bind(realHost),
-      getCanonicalFileName: (fileName) =>
-        realHost.getCanonicalFileName(fileName),
-      getNewLine: realHost.getNewLine.bind(realHost),
-      getDefaultLibFileName: realHost.getDefaultLibFileName.bind(realHost),
+      getCurrentDirectory:
+        currentDirectory != null
+          ? () => currentDirectory
+          : realHost.getCurrentDirectory,
       getSourceFile: (
         fileName,
         languageVersion,
@@ -46,10 +42,7 @@ export class TypeScriptCompiler {
             ),
       readFile: (filePath) =>
         filePath === sourcePath ? sourceContents : realHost.readFile(filePath),
-      useCaseSensitiveFileNames: () => realHost.useCaseSensitiveFileNames(),
-      writeFile(_fileName, _data) {
-        /* nothing */
-      },
+      writeFile: () => void undefined,
     };
   }
 


### PR DESCRIPTION
Streamline the in-memory compiler host by avoiding unnecessary use of
`.bind` when using the "standard" host's functions; and focusing the
diagnostic message gathering only on the example-containing source file
instead of traversing all source files considered in the compilation
step (which would include all involved declarations files, too).

This would make the overall compilation execution faster (although this
does not miracoulously make it extremely fast - there is still some work
involved that takes a while in the compiler itself).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
