### PR TITLE
feat(go): version file in the generated module directory

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -13,6 +13,7 @@ import {
 } from './runtime';
 import { GoClass, GoType, Enum, Interface, Struct } from './types';
 import { findTypeInTree, goPackageName, flatMap } from './util';
+import { VersionFile } from './version-file';
 
 export const GOMOD_FILENAME = 'go.mod';
 export const GO_VERSION = '1.15';
@@ -181,6 +182,7 @@ export class RootPackage extends Package {
   public readonly assembly: Assembly;
   public readonly version: string;
   private readonly readme?: ReadmeFile;
+  private readonly versionFile: VersionFile;
 
   public constructor(assembly: Assembly) {
     const packageName = goPackageName(assembly.name);
@@ -197,6 +199,7 @@ export class RootPackage extends Package {
 
     this.assembly = assembly;
     this.version = assembly.version;
+    this.versionFile = new VersionFile(this.version);
 
     if (this.assembly.readme?.markdown) {
       this.readme = new ReadmeFile(
@@ -212,6 +215,7 @@ export class RootPackage extends Package {
     this.readme?.emit(context);
 
     this.emitGomod(context.code);
+    this.versionFile.emit(context.code);
   }
 
   private emitGomod(code: CodeMaker) {

--- a/packages/jsii-pacmak/lib/targets/go/version-file.ts
+++ b/packages/jsii-pacmak/lib/targets/go/version-file.ts
@@ -1,5 +1,4 @@
-import { CodeMaker } from "codemaker";
-
+import { CodeMaker } from 'codemaker';
 
 /**
  * Represents the version of the go module. This is needed because the version is not
@@ -9,7 +8,7 @@ export class VersionFile {
 
   private static readonly NAME = 'version';
 
-  constructor(private readonly version: string) {}
+  public constructor(private readonly version: string) {}
 
   public emit(code: CodeMaker) {
     code.openFile(VersionFile.NAME);

--- a/packages/jsii-pacmak/lib/targets/go/version-file.ts
+++ b/packages/jsii-pacmak/lib/targets/go/version-file.ts
@@ -5,7 +5,6 @@ import { CodeMaker } from 'codemaker';
  * available in standard go module files.
  */
 export class VersionFile {
-
   private static readonly NAME = 'version';
 
   public constructor(private readonly version: string) {}
@@ -13,6 +12,6 @@ export class VersionFile {
   public emit(code: CodeMaker) {
     code.openFile(VersionFile.NAME);
     code.line(this.version);
-    code.closeFile(VersionFile.NAME)
+    code.closeFile(VersionFile.NAME);
   }
 }

--- a/packages/jsii-pacmak/lib/targets/go/version-file.ts
+++ b/packages/jsii-pacmak/lib/targets/go/version-file.ts
@@ -1,0 +1,19 @@
+import { CodeMaker } from "codemaker";
+
+
+/**
+ * Represents the version of the go module. This is needed because the version is not
+ * available in standard go module files.
+ */
+export class VersionFile {
+
+  private static readonly NAME = 'version';
+
+  constructor(private readonly version: string) {}
+
+  public emit(code: CodeMaker) {
+    code.openFile(VersionFile.NAME);
+    code.line(this.version);
+    code.closeFile(VersionFile.NAME)
+  }
+}

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -17,9 +17,10 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/ 1`] = `
  ┃  ┗━ 📁 foo
  ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
- ┃     ┗━ 📁 jsii
- ┃        ┣━ 📄 jsii.go
- ┃        ┗━ 📄 tarball.embedded.go
+ ┃     ┣━ 📁 jsii
+ ┃     ┃  ┣━ 📄 jsii.go
+ ┃     ┃  ┗━ 📄 tarball.embedded.go
+ ┃     ┗━ 📄 version
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -164,6 +165,11 @@ func Initialize() {
 `;
 
 exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/go/foo/jsii/tarball.embedded.go 1`] = `go/foo/jsii/tarball.embedded.go embeds a tarball`;
+
+exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/go/foo/version 1`] = `
+1.2.3
+
+`;
 
 exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -518,9 +524,10 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/ 1`] = `
  ┃  ┗━ 📁 foo
  ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
- ┃     ┗━ 📁 jsii
- ┃        ┣━ 📄 jsii.go
- ┃        ┗━ 📄 tarball.embedded.go
+ ┃     ┣━ 📁 jsii
+ ┃     ┃  ┣━ 📄 jsii.go
+ ┃     ┃  ┗━ 📄 tarball.embedded.go
+ ┃     ┗━ 📄 version
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -665,6 +672,11 @@ func Initialize() {
 `;
 
 exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/go/foo/jsii/tarball.embedded.go 1`] = `go/foo/jsii/tarball.embedded.go embeds a tarball`;
+
+exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/go/foo/version 1`] = `
+1.2.3
+
+`;
 
 exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1019,9 +1031,10 @@ exports[`foo@2.0.0-rc.42: <outDir>/ 1`] = `
  ┃  ┗━ 📁 foo
  ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
- ┃     ┗━ 📁 jsii
- ┃        ┣━ 📄 jsii.go
- ┃        ┗━ 📄 tarball.embedded.go
+ ┃     ┣━ 📁 jsii
+ ┃     ┃  ┣━ 📄 jsii.go
+ ┃     ┃  ┗━ 📄 tarball.embedded.go
+ ┃     ┗━ 📄 version
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -1158,6 +1171,11 @@ func Initialize() {
 `;
 
 exports[`foo@2.0.0-rc.42: <outDir>/go/foo/jsii/tarball.embedded.go 1`] = `go/foo/jsii/tarball.embedded.go embeds a tarball`;
+
+exports[`foo@2.0.0-rc.42: <outDir>/go/foo/version 1`] = `
+2.0.0-rc.42
+
+`;
 
 exports[`foo@2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1496,9 +1514,10 @@ exports[`foo@4.5.6-pre.1337: <outDir>/ 1`] = `
  ┃  ┗━ 📁 foo
  ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
- ┃     ┗━ 📁 jsii
- ┃        ┣━ 📄 jsii.go
- ┃        ┗━ 📄 tarball.embedded.go
+ ┃     ┣━ 📁 jsii
+ ┃     ┃  ┣━ 📄 jsii.go
+ ┃     ┃  ┗━ 📄 tarball.embedded.go
+ ┃     ┗━ 📄 version
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -1635,6 +1654,11 @@ func Initialize() {
 `;
 
 exports[`foo@4.5.6-pre.1337: <outDir>/go/foo/jsii/tarball.embedded.go 1`] = `go/foo/jsii/tarball.embedded.go embeds a tarball`;
+
+exports[`foo@4.5.6-pre.1337: <outDir>/go/foo/version 1`] = `
+4.5.6-pre.1337
+
+`;
 
 exports[`foo@4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -8,7 +8,8 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/ 1`] = `
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii.go
        ┃  ┗━ 📄 tarball.embedded.go
-       ┗━ 📄 scopejsiicalcbase.go
+       ┣━ 📄 scopejsiicalcbase.go
+       ┗━ 📄 version
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/go.mod 1`] = `
@@ -204,6 +205,11 @@ func StaticConsumer_Consume(args interface{}) {
 
 `;
 
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/version 1`] = `
+0.0.0
+
+`;
+
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
 <root>
  ┗━ 📁 go
@@ -212,7 +218,8 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii.go
        ┃  ┗━ 📄 tarball.embedded.go
-       ┗━ 📄 scopejsiicalcbaseofbase.go
+       ┣━ 📄 scopejsiicalcbaseofbase.go
+       ┗━ 📄 version
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/go.mod 1`] = `
@@ -362,6 +369,11 @@ func (v *VeryBaseProps) GetFoo() VeryIface {
 
 `;
 
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/version 1`] = `
+0.0.0
+
+`;
+
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 <root>
  ┗━ 📁 go
@@ -371,8 +383,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
        ┃  ┣━ 📄 jsii.go
        ┃  ┗━ 📄 tarball.embedded.go
        ┣━ 📄 scopejsiicalclib.go
-       ┗━ 📁 submodule
-          ┗━ 📄 submodule.go
+       ┣━ 📁 submodule
+       ┃  ┗━ 📄 submodule.go
+       ┗━ 📄 version
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/go.mod 1`] = `
@@ -1057,6 +1070,11 @@ func (r *Reflector) AsMap(reflectable IReflectableIface) map[string]interface{} 
 
 `;
 
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/version 1`] = `
+0.0.0
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
 <root>
  ┗━ 📁 go
@@ -1077,22 +1095,23 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┣━ 📁 pythonself
        ┃  ┗━ 📄 pythonself.go
        ┣━ 📄 README.md
-       ┗━ 📁 submodule
-          ┣━ 📁 backreferences
-          ┃  ┗━ 📄 backreferences.go
-          ┣━ 📁 child
-          ┃  ┗━ 📄 child.go
-          ┣━ 📁 isolated
-          ┃  ┗━ 📄 isolated.go
-          ┣━ 📁 nestedsubmodule
-          ┃  ┣━ 📁 deeplynested
-          ┃  ┃  ┗━ 📄 deeplynested.go
-          ┃  ┗━ 📄 nestedsubmodule.go
-          ┣━ 📁 param
-          ┃  ┗━ 📄 param.go
-          ┣━ 📁 returnsparam
-          ┃  ┗━ 📄 returnsparam.go
-          ┗━ 📄 submodule.go
+       ┣━ 📁 submodule
+       ┃  ┣━ 📁 backreferences
+       ┃  ┃  ┗━ 📄 backreferences.go
+       ┃  ┣━ 📁 child
+       ┃  ┃  ┗━ 📄 child.go
+       ┃  ┣━ 📁 isolated
+       ┃  ┃  ┗━ 📄 isolated.go
+       ┃  ┣━ 📁 nestedsubmodule
+       ┃  ┃  ┣━ 📁 deeplynested
+       ┃  ┃  ┃  ┗━ 📄 deeplynested.go
+       ┃  ┃  ┗━ 📄 nestedsubmodule.go
+       ┃  ┣━ 📁 param
+       ┃  ┃  ┗━ 📄 param.go
+       ┃  ┣━ 📁 returnsparam
+       ┃  ┃  ┗━ 📄 returnsparam.go
+       ┃  ┗━ 📄 submodule.go
+       ┗━ 📄 version
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/README.md 1`] = `
@@ -14281,5 +14300,10 @@ func (m *MyClass) MethodWithSpecialParam(param param.SpecialParameterIface) stri
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/version 1`] = `
+0.0.0
 
 `;


### PR DESCRIPTION
Since golang version isn't available anywhere inside the module, we embed a version file so that consumers can access the version. 

This is needed for publishing [go modules](https://github.com/aws/jsii-release/pull/23) using `jsii-release` without the user having to supply the version externally.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
