### PR TITLE
fix(go): enums are not encoded/decoded correctly

### DIFF
--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -166,3 +166,8 @@ func TestReturnsSpecialParam(t *testing.T) {
 		t.Errorf("Expected type: %s; Actual: %s", expected, actual)
 	}
 }
+
+func TestEnum(t *testing.T) {
+	allTypes := calc.NewAllTypes()
+	allTypes.EnumMethod(calc.StringEnumA)
+}

--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -167,7 +167,22 @@ func TestReturnsSpecialParam(t *testing.T) {
 	}
 }
 
-func TestEnum(t *testing.T) {
+func TestEnumUnmarshal(t *testing.T) {
+	actual := calc.EnumDispenser_RandomStringLikeEnum()
+	if actual != calc.StringEnumB {
+		t.Errorf("Expected StringEnum.B. Actual: %s", actual)
+	}
+}
+
+func TestEnumRoundtrip(t *testing.T) {
 	allTypes := calc.NewAllTypes()
-	allTypes.EnumMethod(calc.StringEnumA)
+	actual := allTypes.EnumMethod(calc.StringEnumA)
+	if actual != calc.StringEnumA {
+		t.Errorf("Expected StringEnum.A. Actual: %s", actual)
+	}
+
+	actual = allTypes.EnumMethod(calc.StringEnumC)
+	if actual != calc.StringEnumC {
+		t.Errorf("Expected StringEnum.C. Actual: %s", actual)
+	}
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/api.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/api.go
@@ -89,6 +89,11 @@ type objref struct {
 	InstanceID string `json:"$jsii.byref"`
 }
 
+// EnumRef is a reference to a jsii enum member
+type EnumRef struct {
+	MemberFqn string `json:"$jsii.enum"`
+}
+
 type loadRequest struct {
 	kernelRequester
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
@@ -1,6 +1,7 @@
 package jsii
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -286,8 +287,18 @@ func castAndSetToPtr(ptr interface{}, data interface{}, implMap implementationMa
 		client := getClient()
 		client.objects[ptrVal.Interface()] = ref.InstanceID
 	} else {
-		val := reflect.ValueOf(data)
-		ptrVal.Set(val)
+		// Attempt to unmarshal (again) with the concrete return type. This gives
+		// custom unmarshal logic (e.g. for $jsii.enums) an opportunity to be discovered
+		// based on the actual return type.
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			panic(err)
+		}
+
+		err = json.Unmarshal(bytes, ptr)
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -142,8 +142,27 @@ export abstract class Package {
     );
   }
 
+  /**
+   * Returns all standard library imports required by all types in this package.
+   */
+  protected get stdImports(): string[] {
+    const stdImports = new Set<string>();
+    for (const t of this.types) {
+      for (const imp of t.stdImports) {
+        stdImports.add(imp);
+      }
+    }
+    return Array.from(stdImports);
+  }
+
   private emitImports(code: CodeMaker) {
     code.open('import (');
+
+    // add imports from stdlib
+    for (const imp of this.stdImports) {
+      code.line(`"${imp}"`);
+    }
+
     if (this.usesRuntimePackage) {
       code.line(`${JSII_RT_ALIAS} "${JSII_RT_MODULE_NAME}"`);
     }

--- a/packages/jsii-pacmak/lib/targets/go/types/enum.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/enum.ts
@@ -1,4 +1,5 @@
-import { EnumType } from 'jsii-reflect';
+import { CodeMaker, toPascalCase } from 'codemaker';
+import { EnumMember, EnumType } from 'jsii-reflect';
 
 import { EmitContext } from '../emit-context';
 import { Package } from '../package';
@@ -11,6 +12,10 @@ export class Enum extends GoType {
 
   public constructor(pkg: Package, public type: EnumType) {
     super(pkg, type);
+
+    this.stdImports.add('encoding/json');
+    this.stdImports.add('fmt');
+    this.stdImports.add('errors');
   }
 
   public emit(context: EmitContext) {
@@ -25,16 +30,68 @@ export class Enum extends GoType {
 
     // Const values are prefixed by the wrapped value type
     for (const member of this.type.members) {
-      const enumKey = this.name + code.toPascalCase(member.name);
+      const enumKey = this.constSymbolForMember(member);
       const enumType = this.name;
       code.line(`${enumKey} ${enumType} = "${member.name}"`);
     }
 
     code.close(`)`);
     code.line();
+
+    this.emitMarshal(code);
+    this.emitUnmarshal(code);
   }
 
   public get dependencies(): Package[] {
     return [];
+  }
+
+  /**
+   * @returns the name of the const symbol which represents one of the members
+   * of this enum
+   */
+  private constSymbolForMember(member: EnumMember) {
+    return this.name + toPascalCase(member.name);
+  }
+
+  /**
+   * Emits a MarshalJSON() method for this enum type.
+   */
+  private emitMarshal(code: CodeMaker) {
+    code.openBlock(`func (member ${this.name}) MarshalJSON() ([]byte, error)`);
+    code.line(`fqn := fmt.Sprintf("${this.fqn}/%s", member)`);
+    code.line('return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})');
+    code.closeBlock();
+    code.line();
+  }
+
+  /**
+   * Emits UnmarshalJSON() method for this enum type. It maps from `{
+   * "$jsii.enum": "MEMBER-FQN" }` to the Go enum const.
+   */
+  private emitUnmarshal(code: CodeMaker) {
+    // generate custom unmarshal code
+    code.openBlock(`func (s *${this.name}) UnmarshalJSON(data []byte) error`);
+    code.line('var ref _jsii_.EnumRef');
+    code.line('err := json.Unmarshal(data, &ref)');
+    code.openBlock('if err != nil');
+    code.line('return err');
+    code.closeBlock();
+
+    code.line('switch ref.MemberFqn {');
+
+    for (const member of this.type.members) {
+      code.open(`case "${this.fqn}/${member.name}":`);
+      code.line(`*s = ${this.constSymbolForMember(member)}`);
+      code.line('return nil');
+      code.close();
+    }
+
+    code.line('}');
+    code.line(
+      `return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum '${this.fqn}'", ref.MemberFqn))`,
+    );
+    code.closeBlock();
+    code.line();
   }
 }

--- a/packages/jsii-pacmak/lib/targets/go/types/go-type.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/go-type.ts
@@ -15,6 +15,11 @@ export abstract class GoType {
   public readonly fqn: string;
   public readonly interfaceName: string;
 
+  /**
+   * Set of standard library imports.
+   */
+  public readonly stdImports = new Set<string>();
+
   public constructor(public pkg: Package, public type: Type) {
     this.name = toPascalCase(type.name);
     this.interfaceName = this.name;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -436,6 +436,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 package scopejsiicalclib
 
 import (
+	"encoding/json"
+	"fmt"
+	"errors"
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 	"reflect"
@@ -453,6 +456,30 @@ const (
 	EnumFromScopedModuleValue1 EnumFromScopedModule = "VALUE1"
 	EnumFromScopedModuleValue2 EnumFromScopedModule = "VALUE2"
 )
+
+func (member EnumFromScopedModule) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("@scope/jsii-calc-lib.EnumFromScopedModule/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *EnumFromScopedModule) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "@scope/jsii-calc-lib.EnumFromScopedModule/VALUE1":
+		*s = EnumFromScopedModuleValue1
+		return nil
+
+	case "@scope/jsii-calc-lib.EnumFromScopedModule/VALUE2":
+		*s = EnumFromScopedModuleValue2
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum '@scope/jsii-calc-lib.EnumFromScopedModule'", ref.MemberFqn))
+}
 
 // The general contract for a concrete number.
 // Deprecated.
@@ -1148,6 +1175,9 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/compos
 package composition
 
 import (
+	"encoding/json"
+	"fmt"
+	"errors"
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
@@ -1319,6 +1349,30 @@ const (
 	CompositionStringStyleNormal CompositionStringStyle = "NORMAL"
 	CompositionStringStyleDecorated CompositionStringStyle = "DECORATED"
 )
+
+func (member CompositionStringStyle) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.composition.CompositeOperation.CompositionStringStyle/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *CompositionStringStyle) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.composition.CompositeOperation.CompositionStringStyle/NORMAL":
+		*s = CompositionStringStyleNormal
+		return nil
+
+	case "jsii-calc.composition.CompositeOperation.CompositionStringStyle/DECORATED":
+		*s = CompositionStringStyleDecorated
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.composition.CompositeOperation.CompositionStringStyle'", ref.MemberFqn))
+}
 
 
 `;
@@ -1582,6 +1636,9 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc.go 1`] = 
 package jsiicalc
 
 import (
+	"encoding/json"
+	"fmt"
+	"errors"
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
@@ -2463,6 +2520,34 @@ const (
 	AllTypesEnumYourEnumValue AllTypesEnum = "YOUR_ENUM_VALUE"
 	AllTypesEnumThisIsGreat AllTypesEnum = "THIS_IS_GREAT"
 )
+
+func (member AllTypesEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.AllTypesEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *AllTypesEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.AllTypesEnum/MY_ENUM_VALUE":
+		*s = AllTypesEnumMyEnumValue
+		return nil
+
+	case "jsii-calc.AllTypesEnum/YOUR_ENUM_VALUE":
+		*s = AllTypesEnumYourEnumValue
+		return nil
+
+	case "jsii-calc.AllTypesEnum/THIS_IS_GREAT":
+		*s = AllTypesEnumThisIsGreat
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.AllTypesEnum'", ref.MemberFqn))
+}
 
 // Class interface
 type AllowedMethodNamesIface interface {
@@ -4740,6 +4825,30 @@ const (
 	DeprecatedEnumOptionB DeprecatedEnum = "OPTION_B"
 )
 
+func (member DeprecatedEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.DeprecatedEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *DeprecatedEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.DeprecatedEnum/OPTION_A":
+		*s = DeprecatedEnumOptionA
+		return nil
+
+	case "jsii-calc.DeprecatedEnum/OPTION_B":
+		*s = DeprecatedEnumOptionB
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.DeprecatedEnum'", ref.MemberFqn))
+}
+
 // DeprecatedStructIface is the public interface for the custom type DeprecatedStruct
 // Deprecated: it just wraps a string
 type DeprecatedStructIface interface {
@@ -5771,6 +5880,30 @@ const (
 	ExperimentalEnumOptionB ExperimentalEnum = "OPTION_B"
 )
 
+func (member ExperimentalEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.ExperimentalEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *ExperimentalEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.ExperimentalEnum/OPTION_A":
+		*s = ExperimentalEnumOptionA
+		return nil
+
+	case "jsii-calc.ExperimentalEnum/OPTION_B":
+		*s = ExperimentalEnumOptionB
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.ExperimentalEnum'", ref.MemberFqn))
+}
+
 // ExperimentalStructIface is the public interface for the custom type ExperimentalStruct
 // Experimental.
 type ExperimentalStructIface interface {
@@ -5942,6 +6075,30 @@ const (
 	ExternalEnumOptionA ExternalEnum = "OPTION_A"
 	ExternalEnumOptionB ExternalEnum = "OPTION_B"
 )
+
+func (member ExternalEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.ExternalEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *ExternalEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.ExternalEnum/OPTION_A":
+		*s = ExternalEnumOptionA
+		return nil
+
+	case "jsii-calc.ExternalEnum/OPTION_B":
+		*s = ExternalEnumOptionB
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.ExternalEnum'", ref.MemberFqn))
+}
 
 // ExternalStructIface is the public interface for the custom type ExternalStruct
 type ExternalStructIface interface {
@@ -11419,6 +11576,26 @@ const (
 	SingletonIntEnumSingletonInt SingletonIntEnum = "SINGLETON_INT"
 )
 
+func (member SingletonIntEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.SingletonIntEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *SingletonIntEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.SingletonIntEnum/SINGLETON_INT":
+		*s = SingletonIntEnumSingletonInt
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.SingletonIntEnum'", ref.MemberFqn))
+}
+
 // Class interface
 type SingletonStringIface interface {
 	IsSingletonString(value string) bool
@@ -11450,6 +11627,26 @@ type SingletonStringEnum string
 const (
 	SingletonStringEnumSingletonString SingletonStringEnum = "SINGLETON_STRING"
 )
+
+func (member SingletonStringEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.SingletonStringEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *SingletonStringEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.SingletonStringEnum/SINGLETON_STRING":
+		*s = SingletonStringEnumSingletonString
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.SingletonStringEnum'", ref.MemberFqn))
+}
 
 // SmellyStructIface is the public interface for the custom type SmellyStruct
 type SmellyStructIface interface {
@@ -11613,6 +11810,30 @@ const (
 	StableEnumOptionA StableEnum = "OPTION_A"
 	StableEnumOptionB StableEnum = "OPTION_B"
 )
+
+func (member StableEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.StableEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *StableEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.StableEnum/OPTION_A":
+		*s = StableEnumOptionA
+		return nil
+
+	case "jsii-calc.StableEnum/OPTION_B":
+		*s = StableEnumOptionB
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.StableEnum'", ref.MemberFqn))
+}
 
 // StableStructIface is the public interface for the custom type StableStruct
 type StableStructIface interface {
@@ -11932,6 +12153,34 @@ const (
 	StringEnumB StringEnum = "B"
 	StringEnumC StringEnum = "C"
 )
+
+func (member StringEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.StringEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *StringEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.StringEnum/A":
+		*s = StringEnumA
+		return nil
+
+	case "jsii-calc.StringEnum/B":
+		*s = StringEnumB
+		return nil
+
+	case "jsii-calc.StringEnum/C":
+		*s = StringEnumC
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.StringEnum'", ref.MemberFqn))
+}
 
 // Class interface
 type StripInternalIface interface {
@@ -13788,6 +14037,9 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/ch
 package child
 
 import (
+	"encoding/json"
+	"fmt"
+	"errors"
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 	"reflect"
@@ -13799,6 +14051,26 @@ const (
 	AwesomenessAwesome Awesomeness = "AWESOME"
 )
 
+func (member Awesomeness) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.submodule.child.Awesomeness/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *Awesomeness) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.submodule.child.Awesomeness/AWESOME":
+		*s = AwesomenessAwesome
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.submodule.child.Awesomeness'", ref.MemberFqn))
+}
+
 type Goodness string
 
 const (
@@ -13806,6 +14078,34 @@ const (
 	GoodnessReallyGood Goodness = "REALLY_GOOD"
 	GoodnessAmazinglyGood Goodness = "AMAZINGLY_GOOD"
 )
+
+func (member Goodness) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.submodule.child.Goodness/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *Goodness) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.submodule.child.Goodness/PRETTY_GOOD":
+		*s = GoodnessPrettyGood
+		return nil
+
+	case "jsii-calc.submodule.child.Goodness/REALLY_GOOD":
+		*s = GoodnessReallyGood
+		return nil
+
+	case "jsii-calc.submodule.child.Goodness/AMAZINGLY_GOOD":
+		*s = GoodnessAmazinglyGood
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.submodule.child.Goodness'", ref.MemberFqn))
+}
 
 // Class interface
 type InnerClassIface interface {
@@ -13924,6 +14224,26 @@ type SomeEnum string
 const (
 	SomeEnumSome SomeEnum = "SOME"
 )
+
+func (member SomeEnum) MarshalJSON() ([]byte, error) {
+	fqn := fmt.Sprintf("jsii-calc.submodule.child.SomeEnum/%s", member)
+	return json.Marshal(_jsii_.EnumRef{MemberFqn: fqn})
+}
+
+func (s *SomeEnum) UnmarshalJSON(data []byte) error {
+	var ref _jsii_.EnumRef
+	err := json.Unmarshal(data, &ref)
+	if err != nil {
+		return err
+	}
+	switch ref.MemberFqn {
+	case "jsii-calc.submodule.child.SomeEnum/SOME":
+		*s = SomeEnumSome
+		return nil
+
+	}
+	return errors.New(fmt.Sprintf("Invalid enum member FQN '%s' for enum 'jsii-calc.submodule.child.SomeEnum'", ref.MemberFqn))
+}
 
 // SomeStructIface is the public interface for the custom type SomeStruct
 type SomeStructIface interface {


### PR DESCRIPTION
Enum values are represented in the jsii kernel as `{ "$jsii.enum": "fqn/Member" }`. To that end, generate custom marshaling and unmarshalling code for enum types.

Marshaling is mostly straightforward: use the value of the Go constant to render the `$jsii.enum` object.

In order to for the custom unmarshling logic to be triggered, we need to call `json.Unmarshal` with a pointer to the specific enum type. Luckily, we know it since jsii APIs are strongly-typed. To that end, change the code of `castAndSetToPtr` to round-trip to JSON and back with the specific return value pointer, which encodes the enum type. This will allow custom unmarshlers in Go to be used.

Added a bunch of tests to verify.

Fixes #2534

---

Additional tests:

- [ ] Nested enum inside of struct
- [ ] Optional enum

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
