### PR TITLE
fix(python): update `cattrs` dependency specification

### DIFF
--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -31,12 +31,13 @@ setuptools.setup(
     },
     install_requires=[
         "attrs~=20.1",
-        "cattrs~=1.0",
+        "cattrs~=1.0.0 ; python_version < '3.7'",
+        "cattrs~=1.1.0 ; python_version >= '3.7'",
         "importlib_resources ; python_version < '3.7'",
         "python-dateutil",
         "typing_extensions~=3.7",
     ],
-    python_requires=">=3.6",
+    python_requires="~=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
`cattrs>=1.1.0` dropped support for python 3.6, and added support for
python 3.9. Consequently, declare a dependency on `cattrs~=1.0.0` when
the python runtime is `< 3.7`, and on `cattrs~=1.1.0` when the python
runtime is `>= 3.7` in order to get the correct dependency brought in.

Fixes aws/aws-cdk#11219

Caused by https://github.com/Tinche/cattrs/commit/eb454d45ee198ef008b92a490ec67e1ed154b26f

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
