### PR TITLE
chore: improve code to get symbol/node names

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -697,8 +697,7 @@ export class Assembler implements Emitter {
 
           this._diagnostics.push(
             JsiiDiagnostic.JSII_3003_SYMBOL_IS_EXPORTED_TWICE.create(
-              (symbol.valueDeclaration as { name?: ts.Node }).name ??
-                symbol.valueDeclaration,
+              _nameOrDeclarationNode(symbol),
               refs[0].name,
               refs[1].name,
             )
@@ -876,7 +875,7 @@ export class Assembler implements Emitter {
       return allTypes;
     } else {
       this._diagnostics.push(
-        JsiiDiagnostic.JSII_9998_UNSUPORTED_NODE.create(node, node.kind),
+        JsiiDiagnostic.JSII_9998_UNSUPPORTED_NODE.create(node, node.kind),
       );
     }
 
@@ -899,13 +898,10 @@ export class Assembler implements Emitter {
         (name) => `${this.projectInfo.name}.${name}` === jsiiType!.fqn,
       );
       if (colliding != null) {
-        const submoduleDecl =
-          submodule.valueDeclaration ?? submodule.declarations[0];
-        const submoduleDeclName =
-          (submoduleDecl as { name?: ts.Node }).name ?? submoduleDecl;
+        const submoduleDeclName = _nameOrDeclarationNode(submodule);
         this._diagnostics.push(
           JsiiDiagnostic.JSII_5011_SUBMODULE_NAME_CONFLICT.create(
-            (node as { name?: ts.Node }).name ?? node,
+            ts.getNameOfDeclaration(node) ?? node,
             submodule.name,
             jsiiType.name,
             candidates,
@@ -941,7 +937,7 @@ export class Assembler implements Emitter {
           if (nestedType.namespace !== nestedContext.namespace.join('.')) {
             this._diagnostics.push(
               JsiiDiagnostic.JSII_5012_NAMESPACE_IN_TYPE.create(
-                (node as { name?: ts.Node }).name ?? node,
+                ts.getNameOfDeclaration(node) ?? node,
                 jsiiType.fqn,
                 nestedType.namespace!,
               ),
@@ -1167,7 +1163,7 @@ export class Assembler implements Emitter {
           continue;
         } else if (clause.token !== ts.SyntaxKind.ImplementsKeyword) {
           this._diagnostics.push(
-            JsiiDiagnostic.JSII_9998_UNSUPORTED_NODE.create(
+            JsiiDiagnostic.JSII_9998_UNSUPPORTED_NODE.create(
               clause,
               `Ignoring ${ts.SyntaxKind[clause.token]} heritage clause`,
             ),
@@ -1296,7 +1292,7 @@ export class Assembler implements Emitter {
           );
         } else {
           this._diagnostics.push(
-            JsiiDiagnostic.JSII_9998_UNSUPORTED_NODE.create(
+            JsiiDiagnostic.JSII_9998_UNSUPPORTED_NODE.create(
               memberDecl,
               memberDecl.kind,
             ),
@@ -1511,7 +1507,7 @@ export class Assembler implements Emitter {
    */
   private _isPrivateOrInternal(
     symbol: ts.Symbol,
-    validateDeclaration?: ts.Declaration & { name?: ts.Node },
+    validateDeclaration?: ts.Declaration,
   ): boolean {
     const hasInternalJsDocTag = _hasInternalJsDocTag(symbol);
     const hasUnderscorePrefix =
@@ -1535,7 +1531,7 @@ export class Assembler implements Emitter {
       if (!hasUnderscorePrefix) {
         this._diagnostics.push(
           JsiiDiagnostic.JSII_8005_INTERNAL_UNDERSCORE.create(
-            validateDeclaration.name ?? validateDeclaration,
+            ts.getNameOfDeclaration(validateDeclaration) ?? validateDeclaration,
             symbol.name,
           ),
         );
@@ -1544,7 +1540,7 @@ export class Assembler implements Emitter {
       if (!hasInternalJsDocTag) {
         this._diagnostics.push(
           JsiiDiagnostic.JSII_8006_UNDERSCORE_INTERNAL.create(
-            validateDeclaration.name ?? validateDeclaration,
+            ts.getNameOfDeclaration(validateDeclaration) ?? validateDeclaration,
             symbol.name,
           ),
         );
@@ -1753,11 +1749,10 @@ export class Assembler implements Emitter {
               type.symbol.declarations[0]) as ts.InterfaceDeclaration,
           );
         } else {
-          const declaration = member.valueDeclaration ?? member.declarations[0];
           this._diagnostics.push(
-            JsiiDiagnostic.JSII_9998_UNSUPORTED_NODE.create(
-              declaration,
-              declaration.kind,
+            JsiiDiagnostic.JSII_9998_UNSUPPORTED_NODE.create(
+              _nameOrDeclarationNode(member),
+              (member.valueDeclaration ?? member.declarations[0]).kind,
             ),
           );
         }
@@ -1789,7 +1784,7 @@ export class Assembler implements Emitter {
         if (!jsiiType.datatype && !interfaceName) {
           this._diagnostics.push(
             JsiiDiagnostic.JSII_8007_BEHAVIORAL_INTERFACE_NAME.create(
-              (declaration as { name?: ts.Node }).name ?? declaration,
+              ts.getNameOfDeclaration(declaration) ?? declaration,
               jsiiType.name,
             ),
           );
@@ -1805,11 +1800,9 @@ export class Assembler implements Emitter {
           for (const prop of jsiiType.properties ?? []) {
             if (!prop.immutable) {
               const p = type.getProperty(prop.name)!;
-              const declaration: ts.Node & { name?: ts.Node } =
-                p.valueDeclaration ?? p.declarations[0];
               this._diagnostics.push(
                 JsiiDiagnostic.JSII_3008_STRUCT_PROPS_MUST_BE_READONLY.create(
-                  declaration.name ?? declaration,
+                  _nameOrDeclarationNode(p),
                   p.name,
                   jsiiType,
                 ),
@@ -3056,6 +3049,19 @@ function paramDocs(
  */
 function _isThisType(type: ts.Type, typeChecker: ts.TypeChecker): boolean {
   return typeChecker.typeToTypeNode(type)?.kind === ts.SyntaxKind.ThisKeyword;
+}
+
+/**
+ * Gets the name node for a given symbol; or it's first declaration if no name can be found. This is
+ * intended for use in placing problem markers on the right location.
+ *
+ * @param symbol the symbol for which the name node is needed.
+ *
+ * @returns the name node for the symbol, or the symbol's first declaration.
+ */
+function _nameOrDeclarationNode(symbol: ts.Symbol): ts.Node {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations[0];
+  return ts.getNameOfDeclaration(declaration) ?? declaration;
 }
 
 /**

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -739,7 +739,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'miscellaneous/unknown-error',
   });
 
-  public static readonly JSII_9998_UNSUPORTED_NODE = Code.message({
+  public static readonly JSII_9998_UNSUPPORTED_NODE = Code.message({
     code: 9998,
     formatter: (kindOrMessage: ts.SyntaxKind | string) =>
       typeof kindOrMessage === 'string'


### PR DESCRIPTION
This is used a lot in order to create the location pointer for diagnostics message,
and the typescript compiler API provides a convenient way to extract the name of a
declaration without having to escape type checking.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
