### PR TITLE
fix(python): process.terminate() got an unexpected keyword argument 'timeout'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.17.1](https://github.com/aws/jsii/compare/v1.17.0...v1.17.1) (2021-01-13)
+
+### Bug Fixes
+
+* **python:** process.terminate() got an unexpected keyword argument 'timeout' ([#2421](https://github.com/aws/jsii/issues/2421)), closes [#2398](https://github.com/aws/jsii/issues/2398)
+
+
 ## [1.17.0](https://github.com/aws/jsii/compare/v1.16.0...v1.17.0) (2021-01-13)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,13 +2,11 @@
   "lerna": "3.13.1",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "command": {
     "bootstrap": {
       "rejectCycles": true
     }
   },
-  "version": "1.17.0"
+  "version": "1.17.1"
 }

--- a/packages/@jsii/python-runtime/src/jsii/_kernel/providers/process.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/providers/process.py
@@ -298,10 +298,7 @@ class _NodeProcess:
         try:
             self._process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            try:
-                self._process.terminate(timeout=5)
-            except subprocess.TimeoutExpired:
-                self._process.kill()
+            self._process.terminate()
 
         self._ctx_stack.close()
 


### PR DESCRIPTION
Corrected usage of `process.terminate` to remove unexpected `timeout`
argument. Not sure how this did not surface in integration tests (will
investigate later).

Fixes #2398

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
