### PR TITLE
fix: bad working directory in go runtime push

### DIFF
--- a/.github/workflows/push-go-runtime.yml
+++ b/.github/workflows/push-go-runtime.yml
@@ -40,7 +40,7 @@ jobs:
           --scope @jsii/go-runtime
       - name: Build Repo Directory
         id: build-repo-dir
-        working-directory: $GITHUB_WORKSPACE/packages/@jsii/go-runtime
+        working-directory: ${{ github.workspace }}/packages/@jsii/go-runtime
         env:
           JSII_RUNTIME_REPO_NAME: ${{ secrets.JSII_RUNTIME_REPO_NAME }}
           JSII_RUNTIME_REPO_USERNAME: ${{ secrets.JSII_RUNTIME_REPO_USERNAME }}


### PR DESCRIPTION
Fixes working directory syntax for go runtime push action by using
context instead of env var.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
