### PR TITLE
fix(java): exception is logged when Java VM is shutting down

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -61,6 +61,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <!-- Versions of the dependencies -->
         <hamcrest.version>[1.3,1.4-a0)</hamcrest.version>
         <jackson.version>[2.11.3,2.12-a0)</jackson.version>
+        <javax-annotations.version>[1.3.2,1.4.0)</javax-annotations.version>
         <jetbrains-annotations.version>[13.0.0,20.0-a0)</jetbrains-annotations.version>
         <junit.version>[5.7.0,5.8-a0)</junit.version>
         <mockito.version>[3.5.13,4.0-a0)</mockito.version>
@@ -118,6 +119,13 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>\${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>\${javax-annotations.version}</version>
         </dependency>
     </dependencies>
 

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -221,7 +221,11 @@ public final class JsiiRuntime {
 
             // We shut down already, no need for the shutdown hook anymore
             if (this.shutdownHook != null) {
-                Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+                try {
+                    Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+                } catch (final IllegalStateException ise) {
+                    // VM Shutdown is in progress, removal is now impossible (and unnecessary)
+                }
                 this.shutdownHook = null;
             }
         } catch (final IOException ioe) {


### PR DESCRIPTION
Guards against the `IllegalStateException` that will be thrown upon
attempting to remove a shutdown hook during VM shut down. In such cases,
the removal is no longer possible nor necessary, so the exception can be
safely ignored.

Fixes #2303



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
