### PR TITLE
chore: add Python 3.9 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,6 +238,11 @@ jobs:
             java: '8'
             node: '10'
             os: ubuntu-latest
+          - python: '3.9'
+            dotnet: '3.1.x'
+            java: '8'
+            node: '10'
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -4,7 +4,7 @@ pull_request_rules:
   - name: label core
     actions:
       label:
-        add: [ contribution/core ]
+        add: [contribution/core]
     conditions:
       - author~=^(eladb|RomainMuller|garnaat|nija-at|shivlaks|skinny85|rix0rrr|NGL321|Jerry-AWS|SomayaB|MrArnoldPalmer|NetaNir|iliapolo|njlynch)$
       - -label~="contribution/core"
@@ -25,9 +25,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -45,10 +45,11 @@ pull_request_rules:
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
-      # One test for Python 3.6, 3.7, and 3.8
+      # One test for Python 3.6 through 3.9
       - status-success~=^Test \(.* python 3\.6[ )].*$
       - status-success~=^Test \(.* python 3\.7[ )].*$
       - status-success~=^Test \(.* python 3\.8[ )].*$
+      - status-success~=^Test \(.* python 3\.9[ )].*$
 
   - name: Synchronize that PR to upstream and merge it (squash)
     actions:
@@ -73,9 +74,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -93,10 +94,11 @@ pull_request_rules:
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
-      # One test for Python 3.6, 3.7, and 3.8
+      # One test for Python 3.6 through 3.9
       - status-success~=^Test \(.* python 3\.6[ )].*$
       - status-success~=^Test \(.* python 3\.7[ )].*$
       - status-success~=^Test \(.* python 3\.8[ )].*$
+      - status-success~=^Test \(.* python 3\.9[ )].*$
 
   - name: Synchronize that PR to upstream and merge it (no-squash)
     actions:
@@ -121,9 +123,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -141,10 +143,11 @@ pull_request_rules:
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
-      # One test for Python 3.6, 3.7, and 3.8
+      # One test for Python 3.6 through 3.9
       - status-success~=^Test \(.* python 3\.6[ )].*$
       - status-success~=^Test \(.* python 3\.7[ )].*$
       - status-success~=^Test \(.* python 3\.8[ )].*$
+      - status-success~=^Test \(.* python 3\.9[ )].*$
 
   - name: Clean branch up
     actions:

--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
         "Typing :: Typed",

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1721,6 +1721,7 @@ class Package {
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Typing :: Typed',
       ],
     };

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -442,6 +442,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed"
     ]
 }
@@ -925,6 +926,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed"
     ]
 }
@@ -1387,6 +1389,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed"
     ]
 }
@@ -1847,6 +1850,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed"
     ]
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -83,6 +83,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed",
         "License :: OSI Approved"
     ]
@@ -329,6 +330,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed",
         "License :: OSI Approved"
     ]
@@ -570,6 +572,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed",
         "Development Status :: 7 - Inactive",
         "License :: OSI Approved"
@@ -1421,6 +1424,7 @@ kwargs = json.loads(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Typing :: Typed",
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved",


### PR DESCRIPTION
It is apparently now supported by cattrs so we can finally start testing
against it, too.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
