### PR TITLE
fix(jsii): annotation '@internal' causes missing type declarations downstream

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -32,7 +32,7 @@ const BASE_COMPILER_OPTIONS: ts.CompilerOptions = {
   strict: true,
   strictNullChecks: true,
   strictPropertyInitialization: true,
-  stripInternal: true,
+  stripInternal: false,
   target: ts.ScriptTarget.ES2018,
 };
 


### PR DESCRIPTION
Stop setting `stipInternal: true` in `tsconfig.json` files, as this makes it impossible
to mark intentionally unexported types as `@internal` without causing downstream
compilation failures due to missing type declarations.

Fixes #1947
Related to #1830 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
