### PR TITLE
docs: update copyright year

### DIFF
--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -4,7 +4,7 @@ repo_name: aws/jsii
 repo_url: https://github.com/aws/jsii
 site_url: https://aws.github.io/jsii/
 edit_uri: edit/main/gh-pages/content/
-copyright: Copyright &copy; 2020 Amazon Web Services, Inc.
+copyright: Copyright &copy; 2021 Amazon Web Services, Inc.
 
 docs_dir: content
 extra_css:


### PR DESCRIPTION
Updates docs copyright year (2020 -> 2021)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
