### PR TITLE
fix(go): invalid major version suffix for submodules and jsii init

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/package.json
+++ b/packages/@jsii/dotnet-runtime-test/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@jsii/dotnet-runtime": "^0.0.0",
     "@types/node": "^10.17.51",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "jsii-pacmak": "^0.0.0",
     "typescript": "~3.9.7"
   }

--- a/packages/@jsii/go-runtime/go.mod
+++ b/packages/@jsii/go-runtime/go.mod
@@ -4,14 +4,14 @@ go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws/jsii/jsii-calc/go/jsiicalc v0.0.0
+	github.com/aws/jsii/jsii-calc/go/jsiicalc/v3 v3.20.120
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
 )
 
 replace (
 	github.com/aws/jsii-runtime-go v0.0.0 => ./jsii-runtime-go
-	github.com/aws/jsii/jsii-calc/go/jsiicalc v0.0.0 => ./jsii-calc/go/jsiicalc
+	github.com/aws/jsii/jsii-calc/go/jsiicalc/v3 v3.20.120 => ./jsii-calc/go/jsiicalc
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbase
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0 => ./jsii-calc/go/scopejsiicalcbaseofbase
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1 => ./jsii-calc/go/scopejsiicalcbaseofbase
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0 => ./jsii-calc/go/scopejsiicalclib
 )

--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/aws/jsii-runtime-go"
-	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc"
-	param "github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
-	returnsParam "github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/returnsparam"
+	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3"
+	param "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
+	returnsParam "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/returnsparam"
 	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 )
 

--- a/packages/@jsii/go-runtime/package.json
+++ b/packages/@jsii/go-runtime/package.json
@@ -27,7 +27,7 @@
     "codemaker": "^0.0.0",
     "eslint": "^7.19.0",
     "fs-extra": "^9.1.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "jsii-pacmak": "^0.0.0",
     "prettier": "^2.2.1",
     "ts-node": "^9.1.1",

--- a/packages/@jsii/java-runtime-test/package.json
+++ b/packages/@jsii/java-runtime-test/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@jsii/java-runtime": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "jsii-pacmak": "^0.0.0"
   }
 }

--- a/packages/@jsii/kernel/package.json
+++ b/packages/@jsii/kernel/package.json
@@ -47,7 +47,7 @@
     "jest": "^26.6.3",
     "jest-expect-message": "^1.0.2",
     "jsii-build-tools": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.0",
     "typescript": "~3.9.7"

--- a/packages/@jsii/python-runtime/package.json
+++ b/packages/@jsii/python-runtime/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "fs-extra": "^9.1.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "jsii-pacmak": "^0.0.0",
     "ts-node": "^9.1.1",
     "typescript": "~3.9.7"

--- a/packages/@jsii/runtime/package.json
+++ b/packages/@jsii/runtime/package.json
@@ -45,7 +45,7 @@
     "eslint": "^7.19.0",
     "jest": "^26.6.3",
     "jsii-build-tools": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "prettier": "^2.2.1",
     "source-map-loader": "^2.0.0",
     "ts-jest": "^26.5.0",

--- a/packages/@scope/jsii-calc-base-of-base/package.json
+++ b/packages/@scope/jsii-calc-base-of-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scope/jsii-calc-base-of-base",
-  "version": "0.0.0",
+  "version": "2.1.1",
   "private": true,
   "description": "An example transitive dependency for jsii-calc.",
   "license": "Apache-2.0",

--- a/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
@@ -160,6 +160,6 @@
       ]
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "gQIWvOsvmhX7k2K1qu+J1cLhGwJ8ASHsRF0veu4zHPU="
+  "version": "2.1.1",
+  "fingerprint": "rbtJN11MzD+pqofNrrkTb/GoS1wpG+lpZoOWh+HXysE="
 }

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -29,10 +29,10 @@
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },
   "dependencies": {
-    "@scope/jsii-calc-base-of-base": "^0.0.0"
+    "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "peerDependencies": {
-    "@scope/jsii-calc-base-of-base": "^0.0.0"
+    "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "devDependencies": {
     "@types/node": "^10.17.51",

--- a/packages/@scope/jsii-calc-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base/test/assembly.jsii
@@ -8,7 +8,7 @@
     "url": "https://aws.amazon.com"
   },
   "dependencies": {
-    "@scope/jsii-calc-base-of-base": "^0.0.0"
+    "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "dependencyClosure": {
     "@scope/jsii-calc-base-of-base": {
@@ -201,5 +201,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "nk3lZyZihw8+X5KKk4nmX16b78gkSh2KmOCC72ZlkYk="
+  "fingerprint": "rKhrKvGvuY8DnHhiQFIGMiFOU8AU+S9ZVk9c3/rUJNk="
 }

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@scope/jsii-calc-base": "^0.0.0",
-    "@scope/jsii-calc-base-of-base": "^0.0.0"
+    "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "devDependencies": {
     "@types/node": "^10.17.51",

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@scope/jsii-calc-base": "^0.0.0",
-    "@scope/jsii-calc-base-of-base": "^0.0.0"
+    "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "dependencyClosure": {
     "@scope/jsii-calc-base": {
@@ -776,5 +776,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "mkucsthH8x3P091hrbSKScb4He4QUc1ukov38vWDTn8="
+  "fingerprint": "7STgxc8/b+pajng4R4fEptbcOF2aQJBiQkO4bMAWpI4="
 }

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsii-calc",
-  "version": "0.0.0",
+  "version": "3.20.120",
   "private": true,
   "description": "A simple calcuator built on JSII.",
   "stability": "stable",

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -14439,6 +14439,6 @@
       "namespace": "submodule.returnsparam"
     }
   },
-  "version": "0.0.0",
-  "fingerprint": "s0WTodgbAHDmgEPpTYorSZ2mi7rj+NjClzGmC3nucF4="
+  "version": "3.20.120",
+  "fingerprint": "Qv5CJVZ6t7cfQmCSHOLrbefAuLKX9JUbhUCSh+mD+po="
 }

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -79,9 +79,9 @@ export abstract class Package {
     const moduleName = this.root.moduleName;
     const prefix = moduleName !== '' ? `${moduleName}/` : '';
     const rootPackageName = this.root.packageName;
-    const suffix = this.filePath !== '' ? `/${this.filePath}` : ``;
     const versionSuffix = determineMajorVersionSuffix(this.version);
-    return `${prefix}${rootPackageName}${suffix}${versionSuffix}`;
+    const suffix = this.filePath !== '' ? `/${this.filePath}` : ``;
+    return `${prefix}${rootPackageName}${versionSuffix}${suffix}`;
   }
 
   /*
@@ -150,7 +150,7 @@ export abstract class Package {
 
     if (this.usesInitPackage) {
       code.line(
-        `${JSII_INIT_ALIAS} "${this.root.moduleName}/${this.root.packageName}/${JSII_INIT_PACKAGE}"`,
+        `${JSII_INIT_ALIAS} "${this.root.goModuleName}/${JSII_INIT_PACKAGE}"`,
       );
     }
 

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -65,7 +65,7 @@
     "eslint": "^7.19.0",
     "jest": "^26.6.3",
     "jsii-build-tools": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.0",
     "typescript": "~3.9.7"

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -2049,7 +2049,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┗━ 📄 WithPrivatePropertyInConstructor.cs
        ┣━ 📄 Amazon.JSII.Tests.CalculatorPackageId.csproj
        ┣━ 📄 AssemblyInfo.cs
-       ┗━ 📄 jsii-calc-0.0.0.tgz
+       ┗━ 📄 jsii-calc-3.20.120.tgz
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon.JSII.Tests.CalculatorPackageId.csproj 1`] = `
@@ -2060,7 +2060,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     <PackageIconUrl>https://sdk-for-net.amazonwebservices.com/images/AWSLogo128x128.png</PackageIconUrl>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageVersion>0.0.0</PackageVersion>
+    <PackageVersion>3.20.120</PackageVersion>
     <!-- Additional Metadata -->
     <Authors>Amazon Web Services</Authors>
     <Company>Amazon Web Services</Company>
@@ -2079,7 +2079,7 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="jsii-calc-0.0.0.tgz" />
+    <EmbeddedResource Include="jsii-calc-3.20.120.tgz" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
@@ -15117,8 +15117,8 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/AssemblyInfo.cs 1`] = `
 using Amazon.JSII.Runtime.Deputy;
 
-[assembly: JsiiAssembly("jsii-calc", "0.0.0", "jsii-calc-0.0.0.tgz")]
+[assembly: JsiiAssembly("jsii-calc", "3.20.120", "jsii-calc-3.20.120.tgz")]
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/jsii-calc-0.0.0.tgz 1`] = `dotnet/Amazon.JSII.Tests.CalculatorPackageId/jsii-calc-0.0.0.tgz is a tarball`;
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/jsii-calc-3.20.120.tgz 1`] = `dotnet/Amazon.JSII.Tests.CalculatorPackageId/jsii-calc-3.20.120.tgz is a tarball`;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -51,7 +51,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/dotnet/Amazon.JSII
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[2.1.1,3.0.0)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -303,7 +303,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
        ┃              ┗━ 📄 VeryBaseProps.cs
        ┣━ 📄 Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId.csproj
        ┣━ 📄 AssemblyInfo.cs
-       ┗━ 📄 scope-jsii-calc-base-of-base-0.0.0.tgz
+       ┗━ 📄 scope-jsii-calc-base-of-base-2.1.1.tgz
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId.csproj 1`] = `
@@ -313,7 +313,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
     <Description>An example transitive dependency for jsii-calc.</Description>
     <PackageId>Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageVersion>0.0.0</PackageVersion>
+    <PackageVersion>2.1.1</PackageVersion>
     <!-- Additional Metadata -->
     <Authors>Amazon Web Services</Authors>
     <Company>Amazon Web Services</Company>
@@ -331,7 +331,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="scope-jsii-calc-base-of-base-0.0.0.tgz" />
+    <EmbeddedResource Include="scope-jsii-calc-base-of-base-2.1.1.tgz" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
@@ -532,11 +532,11 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.BaseOfBaseNamespace
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/AssemblyInfo.cs 1`] = `
 using Amazon.JSII.Runtime.Deputy;
 
-[assembly: JsiiAssembly("@scope/jsii-calc-base-of-base", "0.0.0", "scope-jsii-calc-base-of-base-0.0.0.tgz")]
+[assembly: JsiiAssembly("@scope/jsii-calc-base-of-base", "2.1.1", "scope-jsii-calc-base-of-base-2.1.1.tgz")]
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/scope-jsii-calc-base-of-base-0.0.0.tgz 1`] = `dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/scope-jsii-calc-base-of-base-0.0.0.tgz is a tarball`;
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/scope-jsii-calc-base-of-base-2.1.1.tgz 1`] = `dotnet/Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId/scope-jsii-calc-base-of-base-2.1.1.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 <root>
@@ -602,7 +602,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/dotnet/Amazon.JSII.
   <ItemGroup>
     <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
     <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="(,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[2.1.1,3.0.0)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -19,7 +19,7 @@ go 1.15
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1
 )
 
 `;
@@ -31,7 +31,7 @@ import (
 	rt "github.com/aws/jsii-runtime-go"
 	"sync"
 	// Initialization endpoints of dependencies
-	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 )
 
 var once sync.Once
@@ -60,7 +60,7 @@ import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 )
 
 // Class interface
@@ -223,7 +223,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/go.mod 1`] = `
-module github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase
+module github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2
 
 go 1.15
 
@@ -248,7 +248,7 @@ var once sync.Once
 func Initialize() {
 	once.Do(func(){
 		// Load this library into the kernel
-		rt.Load("@scope/jsii-calc-base-of-base", "0.0.0", tarball)
+		rt.Load("@scope/jsii-calc-base-of-base", "2.1.1", tarball)
 	})
 }
 
@@ -262,7 +262,7 @@ package scopejsiicalcbaseofbase
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 	"reflect"
 )
 
@@ -370,7 +370,7 @@ func (v *VeryBaseProps) GetFoo() VeryIface {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/version 1`] = `
-0.0.0
+2.1.1
 
 `;
 
@@ -396,7 +396,7 @@ go 1.15
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1
 )
 
 `;
@@ -409,7 +409,7 @@ import (
 	"sync"
 	// Initialization endpoints of dependencies
 	scopejsiicalcbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
-	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/jsii"
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 )
 
 var once sync.Once
@@ -439,7 +439,7 @@ import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
 )
 
@@ -1587,7 +1587,7 @@ import (
 	"reflect"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
 )

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -14304,6 +14304,6 @@ func (m *MyClass) MethodWithSpecialParam(param param.SpecialParameterIface) stri
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/version 1`] = `
-0.0.0
+3.20.120
 
 `;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -1149,7 +1149,7 @@ package composition
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 )
@@ -1328,7 +1328,7 @@ package derivedclasshasnoproperties
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 )
 
@@ -1424,7 +1424,7 @@ func (d *Derived) SetProp(val string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/go.mod 1`] = `
-module github.com/aws/jsii/jsii-calc/go/jsiicalc
+module github.com/aws/jsii/jsii-calc/go/jsiicalc/v3
 
 go 1.15
 
@@ -1441,7 +1441,7 @@ package interfaceinnamespaceincludesclasses
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 )
 
@@ -1569,7 +1569,7 @@ func Initialize() {
 		scopejsiicalclib.Initialize()
 
 		// Load this library into the kernel
-		rt.Load("jsii-calc", "0.0.0", tarball)
+		rt.Load("jsii-calc", "3.20.120", tarball)
 	})
 }
 
@@ -1583,10 +1583,10 @@ package jsiicalc
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/composition"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
@@ -13614,7 +13614,7 @@ package pythonself
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 )
 
@@ -13754,7 +13754,7 @@ package backreferences
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule"
 )
 
 // MyClassReferenceIface is the public interface for the custom type MyClassReference
@@ -13789,7 +13789,7 @@ package child
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
 )
 
@@ -14040,8 +14040,8 @@ package nestedsubmodule
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/child"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/child"
 )
 
 // Class interface
@@ -14123,9 +14123,9 @@ package returnsparam
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 )
 
 // Class interface
@@ -14173,12 +14173,12 @@ package submodule
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/nestedsubmodule/deeplynested"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/child"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/submodule/param"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/nestedsubmodule/deeplynested"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/child"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 )
 
 // Class interface

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -2786,7 +2786,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
                       ┗━ 📁 tests
                          ┗━ 📁 calculator
                             ┣━ 📄 $Module.txt
-                            ┗━ 📄 jsii-calc@0.0.0.jsii.tgz
+                            ┗━ 📄 jsii-calc@3.20.120.jsii.tgz
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/java/pom.xml 1`] = `
@@ -2840,7 +2840,7 @@ exports[`Generated code for "jsii-calc": <outDir>/java/pom.xml 1`] = `
   </scm>
   <groupId>software.amazon.jsii.tests</groupId>
   <artifactId>calculator</artifactId>
-  <version>0.0.0</version>
+  <version>3.20.120</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -3016,7 +3016,7 @@ public final class $Module extends JsiiModule {
     private final Map<String, Class<?>> cache = new HashMap<>();
 
     public $Module() {
-        super("jsii-calc", "0.0.0", $Module.class, "jsii-calc@0.0.0.jsii.tgz");
+        super("jsii-calc", "3.20.120", $Module.class, "jsii-calc@3.20.120.jsii.tgz");
     }
 
     @Override
@@ -21545,4 +21545,4 @@ jsii-calc.submodule.returnsparam.ReturnsSpecialParameter=software.amazon.jsii.te
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/java/src/main/resources/software/amazon/jsii/tests/calculator/jsii-calc@0.0.0.jsii.tgz 1`] = `java/src/main/resources/software/amazon/jsii/tests/calculator/jsii-calc@0.0.0.jsii.tgz is a tarball`;
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/resources/software/amazon/jsii/tests/calculator/jsii-calc@3.20.120.jsii.tgz 1`] = `java/src/main/resources/software/amazon/jsii/tests/calculator/jsii-calc@3.20.120.jsii.tgz is a tarball`;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -68,7 +68,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/java/pom.xml 1`] =
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
       <artifactId>calculator-base-of-base</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[2.1.1,3.0.0)</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>
@@ -536,7 +536,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
                          ┗━ 📁 calculator
                             ┗━ 📁 baseofbase
                                ┣━ 📄 $Module.txt
-                               ┗━ 📄 jsii-calc-base-of-base@0.0.0.jsii.tgz
+                               ┗━ 📄 jsii-calc-base-of-base@2.1.1.jsii.tgz
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/pom.xml 1`] = `
@@ -569,7 +569,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/pom.x
   </scm>
   <groupId>software.amazon.jsii.tests</groupId>
   <artifactId>calculator-base-of-base</artifactId>
-  <version>0.0.0</version>
+  <version>2.1.1</version>
   <packaging>jar</packaging>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -732,7 +732,7 @@ public final class $Module extends JsiiModule {
     private final Map<String, Class<?>> cache = new HashMap<>();
 
     public $Module() {
-        super("@scope/jsii-calc-base-of-base", "0.0.0", $Module.class, "jsii-calc-base-of-base@0.0.0.jsii.tgz");
+        super("@scope/jsii-calc-base-of-base", "2.1.1", $Module.class, "jsii-calc-base-of-base@2.1.1.jsii.tgz");
     }
 
     @Override
@@ -973,7 +973,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/src/m
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/src/main/resources/software/amazon/jsii/tests/calculator/baseofbase/jsii-calc-base-of-base@0.0.0.jsii.tgz 1`] = `java/src/main/resources/software/amazon/jsii/tests/calculator/baseofbase/jsii-calc-base-of-base@0.0.0.jsii.tgz is a tarball`;
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/src/main/resources/software/amazon/jsii/tests/calculator/baseofbase/jsii-calc-base-of-base@2.1.1.jsii.tgz 1`] = `java/src/main/resources/software/amazon/jsii/tests/calculator/baseofbase/jsii-calc-base-of-base@2.1.1.jsii.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 <root>
@@ -1059,7 +1059,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/java/pom.xml 1`] = 
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
       <artifactId>calculator-base-of-base</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[2.1.1,3.0.0)</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -73,7 +73,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "scope.jsii-calc-base-of-base<0.0.1"
+        "scope.jsii-calc-base-of-base>=2.1.1, <3.0.0"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -281,7 +281,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
              ┣━ 📄 __init__.py
              ┣━ 📁 _jsii
              ┃  ┣━ 📄 __init__.py
-             ┃  ┗━ 📄 jsii-calc-base-of-base@0.0.0.jsii.tgz
+             ┃  ┗━ 📄 jsii-calc-base-of-base@2.1.1.jsii.tgz
              ┗━ 📄 py.typed
 `;
 
@@ -310,7 +310,7 @@ kwargs = json.loads(
     """
 {
     "name": "scope.jsii-calc-base-of-base",
-    "version": "0.0.0",
+    "version": "2.1.1",
     "description": "An example transitive dependency for jsii-calc.",
     "license": "Apache-2.0",
     "url": "https://github.com/aws/jsii",
@@ -331,7 +331,7 @@ kwargs = json.loads(
     ],
     "package_data": {
         "scope.jsii_calc_base_of_base._jsii": [
-            "jsii-calc-base-of-base@0.0.0.jsii.tgz"
+            "jsii-calc-base-of-base@2.1.1.jsii.tgz"
         ],
         "scope.jsii_calc_base_of_base": [
             "py.typed"
@@ -486,9 +486,9 @@ import typing_extensions
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
     "@scope/jsii-calc-base-of-base",
-    "0.0.0",
+    "2.1.1",
     __name__[0:-6],
-    "jsii-calc-base-of-base@0.0.0.jsii.tgz",
+    "jsii-calc-base-of-base@2.1.1.jsii.tgz",
 )
 
 __all__ = [
@@ -499,7 +499,7 @@ publication.publish()
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/python/src/scope/jsii_calc_base_of_base/_jsii/jsii-calc-base-of-base@0.0.0.jsii.tgz 1`] = `python/src/scope/jsii_calc_base_of_base/_jsii/jsii-calc-base-of-base@0.0.0.jsii.tgz is a tarball`;
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/python/src/scope/jsii_calc_base_of_base/_jsii/jsii-calc-base-of-base@2.1.1.jsii.tgz 1`] = `python/src/scope/jsii_calc_base_of_base/_jsii/jsii-calc-base-of-base@2.1.1.jsii.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/python/src/scope/jsii_calc_base_of_base/py.typed 1`] = `
 
@@ -582,7 +582,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "scope.jsii-calc-base-of-base<0.0.1",
+        "scope.jsii-calc-base-of-base>=2.1.1, <3.0.0",
         "scope.jsii-calc-base<0.0.1"
     ],
     "classifiers": [

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -1311,7 +1311,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃  ┣━ 📄 __init__.py
           ┃  ┣━ 📁 bin
           ┃  ┃  ┗━ 📄 calc
-          ┃  ┗━ 📄 jsii-calc@0.0.0.jsii.tgz
+          ┃  ┗━ 📄 jsii-calc@3.20.120.jsii.tgz
           ┣━ 📁 composition
           ┃  ┗━ 📄 __init__.py
           ┣━ 📁 derived_class_has_no_properties
@@ -1392,7 +1392,7 @@ kwargs = json.loads(
     """
 {
     "name": "jsii-calc",
-    "version": "0.0.0",
+    "version": "3.20.120",
     "description": "A simple calcuator built on JSII.",
     "license": "Apache-2.0",
     "url": "https://github.com/aws/jsii",
@@ -1426,7 +1426,7 @@ kwargs = json.loads(
     ],
     "package_data": {
         "jsii_calc._jsii": [
-            "jsii-calc@0.0.0.jsii.tgz"
+            "jsii-calc@3.20.120.jsii.tgz"
         ],
         "jsii_calc": [
             "py.typed"
@@ -8810,7 +8810,7 @@ import scope.jsii_calc_base._jsii
 import scope.jsii_calc_lib._jsii
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "jsii-calc", "0.0.0", __name__[0:-6], "jsii-calc@0.0.0.jsii.tgz"
+    "jsii-calc", "3.20.120", __name__[0:-6], "jsii-calc@3.20.120.jsii.tgz"
 )
 
 __all__ = [
@@ -8828,14 +8828,14 @@ import jsii
 import sys
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
-    "jsii-calc", "0.0.0", "jsii_calc", "jsii-calc@0.0.0.jsii.tgz"
+    "jsii-calc", "3.20.120", "jsii_calc", "jsii-calc@3.20.120.jsii.tgz"
 )
 
 __jsii_assembly__.invokeBinScript("jsii-calc", "calc", sys.argv[1:])
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/_jsii/jsii-calc@0.0.0.jsii.tgz 1`] = `python/src/jsii_calc/_jsii/jsii-calc@0.0.0.jsii.tgz is a tarball`;
+exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/_jsii/jsii-calc@3.20.120.jsii.tgz 1`] = `python/src/jsii_calc/_jsii/jsii-calc@3.20.120.jsii.tgz is a tarball`;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/composition/__init__.py 1`] = `
 import abc

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -50,7 +50,7 @@
     "jest": "^26.6.3",
     "jsii": "^0.0.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-calc": "^0.0.0",
+    "jsii-calc": "^3.20.120",
     "prettier": "^2.2.1",
     "typescript": "~3.9.7"
   }

--- a/scripts/align-version.js
+++ b/scripts/align-version.js
@@ -6,24 +6,23 @@ const fs = require('fs');
 
 const marker = require('./get-version-marker');
 const repoVersion = require('./get-version');
-const exclude = [
-  '@fixtures/jsii-calc-bundled',
-  'jsii-calc', // tests major version >2 for go
-];
 
 for (const file of process.argv.splice(2)) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
   // Ignore fixture packages
-  if (exclude.includes(pkg.name)) {
+  if (pkg.name === '@fixtures/jsii-calc-bundled') {
     continue;
   }
 
-  if (pkg.version !== marker) {
-    throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
-  }
+  // we keep jsii-calc as 3.2.120 to test go major version suffix
+  if (pkg.name !== 'jsii-calc') {
+    if (pkg.version !== marker) {
+      throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
+    }
 
-  pkg.version = repoVersion;
+    pkg.version = repoVersion;
+  }
 
   processSection(pkg.dependencies || { }, file);
   processSection(pkg.devDependencies || { }, file);

--- a/scripts/align-version.js
+++ b/scripts/align-version.js
@@ -7,6 +7,11 @@ const fs = require('fs');
 const marker = require('./get-version-marker');
 const repoVersion = require('./get-version');
 
+const exclude = [
+  'jsii-calc',
+  '@scope/jsii-calc-base-of-base'
+]
+
 for (const file of process.argv.splice(2)) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
@@ -15,8 +20,8 @@ for (const file of process.argv.splice(2)) {
     continue;
   }
 
-  // we keep jsii-calc as 3.2.120 to test go major version suffix
-  if (pkg.name !== 'jsii-calc') {
+  // jsii-calc have special versions to test golang major version suffix
+  if (exclude.includes(pkg.name)) {
     if (pkg.version !== marker) {
       throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
     }

--- a/scripts/align-version.js
+++ b/scripts/align-version.js
@@ -21,7 +21,7 @@ for (const file of process.argv.splice(2)) {
   }
 
   // jsii-calc have special versions to test golang major version suffix
-  if (exclude.includes(pkg.name)) {
+  if (!exclude.includes(pkg.name)) {
     if (pkg.version !== marker) {
       throw new Error(`unexpected - all package.json files in this repo should have a version of ${marker}: ${file}`);
     }

--- a/scripts/align-version.js
+++ b/scripts/align-version.js
@@ -6,12 +6,16 @@ const fs = require('fs');
 
 const marker = require('./get-version-marker');
 const repoVersion = require('./get-version');
+const exclude = [
+  '@fixtures/jsii-calc-bundled',
+  'jsii-calc', // tests major version >2 for go
+];
 
 for (const file of process.argv.splice(2)) {
   const pkg = JSON.parse(fs.readFileSync(file).toString());
 
   // Ignore fixture packages
-  if (pkg.name === '@fixtures/jsii-calc-bundled') {
+  if (exclude.includes(pkg.name)) {
     continue;
   }
 


### PR DESCRIPTION
The major version suffix introduced in #2507 was added at the end of the full module name, but for submodules, the suffix is needed only after the root package name.

Additionally, the `_init_` import failed to include the major version suffix as well.

In order to cover these cases in tests, change the version of `jsii-calc` to `3.20.120` and `@scope/jsii-calc-base-of-base` to `2.1.1` so that it will be a MV larger then 2.0 and we can verify this works both from top-level modules, submodules and transitive local dependencies.

Fixes #2507



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
