### PR TITLE
chore: update test matrix to .NET5 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,8 +217,7 @@ jobs:
             python: '3.6'
           # Test alternate .NETs
           - java: '8'
-            # Current release info can be found at https://dotnet.microsoft.com/download/dotnet/5.0
-            dotnet: '5.0.100-rc.2.20479.15' # Pre-release matching requires exact version for now
+            dotnet: '5.0.x'
             node: '10'
             os: ubuntu-latest
             python: '3.6'

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -4,7 +4,7 @@ pull_request_rules:
   - name: label core
     actions:
       label:
-        add: [ contribution/core ]
+        add: [contribution/core]
     conditions:
       - author~=^(eladb|RomainMuller|garnaat|nija-at|shivlaks|skinny85|rix0rrr|NGL321|Jerry-AWS|SomayaB|MrArnoldPalmer|NetaNir|iliapolo|njlynch)$
       - -label~="contribution/core"
@@ -25,9 +25,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -42,6 +42,9 @@ pull_request_rules:
       - status-success~=^Test \(.* node 10 .*$
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
+      # One test for each supported dotnet version
+      - status-success~=^Test \(.* dotnet 3\.1\.x .*$
+      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
@@ -73,9 +76,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -90,6 +93,9 @@ pull_request_rules:
       - status-success~=^Test \(.* node 10 .*$
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
+      # One test for each supported dotnet version
+      - status-success~=^Test \(.* dotnet 3\.1\.x .*$
+      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
@@ -121,9 +127,9 @@ pull_request_rules:
       - -merged
       - -closed
       - -approved-reviews-by~=author
-      - "#approved-reviews-by>=1"
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
+      - '#approved-reviews-by>=1'
+      - '#review-requested=0'
+      - '#changes-requested-reviews-by=0'
       - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
@@ -138,6 +144,9 @@ pull_request_rules:
       - status-success~=^Test \(.* node 10 .*$
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
+      # One test for each supported dotnet version
+      - status-success~=^Test \(.* dotnet 3\.1\.x .*$
+      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$


### PR DESCRIPTION
General availability was announced: https://dotnet.microsoft.com/download/dotnet/5.0



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
