### PR TITLE
chore: stop using symlinks for jest config

### DIFF
--- a/packages/@jsii/kernel/jest.config.ts
+++ b/packages/@jsii/kernel/jest.config.ts
@@ -1,1 +1,3 @@
-../../../jest.config.ts
+import config from '../../../jest.config';
+
+export default config;

--- a/packages/codemaker/jest.config.ts
+++ b/packages/codemaker/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;

--- a/packages/jsii-config/jest.config.ts
+++ b/packages/jsii-config/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;

--- a/packages/jsii-diff/jest.config.ts
+++ b/packages/jsii-diff/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;

--- a/packages/jsii-rosetta/jest.config.ts
+++ b/packages/jsii-rosetta/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;

--- a/packages/jsii/jest.config.ts
+++ b/packages/jsii/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;

--- a/packages/oo-ascii-tree/jest.config.ts
+++ b/packages/oo-ascii-tree/jest.config.ts
@@ -1,1 +1,3 @@
-../../jest.config.ts
+import config from '../../jest.config';
+
+export default config;


### PR DESCRIPTION
Apparently, CodePipeline does not correctly read them out from GitHub,
and this results in text files containing the referent path. How
Windows-esque!



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
