### PR TITLE
chore: tune diff-test for superchain build test

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -27,9 +27,9 @@ jobs:
             echo "::set-output name=result::true"
           else
             # Fetch the base and head refs from origin so we can safely diff 'em
-            git fetch --depth=1 --quiet origin ${{ github.base_ref }} ${{ github.head_ref }}
+            git fetch --depth=1 --quiet origin ${{ github.base_ref }}
             # Otherwise, only run if the Dockerfile changed
-            changed=$(git diff --name-only origin/${{ github.base_ref }}..origin/${{ github.head_ref }})
+            changed=$(git diff --name-only origin/${{ github.base_ref }}..HEAD
             if grep Dockerfile <<< "${changed}" ; then
               echo '⏯ Dockerfile changed'
               echo "::set-output name=result::true"

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -29,7 +29,7 @@ jobs:
             # Fetch the base and head refs from origin so we can safely diff 'em
             git fetch --depth=1 --quiet origin ${{ github.base_ref }}
             # Otherwise, only run if the Dockerfile changed
-            changed=$(git diff --name-only origin/${{ github.base_ref }}..HEAD
+            changed=$(git diff --name-only origin/${{ github.base_ref }}..HEAD)
             if grep Dockerfile <<< "${changed}" ; then
               echo '⏯ Dockerfile changed'
               echo "::set-output name=result::true"


### PR DESCRIPTION
The head ref isn't always available from `origin` (e.g: when the PR is from a fork). Use `HEAD` instead, even though this might actually result in the occasional false positive (which is OK - false negatives would be what's problematic).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
