### PR TITLE
docs: fix typo in index.md

### DIFF
--- a/gh-pages/content/index.md
+++ b/gh-pages/content/index.md
@@ -23,7 +23,7 @@ Consider the following **TypeScript** class:
 
 ```ts
 /**
- * A siple greeter, hello world style.
+ * A simple greeter, hello world style.
  */
 export class Greeter {
   /**


### PR DESCRIPTION
Fixes a typo on the main page of [aws.github.io/jsii](aws.github.io/jsii).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
