### PR TITLE
chore: stop running yarn upgrade at end of image build

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -109,9 +109,4 @@ LABEL org.opencontainers.image.created=${BUILD_TIMESTAMP}                       
       org.opencontainers.image.revision=$COMMIT_ID                                                                      \
       org.opencontainers.image.authors="Amazon Web Services (https://aws.amazon.com)"
 
-# Upgrade all packages that weren't up-to-date just yet (last so it risks invalidating cache less)
-# This is the second time we do it (this layer may be empty)... It's in case we re-used a cached layer the first time
-RUN yum -y upgrade                                                                                                      \
-  && yum clean all && rm -rf /var/cache/yum
-
 CMD ["/bin/bash"]


### PR DESCRIPTION
This would posisbly cause the .NET SDK to be upgraded to a version that is significantly
more recent than it should be (i.e: take us from .NET Core 3.1 to .NET 5.0), which is
undesirable and can cause problems down the line (in particular, it currently fails to
update the fsharp distribution because this is not yet available on the mirrors).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
