### PR TITLE
chore: increase concurrency of integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,7 +420,7 @@ jobs:
 
       - name: Integration Test (build)
         run: |-
-          npx lerna run build --concurrency=1 --stream 2>&1 > ${{ runner.temp }}/build.log
+          npx lerna run build --concurrency=2 --stream 2>&1 > ${{ runner.temp }}/build.log
         working-directory: aws-cdk
         env:
           # Make lots of memory available, aws-cdk-lib is __large__


### PR DESCRIPTION
Allow 2 concurrent builds to improve execution speed without risking too much pressure on memory in the GitHub Actions workers.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
