### PR TITLE
fix(rosetta,pacmak): TypeError in node 10 with --experimental-worker

### DIFF
--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -43,6 +43,7 @@
     "commonmark": "^0.29.3",
     "escape-string-regexp": "^4.0.0",
     "fs-extra": "^9.1.0",
+    "graceful-fs": "4.2.4",
     "jsii-reflect": "^0.0.0",
     "jsii-rosetta": "^0.0.0",
     "semver": "^7.3.4",

--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -34,6 +34,7 @@
     "@jsii/spec": "^0.0.0",
     "commonmark": "^0.29.3",
     "fs-extra": "^9.1.0",
+    "graceful-fs": "4.2.4",
     "typescript": "~3.9.7",
     "xmldom": "^0.4.0",
     "yargs": "^16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,7 +4562,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@4.2.4, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==


### PR DESCRIPTION
isaacs/node-graceful-fs#204 prevents `graceful-fs` (a dependency of
`fs-extra`) from loading in a worker thread when using node < 12. The
issue affects only version `4.2.5`, so pinning both `jsii-rosetta` and
`jsii-pacmak` (both of which may use worker threads when available) to
the last known good version: `4.2.4`, until a fixed release of
`graceful-fs` is released.

---

Note - this replaces the solution introduced in 5822e48 (#2550), which
turned out to not be complete enough (I mistakenly through the issue was
introduced by a recent change in our code, while it was triggered in other
places, actually due to a recent release of `graceful-fs`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
