### PR TITLE
chore(actions): stop using set-env and add-path (#2177)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,7 @@ jobs:
       - name: 'Windows: Put GitBash ahead of $PATH'
         if: runner.os == 'Windows'
         run: |-
-          echo "::add-path::C:\Program Files\Git\usr\bin"
+          echo "C:\Program Files\Git\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Extract Artifact
         run: |-
           echo "::group::Untar Archive"
@@ -409,14 +409,14 @@ jobs:
           npm install --no-save ${{ runner.temp }}/private/*.tgz --only=prod
 
           # Setting environment variables for next jobs
-          echo "::set-env name=JSII::${{ github.workspace }}/node_modules/.bin/jsii"
-          echo "::set-env name=CDK_BUILD_JSII::${{ github.workspace }}/node_modules/.bin/jsii"
+          echo "JSII=${{ github.workspace }}/node_modules/.bin/jsii" >> $GITHUB_ENV
+          echo "CDK_BUILD_JSII=${{ github.workspace }}/node_modules/.bin/jsii" >> $GITHUB_ENV
 
-          echo "::set-env name=PACMAK::${{ github.workspace }}/node_modules/.bin/jsii-pacmak"
-          echo "::set-env name=CDK_PACKAGE_JSII_PACMAK::${{ github.workspace }}/node_modules/.bin/jsii-pacmak"
+          echo "PACMAK=${{ github.workspace }}/node_modules/.bin/jsii-pacmak" >> $GITHUB_ENV
+          echo "CDK_PACKAGE_JSII_PACMAK=${{ github.workspace }}/node_modules/.bin/jsii-pacmak" >> $GITHUB_ENV
 
-          echo "::set-env name=ROSETTA::${{ github.workspace }}/node_modules/.bin/jsii-rosetta"
-          echo "::set-env name=CDK_PACKAGE_JSII_ROSETTA::${{ github.workspace }}/node_modules/.bin/jsii-rosetta"
+          echo "ROSETTA=${{ github.workspace }}/node_modules/.bin/jsii-rosetta" >> $GITHUB_ENV
+          echo "CDK_PACKAGE_JSII_ROSETTA=${{ github.workspace }}/node_modules/.bin/jsii-rosetta" >> $GITHUB_ENV
 
       - name: Integration Test (build)
         run: |-


### PR DESCRIPTION
The `set-env` and `add-path` commands are deprecated as a consequence of
CVE-2020-15228. The replacement operates by writing text in special
files, the path of which is exposed by special environment variables.

Deprecation notice: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
