### PR TITLE
fix(go): major version suffix is missing in module names for >=v2

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -44,8 +44,10 @@ export class Golang extends Target {
     // run `go build` with local.go.mod
     await go('build', ['-modfile', localGoMod], { cwd: pkgDir });
 
-    // delete local.go.mod from the output directory so it doesn't get published
-    await fs.unlink(path.join(pkgDir, localGoMod));
+    // delete local.go.mod and local.go.sum from the output directory so it doesn't get published
+    const localGoSum = `${path.basename(localGoMod, '.mod')}.sum`;
+    await tryUnlink(path.join(pkgDir, localGoMod));
+    await tryUnlink(path.join(pkgDir, localGoSum));
   }
 
   /**
@@ -228,4 +230,12 @@ function tryFindLocalRuntime() {
 async function go(command: string, args: string[], options: { cwd: string }) {
   const { cwd } = options;
   return shell('go', [command, ...args], { cwd });
+}
+
+async function tryUnlink(filePath: string) {
+  if (!(await fs.pathExists(filePath))) {
+    return;
+  }
+
+  await fs.unlink(filePath);
 }

--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -46,8 +46,8 @@ export class Golang extends Target {
 
     // delete local.go.mod and local.go.sum from the output directory so it doesn't get published
     const localGoSum = `${path.basename(localGoMod, '.mod')}.sum`;
-    await tryUnlink(path.join(pkgDir, localGoMod));
-    await tryUnlink(path.join(pkgDir, localGoSum));
+    await fs.remove(path.join(pkgDir, localGoMod));
+    await fs.remove(path.join(pkgDir, localGoSum));
   }
 
   /**
@@ -230,12 +230,4 @@ function tryFindLocalRuntime() {
 async function go(command: string, args: string[], options: { cwd: string }) {
   const { cwd } = options;
   return shell('go', [command, ...args], { cwd });
-}
-
-async function tryUnlink(filePath: string) {
-  if (!(await fs.pathExists(filePath))) {
-    return;
-  }
-
-  await fs.unlink(filePath);
 }

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -348,6 +348,20 @@ export class InternalPackage extends Package {
   }
 }
 
+/**
+ * Go requires that when a module major version is v2.0 and above, the module
+ * name will have a `/vNN` suffix (where `NN` is the major version).
+ *
+ * > Starting with major version 2, module paths must have a major version
+ * > suffix like /v2 that matches the major version. For example, if a module
+ * > has the path example.com/mod at v1.0.0, it must have the path
+ * > example.com/mod/v2 at version v2.0.0.
+ *
+ * @see https://golang.org/ref/mod#major-version-suffixes
+ * @param version The module version (e.g. `2.3.0`)
+ * @returns a suffix to append to the module name in the form (`/vNN`). If the
+ * module version is `0.x` or `1.x`, returns an empty string.
+ */
 function determineMajorVersionSuffix(version: string) {
   const sv = semver.parse(version);
   if (!sv) {
@@ -361,5 +375,5 @@ function determineMajorVersionSuffix(version: string) {
     return '';
   }
 
-  return `/v${sv.major.toString()}`;
+  return `/v${sv.major}`;
 }

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -289,7 +289,7 @@ export class RootPackage extends Package {
       code.line('// Initialization endpoints of dependencies');
       for (const pkg of dependencies) {
         code.line(
-          `${pkg.packageName} "${pkg.root.moduleName}/${pkg.root.packageName}/${JSII_INIT_PACKAGE}"`,
+          `${pkg.packageName} "${pkg.root.goModuleName}/${JSII_INIT_PACKAGE}"`,
         );
       }
     }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -132,7 +132,7 @@ go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v1337.42.1337
-	bar v2.0.0-rc.42
+	bar/v2 v2.0.0-rc.42
 )
 
 `;
@@ -633,7 +633,7 @@ go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v1337.42.1337
-	bar v4.5.6-pre.1337
+	bar/v4 v4.5.6-pre.1337
 )
 
 `;
@@ -1126,7 +1126,7 @@ import (
 `;
 
 exports[`foo@2.0.0-rc.42: <outDir>/go/foo/go.mod 1`] = `
-module foo
+module foo/v2
 
 go 1.15
 
@@ -1603,7 +1603,7 @@ import (
 `;
 
 exports[`foo@4.5.6-pre.1337: <outDir>/go/foo/go.mod 1`] = `
-module foo
+module foo/v4
 
 go 1.15
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -144,7 +144,7 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	bar "/bar/jsii"
+	bar "bar/v2/jsii"
 )
 
 var once sync.Once
@@ -645,7 +645,7 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	bar "/bar/jsii"
+	bar "bar/v4/jsii"
 )
 
 var once sync.Once


### PR DESCRIPTION
According to the [go modules spec], starting from 2.0.0, module names must include
A “major version suffix” (e.g. `/v2`).

[go modules spec]: https://golang.org/ref/mod#major-version-suffixes

Fixes https://github.com/aws/jsii/issues/2506

This commit also fixes #2509 by deleting the `local.go.sum` file from the output.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
