### PR TITLE
fix(jsii): errors when invoking with a project root argument

### DIFF
--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -15,43 +15,46 @@ const warningTypes = Object.keys(enabledWarnings);
 (async () => {
   const argv = yargs
     .env('JSII')
-    .command(['$0', 'compile'], 'Compiles a jsii/TypeScript project', (argv) =>
-      argv
-        .positional('PROJECT_ROOT', {
-          type: 'string',
-          desc: 'The root of the project to be compiled',
-          default: '.',
-          normalize: true,
-        })
-        .option('watch', {
-          alias: 'w',
-          type: 'boolean',
-          desc: 'Watch for file changes and recompile automatically',
-        })
-        .option('project-references', {
-          alias: 'r',
-          type: 'boolean',
-          desc:
-            'Generate TypeScript project references (also [package.json].jsii.projectReferences)',
-        })
-        .option('fix-peer-dependencies', {
-          type: 'boolean',
-          default: true,
-          desc:
-            'Automatically add missing entries in the peerDependencies section of package.json',
-        })
-        .options('fail-on-warnings', {
-          alias: 'Werr',
-          type: 'boolean',
-          desc: 'Treat warnings as errors',
-        })
-        .option('silence-warnings', {
-          type: 'array',
-          default: [],
-          desc: `List of warnings to silence (warnings: ${warningTypes.join(
-            ',',
-          )})`,
-        }),
+    .command(
+      ['$0 [PROJECT_ROOT]', 'compile [PROJECT_ROOT]'],
+      'Compiles a jsii/TypeScript project',
+      (argv) =>
+        argv
+          .positional('PROJECT_ROOT', {
+            type: 'string',
+            desc: 'The root of the project to be compiled',
+            default: '.',
+            normalize: true,
+          })
+          .option('watch', {
+            alias: 'w',
+            type: 'boolean',
+            desc: 'Watch for file changes and recompile automatically',
+          })
+          .option('project-references', {
+            alias: 'r',
+            type: 'boolean',
+            desc:
+              'Generate TypeScript project references (also [package.json].jsii.projectReferences)',
+          })
+          .option('fix-peer-dependencies', {
+            type: 'boolean',
+            default: true,
+            desc:
+              'Automatically add missing entries in the peerDependencies section of package.json',
+          })
+          .options('fail-on-warnings', {
+            alias: 'Werr',
+            type: 'boolean',
+            desc: 'Treat warnings as errors',
+          })
+          .option('silence-warnings', {
+            type: 'array',
+            default: [],
+            desc: `List of warnings to silence (warnings: ${warningTypes.join(
+              ',',
+            )})`,
+          }),
     )
     .option('verbose', {
       alias: 'v',

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -203,7 +203,7 @@ export class Compiler implements Emitter {
       },
       // Make the references absolute for the compiler
       projectReferences: tsconf.references?.map((ref) => ({
-        path: path.resolve(ref.path),
+        path: path.resolve(path.dirname(this.configPath), ref.path),
       })),
       host: this.compilerHost,
     });


### PR DESCRIPTION
There were two bugs pertaining to invoking `jsii` with a project root
argument (e.g: `jsii path/to/project`):

- The positional argument was not correctly processed by `yargs` because
  it was not mentionned in the `command` description.
- The project reference resolution code did not resolve relative paths
  from the correct starting point (`cwd` instead of the project root),
  resulting in compiler errors.

This change fixes both.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
