### PR TITLE
fix(go): Submodule File Paths

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -74,7 +74,7 @@ export abstract class Package {
         const moduleName = pack.root.moduleName;
         const prefix = moduleName !== '' ? `${moduleName}/` : '';
         const rootPackageName = pack.root.packageName;
-        const suffix = pack.filePath !== '' ? `/${pack.filePath}` : '';
+        const suffix = pack.filePath !== '' ? `/${pack.filePath}` : ``;
         return `${prefix}${rootPackageName}${suffix}`;
       }),
     );
@@ -258,11 +258,12 @@ export class RootPackage extends Package {
  * InternalPackage refers to any go package within a given JSII module.
  */
 export class InternalPackage extends Package {
-  public readonly pkg: Package;
+  public readonly parent: Package;
 
-  public constructor(root: Package, pkg: Package, assembly: JsiiSubmodule) {
+  public constructor(root: Package, parent: Package, assembly: JsiiSubmodule) {
     const packageName = goPackageName(assembly.name);
-    const filePath = pkg === root ? packageName : pkg.filePath;
+    const filePath =
+      parent === root ? packageName : `${parent.filePath}/${packageName}`;
 
     super(
       assembly.types,
@@ -273,6 +274,6 @@ export class InternalPackage extends Package {
       root,
     );
 
-    this.pkg = pkg;
+    this.parent = parent;
   }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -736,11 +736,16 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃  ┗━ 📄 pythonself.go
        ┣━ 📄 README.md
        ┗━ 📁 submodule
-          ┣━ 📄 backreferences.go
-          ┣━ 📄 child.go
-          ┣━ 📄 deeplynested.go
-          ┣━ 📄 isolated.go
-          ┣━ 📄 nestedsubmodule.go
+          ┣━ 📁 backreferences
+          ┃  ┗━ 📄 backreferences.go
+          ┣━ 📁 child
+          ┃  ┗━ 📄 child.go
+          ┣━ 📁 isolated
+          ┃  ┗━ 📄 isolated.go
+          ┣━ 📁 nestedsubmodule
+          ┃  ┣━ 📁 deeplynested
+          ┃  ┃  ┗━ 📄 deeplynested.go
+          ┃  ┗━ 📄 nestedsubmodule.go
           ┗━ 📄 submodule.go
 `;
 
@@ -9411,7 +9416,7 @@ func (s *StructWithSelf) GetSelf() string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/backreferences.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/backreferences/backreferences.go 1`] = `
 package backreferences
 
 import (
@@ -9438,7 +9443,7 @@ func (m *MyClassReference) GetReference() submodule.MyClass {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/child.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/child/child.go 1`] = `
 package child
 
 import (
@@ -9591,22 +9596,7 @@ func (s *Structure) GetBool() bool {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/deeplynested.go 1`] = `
-package deeplynested
-
-import (
-	_jsii_ "github.com/aws-cdk/jsii/jsii-experimental"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/jsii"
-)
-
-type INamespaced interface {
-	GetDefinedAt() string
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/isolated.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/isolated/isolated.go 1`] = `
 package isolated
 
 import (
@@ -9636,12 +9626,28 @@ func Kwargs_Method(props child.KwargsProps) bool {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/nestedsubmodule.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/nestedsubmodule/deeplynested/deeplynested.go 1`] = `
+package deeplynested
+
+import (
+	_jsii_ "github.com/aws-cdk/jsii/jsii-experimental"
+	_init_ "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/jsii"
+)
+
+type INamespaced interface {
+	GetDefinedAt() string
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/golang/jsiicalc/submodule/nestedsubmodule/nestedsubmodule.go 1`] = `
 package nestedsubmodule
 
 import (
 	_jsii_ "github.com/aws-cdk/jsii/jsii-experimental"
-	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule/child"
 	_init_ "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/jsii"
 )
 
@@ -9685,7 +9691,8 @@ package submodule
 
 import (
 	_jsii_ "github.com/aws-cdk/jsii/jsii-experimental"
-	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/submodule/child"
 	"github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc"
 	_init_ "github.com/aws-cdk/jsii/jsii-calc/golang/jsiicalc/jsii"
 )


### PR DESCRIPTION
fix(go): Submodule File Paths

Fixes go code generation for submodules. File paths were only nesting
for immediate children and not deeply nested ones.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
