### PR TITLE
chore(go): minor refactors in go runtime

### DIFF
--- a/packages/@jsii/go-runtime/go.mod
+++ b/packages/@jsii/go-runtime/go.mod
@@ -1,17 +1,17 @@
-module github.com/aws-cdk/jsii
+module github.com/aws/jsii
 
 go 1.15
 
 require (
-	github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
 	github.com/aws/jsii-runtime-go v0.0.0
+	github.com/aws/jsii/jsii-calc/go/jsiicalc v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
 )
 
 replace (
-	github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc v0.0.0 => ./jsii-calc/go/jsiicalc
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbase
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbaseofbase
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib v0.0.0 => ./jsii-calc/go/scopejsiicalclib
 	github.com/aws/jsii-runtime-go v0.0.0 => ./jsii-runtime-go
+	github.com/aws/jsii/jsii-calc/go/jsiicalc v0.0.0 => ./jsii-calc/go/jsiicalc
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbase
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbaseofbase
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0 => ./jsii-calc/go/scopejsiicalclib
 )

--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
-	calc "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc"
-	param "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/param"
-	returnsParam "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/returnsparam"
-	calclib "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii-runtime-go"
 	"math"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/aws/jsii-runtime-go"
+	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc"
+	param "github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
+	returnsParam "github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/returnsparam"
+	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 )
 
 func TestMain(m *testing.M) {

--- a/packages/@jsii/go-runtime/jsii-runtime-go/api.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/api.go
@@ -24,6 +24,8 @@ func (o override) isOverride() {
 // FQN represents a fully-qualified type name in the jsii type system.
 type FQN string
 
+// MethodOverride is used to register a "go-native" implementation to be
+// substituted to the default javascript implementation on the created object.
 type MethodOverride struct {
 	override
 
@@ -31,6 +33,8 @@ type MethodOverride struct {
 	Cookie *string `json:"cookie"`
 }
 
+// PropertyOverride is used to register a "go-native" implementation to be
+// substituted to the default javascript implementation on the created object.
 type PropertyOverride struct {
 	override
 
@@ -59,7 +63,7 @@ func isPropertyOverride(value Override) bool {
 // KernelRequest and KernelResponse allow creating a union of KernelRequest and
 // KernelResponse types by defining private method implemented by a private
 // custom type, which is embedded in all relevant types.
-type KernelRequest interface {
+type kernelRequest interface {
 	isRequest()
 }
 
@@ -70,7 +74,7 @@ func (r kernelRequester) isRequest() {
 	return
 }
 
-type KernelResponse interface {
+type kernelResponse interface {
 	isResponse()
 }
 
@@ -82,19 +86,19 @@ func (r kernelResponder) isResponse() {
 }
 
 type objref struct {
-	JsiiInstanceId string `json:"$jsii.byref"`
+	InstanceID string `json:"$jsii.byref"`
 }
 
-type LoadRequest struct {
+type loadRequest struct {
 	kernelRequester
 
-	Api     string `json:"api"`
+	API     string `json:"api"`
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	Tarball string `json:"tarball"`
 }
 
-type LoadResponse struct {
+type loadResponse struct {
 	kernelResponder
 
 	Assembly string  `json:"assembly"`
@@ -104,10 +108,10 @@ type LoadResponse struct {
 type createRequest struct {
 	kernelRequester
 
-	Api        string        `json:"api"`
-	Fqn        FQN           `json:"fqn"`
+	API        string        `json:"api"`
+	FQN        FQN           `json:"fqn"`
 	Interfaces []FQN         `json:"interfaces"`
-	Args       []interface{} `json:"args"`
+	Arguments  []interface{} `json:"args"`
 	Overrides  []Override    `json:"overrides"`
 }
 
@@ -115,33 +119,33 @@ type createRequest struct {
 type createResponse struct {
 	kernelResponder
 
-	JsiiInstanceId string `json:"$jsii.byref"`
+	InstanceID string `json:"$jsii.byref"`
 }
 
-type DelRequest struct {
+type delRequest struct {
 	kernelRequester
 
-	Api    string `json:"api"`
-	Objref objref `json:"objref"`
+	API    string `json:"api"`
+	ObjRef objref `json:"objref"`
 }
 
-type DelResponse struct {
+type delResponse struct {
 	kernelResponder
 }
 
 type getRequest struct {
 	kernelRequester
 
-	Api      string `json:"api"`
+	API      string `json:"api"`
 	Property string `json:"property"`
-	Objref   objref `json:"objref"`
+	ObjRef   objref `json:"objref"`
 }
 
 type staticGetRequest struct {
 	kernelRequester
 
-	Api      string `json:"api"`
-	Fqn      FQN    `json:"fqn"`
+	API      string `json:"api"`
+	FQN      FQN    `json:"fqn"`
 	Property string `json:"property"`
 }
 
@@ -154,17 +158,17 @@ type getResponse struct {
 type setRequest struct {
 	kernelRequester
 
-	Api      string      `json:"api"`
+	API      string      `json:"api"`
 	Property string      `json:"property"`
 	Value    interface{} `json:"value"`
-	Objref   objref      `json:"objref"`
+	ObjRef   objref      `json:"objref"`
 }
 
 type staticSetRequest struct {
 	kernelRequester
 
-	Api      string      `json:"api"`
-	Fqn      FQN         `json:"fqn"`
+	API      string      `json:"api"`
+	FQN      FQN         `json:"fqn"`
 	Property string      `json:"property"`
 	Value    interface{} `json:"value"`
 }
@@ -176,19 +180,19 @@ type setResponse struct {
 type staticInvokeRequest struct {
 	kernelRequester
 
-	Api    string        `json:"api"`
-	Fqn    FQN           `json:"fqn"`
-	Method string        `json:"method"`
-	Args   []interface{} `json:"args"`
+	API       string        `json:"api"`
+	FQN       FQN           `json:"fqn"`
+	Method    string        `json:"method"`
+	Arguments []interface{} `json:"args"`
 }
 
 type invokeRequest struct {
 	kernelRequester
 
-	Api    string        `json:"api"`
-	Method string        `json:"method"`
-	Args   []interface{} `json:"args"`
-	Objref objref        `json:"objref"`
+	API       string        `json:"api"`
+	Method    string        `json:"method"`
+	Arguments []interface{} `json:"args"`
+	ObjRef    objref        `json:"objref"`
 }
 
 type invokeResponse struct {
@@ -197,115 +201,115 @@ type invokeResponse struct {
 	Result interface{} `json:"result"`
 }
 
-type BeginRequest struct {
+type beginRequest struct {
 	kernelRequester
 
-	Api    string        `json:"api"`
-	Method *string       `json:"method"`
-	Args   []interface{} `json:"args"`
-	Objref objref        `json:"objref"`
+	API       string        `json:"api"`
+	Method    *string       `json:"method"`
+	Arguments []interface{} `json:"args"`
+	ObjRef    objref        `json:"objref"`
 }
 
-type BeginResponse struct {
+type beginResponse struct {
 	kernelResponder
 
-	Promiseid *string `json:"promise_id"`
+	PromiseID *string `json:"promise_id"`
 }
 
-type EndRequest struct {
+type endRequest struct {
 	kernelRequester
 
-	Api       string  `json:"api"`
-	Promiseid *string `json:"promise_id"`
+	API       string  `json:"api"`
+	PromiseID *string `json:"promise_id"`
 }
 
-type EndResponse struct {
+type endResponse struct {
 	kernelResponder
 
 	Result interface{} `json:"result"`
 }
 
-type CallbacksRequest struct {
+type callbacksRequest struct {
 	kernelRequester
 
-	Api string `json:"api"`
+	API string `json:"api"`
 }
 
-type CallbacksResponse struct {
+type callbacksResponse struct {
 	kernelResponder
 
-	Callbacks []Callback `json:"callbacks"`
+	Callbacks []callback `json:"callbacks"`
 }
 
-type CompleteRequest struct {
+type completeRequest struct {
 	kernelRequester
 
-	Api    string      `json:"api"`
-	Cbid   *string     `json:"cbid"`
-	Err    *string     `json:"err"`
-	Result interface{} `json:"result"`
+	API        string      `json:"api"`
+	CallbackID *string     `json:"cbid"`
+	Error      *string     `json:"err"`
+	Result     interface{} `json:"result"`
 }
 
-type CompleteResponse struct {
+type completeResponse struct {
 	kernelResponder
 
-	Cbid *string `json:"cbid"`
+	CallbackID *string `json:"cbid"`
 }
 
-type NamingRequest struct {
+type namingRequest struct {
 	kernelRequester
 
-	Api      string `json:"api"`
+	API      string `json:"api"`
 	Assembly string `json:"assembly"`
 }
 
-type NamingResponse struct {
+type namingResponse struct {
 	kernelResponder
 	// readonly naming: {
 	//   readonly [language: string]: { readonly [key: string]: any } | undefined;
 	// };
 }
 
-type StatsRequest struct {
+type statsRequest struct {
 	kernelRequester
 
-	Api string `json:"api"`
+	API string `json:"api"`
 }
 
-type StatsResponse struct {
+type statsResponse struct {
 	kernelResponder
 
 	ObjectCount float64 `json:"object_count"`
 }
 
 // HelloResponse?
-type InitOkResponse struct {
+type initOKResponse struct {
 	kernelResponder
 
 	Hello string `json:"hello"`
 }
 
-type Callback struct {
-	Cbid   *string       `json:"cbid"`
-	Cookie *string       `json:"cookie"`
-	Invoke invokeRequest `json:"invoke"`
-	Get    getRequest    `json:"get"`
-	Set    setRequest    `json:"set"`
+type callback struct {
+	CallbackID *string       `json:"cbid"`
+	Cookie     *string       `json:"cookie"`
+	Invoke     invokeRequest `json:"invoke"`
+	Get        getRequest    `json:"get"`
+	Set        setRequest    `json:"set"`
 }
 
-type OkayResponse struct {
-	Ok interface{} `json:"ok"`
+type okayResponse struct {
+	OK interface{} `json:"ok"`
 }
 
-type ErrorResponse struct {
+type errorResponse struct {
 	Error *string `json:"error"`
 	Stack *string `json:"stack"`
 }
 
-// Custom unmarshalling implementation for response structs. Creating new types
-// is required in order to avoid infinite recursion.
-func (r *LoadResponse) UnmarshalJSON(data []byte) error {
-	type response LoadResponse
+// UnmarshalJSON provides custom unmarshalling implementation for response
+// structs. Creating new types is required in order to avoid infinite recursion.
+func (r *loadResponse) UnmarshalJSON(data []byte) error {
+	type response loadResponse
 	return unmarshalKernelResponse(data, (*response)(r))
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/client.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -20,8 +19,6 @@ var (
 	clientInstanceMutex sync.Mutex
 	clientOnce          sync.Once
 )
-
-type Any interface{}
 
 // The client struct owns the jsii child process and its io interfaces. It also
 // owns a map (objects) that tracks all object references by ID. This is used
@@ -38,12 +35,6 @@ type client struct {
 	tmpdir string
 
 	objects map[interface{}]string
-}
-
-func CheckFatalError(e error) {
-	if e != nil {
-		log.Fatal(e)
-	}
 }
 
 // getClient returns a singleton client instance, initializing one the first
@@ -170,7 +161,7 @@ func newClient() (*client, error) {
 	return clientinstance, nil
 }
 
-func (c *client) request(req KernelRequest, res KernelResponse) error {
+func (c *client) request(req kernelRequest, res kernelResponse) error {
 	err := c.writer.Encode(req)
 	if err != nil {
 		return err
@@ -179,7 +170,7 @@ func (c *client) request(req KernelRequest, res KernelResponse) error {
 	return c.response(res)
 }
 
-func (c *client) response(res KernelResponse) error {
+func (c *client) response(res kernelResponse) error {
 	if c.reader.More() {
 		return c.reader.Decode(res)
 	}
@@ -189,7 +180,7 @@ func (c *client) response(res KernelResponse) error {
 }
 
 func (c *client) processHello() (string, error) {
-	response := InitOkResponse{}
+	response := initOKResponse{}
 
 	if err := c.response(&response); err != nil {
 		return "", err
@@ -205,8 +196,8 @@ func (c *client) findObjectRef(obj interface{}) (refid string, ok bool) {
 	return
 }
 
-func (c *client) load(request LoadRequest) (LoadResponse, error) {
-	response := LoadResponse{}
+func (c *client) load(request loadRequest) (loadResponse, error) {
+	response := loadResponse{}
 	return response, c.request(request, &response)
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/client_test.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/client_test.go
@@ -20,8 +20,8 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("Client Load Error", func(t *testing.T) {
-		request := LoadRequest{
-			Api:     "load",
+		request := loadRequest{
+			API:     "load",
 			Name:    "jsii-calc",
 			Version: "0.0.0",
 			Tarball: "jsii-calc-tarball.tgz",

--- a/packages/@jsii/go-runtime/package.json
+++ b/packages/@jsii/go-runtime/package.json
@@ -6,13 +6,13 @@
   "main": "index.js",
   "scripts": {
     "build": "npm run gen:rt && (cd ./jsii-runtime-go && go build)",
-    "fmt": "go fmt ./jsii-runtime-go ./jsii-calc-test",
+    "fmt": "go fmt ./... && (cd ./jsii-runtime-go; go fmt)",
     "gen:calc": "ts-node build-tools/gen-calc.ts",
     "gen:rt": "ts-node build-tools/gen.ts",
     "generate": "npm run gen:rt && npm run gen:calc",
-    "lint": "eslint . --ext .ts --ignore-path=.gitignore",
+    "lint": "go vet ./... && (cd ./jsii-runtime-go; go vet)",
     "lint:fix": "yarn lint --fix",
-    "test": "(cd ./jsii-runtime-go && go test) && npm run test:calc",
+    "test": "(cd ./jsii-runtime-go; go test) && npm run test:calc",
     "test:calc": "npm run gen:calc && go test ./jsii-calc-test"
   },
   "keywords": [],

--- a/packages/@jsii/go-runtime/package.json
+++ b/packages/@jsii/go-runtime/package.json
@@ -6,13 +6,13 @@
   "main": "index.js",
   "scripts": {
     "build": "npm run gen:rt && (cd ./jsii-runtime-go && go build)",
-    "fmt": "go fmt ./... && (cd ./jsii-runtime-go; go fmt)",
+    "fmt": "go fmt ./... && (cd ./jsii-runtime-go && go fmt)",
     "gen:calc": "ts-node build-tools/gen-calc.ts",
     "gen:rt": "ts-node build-tools/gen.ts",
     "generate": "npm run gen:rt && npm run gen:calc",
-    "lint": "go vet ./... && (cd ./jsii-runtime-go; go vet)",
+    "lint": "go vet ./... && (cd ./jsii-runtime-go && go vet)",
     "lint:fix": "yarn lint --fix",
-    "test": "(cd ./jsii-runtime-go; go test) && npm run test:calc",
+    "test": "(cd ./jsii-runtime-go && go test) && npm run test:calc",
     "test:calc": "npm run gen:calc && go test ./jsii-calc-test"
   },
   "keywords": [],

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -400,7 +400,7 @@ defineTest(
         packageId: 'Amazon.JSII.Tests.CalculatorPackageId',
       },
       go: {
-        moduleName: 'github.com/aws-cdk/jsii/jsii-calc/go',
+        moduleName: 'github.com/aws/jsii/jsii-calc/go',
       },
       java: {
         package: 'software.amazon.jsii.tests.calculator',
@@ -424,7 +424,7 @@ defineTest(
           versionSuffix: '-devpreview',
         },
         go: {
-          moduleName: 'github.com/aws-cdk/jsii/jsii-calc/go',
+          moduleName: 'github.com/aws/jsii/jsii-calc/go',
         },
         java: {
           package: 'software.amazon.jsii.tests.calculator.lib',

--- a/packages/@scope/jsii-calc-base-of-base/package.json
+++ b/packages/@scope/jsii-calc-base-of-base/package.json
@@ -40,7 +40,7 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator.baseofbase",

--- a/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
@@ -34,7 +34,7 @@
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId"
     },
     "go": {
-      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go"
     },
     "java": {
       "maven": {
@@ -161,5 +161,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "5CKE8vMY9yfI2nwINNFdsXEWiu+2IweLBMNSugSydHM="
+  "fingerprint": "gQIWvOsvmhX7k2K1qu+J1cLhGwJ8ASHsRF0veu4zHPU="
 }

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -55,7 +55,7 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator.base",

--- a/packages/@scope/jsii-calc-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base/test/assembly.jsii
@@ -18,7 +18,7 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -64,7 +64,7 @@
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
     },
     "go": {
-      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go"
     },
     "java": {
       "maven": {
@@ -167,5 +167,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "F9tU1Iv94F6IXwyru+WBj8ZFoLXV68trXOYxDlBYC7U="
+  "fingerprint": "Ajk3MslkfbYCrArr+xpk4fCqUsDaJMcCWIRdaVGDWDo="
 }

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -49,7 +49,7 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator.lib",

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -19,7 +19,7 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -44,7 +44,7 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -114,7 +114,7 @@
       "versionSuffix": "-devpreview"
     },
     "go": {
-      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go"
     },
     "java": {
       "maven": {
@@ -776,5 +776,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "BqEkQT524+O0HPCm2HAxdE9sEOKWFE2fXLcKLS7MK0M="
+  "fingerprint": "mkucsthH8x3P091hrbSKScb4He4QUc1ukov38vWDTn8="
 }

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -63,7 +63,7 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator",

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -49,7 +49,7 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -74,7 +74,7 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -119,7 +119,7 @@
           "versionSuffix": "-devpreview"
         },
         "go": {
-          "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go"
         },
         "java": {
           "maven": {
@@ -263,7 +263,7 @@
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId"
     },
     "go": {
-      "moduleName": "github.com/aws-cdk/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go"
     },
     "java": {
       "maven": {
@@ -14435,5 +14435,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "2KFlnOkWR5oOwLlri+7JlkA0BsYvnRkpBrk4nPWnJfw="
+  "fingerprint": "QBNTpJpMg4zFjgJmkYmVTVJ0wMJ1cNIfs7vz8MBqngc="
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -12,13 +12,13 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/go.mod 1`] = `
-module github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase
+module github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase
 
 go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
 )
 
 `;
@@ -30,7 +30,7 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	scopejsiicalcbaseofbase "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
 )
 
 var once sync.Once
@@ -57,9 +57,9 @@ package scopejsiicalcbase
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
 )
 
 // Class interface
@@ -181,7 +181,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/go.mod 1`] = `
-module github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase
+module github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase
 
 go 1.15
 
@@ -220,7 +220,7 @@ package scopejsiicalcbaseofbase
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
 	"reflect"
 )
 
@@ -341,14 +341,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/go.mod 1`] = `
-module github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib
+module github.com/aws/jsii/jsii-calc/go/scopejsiicalclib
 
 go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
 )
 
 `;
@@ -360,8 +360,8 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	scopejsiicalcbase "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
-	scopejsiicalcbaseofbase "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	scopejsiicalcbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
 )
 
 var once sync.Once
@@ -389,10 +389,10 @@ package scopejsiicalclib
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
 )
 
 // Check that enums from \\@scoped packages can be references.
@@ -841,7 +841,7 @@ package submodule
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 	"reflect"
 )
 
@@ -1095,9 +1095,9 @@ package composition
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 )
 
 // Class interface
@@ -1274,7 +1274,7 @@ package derivedclasshasnoproperties
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
 )
 
@@ -1370,15 +1370,15 @@ func (d *Derived) SetProp(val string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/go.mod 1`] = `
-module github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc
+module github.com/aws/jsii/jsii-calc/go/jsiicalc
 
 go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
-	github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
 )
 
 `;
@@ -1388,7 +1388,7 @@ package interfaceinnamespaceincludesclasses
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
 )
 
@@ -1501,9 +1501,9 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	scopejsiicalcbase "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
-	scopejsiicalcbaseofbase "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
-	scopejsiicalclib "github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+	scopejsiicalcbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	scopejsiicalclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 )
 
 var once sync.Once
@@ -1532,13 +1532,13 @@ package jsiicalc
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/composition"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalcbase"
-	"github.com/aws-cdk/jsii/jsii-calc/go/scopejsiicalclib/submodule"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/composition"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
 )
 
 // Class interface
@@ -13563,7 +13563,7 @@ package pythonself
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
 )
 
@@ -13703,7 +13703,7 @@ package backreferences
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule"
 )
 
 // MyClassReferenceIface is the public interface for the custom type MyClassReference
@@ -13738,7 +13738,7 @@ package child
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
 )
 
@@ -13989,8 +13989,8 @@ package nestedsubmodule
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/child"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/child"
 )
 
 // Class interface
@@ -14072,9 +14072,9 @@ package returnsparam
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/param"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
 )
 
 // Class interface
@@ -14122,12 +14122,12 @@ package submodule
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
 	"reflect"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/child"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc"
-	"github.com/aws-cdk/jsii/jsii-calc/go/jsiicalc/submodule/param"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/child"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
 )
 
 // Class interface


### PR DESCRIPTION
A collection of mostly cosmetic changes aimed at making the code closer
to "release" status, reducing the risk of inadvertently creating dependencies
on implementation details, and ensuring naming is "idiomatic" looking.

- Hidden types that do not need to be exported (in particular, all the
  request and response types from `api.go`)
- Renamed members to match go's naming conventions more closely. This
  means acronyms are fully upper-cased (e.g `Api` became `API`, etc...)
- Avoided abbreviating struct member names in favor of a more
  descriptive naming. This affects relatively few properties.
- Added minimal documentation strings on exported functions (and some
  hidden functions, too). At this stage all exported symbols have "some"
  documentation string on them.
- Removed the `aws-cdk` element of the go module name of the `jsii-calc`
  packages as this was out-of-place.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
