### PR TITLE
fix(pacmak): examples with multi-line strings produce invalid python docstrings

### DIFF
--- a/packages/jsii-calc/lib/documented.ts
+++ b/packages/jsii-calc/lib/documented.ts
@@ -6,6 +6,13 @@
  *
  * Multiple paragraphs are separated by an empty line.
  *
+ * @example
+ * const x = 12 + 44;
+ * const s1 = "string";
+ * const s2 = "string \nwith new newlines"; // see https://github.com/aws/jsii/issues/2569
+ * const s3 = `string
+ *             with
+ *             new lines`;
  * @stable
  */
 export class DocumentedClass {

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -4144,6 +4144,7 @@
     "jsii-calc.DocumentedClass": {
       "assembly": "jsii-calc",
       "docs": {
+        "example": "const x = 12 + 44;\nconst s1 = \"string\";\nconst s2 = \"string \\nwith new newlines\"; // see https://github.com/aws/jsii/issues/2569\nconst s3 = `string\n            with\n            new lines`;",
         "remarks": "This is the meat of the TSDoc comment. It may contain\nmultiple lines and multiple paragraphs.\n\nMultiple paragraphs are separated by an empty line.",
         "stability": "stable",
         "summary": "Here's the first line of the TSDoc comment."
@@ -4157,7 +4158,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 11
+        "line": 18
       },
       "methods": [
         {
@@ -4169,7 +4170,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 21
+            "line": 28
           },
           "name": "greet",
           "parameters": [
@@ -4197,7 +4198,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 31
+            "line": 38
           },
           "name": "hola"
         }
@@ -5239,7 +5240,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 39
+        "line": 46
       },
       "name": "Greetee",
       "properties": [
@@ -5253,7 +5254,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 45
+            "line": 52
           },
           "name": "name",
           "optional": true,
@@ -9391,7 +9392,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 54
+        "line": 61
       },
       "methods": [
         {
@@ -9401,7 +9402,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 58
+            "line": 65
           },
           "name": "doAThing"
         }
@@ -14440,5 +14441,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "Qv5CJVZ6t7cfQmCSHOLrbefAuLKX9JUbhUCSh+mD+po="
+  "fingerprint": "DELAKIDgUwCEVXhZflQBdllcDRnscledlYW0UXrjzbM="
 }

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -42,6 +42,10 @@ const requirementsFile = path.resolve(
   'requirements-dev.txt',
 );
 
+// we use single-quotes for multi-line strings to allow examples within the
+// docstrings themselves to include double-quotes (see https://github.com/aws/jsii/issues/2569)
+const DOCSTRING_QUOTES = "'''";
+
 export default class Python extends Target {
   protected readonly generator: PythonGenerator;
 
@@ -1571,9 +1575,9 @@ class PythonModule implements PythonType {
       this.fqn === this.assembly.name &&
       this.package.convertedReadme.trim().length > 0
     ) {
-      code.line('"""');
+      code.line(DOCSTRING_QUOTES);
       code.line(this.package.convertedReadme);
-      code.line('"""');
+      code.line(DOCSTRING_QUOTES);
     }
   }
 
@@ -2189,16 +2193,16 @@ class PythonGenerator extends Generator {
     }
 
     if (lines.length === 1) {
-      code.line(`"""${lines[0]}"""`);
+      code.line(`${DOCSTRING_QUOTES}${lines[0]}${DOCSTRING_QUOTES}`);
     } else {
-      code.line(`"""${lines[0]}`);
+      code.line(`${DOCSTRING_QUOTES}${lines[0]}`);
       lines.splice(0, 1);
 
       for (const line of lines) {
         code.line(line);
       }
 
-      code.line('"""');
+      code.line(DOCSTRING_QUOTES);
     }
     if (options.trailingNewLine) {
       code.line();

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -4907,6 +4907,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// 
     /// Multiple paragraphs are separated by an empty line.
     /// </remarks>
+    /// <example>
+    /// <code>// Example automatically generated. See https://github.com/aws/jsii/issues/826
+    /// int x = 12 + 44;
+    /// string s1 = "string";
+    /// string s2 = @"string
+    /// with new newlines";// see https://github.com/aws/jsii/issues/2569
+    /// string s3 = @"string
+    /// with
+    /// new lines";</code>
+    /// </example>
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DocumentedClass), fullyQualifiedName: "jsii-calc.DocumentedClass")]
     public class DocumentedClass : DeputyBase
     {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -5208,6 +5208,9 @@ type DocumentedClassIface interface {
 // multiple lines and multiple paragraphs.
 //
 // Multiple paragraphs are separated by an empty line.
+//
+// TODO: EXAMPLE
+//
 // Struct proxy
 type DocumentedClass struct {
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -7404,6 +7404,15 @@ package software.amazon.jsii.tests.calculator;
  * multiple lines and multiple paragraphs.
  * <p>
  * Multiple paragraphs are separated by an empty line.
+ * <p>
+ * Example:
+ * <p>
+ * <blockquote><pre>{@code
+ * // Example automatically generated. See https://github.com/aws/jsii/issues/826
+ * Number x = 12 + 44;
+ * String s1 = "string";
+ * String s2 = "string \\nwith new newlines";// see https://github.com/aws/jsii/issues/2569
+ * String s3 = "string\\n            with\\n            new lines";}</pre></blockquote>
  */
 @javax.annotation.Generated(value = "jsii-pacmak")
 @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -117,7 +117,7 @@ import scope.jsii_calc_base_of_base
 
 
 class Base(metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-base.Base"):
-    """A base class."""
+    '''A base class.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_BaseProxy"]:
@@ -128,9 +128,9 @@ class Base(metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-base.Ba
 
     @jsii.member(jsii_name="typeName")
     def type_name(self) -> typing.Any:
-        """
+        '''
         :return: the name of the class (to verify native type names are created for derived classes).
-        """
+        '''
         return typing.cast(typing.Any, jsii.invoke(self, "typeName", []))
 
 
@@ -150,10 +150,10 @@ class BaseProps(scope.jsii_calc_base_of_base.VeryBaseProps):
         foo: scope.jsii_calc_base_of_base.Very,
         bar: builtins.str,
     ) -> None:
-        """
+        '''
         :param foo: -
         :param bar: -
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
             "bar": bar,
@@ -211,7 +211,7 @@ class StaticConsumer(
     metaclass=jsii.JSIIMeta,
     jsii_type="@scope/jsii-calc-base.StaticConsumer",
 ):
-    """Hides the transitive dependency of base-of-base."""
+    '''Hides the transitive dependency of base-of-base.'''
 
     def __init__(self) -> None:
         jsii.create(StaticConsumer, self, [])
@@ -219,9 +219,9 @@ class StaticConsumer(
     @jsii.member(jsii_name="consume") # type: ignore[misc]
     @builtins.classmethod
     def consume(cls, *args: typing.Any) -> None:
-        """
+        '''
         :param args: -
-        """
+        '''
         return typing.cast(None, jsii.sinvoke(cls, "consume", [*args]))
 
 
@@ -407,26 +407,26 @@ class StaticConsumer(
     @jsii.member(jsii_name="consume") # type: ignore[misc]
     @builtins.classmethod
     def consume(cls, *_args: typing.Any) -> None:
-        """
+        '''
         :param _args: -
-        """
+        '''
         return typing.cast(None, jsii.sinvoke(cls, "consume", [*_args]))
 
 
 class Very(metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-base-of-base.Very"):
-    """(experimental) Something here.
+    '''(experimental) Something here.
 
     :stability: experimental
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(Very, self, [])
 
     @jsii.member(jsii_name="hey")
     def hey(self) -> jsii.Number:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "hey", []))
 
 
@@ -437,9 +437,9 @@ class Very(metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-base-of-base.Ver
 )
 class VeryBaseProps:
     def __init__(self, *, foo: Very) -> None:
-        """
+        '''
         :param foo: -
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
         }
@@ -629,29 +629,29 @@ import scope.jsii_calc_base
 
 @jsii.enum(jsii_type="@scope/jsii-calc-lib.EnumFromScopedModule")
 class EnumFromScopedModule(enum.Enum):
-    """(deprecated) Check that enums from @scoped packages can be references.
+    '''(deprecated) Check that enums from @scoped packages can be references.
 
     See awslabs/jsii#138
 
     :stability: deprecated
-    """
+    '''
 
     VALUE1 = "VALUE1"
-    """
+    '''
     :stability: deprecated
-    """
+    '''
     VALUE2 = "VALUE2"
-    """
+    '''
     :stability: deprecated
-    """
+    '''
 
 
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IDoublable")
 class IDoublable(typing_extensions.Protocol):
-    """(deprecated) The general contract for a concrete number.
+    '''(deprecated) The general contract for a concrete number.
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IDoublableProxy"]:
@@ -660,38 +660,38 @@ class IDoublable(typing_extensions.Protocol):
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         ...
 
 
 class _IDoublableProxy:
-    """(deprecated) The general contract for a concrete number.
+    '''(deprecated) The general contract for a concrete number.
 
     :stability: deprecated
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "@scope/jsii-calc-lib.IDoublable"
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         return typing.cast(jsii.Number, jsii.get(self, "doubleValue"))
 
 
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IFriendly")
 class IFriendly(typing_extensions.Protocol):
-    """(deprecated) Applies to classes that are considered friendly.
+    '''(deprecated) Applies to classes that are considered friendly.
 
     These classes can be greeted with
     a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IFriendlyProxy"]:
@@ -699,30 +699,30 @@ class IFriendly(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> builtins.str:
-        """(deprecated) Say hello!
+        '''(deprecated) Say hello!
 
         :stability: deprecated
-        """
+        '''
         ...
 
 
 class _IFriendlyProxy:
-    """(deprecated) Applies to classes that are considered friendly.
+    '''(deprecated) Applies to classes that are considered friendly.
 
     These classes can be greeted with
     a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
 
     :stability: deprecated
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "@scope/jsii-calc-lib.IFriendly"
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> builtins.str:
-        """(deprecated) Say hello!
+        '''(deprecated) Say hello!
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "hello", []))
 
 
@@ -731,13 +731,13 @@ class IThreeLevelsInterface(
     scope.jsii_calc_base.IBaseInterface,
     typing_extensions.Protocol,
 ):
-    """(deprecated) Interface that inherits from packages 2 levels up the tree.
+    '''(deprecated) Interface that inherits from packages 2 levels up the tree.
 
     Their presence validates that .NET/Java/jsii-reflect can track all fields
     far enough up the tree.
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IThreeLevelsInterfaceProxy"]:
@@ -745,30 +745,30 @@ class IThreeLevelsInterface(
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         ...
 
 
 class _IThreeLevelsInterfaceProxy(
     jsii.proxy_for(scope.jsii_calc_base.IBaseInterface) # type: ignore[misc]
 ):
-    """(deprecated) Interface that inherits from packages 2 levels up the tree.
+    '''(deprecated) Interface that inherits from packages 2 levels up the tree.
 
     Their presence validates that .NET/Java/jsii-reflect can track all fields
     far enough up the tree.
 
     :stability: deprecated
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "@scope/jsii-calc-lib.IThreeLevelsInterface"
 
     @jsii.member(jsii_name="baz")
     def baz(self) -> None:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "baz", []))
 
 
@@ -789,14 +789,14 @@ class MyFirstStruct:
         astring: builtins.str,
         first_optional: typing.Optional[typing.List[builtins.str]] = None,
     ) -> None:
-        """(deprecated) This is the first struct we have created in jsii.
+        '''(deprecated) This is the first struct we have created in jsii.
 
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
         :param first_optional: 
 
         :stability: deprecated
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "anumber": anumber,
             "astring": astring,
@@ -806,29 +806,29 @@ class MyFirstStruct:
 
     @builtins.property
     def anumber(self) -> jsii.Number:
-        """(deprecated) An awesome number value.
+        '''(deprecated) An awesome number value.
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("anumber")
         assert result is not None, "Required property 'anumber' is missing"
         return typing.cast(jsii.Number, result)
 
     @builtins.property
     def astring(self) -> builtins.str:
-        """(deprecated) A string value.
+        '''(deprecated) A string value.
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("astring")
         assert result is not None, "Required property 'astring' is missing"
         return typing.cast(builtins.str, result)
 
     @builtins.property
     def first_optional(self) -> typing.Optional[typing.List[builtins.str]]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("first_optional")
         return typing.cast(typing.Optional[typing.List[builtins.str]], result)
 
@@ -849,10 +849,10 @@ class NumericValue(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="@scope/jsii-calc-lib.NumericValue",
 ):
-    """(deprecated) Abstract class which represents a numeric value.
+    '''(deprecated) Abstract class which represents a numeric value.
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_NumericValueProxy"]:
@@ -863,20 +863,20 @@ class NumericValue(
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value.
+        '''(deprecated) String representation of the value.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     @abc.abstractmethod
     def value(self) -> jsii.Number:
-        """(deprecated) The value.
+        '''(deprecated) The value.
 
         :stability: deprecated
-        """
+        '''
         ...
 
 
@@ -886,10 +886,10 @@ class _NumericValueProxy(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The value.
+        '''(deprecated) The value.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
 
@@ -898,10 +898,10 @@ class Operation(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="@scope/jsii-calc-lib.Operation",
 ):
-    """(deprecated) Represents an operation on values.
+    '''(deprecated) Represents an operation on values.
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_OperationProxy"]:
@@ -913,10 +913,10 @@ class Operation(
     @jsii.member(jsii_name="toString") # type: ignore[misc]
     @abc.abstractmethod
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value.
+        '''(deprecated) String representation of the value.
 
         :stability: deprecated
-        """
+        '''
         ...
 
 
@@ -925,10 +925,10 @@ class _OperationProxy(
 ):
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value.
+        '''(deprecated) String representation of the value.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
 
@@ -949,14 +949,14 @@ class StructWithOnlyOptionals:
         optional2: typing.Optional[jsii.Number] = None,
         optional3: typing.Optional[builtins.bool] = None,
     ) -> None:
-        """(deprecated) This is a struct with only optional properties.
+        '''(deprecated) This is a struct with only optional properties.
 
         :param optional1: (deprecated) The first optional!
         :param optional2: 
         :param optional3: 
 
         :stability: deprecated
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if optional1 is not None:
             self._values["optional1"] = optional1
@@ -967,26 +967,26 @@ class StructWithOnlyOptionals:
 
     @builtins.property
     def optional1(self) -> typing.Optional[builtins.str]:
-        """(deprecated) The first optional!
+        '''(deprecated) The first optional!
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("optional1")
         return typing.cast(typing.Optional[builtins.str], result)
 
     @builtins.property
     def optional2(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("optional2")
         return typing.cast(typing.Optional[jsii.Number], result)
 
     @builtins.property
     def optional3(self) -> typing.Optional[builtins.bool]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("optional3")
         return typing.cast(typing.Optional[builtins.bool], result)
 
@@ -1008,36 +1008,36 @@ class Number(
     metaclass=jsii.JSIIMeta,
     jsii_type="@scope/jsii-calc-lib.Number",
 ):
-    """(deprecated) Represents a concrete number.
+    '''(deprecated) Represents a concrete number.
 
     :stability: deprecated
-    """
+    '''
 
     def __init__(self, value: jsii.Number) -> None:
-        """(deprecated) Creates a Number object.
+        '''(deprecated) Creates a Number object.
 
         :param value: The number.
 
         :stability: deprecated
-        """
+        '''
         jsii.create(Number, self, [value])
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="doubleValue")
     def double_value(self) -> jsii.Number:
-        """(deprecated) The number multiplied by 2.
+        '''(deprecated) The number multiplied by 2.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(jsii.Number, jsii.get(self, "doubleValue"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The number.
+        '''(deprecated) The number.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
 
@@ -1101,9 +1101,9 @@ from .._jsii import *
 
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.submodule.IReflectable")
 class IReflectable(typing_extensions.Protocol):
-    """
+    '''
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IReflectableProxy"]:
@@ -1112,25 +1112,25 @@ class IReflectable(typing_extensions.Protocol):
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="entries")
     def entries(self) -> typing.List["ReflectableEntry"]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         ...
 
 
 class _IReflectableProxy:
-    """
+    '''
     :stability: deprecated
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "@scope/jsii-calc-lib.submodule.IReflectable"
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="entries")
     def entries(self) -> typing.List["ReflectableEntry"]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         return typing.cast(typing.List["ReflectableEntry"], jsii.get(self, "entries"))
 
 
@@ -1138,32 +1138,32 @@ class NestingClass(
     metaclass=jsii.JSIIMeta,
     jsii_type="@scope/jsii-calc-lib.submodule.NestingClass",
 ):
-    """(deprecated) This class is here to show we can use nested classes across module boundaries.
+    '''(deprecated) This class is here to show we can use nested classes across module boundaries.
 
     :stability: deprecated
-    """
+    '''
 
     class NestedClass(
         metaclass=jsii.JSIIMeta,
         jsii_type="@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
     ):
-        """(deprecated) This class is here to show we can use nested classes across module boundaries.
+        '''(deprecated) This class is here to show we can use nested classes across module boundaries.
 
         :stability: deprecated
-        """
+        '''
 
         def __init__(self) -> None:
-            """
+            '''
             :stability: deprecated
-            """
+            '''
             jsii.create(NestedClass, self, [])
 
         @builtins.property # type: ignore[misc]
         @jsii.member(jsii_name="property")
         def property(self) -> builtins.str:
-            """
+            '''
             :stability: deprecated
-            """
+            '''
             return typing.cast(builtins.str, jsii.get(self, "property"))
 
     @jsii.data_type(
@@ -1173,23 +1173,23 @@ class NestingClass(
     )
     class NestedStruct:
         def __init__(self, *, name: builtins.str) -> None:
-            """(deprecated) This is a struct, nested within a class.
+            '''(deprecated) This is a struct, nested within a class.
 
             Normal.
 
             :param name: 
 
             :stability: deprecated
-            """
+            '''
             self._values: typing.Dict[str, typing.Any] = {
                 "name": name,
             }
 
         @builtins.property
         def name(self) -> builtins.str:
-            """
+            '''
             :stability: deprecated
-            """
+            '''
             result = self._values.get("name")
             assert result is not None, "Required property 'name' is missing"
             return typing.cast(builtins.str, result)
@@ -1213,12 +1213,12 @@ class NestingClass(
 )
 class ReflectableEntry:
     def __init__(self, *, key: builtins.str, value: typing.Any) -> None:
-        """
+        '''
         :param key: 
         :param value: 
 
         :stability: deprecated
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "key": key,
             "value": value,
@@ -1226,18 +1226,18 @@ class ReflectableEntry:
 
     @builtins.property
     def key(self) -> builtins.str:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("key")
         assert result is not None, "Required property 'key' is missing"
         return typing.cast(builtins.str, result)
 
     @builtins.property
     def value(self) -> typing.Any:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("value")
         assert result is not None, "Required property 'value' is missing"
         return typing.cast(typing.Any, result)
@@ -1258,14 +1258,14 @@ class Reflector(
     metaclass=jsii.JSIIMeta,
     jsii_type="@scope/jsii-calc-lib.submodule.Reflector",
 ):
-    """
+    '''
     :stability: deprecated
-    """
+    '''
 
     def __init__(self) -> None:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         jsii.create(Reflector, self, [])
 
     @jsii.member(jsii_name="asMap")
@@ -1273,11 +1273,11 @@ class Reflector(
         self,
         reflectable: IReflectable,
     ) -> typing.Mapping[builtins.str, typing.Any]:
-        """
+        '''
         :param reflectable: -
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
 
 
@@ -1469,7 +1469,7 @@ setuptools.setup(**kwargs)
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/__init__.py 1`] = `
-"""
+'''
 # jsii Calculator
 
 This library is used to demonstrate and test the features of JSII
@@ -1497,7 +1497,7 @@ calculator.add(10)
 # This is totes a magic comment in here, just you wait!
 foo = "bar"
 \`\`\`
-"""
+'''
 import abc
 import builtins
 import datetime
@@ -1567,7 +1567,7 @@ class AbstractSuite(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.AbstractSuite",
 ):
-    """Ensures abstract members implementations correctly register overrides in various languages."""
+    '''Ensures abstract members implementations correctly register overrides in various languages.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_AbstractSuiteProxy"]:
@@ -1579,17 +1579,17 @@ class AbstractSuite(
     @jsii.member(jsii_name="someMethod") # type: ignore[misc]
     @abc.abstractmethod
     def _some_method(self, str: builtins.str) -> builtins.str:
-        """
+        '''
         :param str: -
-        """
+        '''
         ...
 
     @jsii.member(jsii_name="workItAll")
     def work_it_all(self, seed: builtins.str) -> builtins.str:
-        """Sets \`\`seed\`\` to \`\`this.property\`\`, then calls \`\`someMethod\`\` with \`\`this.property\`\` and returns the result.
+        '''Sets \`\`seed\`\` to \`\`this.property\`\`, then calls \`\`someMethod\`\` with \`\`this.property\`\` and returns the result.
 
         :param seed: a \`\`string\`\`.
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "workItAll", [seed]))
 
     @builtins.property # type: ignore[misc]
@@ -1607,9 +1607,9 @@ class AbstractSuite(
 class _AbstractSuiteProxy(AbstractSuite):
     @jsii.member(jsii_name="someMethod")
     def _some_method(self, str: builtins.str) -> builtins.str:
-        """
+        '''
         :param str: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "someMethod", [str]))
 
     @builtins.property # type: ignore[misc]
@@ -1623,20 +1623,20 @@ class _AbstractSuiteProxy(AbstractSuite):
 
 
 class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
-    """This class includes property for all types supported by jsii.
+    '''This class includes property for all types supported by jsii.
 
     The setters will validate
     that the value set is of the expected type and throw otherwise.
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(AllTypes, self, [])
 
     @jsii.member(jsii_name="anyIn")
     def any_in(self, inp: typing.Any) -> None:
-        """
+        '''
         :param inp: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "anyIn", [inp]))
 
     @jsii.member(jsii_name="anyOut")
@@ -1645,9 +1645,9 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
 
     @jsii.member(jsii_name="enumMethod")
     def enum_method(self, value: "StringEnum") -> "StringEnum":
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast("StringEnum", jsii.invoke(self, "enumMethod", [value]))
 
     @builtins.property # type: ignore[misc]
@@ -1855,36 +1855,36 @@ class AllowedMethodNames(
 
     @jsii.member(jsii_name="getBar")
     def get_bar(self, _p1: builtins.str, _p2: jsii.Number) -> None:
-        """
+        '''
         :param _p1: -
         :param _p2: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "getBar", [_p1, _p2]))
 
     @jsii.member(jsii_name="getFoo")
     def get_foo(self, with_param: builtins.str) -> builtins.str:
-        """getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
+        '''getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
 
         :param with_param: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "getFoo", [with_param]))
 
     @jsii.member(jsii_name="setBar")
     def set_bar(self, _x: builtins.str, _y: jsii.Number, _z: builtins.bool) -> None:
-        """
+        '''
         :param _x: -
         :param _y: -
         :param _z: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "setBar", [_x, _y, _z]))
 
     @jsii.member(jsii_name="setFoo")
     def set_foo(self, _x: builtins.str, _y: jsii.Number) -> None:
-        """setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
+        '''setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
 
         :param _x: -
         :param _y: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "setFoo", [_x, _y]))
 
 
@@ -1899,11 +1899,11 @@ class AmbiguousParameters(
         scope: builtins.str,
         props: typing.Optional[builtins.bool] = None,
     ) -> None:
-        """
+        '''
         :param scope_: -
         :param scope: 
         :param props: 
-        """
+        '''
         props_ = StructParameterType(scope=scope, props=props)
 
         jsii.create(AmbiguousParameters, self, [scope_, props_])
@@ -1932,17 +1932,17 @@ class AsyncVirtualMethods(
 
     @jsii.member(jsii_name="callMe2")
     def call_me2(self) -> jsii.Number:
-        """Just calls "overrideMeToo"."""
+        '''Just calls "overrideMeToo".'''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "callMe2", []))
 
     @jsii.member(jsii_name="callMeDoublePromise")
     def call_me_double_promise(self) -> jsii.Number:
-        """This method calls the "callMe" async method indirectly, which will then invoke a virtual method.
+        '''This method calls the "callMe" async method indirectly, which will then invoke a virtual method.
 
         This is a "double promise" situation, which
         means that callbacks are not going to be available immediate, but only
         after an "immediates" cycle.
-        """
+        '''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "callMeDoublePromise", []))
 
     @jsii.member(jsii_name="dontOverrideMe")
@@ -1951,9 +1951,9 @@ class AsyncVirtualMethods(
 
     @jsii.member(jsii_name="overrideMe")
     def override_me(self, mult: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param mult: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMe", [mult]))
 
     @jsii.member(jsii_name="overrideMeToo")
@@ -1985,7 +1985,7 @@ class BinaryOperation(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.BinaryOperation",
 ):
-    """Represents an operation with two operands."""
+    '''Represents an operation with two operands.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_BinaryOperationProxy"]:
@@ -1996,28 +1996,28 @@ class BinaryOperation(
         lhs: scope.jsii_calc_lib.NumericValue,
         rhs: scope.jsii_calc_lib.NumericValue,
     ) -> None:
-        """Creates a BinaryOperation.
+        '''Creates a BinaryOperation.
 
         :param lhs: Left-hand side operand.
         :param rhs: Right-hand side operand.
-        """
+        '''
         jsii.create(BinaryOperation, self, [lhs, rhs])
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> builtins.str:
-        """(deprecated) Say hello!"""
+        '''(deprecated) Say hello!'''
         return typing.cast(builtins.str, jsii.invoke(self, "hello", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="lhs")
     def lhs(self) -> scope.jsii_calc_lib.NumericValue:
-        """Left-hand side operand."""
+        '''Left-hand side operand.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "lhs"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="rhs")
     def rhs(self) -> scope.jsii_calc_lib.NumericValue:
-        """Right-hand side operand."""
+        '''Right-hand side operand.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "rhs"))
 
 
@@ -2031,7 +2031,7 @@ class BurriedAnonymousObject(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.BurriedAnonymousObject",
 ):
-    """See https://github.com/aws/aws-cdk/issues/7977."""
+    '''See https://github.com/aws/aws-cdk/issues/7977.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_BurriedAnonymousObjectProxy"]:
@@ -2047,24 +2047,24 @@ class BurriedAnonymousObject(
     @jsii.member(jsii_name="giveItBack") # type: ignore[misc]
     @abc.abstractmethod
     def give_it_back(self, value: typing.Any) -> typing.Any:
-        """Implement this method and have it return it's parameter.
+        '''Implement this method and have it return it's parameter.
 
         :param value: the value that should be returned.
 
         :return: \`\`value\`\`
-        """
+        '''
         ...
 
 
 class _BurriedAnonymousObjectProxy(BurriedAnonymousObject):
     @jsii.member(jsii_name="giveItBack")
     def give_it_back(self, value: typing.Any) -> typing.Any:
-        """Implement this method and have it return it's parameter.
+        '''Implement this method and have it return it's parameter.
 
         :param value: the value that should be returned.
 
         :return: \`\`value\`\`
-        """
+        '''
         return typing.cast(typing.Any, jsii.invoke(self, "giveItBack", [value]))
 
 
@@ -2073,7 +2073,7 @@ class Calculator(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Calculator",
 ):
-    """A calculator which maintains a current value and allows adding operations.
+    '''A calculator which maintains a current value and allows adding operations.
 
     Here's how you use it::
 
@@ -2092,7 +2092,7 @@ class Calculator(
         calculator.add(5)
         calculator.mul(3)
         print(calculator.expression.value)
-    """
+    '''
 
     def __init__(
         self,
@@ -2100,11 +2100,11 @@ class Calculator(
         initial_value: typing.Optional[jsii.Number] = None,
         maximum_value: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """Creates a Calculator object.
+        '''Creates a Calculator object.
 
         :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
         :param maximum_value: The maximum value the calculator can store. Default: none
-        """
+        '''
         props = CalculatorProps(
             initial_value=initial_value, maximum_value=maximum_value
         )
@@ -2113,48 +2113,48 @@ class Calculator(
 
     @jsii.member(jsii_name="add")
     def add(self, value: jsii.Number) -> None:
-        """Adds a number to the current value.
+        '''Adds a number to the current value.
 
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "add", [value]))
 
     @jsii.member(jsii_name="mul")
     def mul(self, value: jsii.Number) -> None:
-        """Multiplies the current value by a number.
+        '''Multiplies the current value by a number.
 
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "mul", [value]))
 
     @jsii.member(jsii_name="neg")
     def neg(self) -> None:
-        """Negates the current value."""
+        '''Negates the current value.'''
         return typing.cast(None, jsii.invoke(self, "neg", []))
 
     @jsii.member(jsii_name="pow")
     def pow(self, value: jsii.Number) -> None:
-        """Raises the current value by a power.
+        '''Raises the current value by a power.
 
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "pow", [value]))
 
     @jsii.member(jsii_name="readUnionValue")
     def read_union_value(self) -> jsii.Number:
-        """Returns teh value of the union property (if defined)."""
+        '''Returns teh value of the union property (if defined).'''
         return typing.cast(jsii.Number, jsii.invoke(self, "readUnionValue", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.NumericValue:
-        """Returns the expression."""
+        '''Returns the expression.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="operationsLog")
     def operations_log(self) -> typing.List[scope.jsii_calc_lib.NumericValue]:
-        """A log of all operations."""
+        '''A log of all operations.'''
         return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "operationsLog"))
 
     @builtins.property # type: ignore[misc]
@@ -2162,13 +2162,13 @@ class Calculator(
     def operations_map(
         self,
     ) -> typing.Mapping[builtins.str, typing.List[scope.jsii_calc_lib.NumericValue]]:
-        """A map of per operation name of all operations performed."""
+        '''A map of per operation name of all operations performed.'''
         return typing.cast(typing.Mapping[builtins.str, typing.List[scope.jsii_calc_lib.NumericValue]], jsii.get(self, "operationsMap"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="curr")
     def curr(self) -> scope.jsii_calc_lib.NumericValue:
-        """The current value."""
+        '''The current value.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "curr"))
 
     @curr.setter
@@ -2178,7 +2178,7 @@ class Calculator(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="maxValue")
     def max_value(self) -> typing.Optional[jsii.Number]:
-        """The maximum value allows in this calculator."""
+        '''The maximum value allows in this calculator.'''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "maxValue"))
 
     @max_value.setter
@@ -2190,7 +2190,7 @@ class Calculator(
     def union_property(
         self,
     ) -> typing.Optional[typing.Union["Add", "Multiply", "Power"]]:
-        """Example of a property that accepts a union of types."""
+        '''Example of a property that accepts a union of types.'''
         return typing.cast(typing.Optional[typing.Union["Add", "Multiply", "Power"]], jsii.get(self, "unionProperty"))
 
     @union_property.setter
@@ -2213,11 +2213,11 @@ class CalculatorProps:
         initial_value: typing.Optional[jsii.Number] = None,
         maximum_value: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """Properties for Calculator.
+        '''Properties for Calculator.
 
         :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
         :param maximum_value: The maximum value the calculator can store. Default: none
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if initial_value is not None:
             self._values["initial_value"] = initial_value
@@ -2226,21 +2226,21 @@ class CalculatorProps:
 
     @builtins.property
     def initial_value(self) -> typing.Optional[jsii.Number]:
-        """The initial value of the calculator.
+        '''The initial value of the calculator.
 
         NOTE: Any number works here, it's fine.
 
         :default: 0
-        """
+        '''
         result = self._values.get("initial_value")
         return typing.cast(typing.Optional[jsii.Number], result)
 
     @builtins.property
     def maximum_value(self) -> typing.Optional[jsii.Number]:
-        """The maximum value the calculator can store.
+        '''The maximum value the calculator can store.
 
         :default: none
-        """
+        '''
         result = self._values.get("maximum_value")
         return typing.cast(typing.Optional[jsii.Number], result)
 
@@ -2265,10 +2265,10 @@ class ClassWithCollections(
         map: typing.Mapping[builtins.str, builtins.str],
         array: typing.List[builtins.str],
     ) -> None:
-        """
+        '''
         :param map: -
         :param array: -
-        """
+        '''
         jsii.create(ClassWithCollections, self, [map, array])
 
     @jsii.member(jsii_name="createAList") # type: ignore[misc]
@@ -2319,7 +2319,7 @@ class ClassWithCollections(
 
 
 class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"):
-    """This class has docs.
+    '''This class has docs.
 
     The docs are great. They're a bunch of tags.
 
@@ -2331,7 +2331,7 @@ class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"
         # Example automatically generated. See https://github.com/aws/jsii/issues/826
         def an_example():
             pass
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(ClassWithDocs, self, [])
@@ -2342,16 +2342,16 @@ class ClassWithJavaReservedWords(
     jsii_type="jsii-calc.ClassWithJavaReservedWords",
 ):
     def __init__(self, int: builtins.str) -> None:
-        """
+        '''
         :param int: -
-        """
+        '''
         jsii.create(ClassWithJavaReservedWords, self, [int])
 
     @jsii.member(jsii_name="import")
     def import_(self, assert_: builtins.str) -> builtins.str:
-        """
+        '''
         :param assert_: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "import", [assert_]))
 
     @builtins.property # type: ignore[misc]
@@ -2381,10 +2381,10 @@ class ConfusingToJackson(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ConfusingToJackson",
 ):
-    """This tries to confuse Jackson by having overloaded property setters.
+    '''This tries to confuse Jackson by having overloaded property setters.
 
     :see: https://github.com/aws/aws-cdk/issues/4080
-    """
+    '''
 
     @jsii.member(jsii_name="makeInstance") # type: ignore[misc]
     @builtins.classmethod
@@ -2422,9 +2422,9 @@ class ConfusingToJacksonStruct:
         *,
         union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]] = None,
     ) -> None:
-        """
+        '''
         :param union_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if union_property is not None:
             self._values["union_property"] = union_property
@@ -2453,9 +2453,9 @@ class ConstructorPassesThisOut(
     jsii_type="jsii-calc.ConstructorPassesThisOut",
 ):
     def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
-        """
+        '''
         :param consumer: -
-        """
+        '''
         jsii.create(ConstructorPassesThisOut, self, [consumer])
 
 
@@ -2504,9 +2504,9 @@ class ConsumePureInterface(
     jsii_type="jsii-calc.ConsumePureInterface",
 ):
     def __init__(self, delegate: "IStructReturningDelegate") -> None:
-        """
+        '''
         :param delegate: -
-        """
+        '''
         jsii.create(ConsumePureInterface, self, [delegate])
 
     @jsii.member(jsii_name="workItBaby")
@@ -2518,11 +2518,11 @@ class ConsumerCanRingBell(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ConsumerCanRingBell",
 ):
-    """Test calling back to consumers that implement interfaces.
+    '''Test calling back to consumers that implement interfaces.
 
     Check that if a JSII consumer implements IConsumerWithInterfaceParam, they can call
     the method on the argument that they're passed...
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(ConsumerCanRingBell, self, [])
@@ -2533,12 +2533,12 @@ class ConsumerCanRingBell(
         cls,
         ringer: "IBellRinger",
     ) -> builtins.bool:
-        """...if the interface is implemented using an object literal.
+        '''...if the interface is implemented using an object literal.
 
         Returns whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
 
     @jsii.member(jsii_name="staticImplementedByPrivateClass") # type: ignore[misc]
@@ -2547,74 +2547,74 @@ class ConsumerCanRingBell(
         cls,
         ringer: "IBellRinger",
     ) -> builtins.bool:
-        """...if the interface is implemented using a private class.
+        '''...if the interface is implemented using a private class.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
 
     @jsii.member(jsii_name="staticImplementedByPublicClass") # type: ignore[misc]
     @builtins.classmethod
     def static_implemented_by_public_class(cls, ringer: "IBellRinger") -> builtins.bool:
-        """...if the interface is implemented using a public class.
+        '''...if the interface is implemented using a public class.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
 
     @jsii.member(jsii_name="staticWhenTypedAsClass") # type: ignore[misc]
     @builtins.classmethod
     def static_when_typed_as_class(cls, ringer: "IConcreteBellRinger") -> builtins.bool:
-        """If the parameter is a concrete class instead of an interface.
+        '''If the parameter is a concrete class instead of an interface.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
 
     @jsii.member(jsii_name="implementedByObjectLiteral")
     def implemented_by_object_literal(self, ringer: "IBellRinger") -> builtins.bool:
-        """...if the interface is implemented using an object literal.
+        '''...if the interface is implemented using an object literal.
 
         Returns whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
 
     @jsii.member(jsii_name="implementedByPrivateClass")
     def implemented_by_private_class(self, ringer: "IBellRinger") -> builtins.bool:
-        """...if the interface is implemented using a private class.
+        '''...if the interface is implemented using a private class.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
 
     @jsii.member(jsii_name="implementedByPublicClass")
     def implemented_by_public_class(self, ringer: "IBellRinger") -> builtins.bool:
-        """...if the interface is implemented using a public class.
+        '''...if the interface is implemented using a public class.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
 
     @jsii.member(jsii_name="whenTypedAsClass")
     def when_typed_as_class(self, ringer: "IConcreteBellRinger") -> builtins.bool:
-        """If the parameter is a concrete class instead of an interface.
+        '''If the parameter is a concrete class instead of an interface.
 
         Return whether the bell was rung.
 
         :param ringer: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
 
 
@@ -2630,9 +2630,9 @@ class ConsumersOfThisCrazyTypeSystem(
         self,
         obj: "IAnotherPublicInterface",
     ) -> builtins.str:
-        """
+        '''
         :param obj: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
 
     @jsii.member(jsii_name="consumeNonInternalInterface")
@@ -2640,14 +2640,14 @@ class ConsumersOfThisCrazyTypeSystem(
         self,
         obj: "INonInternalInterface",
     ) -> typing.Any:
-        """
+        '''
         :param obj: -
-        """
+        '''
         return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
 
 
 class DataRenderer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DataRenderer"):
-    """Verifies proper type handling through dynamic overrides."""
+    '''Verifies proper type handling through dynamic overrides.'''
 
     def __init__(self) -> None:
         jsii.create(DataRenderer, self, [])
@@ -2660,11 +2660,11 @@ class DataRenderer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DataRenderer"):
         astring: builtins.str,
         first_optional: typing.Optional[typing.List[builtins.str]] = None,
     ) -> builtins.str:
-        """
+        '''
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
         :param first_optional: 
-        """
+        '''
         data = scope.jsii_calc_lib.MyFirstStruct(
             anumber=anumber, astring=astring, first_optional=first_optional
         )
@@ -2676,16 +2676,16 @@ class DataRenderer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DataRenderer"):
         self,
         data: typing.Mapping[builtins.str, typing.Any],
     ) -> builtins.str:
-        """
+        '''
         :param data: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "renderArbitrary", [data]))
 
     @jsii.member(jsii_name="renderMap")
     def render_map(self, map: typing.Mapping[builtins.str, typing.Any]) -> builtins.str:
-        """
+        '''
         :param map: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "renderMap", [map]))
 
 
@@ -2699,11 +2699,11 @@ class DefaultedConstructorArgument(
         arg2: typing.Optional[builtins.str] = None,
         arg3: typing.Optional[datetime.datetime] = None,
     ) -> None:
-        """
+        '''
         :param arg1: -
         :param arg2: -
         :param arg3: -
-        """
+        '''
         jsii.create(DefaultedConstructorArgument, self, [arg1, arg2, arg3])
 
     @builtins.property # type: ignore[misc]
@@ -2723,11 +2723,11 @@ class DefaultedConstructorArgument(
 
 
 class Demonstrate982(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Demonstrate982"):
-    """1.
+    '''1.
 
     call #takeThis() -> An ObjectRef will be provisioned for the value (it'll be re-used!)
     2. call #takeThisToo() -> The ObjectRef from before will need to be down-cased to the ParentStruct982 type
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(Demonstrate982, self, [])
@@ -2735,65 +2735,65 @@ class Demonstrate982(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Demonstrate98
     @jsii.member(jsii_name="takeThis") # type: ignore[misc]
     @builtins.classmethod
     def take_this(cls) -> "ChildStruct982":
-        """It's dangerous to go alone!"""
+        '''It's dangerous to go alone!'''
         return typing.cast("ChildStruct982", jsii.sinvoke(cls, "takeThis", []))
 
     @jsii.member(jsii_name="takeThisToo") # type: ignore[misc]
     @builtins.classmethod
     def take_this_too(cls) -> "ParentStruct982":
-        """It's dangerous to go alone!"""
+        '''It's dangerous to go alone!'''
         return typing.cast("ParentStruct982", jsii.sinvoke(cls, "takeThisToo", []))
 
 
 class DeprecatedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DeprecatedClass"):
-    """
+    '''
     :deprecated: a pretty boring class
 
     :stability: deprecated
-    """
+    '''
 
     def __init__(
         self,
         readonly_string: builtins.str,
         mutable_number: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param readonly_string: -
         :param mutable_number: -
 
         :deprecated: this constructor is "just" okay
 
         :stability: deprecated
-        """
+        '''
         jsii.create(DeprecatedClass, self, [readonly_string, mutable_number])
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :deprecated: it was a bad idea
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="readonlyProperty")
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :deprecated: this is not always "wazoo", be ready to be disappointed
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(builtins.str, jsii.get(self, "readonlyProperty"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :deprecated: shouldn't have been mutable
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -2803,24 +2803,24 @@ class DeprecatedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DeprecatedCl
 
 @jsii.enum(jsii_type="jsii-calc.DeprecatedEnum")
 class DeprecatedEnum(enum.Enum):
-    """
+    '''
     :deprecated: your deprecated selection of bad options
 
     :stability: deprecated
-    """
+    '''
 
     OPTION_A = "OPTION_A"
-    """
+    '''
     :deprecated: option A is not great
 
     :stability: deprecated
-    """
+    '''
     OPTION_B = "OPTION_B"
-    """
+    '''
     :deprecated: option B is kinda bad, too
 
     :stability: deprecated
-    """
+    '''
 
 
 @jsii.data_type(
@@ -2830,24 +2830,24 @@ class DeprecatedEnum(enum.Enum):
 )
 class DeprecatedStruct:
     def __init__(self, *, readonly_property: builtins.str) -> None:
-        """
+        '''
         :param readonly_property: 
 
         :deprecated: it just wraps a string
 
         :stability: deprecated
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "readonly_property": readonly_property,
         }
 
     @builtins.property
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :deprecated: well, yeah
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("readonly_property")
         assert result is not None, "Required property 'readonly_property' is missing"
         return typing.cast(builtins.str, result)
@@ -2893,7 +2893,7 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
         optional_any: typing.Any = None,
         optional_array: typing.Optional[typing.List[builtins.str]] = None,
     ) -> None:
-        """A struct which derives from another struct.
+        '''A struct which derives from another struct.
 
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
@@ -2904,7 +2904,7 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
         :param another_optional: This is optional.
         :param optional_any: 
         :param optional_array: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "anumber": anumber,
             "astring": astring,
@@ -2923,29 +2923,29 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
 
     @builtins.property
     def anumber(self) -> jsii.Number:
-        """(deprecated) An awesome number value.
+        '''(deprecated) An awesome number value.
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("anumber")
         assert result is not None, "Required property 'anumber' is missing"
         return typing.cast(jsii.Number, result)
 
     @builtins.property
     def astring(self) -> builtins.str:
-        """(deprecated) A string value.
+        '''(deprecated) A string value.
 
         :stability: deprecated
-        """
+        '''
         result = self._values.get("astring")
         assert result is not None, "Required property 'astring' is missing"
         return typing.cast(builtins.str, result)
 
     @builtins.property
     def first_optional(self) -> typing.Optional[typing.List[builtins.str]]:
-        """
+        '''
         :stability: deprecated
-        """
+        '''
         result = self._values.get("first_optional")
         return typing.cast(typing.Optional[typing.List[builtins.str]], result)
 
@@ -2963,7 +2963,7 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
 
     @builtins.property
     def non_primitive(self) -> "DoubleTrouble":
-        """An example of a non primitive property."""
+        '''An example of a non primitive property.'''
         result = self._values.get("non_primitive")
         assert result is not None, "Required property 'non_primitive' is missing"
         return typing.cast("DoubleTrouble", result)
@@ -2972,7 +2972,7 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
     def another_optional(
         self,
     ) -> typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]]:
-        """This is optional."""
+        '''This is optional.'''
         result = self._values.get("another_optional")
         return typing.cast(typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]], result)
 
@@ -3005,9 +3005,9 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
 )
 class DiamondInheritanceBaseLevelStruct:
     def __init__(self, *, base_level_property: builtins.str) -> None:
-        """
+        '''
         :param base_level_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "base_level_property": base_level_property,
         }
@@ -3045,10 +3045,10 @@ class DiamondInheritanceFirstMidLevelStruct(DiamondInheritanceBaseLevelStruct):
         base_level_property: builtins.str,
         first_mid_level_property: builtins.str,
     ) -> None:
-        """
+        '''
         :param base_level_property: 
         :param first_mid_level_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "base_level_property": base_level_property,
             "first_mid_level_property": first_mid_level_property,
@@ -3093,10 +3093,10 @@ class DiamondInheritanceSecondMidLevelStruct(DiamondInheritanceBaseLevelStruct):
         base_level_property: builtins.str,
         second_mid_level_property: builtins.str,
     ) -> None:
-        """
+        '''
         :param base_level_property: 
         :param second_mid_level_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "base_level_property": base_level_property,
             "second_mid_level_property": second_mid_level_property,
@@ -3150,12 +3150,12 @@ class DiamondInheritanceTopLevelStruct(
         second_mid_level_property: builtins.str,
         top_level_property: builtins.str,
     ) -> None:
-        """
+        '''
         :param base_level_property: 
         :param first_mid_level_property: 
         :param second_mid_level_property: 
         :param top_level_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "base_level_property": base_level_property,
             "first_mid_level_property": first_mid_level_property,
@@ -3203,27 +3203,27 @@ class DisappointingCollectionSource(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.DisappointingCollectionSource",
 ):
-    """Verifies that null/undefined can be returned for optional collections.
+    '''Verifies that null/undefined can be returned for optional collections.
 
     This source of collections is disappointing - it'll always give you nothing :(
-    """
+    '''
 
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="maybeList")
     def MAYBE_LIST(cls) -> typing.Optional[typing.List[builtins.str]]:
-        """Some List of strings, maybe?
+        '''Some List of strings, maybe?
 
         (Nah, just a billion dollars mistake!)
-        """
+        '''
         return typing.cast(typing.Optional[typing.List[builtins.str]], jsii.sget(cls, "maybeList"))
 
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="maybeMap")
     def MAYBE_MAP(cls) -> typing.Optional[typing.Mapping[builtins.str, jsii.Number]]:
-        """Some Map of strings to numbers, maybe?
+        '''Some Map of strings to numbers, maybe?
 
         (Nah, just a billion dollars mistake!)
-        """
+        '''
         return typing.cast(typing.Optional[typing.Mapping[builtins.str, jsii.Number]], jsii.sget(cls, "maybeMap"))
 
 
@@ -3236,9 +3236,9 @@ class DoNotOverridePrivates(
 
     @jsii.member(jsii_name="changePrivatePropertyValue")
     def change_private_property_value(self, new_value: builtins.str) -> None:
-        """
+        '''
         :param new_value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "changePrivatePropertyValue", [new_value]))
 
     @jsii.member(jsii_name="privateMethodValue")
@@ -3254,7 +3254,7 @@ class DoNotRecognizeAnyAsOptional(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.DoNotRecognizeAnyAsOptional",
 ):
-    """jsii#284: do not recognize "any" as an optional argument."""
+    '''jsii#284: do not recognize "any" as an optional argument.'''
 
     def __init__(self) -> None:
         jsii.create(DoNotRecognizeAnyAsOptional, self, [])
@@ -3266,29 +3266,40 @@ class DoNotRecognizeAnyAsOptional(
         _optional_any: typing.Any = None,
         _optional_string: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param _required_any: -
         :param _optional_any: -
         :param _optional_string: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", [_required_any, _optional_any, _optional_string]))
 
 
 class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
-    """Here's the first line of the TSDoc comment.
+    '''Here's the first line of the TSDoc comment.
 
     This is the meat of the TSDoc comment. It may contain
     multiple lines and multiple paragraphs.
 
     Multiple paragraphs are separated by an empty line.
-    """
+
+    Example::
+
+        # Example automatically generated. See https://github.com/aws/jsii/issues/826
+        x = 12 + 44
+        s1 = "string"
+        s2 = """string
+        with new newlines"""# see https://github.com/aws/jsii/issues/2569
+        s3 = """string
+                    with
+                    new lines"""
+    '''
 
     def __init__(self) -> None:
         jsii.create(DocumentedClass, self, [])
 
     @jsii.member(jsii_name="greet")
     def greet(self, *, name: typing.Optional[builtins.str] = None) -> jsii.Number:
-        """Greet the indicated person.
+        '''Greet the indicated person.
 
         This will print out a friendly greeting intended for the indicated person.
 
@@ -3298,17 +3309,17 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
         A number that everyone knows very well and represents the answer
         to the ultimate question
-        """
+        '''
         greetee = Greetee(name=name)
 
         return typing.cast(jsii.Number, jsii.invoke(self, "greet", [greetee]))
 
     @jsii.member(jsii_name="hola")
     def hola(self) -> None:
-        """(experimental) Say ¡Hola!
+        '''(experimental) Say ¡Hola!
 
         :stability: experimental
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "hola", []))
 
 
@@ -3325,10 +3336,10 @@ class DontComplainAboutVariadicAfterOptional(
         optional: typing.Optional[builtins.str] = None,
         *things: builtins.str,
     ) -> builtins.str:
-        """
+        '''
         :param optional: -
         :param things: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "optionalAndVariadic", [optional, *things]))
 
 
@@ -3336,12 +3347,12 @@ class DynamicPropertyBearer(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.DynamicPropertyBearer",
 ):
-    """Ensures we can override a dynamic property that was inherited."""
+    '''Ensures we can override a dynamic property that was inherited.'''
 
     def __init__(self, value_store: builtins.str) -> None:
-        """
+        '''
         :param value_store: -
-        """
+        '''
         jsii.create(DynamicPropertyBearer, self, [value_store])
 
     @builtins.property # type: ignore[misc]
@@ -3369,19 +3380,19 @@ class DynamicPropertyBearerChild(
     jsii_type="jsii-calc.DynamicPropertyBearerChild",
 ):
     def __init__(self, original_value: builtins.str) -> None:
-        """
+        '''
         :param original_value: -
-        """
+        '''
         jsii.create(DynamicPropertyBearerChild, self, [original_value])
 
     @jsii.member(jsii_name="overrideValue")
     def override_value(self, new_value: builtins.str) -> builtins.str:
-        """Sets \`\`this.dynamicProperty\`\` to the new value, and returns the old value.
+        '''Sets \`\`this.dynamicProperty\`\` to the new value, and returns the old value.
 
         :param new_value: the new value to be set.
 
         :return: the old value that was set.
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "overrideValue", [new_value]))
 
     @builtins.property # type: ignore[misc]
@@ -3391,48 +3402,48 @@ class DynamicPropertyBearerChild(
 
 
 class Entropy(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Entropy"):
-    """This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either)."""
+    '''This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_EntropyProxy"]:
         return _EntropyProxy
 
     def __init__(self, clock: "IWallClock") -> None:
-        """Creates a new instance of Entropy.
+        '''Creates a new instance of Entropy.
 
         :param clock: your implementation of \`\`WallClock\`\`.
-        """
+        '''
         jsii.create(Entropy, self, [clock])
 
     @jsii.member(jsii_name="increase")
     def increase(self) -> builtins.str:
-        """Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
+        '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
 
         :return: the time from the \`\`WallClock\`\`.
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "increase", []))
 
     @jsii.member(jsii_name="repeat") # type: ignore[misc]
     @abc.abstractmethod
     def repeat(self, word: builtins.str) -> builtins.str:
-        """Implement this method such that it returns \`\`word\`\`.
+        '''Implement this method such that it returns \`\`word\`\`.
 
         :param word: the value to return.
 
         :return: \`\`word\`\`.
-        """
+        '''
         ...
 
 
 class _EntropyProxy(Entropy):
     @jsii.member(jsii_name="repeat")
     def repeat(self, word: builtins.str) -> builtins.str:
-        """Implement this method such that it returns \`\`word\`\`.
+        '''Implement this method such that it returns \`\`word\`\`.
 
         :param word: the value to return.
 
         :return: \`\`word\`\`.
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "repeat", [word]))
 
 
@@ -3462,26 +3473,26 @@ class EraseUndefinedHashValues(
         opts: "EraseUndefinedHashValuesOptions",
         key: builtins.str,
     ) -> builtins.bool:
-        """Returns \`\`true\`\` if \`\`key\`\` is defined in \`\`opts\`\`.
+        '''Returns \`\`true\`\` if \`\`key\`\` is defined in \`\`opts\`\`.
 
         Used to check that undefined/null hash values
         are being erased when sending values from native code to JS.
 
         :param opts: -
         :param key: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "doesKeyExist", [opts, key]))
 
     @jsii.member(jsii_name="prop1IsNull") # type: ignore[misc]
     @builtins.classmethod
     def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-        """We expect "prop1" to be erased."""
+        '''We expect "prop1" to be erased.'''
         return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.sinvoke(cls, "prop1IsNull", []))
 
     @jsii.member(jsii_name="prop2IsUndefined") # type: ignore[misc]
     @builtins.classmethod
     def prop2_is_undefined(cls) -> typing.Mapping[builtins.str, typing.Any]:
-        """We expect "prop2" to be erased."""
+        '''We expect "prop2" to be erased.'''
         return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.sinvoke(cls, "prop2IsUndefined", []))
 
 
@@ -3497,10 +3508,10 @@ class EraseUndefinedHashValuesOptions:
         option1: typing.Optional[builtins.str] = None,
         option2: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param option1: 
         :param option2: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if option1 is not None:
             self._values["option1"] = option1
@@ -3533,44 +3544,44 @@ class ExperimentalClass(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ExperimentalClass",
 ):
-    """
+    '''
     :stability: experimental
-    """
+    '''
 
     def __init__(
         self,
         readonly_string: builtins.str,
         mutable_number: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param readonly_string: -
         :param mutable_number: -
 
         :stability: experimental
-        """
+        '''
         jsii.create(ExperimentalClass, self, [readonly_string, mutable_number])
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="readonlyProperty")
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(builtins.str, jsii.get(self, "readonlyProperty"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -3580,18 +3591,18 @@ class ExperimentalClass(
 
 @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
 class ExperimentalEnum(enum.Enum):
-    """
+    '''
     :stability: experimental
-    """
+    '''
 
     OPTION_A = "OPTION_A"
-    """
+    '''
     :stability: experimental
-    """
+    '''
     OPTION_B = "OPTION_B"
-    """
+    '''
     :stability: experimental
-    """
+    '''
 
 
 @jsii.data_type(
@@ -3601,20 +3612,20 @@ class ExperimentalEnum(enum.Enum):
 )
 class ExperimentalStruct:
     def __init__(self, *, readonly_property: builtins.str) -> None:
-        """
+        '''
         :param readonly_property: 
 
         :stability: experimental
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "readonly_property": readonly_property,
         }
 
     @builtins.property
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         result = self._values.get("readonly_property")
         assert result is not None, "Required property 'readonly_property' is missing"
         return typing.cast(builtins.str, result)
@@ -3636,9 +3647,9 @@ class ExportedBaseClass(
     jsii_type="jsii-calc.ExportedBaseClass",
 ):
     def __init__(self, success: builtins.bool) -> None:
-        """
+        '''
         :param success: -
-        """
+        '''
         jsii.create(ExportedBaseClass, self, [success])
 
     @builtins.property # type: ignore[misc]
@@ -3654,10 +3665,10 @@ class ExportedBaseClass(
 )
 class ExtendsInternalInterface:
     def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
-        """
+        '''
         :param boom: 
         :param prop: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "boom": boom,
             "prop": prop,
@@ -3688,44 +3699,44 @@ class ExtendsInternalInterface:
 
 
 class ExternalClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ExternalClass"):
-    """
+    '''
     :external: true
-    """
+    '''
 
     def __init__(
         self,
         readonly_string: builtins.str,
         mutable_number: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param readonly_string: -
         :param mutable_number: -
 
         :external: true
-        """
+        '''
         jsii.create(ExternalClass, self, [readonly_string, mutable_number])
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :external: true
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="readonlyProperty")
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :external: true
-        """
+        '''
         return typing.cast(builtins.str, jsii.get(self, "readonlyProperty"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :external: true
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -3735,18 +3746,18 @@ class ExternalClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ExternalClass"
 
 @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
 class ExternalEnum(enum.Enum):
-    """
+    '''
     :external: true
-    """
+    '''
 
     OPTION_A = "OPTION_A"
-    """
+    '''
     :external: true
-    """
+    '''
     OPTION_B = "OPTION_B"
-    """
+    '''
     :external: true
-    """
+    '''
 
 
 @jsii.data_type(
@@ -3756,20 +3767,20 @@ class ExternalEnum(enum.Enum):
 )
 class ExternalStruct:
     def __init__(self, *, readonly_property: builtins.str) -> None:
-        """
+        '''
         :param readonly_property: 
 
         :external: true
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "readonly_property": readonly_property,
         }
 
     @builtins.property
     def readonly_property(self) -> builtins.str:
-        """
+        '''
         :external: true
-        """
+        '''
         result = self._values.get("readonly_property")
         assert result is not None, "Required property 'readonly_property' is missing"
         return typing.cast(builtins.str, result)
@@ -3804,7 +3815,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         astring: builtins.str,
         first_optional: typing.Optional[typing.List[builtins.str]] = None,
     ) -> scope.jsii_calc_lib.MyFirstStruct:
-        """Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
+        '''Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
 
         :param another_required: 
         :param bool: 
@@ -3815,7 +3826,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
         :param first_optional: 
-        """
+        '''
         derived = DerivedStruct(
             another_required=another_required,
             bool=bool,
@@ -3844,7 +3855,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         astring: builtins.str,
         first_optional: typing.Optional[typing.List[builtins.str]] = None,
     ) -> "DoubleTrouble":
-        """Returns the boolean from a DerivedStruct struct.
+        '''Returns the boolean from a DerivedStruct struct.
 
         :param another_required: 
         :param bool: 
@@ -3855,7 +3866,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
         :param first_optional: 
-        """
+        '''
         derived = DerivedStruct(
             another_required=another_required,
             bool=bool,
@@ -3878,12 +3889,12 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         astring: builtins.str,
         first_optional: typing.Optional[typing.List[builtins.str]] = None,
     ) -> jsii.Number:
-        """Returns the "anumber" from a MyFirstStruct struct;
+        '''Returns the "anumber" from a MyFirstStruct struct;
 
         :param anumber: (deprecated) An awesome number value.
         :param astring: (deprecated) A string value.
         :param first_optional: 
-        """
+        '''
         first = scope.jsii_calc_lib.MyFirstStruct(
             anumber=anumber, astring=astring, first_optional=first_optional
         )
@@ -3903,20 +3914,20 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
 )
 class Greetee:
     def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
-        """These are some arguments you can pass to a method.
+        '''These are some arguments you can pass to a method.
 
         :param name: The name of the greetee. Default: world
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if name is not None:
             self._values["name"] = name
 
     @builtins.property
     def name(self) -> typing.Optional[builtins.str]:
-        """The name of the greetee.
+        '''The name of the greetee.
 
         :default: world
-        """
+        '''
         result = self._values.get("name")
         return typing.cast(typing.Optional[builtins.str], result)
 
@@ -3941,15 +3952,15 @@ class GreetingAugmenter(
 
     @jsii.member(jsii_name="betterGreeting")
     def better_greeting(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
-        """
+        '''
         :param friendly: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
 
 
 @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
 class IAnonymousImplementationProvider(typing_extensions.Protocol):
-    """We can return an anonymous interface implementation from an override without losing the interface declarations."""
+    '''We can return an anonymous interface implementation from an override without losing the interface declarations.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IAnonymousImplementationProviderProxy"]:
@@ -3965,7 +3976,7 @@ class IAnonymousImplementationProvider(typing_extensions.Protocol):
 
 
 class _IAnonymousImplementationProviderProxy:
-    """We can return an anonymous interface implementation from an override without losing the interface declarations."""
+    '''We can return an anonymous interface implementation from an override without losing the interface declarations.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IAnonymousImplementationProvider"
 
@@ -4057,7 +4068,7 @@ class _IBellProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IBellRinger")
 class IBellRinger(typing_extensions.Protocol):
-    """Takes the object parameter as an interface."""
+    '''Takes the object parameter as an interface.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IBellRingerProxy"]:
@@ -4065,28 +4076,28 @@ class IBellRinger(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="yourTurn")
     def your_turn(self, bell: IBell) -> None:
-        """
+        '''
         :param bell: -
-        """
+        '''
         ...
 
 
 class _IBellRingerProxy:
-    """Takes the object parameter as an interface."""
+    '''Takes the object parameter as an interface.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IBellRinger"
 
     @jsii.member(jsii_name="yourTurn")
     def your_turn(self, bell: IBell) -> None:
-        """
+        '''
         :param bell: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
 
 
 @jsii.interface(jsii_type="jsii-calc.IConcreteBellRinger")
 class IConcreteBellRinger(typing_extensions.Protocol):
-    """Takes the object parameter as a calss."""
+    '''Takes the object parameter as a calss.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IConcreteBellRingerProxy"]:
@@ -4094,32 +4105,32 @@ class IConcreteBellRinger(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="yourTurn")
     def your_turn(self, bell: "Bell") -> None:
-        """
+        '''
         :param bell: -
-        """
+        '''
         ...
 
 
 class _IConcreteBellRingerProxy:
-    """Takes the object parameter as a calss."""
+    '''Takes the object parameter as a calss.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IConcreteBellRinger"
 
     @jsii.member(jsii_name="yourTurn")
     def your_turn(self, bell: "Bell") -> None:
-        """
+        '''
         :param bell: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
 
 
 @jsii.interface(jsii_type="jsii-calc.IDeprecatedInterface")
 class IDeprecatedInterface(typing_extensions.Protocol):
-    """
+    '''
     :deprecated: useless interface
 
     :stability: deprecated
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IDeprecatedInterfaceProxy"]:
@@ -4128,11 +4139,11 @@ class IDeprecatedInterface(typing_extensions.Protocol):
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :deprecated: could be better
 
         :stability: deprecated
-        """
+        '''
         ...
 
     @mutable_property.setter
@@ -4141,31 +4152,31 @@ class IDeprecatedInterface(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :deprecated: services no purpose
 
         :stability: deprecated
-        """
+        '''
         ...
 
 
 class _IDeprecatedInterfaceProxy:
-    """
+    '''
     :deprecated: useless interface
 
     :stability: deprecated
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IDeprecatedInterface"
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :deprecated: could be better
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -4174,19 +4185,19 @@ class _IDeprecatedInterfaceProxy:
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :deprecated: services no purpose
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
 
 @jsii.interface(jsii_type="jsii-calc.IExperimentalInterface")
 class IExperimentalInterface(typing_extensions.Protocol):
-    """
+    '''
     :stability: experimental
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IExperimentalInterfaceProxy"]:
@@ -4195,9 +4206,9 @@ class IExperimentalInterface(typing_extensions.Protocol):
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         ...
 
     @mutable_property.setter
@@ -4206,25 +4217,25 @@ class IExperimentalInterface(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         ...
 
 
 class _IExperimentalInterfaceProxy:
-    """
+    '''
     :stability: experimental
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IExperimentalInterface"
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -4233,9 +4244,9 @@ class _IExperimentalInterfaceProxy:
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :stability: experimental
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
 
@@ -4280,9 +4291,9 @@ class _IExtendsPrivateInterfaceProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IExternalInterface")
 class IExternalInterface(typing_extensions.Protocol):
-    """
+    '''
     :external: true
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IExternalInterfaceProxy"]:
@@ -4291,9 +4302,9 @@ class IExternalInterface(typing_extensions.Protocol):
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :external: true
-        """
+        '''
         ...
 
     @mutable_property.setter
@@ -4302,25 +4313,25 @@ class IExternalInterface(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :external: true
-        """
+        '''
         ...
 
 
 class _IExternalInterfaceProxy:
-    """
+    '''
     :external: true
-    """
+    '''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IExternalInterface"
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="mutableProperty")
     def mutable_property(self) -> typing.Optional[jsii.Number]:
-        """
+        '''
         :external: true
-        """
+        '''
         return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
 
     @mutable_property.setter
@@ -4329,15 +4340,15 @@ class _IExternalInterfaceProxy:
 
     @jsii.member(jsii_name="method")
     def method(self) -> None:
-        """
+        '''
         :external: true
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "method", []))
 
 
 @jsii.interface(jsii_type="jsii-calc.IFriendlier")
 class IFriendlier(scope.jsii_calc_lib.IFriendly, typing_extensions.Protocol):
-    """Even friendlier classes can implement this interface."""
+    '''Even friendlier classes can implement this interface.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IFriendlierProxy"]:
@@ -4345,42 +4356,42 @@ class IFriendlier(scope.jsii_calc_lib.IFriendly, typing_extensions.Protocol):
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> builtins.str:
-        """Say farewell."""
+        '''Say farewell.'''
         ...
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> builtins.str:
-        """Say goodbye.
+        '''Say goodbye.
 
         :return: A goodbye blessing.
-        """
+        '''
         ...
 
 
 class _IFriendlierProxy(
     jsii.proxy_for(scope.jsii_calc_lib.IFriendly) # type: ignore[misc]
 ):
-    """Even friendlier classes can implement this interface."""
+    '''Even friendlier classes can implement this interface.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IFriendlier"
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> builtins.str:
-        """Say farewell."""
+        '''Say farewell.'''
         return typing.cast(builtins.str, jsii.invoke(self, "farewell", []))
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> builtins.str:
-        """Say goodbye.
+        '''Say goodbye.
 
         :return: A goodbye blessing.
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "goodbye", []))
 
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceImplementedByAbstractClass")
 class IInterfaceImplementedByAbstractClass(typing_extensions.Protocol):
-    """awslabs/jsii#220 Abstract return type."""
+    '''awslabs/jsii#220 Abstract return type.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IInterfaceImplementedByAbstractClassProxy"]:
@@ -4393,7 +4404,7 @@ class IInterfaceImplementedByAbstractClass(typing_extensions.Protocol):
 
 
 class _IInterfaceImplementedByAbstractClassProxy:
-    """awslabs/jsii#220 Abstract return type."""
+    '''awslabs/jsii#220 Abstract return type.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IInterfaceImplementedByAbstractClass"
 
@@ -4453,7 +4464,7 @@ class _IInterfaceWithMethodsProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithOptionalMethodArguments")
 class IInterfaceWithOptionalMethodArguments(typing_extensions.Protocol):
-    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."""
+    '''awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IInterfaceWithOptionalMethodArgumentsProxy"]:
@@ -4465,15 +4476,15 @@ class IInterfaceWithOptionalMethodArguments(typing_extensions.Protocol):
         arg1: builtins.str,
         arg2: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param arg1: -
         :param arg2: -
-        """
+        '''
         ...
 
 
 class _IInterfaceWithOptionalMethodArgumentsProxy:
-    """awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods."""
+    '''awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IInterfaceWithOptionalMethodArguments"
 
@@ -4483,10 +4494,10 @@ class _IInterfaceWithOptionalMethodArgumentsProxy:
         arg1: builtins.str,
         arg2: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param arg1: -
         :param arg2: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "hello", [arg1, arg2]))
 
 
@@ -4708,7 +4719,7 @@ class _INonInternalInterfaceProxy(
 
 @jsii.interface(jsii_type="jsii-calc.IObjectWithProperty")
 class IObjectWithProperty(typing_extensions.Protocol):
-    """Make sure that setters are properly called on objects with interfaces."""
+    '''Make sure that setters are properly called on objects with interfaces.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IObjectWithPropertyProxy"]:
@@ -4729,7 +4740,7 @@ class IObjectWithProperty(typing_extensions.Protocol):
 
 
 class _IObjectWithPropertyProxy:
-    """Make sure that setters are properly called on objects with interfaces."""
+    '''Make sure that setters are properly called on objects with interfaces.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IObjectWithProperty"
 
@@ -4749,7 +4760,7 @@ class _IObjectWithPropertyProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IOptionalMethod")
 class IOptionalMethod(typing_extensions.Protocol):
-    """Checks that optional result from interface method code generates correctly."""
+    '''Checks that optional result from interface method code generates correctly.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IOptionalMethodProxy"]:
@@ -4761,7 +4772,7 @@ class IOptionalMethod(typing_extensions.Protocol):
 
 
 class _IOptionalMethodProxy:
-    """Checks that optional result from interface method code generates correctly."""
+    '''Checks that optional result from interface method code generates correctly.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IOptionalMethod"
 
@@ -4831,7 +4842,7 @@ class _IPublicInterface2Proxy:
 
 @jsii.interface(jsii_type="jsii-calc.IRandomNumberGenerator")
 class IRandomNumberGenerator(typing_extensions.Protocol):
-    """Generates random numbers."""
+    '''Generates random numbers.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IRandomNumberGeneratorProxy"]:
@@ -4839,30 +4850,30 @@ class IRandomNumberGenerator(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number.
+        '''Returns another random number.
 
         :return: A random number.
-        """
+        '''
         ...
 
 
 class _IRandomNumberGeneratorProxy:
-    """Generates random numbers."""
+    '''Generates random numbers.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IRandomNumberGenerator"
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number.
+        '''Returns another random number.
 
         :return: A random number.
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "next", []))
 
 
 @jsii.interface(jsii_type="jsii-calc.IReturnJsii976")
 class IReturnJsii976(typing_extensions.Protocol):
-    """Returns a subclass of a known class which implements an interface."""
+    '''Returns a subclass of a known class which implements an interface.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IReturnJsii976Proxy"]:
@@ -4875,7 +4886,7 @@ class IReturnJsii976(typing_extensions.Protocol):
 
 
 class _IReturnJsii976Proxy:
-    """Returns a subclass of a known class which implements an interface."""
+    '''Returns a subclass of a known class which implements an interface.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IReturnJsii976"
 
@@ -4953,7 +4964,7 @@ class _IStableInterfaceProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IStructReturningDelegate")
 class IStructReturningDelegate(typing_extensions.Protocol):
-    """Verifies that a "pure" implementation of an interface works correctly."""
+    '''Verifies that a "pure" implementation of an interface works correctly.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IStructReturningDelegateProxy"]:
@@ -4965,7 +4976,7 @@ class IStructReturningDelegate(typing_extensions.Protocol):
 
 
 class _IStructReturningDelegateProxy:
-    """Verifies that a "pure" implementation of an interface works correctly."""
+    '''Verifies that a "pure" implementation of an interface works correctly.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IStructReturningDelegate"
 
@@ -4976,7 +4987,7 @@ class _IStructReturningDelegateProxy:
 
 @jsii.interface(jsii_type="jsii-calc.IWallClock")
 class IWallClock(typing_extensions.Protocol):
-    """Implement this interface."""
+    '''Implement this interface.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IWallClockProxy"]:
@@ -4984,18 +4995,18 @@ class IWallClock(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="iso8601Now")
     def iso8601_now(self) -> builtins.str:
-        """Returns the current time, formatted as an ISO-8601 string."""
+        '''Returns the current time, formatted as an ISO-8601 string.'''
         ...
 
 
 class _IWallClockProxy:
-    """Implement this interface."""
+    '''Implement this interface.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IWallClock"
 
     @jsii.member(jsii_name="iso8601Now")
     def iso8601_now(self) -> builtins.str:
-        """Returns the current time, formatted as an ISO-8601 string."""
+        '''Returns the current time, formatted as an ISO-8601 string.'''
         return typing.cast(builtins.str, jsii.invoke(self, "iso8601Now", []))
 
 
@@ -5078,11 +5089,11 @@ class ImplictBaseOfBase(scope.jsii_calc_base.BaseProps):
         bar: builtins.str,
         goo: datetime.datetime,
     ) -> None:
-        """
+        '''
         :param foo: -
         :param bar: -
         :param goo: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
             "bar": bar,
@@ -5123,10 +5134,10 @@ class InterfaceCollections(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.InterfaceCollections",
 ):
-    """Verifies that collections of interfaces or structs are correctly handled.
+    '''Verifies that collections of interfaces or structs are correctly handled.
 
     See: https://github.com/aws/jsii/issues/1196
-    """
+    '''
 
     @jsii.member(jsii_name="listOfInterfaces") # type: ignore[misc]
     @builtins.classmethod
@@ -5150,7 +5161,7 @@ class InterfaceCollections(
 
 
 class InterfacesMaker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InterfacesMaker"):
-    """We can return arrays of interfaces See aws/aws-cdk#2362."""
+    '''We can return arrays of interfaces See aws/aws-cdk#2362.'''
 
     @jsii.member(jsii_name="makeInterfaces") # type: ignore[misc]
     @builtins.classmethod
@@ -5158,18 +5169,18 @@ class InterfacesMaker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InterfacesMa
         cls,
         count: jsii.Number,
     ) -> typing.List[scope.jsii_calc_lib.IDoublable]:
-        """
+        '''
         :param count: -
-        """
+        '''
         return typing.cast(typing.List[scope.jsii_calc_lib.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
 
 
 class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
-    """Checks the "same instance" isomorphism is preserved within the constructor.
+    '''Checks the "same instance" isomorphism is preserved within the constructor.
 
     Create a subclass of this, and assert that \`\`this.myself()\`\` actually returns
     \`\`this\`\` from within the constructor.
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IsomorphismProxy"]:
@@ -5501,7 +5512,7 @@ class Jsii496Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii496Derive
 
 
 class JsiiAgent(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsiiAgent"):
-    """Host runtime version should be set via JSII_AGENT."""
+    '''Host runtime version should be set via JSII_AGENT.'''
 
     def __init__(self) -> None:
         jsii.create(JsiiAgent, self, [])
@@ -5509,15 +5520,15 @@ class JsiiAgent(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsiiAgent"):
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(cls) -> typing.Optional[builtins.str]:
-        """Returns the value of the JSII_AGENT environment variable."""
+        '''Returns the value of the JSII_AGENT environment variable.'''
         return typing.cast(typing.Optional[builtins.str], jsii.sget(cls, "value"))
 
 
 class JsonFormatter(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsonFormatter"):
-    """Make sure structs are un-decorated on the way in.
+    '''Make sure structs are un-decorated on the way in.
 
     :see: https://github.com/aws/aws-cdk/issues/5066
-    """
+    '''
 
     @jsii.member(jsii_name="anyArray") # type: ignore[misc]
     @builtins.classmethod
@@ -5587,19 +5598,19 @@ class JsonFormatter(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.JsonFormatter"
     @jsii.member(jsii_name="stringify") # type: ignore[misc]
     @builtins.classmethod
     def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(typing.Optional[builtins.str], jsii.sinvoke(cls, "stringify", [value]))
 
 
 class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
-    """Validates that nested classes get correct code generation for the occasional forward reference."""
+    '''Validates that nested classes get correct code generation for the occasional forward reference.'''
 
     def __init__(self, *, prop: "LevelOne.PropProperty") -> None:
-        """
+        '''
         :param prop: 
-        """
+        '''
         props = LevelOneProps(prop=prop)
 
         jsii.create(LevelOne, self, [props])
@@ -5616,9 +5627,9 @@ class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
     )
     class PropBooleanValue:
         def __init__(self, *, value: builtins.bool) -> None:
-            """
+            '''
             :param value: 
-            """
+            '''
             self._values: typing.Dict[str, typing.Any] = {
                 "value": value,
             }
@@ -5647,9 +5658,9 @@ class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
     )
     class PropProperty:
         def __init__(self, *, prop: "LevelOne.PropBooleanValue") -> None:
-            """
+            '''
             :param prop: 
-            """
+            '''
             if isinstance(prop, dict):
                 prop = PropBooleanValue(**prop)
             self._values: typing.Dict[str, typing.Any] = {
@@ -5681,9 +5692,9 @@ class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
 )
 class LevelOneProps:
     def __init__(self, *, prop: LevelOne.PropProperty) -> None:
-        """
+        '''
         :param prop: 
-        """
+        '''
         if isinstance(prop, dict):
             prop = LevelOne.PropProperty(**prop)
         self._values: typing.Dict[str, typing.Any] = {
@@ -5729,14 +5740,14 @@ class LoadBalancedFargateServiceProps:
         public_load_balancer: typing.Optional[builtins.bool] = None,
         public_tasks: typing.Optional[builtins.bool] = None,
     ) -> None:
-        """jsii#298: show default values in sphinx documentation, and respect newlines.
+        '''jsii#298: show default values in sphinx documentation, and respect newlines.
 
         :param container_port: The container port of the application load balancer attached to your Fargate service. Corresponds to container port mapping. Default: 80
         :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
         :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
         :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
         :param public_tasks: Determines whether your Fargate Service will be assigned a public IP address. Default: false
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if container_port is not None:
             self._values["container_port"] = container_port
@@ -5751,18 +5762,18 @@ class LoadBalancedFargateServiceProps:
 
     @builtins.property
     def container_port(self) -> typing.Optional[jsii.Number]:
-        """The container port of the application load balancer attached to your Fargate service.
+        '''The container port of the application load balancer attached to your Fargate service.
 
         Corresponds to container port mapping.
 
         :default: 80
-        """
+        '''
         result = self._values.get("container_port")
         return typing.cast(typing.Optional[jsii.Number], result)
 
     @builtins.property
     def cpu(self) -> typing.Optional[builtins.str]:
-        """The number of cpu units used by the task.
+        '''The number of cpu units used by the task.
 
         Valid values, which determines your range of valid values for the memory parameter:
         256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
@@ -5774,13 +5785,13 @@ class LoadBalancedFargateServiceProps:
         This default is set in the underlying FargateTaskDefinition construct.
 
         :default: 256
-        """
+        '''
         result = self._values.get("cpu")
         return typing.cast(typing.Optional[builtins.str], result)
 
     @builtins.property
     def memory_mib(self) -> typing.Optional[builtins.str]:
-        """The amount (in MiB) of memory used by the task.
+        '''The amount (in MiB) of memory used by the task.
 
         This field is required and you must use one of the following values, which determines your range of valid values
         for the cpu parameter:
@@ -5798,25 +5809,25 @@ class LoadBalancedFargateServiceProps:
         This default is set in the underlying FargateTaskDefinition construct.
 
         :default: 512
-        """
+        '''
         result = self._values.get("memory_mib")
         return typing.cast(typing.Optional[builtins.str], result)
 
     @builtins.property
     def public_load_balancer(self) -> typing.Optional[builtins.bool]:
-        """Determines whether the Application Load Balancer will be internet-facing.
+        '''Determines whether the Application Load Balancer will be internet-facing.
 
         :default: true
-        """
+        '''
         result = self._values.get("public_load_balancer")
         return typing.cast(typing.Optional[builtins.bool], result)
 
     @builtins.property
     def public_tasks(self) -> typing.Optional[builtins.bool]:
-        """Determines whether your Fargate Service will be assigned a public IP address.
+        '''Determines whether your Fargate Service will be assigned a public IP address.
 
         :default: false
-        """
+        '''
         result = self._values.get("public_tasks")
         return typing.cast(typing.Optional[builtins.bool], result)
 
@@ -5855,44 +5866,44 @@ class Multiply(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Multiply",
 ):
-    """The "*" binary operation."""
+    '''The "*" binary operation.'''
 
     def __init__(
         self,
         lhs: scope.jsii_calc_lib.NumericValue,
         rhs: scope.jsii_calc_lib.NumericValue,
     ) -> None:
-        """Creates a BinaryOperation.
+        '''Creates a BinaryOperation.
 
         :param lhs: Left-hand side operand.
         :param rhs: Right-hand side operand.
-        """
+        '''
         jsii.create(Multiply, self, [lhs, rhs])
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> builtins.str:
-        """Say farewell."""
+        '''Say farewell.'''
         return typing.cast(builtins.str, jsii.invoke(self, "farewell", []))
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> builtins.str:
-        """Say goodbye."""
+        '''Say goodbye.'''
         return typing.cast(builtins.str, jsii.invoke(self, "goodbye", []))
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number."""
+        '''Returns another random number.'''
         return typing.cast(jsii.Number, jsii.invoke(self, "next", []))
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value."""
+        '''(deprecated) String representation of the value.'''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The value."""
+        '''(deprecated) The value.'''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
 
@@ -5915,16 +5926,16 @@ class NestedClassInstance(
 )
 class NestedStruct:
     def __init__(self, *, number_prop: jsii.Number) -> None:
-        """
+        '''
         :param number_prop: When provided, must be > 0.
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "number_prop": number_prop,
         }
 
     @builtins.property
     def number_prop(self) -> jsii.Number:
-        """When provided, must be > 0."""
+        '''When provided, must be > 0.'''
         result = self._values.get("number_prop")
         assert result is not None, "Required property 'number_prop' is missing"
         return typing.cast(jsii.Number, result)
@@ -5945,39 +5956,39 @@ class NodeStandardLibrary(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.NodeStandardLibrary",
 ):
-    """Test fixture to verify that jsii modules can use the node standard library."""
+    '''Test fixture to verify that jsii modules can use the node standard library.'''
 
     def __init__(self) -> None:
         jsii.create(NodeStandardLibrary, self, [])
 
     @jsii.member(jsii_name="cryptoSha256")
     def crypto_sha256(self) -> builtins.str:
-        """Uses node.js "crypto" module to calculate sha256 of a string.
+        '''Uses node.js "crypto" module to calculate sha256 of a string.
 
         :return: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "cryptoSha256", []))
 
     @jsii.member(jsii_name="fsReadFile")
     def fs_read_file(self) -> builtins.str:
-        """Reads a local resource file (resource.txt) asynchronously.
+        '''Reads a local resource file (resource.txt) asynchronously.
 
         :return: "Hello, resource!"
-        """
+        '''
         return typing.cast(builtins.str, jsii.ainvoke(self, "fsReadFile", []))
 
     @jsii.member(jsii_name="fsReadFileSync")
     def fs_read_file_sync(self) -> builtins.str:
-        """Sync version of fsReadFile.
+        '''Sync version of fsReadFile.
 
         :return: "Hello, resource! SYNC!"
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "fsReadFileSync", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="osPlatform")
     def os_platform(self) -> builtins.str:
-        """Returns the current os.platform() from the "os" node module."""
+        '''Returns the current os.platform() from the "os" node module.'''
         return typing.cast(builtins.str, jsii.get(self, "osPlatform"))
 
 
@@ -5985,20 +5996,20 @@ class NullShouldBeTreatedAsUndefined(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.NullShouldBeTreatedAsUndefined",
 ):
-    """jsii#282, aws-cdk#157: null should be treated as "undefined"."""
+    '''jsii#282, aws-cdk#157: null should be treated as "undefined".'''
 
     def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
-        """
+        '''
         :param _param1: -
         :param optional: -
-        """
+        '''
         jsii.create(NullShouldBeTreatedAsUndefined, self, [_param1, optional])
 
     @jsii.member(jsii_name="giveMeUndefined")
     def give_me_undefined(self, value: typing.Any = None) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "giveMeUndefined", [value]))
 
     @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
@@ -6008,10 +6019,10 @@ class NullShouldBeTreatedAsUndefined(
         array_with_three_elements_and_undefined_as_second_argument: typing.List[typing.Any],
         this_should_be_undefined: typing.Any = None,
     ) -> None:
-        """
+        '''
         :param array_with_three_elements_and_undefined_as_second_argument: 
         :param this_should_be_undefined: 
-        """
+        '''
         input = NullShouldBeTreatedAsUndefinedData(
             array_with_three_elements_and_undefined_as_second_argument=array_with_three_elements_and_undefined_as_second_argument,
             this_should_be_undefined=this_should_be_undefined,
@@ -6048,10 +6059,10 @@ class NullShouldBeTreatedAsUndefinedData:
         array_with_three_elements_and_undefined_as_second_argument: typing.List[typing.Any],
         this_should_be_undefined: typing.Any = None,
     ) -> None:
-        """
+        '''
         :param array_with_three_elements_and_undefined_as_second_argument: 
         :param this_should_be_undefined: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "array_with_three_elements_and_undefined_as_second_argument": array_with_three_elements_and_undefined_as_second_argument,
         }
@@ -6084,19 +6095,19 @@ class NullShouldBeTreatedAsUndefinedData:
 
 
 class NumberGenerator(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.NumberGenerator"):
-    """This allows us to test that a reference can be stored for objects that implement interfaces."""
+    '''This allows us to test that a reference can be stored for objects that implement interfaces.'''
 
     def __init__(self, generator: IRandomNumberGenerator) -> None:
-        """
+        '''
         :param generator: -
-        """
+        '''
         jsii.create(NumberGenerator, self, [generator])
 
     @jsii.member(jsii_name="isSameGenerator")
     def is_same_generator(self, gen: IRandomNumberGenerator) -> builtins.bool:
-        """
+        '''
         :param gen: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
 
     @jsii.member(jsii_name="nextTimes100")
@@ -6117,7 +6128,7 @@ class ObjectRefsInCollections(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ObjectRefsInCollections",
 ):
-    """Verify that object references can be passed inside collections."""
+    '''Verify that object references can be passed inside collections.'''
 
     def __init__(self) -> None:
         jsii.create(ObjectRefsInCollections, self, [])
@@ -6127,10 +6138,10 @@ class ObjectRefsInCollections(
         self,
         values: typing.List[scope.jsii_calc_lib.NumericValue],
     ) -> jsii.Number:
-        """Returns the sum of all values.
+        '''Returns the sum of all values.
 
         :param values: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "sumFromArray", [values]))
 
     @jsii.member(jsii_name="sumFromMap")
@@ -6138,10 +6149,10 @@ class ObjectRefsInCollections(
         self,
         values: typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue],
     ) -> jsii.Number:
-        """Returns the sum of all values in a map.
+        '''Returns the sum of all values in a map.
 
         :param values: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "sumFromMap", [values]))
 
 
@@ -6156,7 +6167,7 @@ class ObjectWithPropertyProvider(
 
 
 class Old(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Old"):
-    """(deprecated) Old class.
+    '''(deprecated) Old class.
 
     :deprecated:
 
@@ -6164,17 +6175,17 @@ class Old(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Old"):
     whatever you like is always the best
 
     :stability: deprecated
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(Old, self, [])
 
     @jsii.member(jsii_name="doAThing")
     def do_a_thing(self) -> None:
-        """(deprecated) Doo wop that thing.
+        '''(deprecated) Doo wop that thing.
 
         :stability: deprecated
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "doAThing", []))
 
 
@@ -6183,9 +6194,9 @@ class OptionalArgumentInvoker(
     jsii_type="jsii-calc.OptionalArgumentInvoker",
 ):
     def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
-        """
+        '''
         :param delegate: -
-        """
+        '''
         jsii.create(OptionalArgumentInvoker, self, [delegate])
 
     @jsii.member(jsii_name="invokeWithOptional")
@@ -6207,11 +6218,11 @@ class OptionalConstructorArgument(
         arg2: builtins.str,
         arg3: typing.Optional[datetime.datetime] = None,
     ) -> None:
-        """
+        '''
         :param arg1: -
         :param arg2: -
         :param arg3: -
-        """
+        '''
         jsii.create(OptionalConstructorArgument, self, [arg1, arg2, arg3])
 
     @builtins.property # type: ignore[misc]
@@ -6237,9 +6248,9 @@ class OptionalConstructorArgument(
 )
 class OptionalStruct:
     def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
-        """
+        '''
         :param field: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {}
         if field is not None:
             self._values["field"] = field
@@ -6266,9 +6277,9 @@ class OptionalStructConsumer(
     jsii_type="jsii-calc.OptionalStructConsumer",
 ):
     def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
-        """
+        '''
         :param field: 
-        """
+        '''
         optional_struct = OptionalStruct(field=field)
 
         jsii.create(OptionalStructConsumer, self, [optional_struct])
@@ -6288,9 +6299,9 @@ class OverridableProtectedMember(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.OverridableProtectedMember",
 ):
-    """
+    '''
     :see: https://github.com/aws/jsii/issues/903
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(OverridableProtectedMember, self, [])
@@ -6331,9 +6342,9 @@ class OverrideReturnsObject(
 
     @jsii.member(jsii_name="test")
     def test(self, obj: IReturnsNumber) -> jsii.Number:
-        """
+        '''
         :param obj: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
 
 
@@ -6344,10 +6355,10 @@ class OverrideReturnsObject(
 )
 class ParentStruct982:
     def __init__(self, *, foo: builtins.str) -> None:
-        """https://github.com/aws/jsii/issues/982.
+        '''https://github.com/aws/jsii/issues/982.
 
         :param foo: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
         }
@@ -6389,11 +6400,11 @@ class PartiallyInitializedThisConsumer(
         dt: datetime.datetime,
         ev: AllTypesEnum,
     ) -> builtins.str:
-        """
+        '''
         :param obj: -
         :param dt: -
         :param ev: -
-        """
+        '''
         ...
 
 
@@ -6405,11 +6416,11 @@ class _PartiallyInitializedThisConsumerProxy(PartiallyInitializedThisConsumer):
         dt: datetime.datetime,
         ev: AllTypesEnum,
     ) -> builtins.str:
-        """
+        '''
         :param obj: -
         :param dt: -
         :param ev: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "consumePartiallyInitializedThis", [obj, dt, ev]))
 
 
@@ -6419,9 +6430,9 @@ class Polymorphism(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Polymorphism"):
 
     @jsii.member(jsii_name="sayHello")
     def say_hello(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
-        """
+        '''
         :param friendly: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
 
 
@@ -6430,39 +6441,39 @@ class Power(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Power",
 ):
-    """The power operation."""
+    '''The power operation.'''
 
     def __init__(
         self,
         base: scope.jsii_calc_lib.NumericValue,
         pow: scope.jsii_calc_lib.NumericValue,
     ) -> None:
-        """Creates a Power operation.
+        '''Creates a Power operation.
 
         :param base: The base of the power.
         :param pow: The number of times to multiply.
-        """
+        '''
         jsii.create(Power, self, [base, pow])
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="base")
     def base(self) -> scope.jsii_calc_lib.NumericValue:
-        """The base of the power."""
+        '''The base of the power.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "base"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.NumericValue:
-        """The expression that this operation consists of.
+        '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
-        """
+        '''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="pow")
     def pow(self) -> scope.jsii_calc_lib.NumericValue:
-        """The number of times to multiply."""
+        '''The number of times to multiply.'''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "pow"))
 
 
@@ -6470,7 +6481,7 @@ class PropertyNamedProperty(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.PropertyNamedProperty",
 ):
-    """Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code."""
+    '''Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.'''
 
     def __init__(self) -> None:
         jsii.create(PropertyNamedProperty, self, [])
@@ -6635,7 +6646,7 @@ class ReferenceEnumFromScopedPackage(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ReferenceEnumFromScopedPackage",
 ):
-    """See awslabs/jsii#138."""
+    '''See awslabs/jsii#138.'''
 
     def __init__(self) -> None:
         jsii.create(ReferenceEnumFromScopedPackage, self, [])
@@ -6646,9 +6657,9 @@ class ReferenceEnumFromScopedPackage(
 
     @jsii.member(jsii_name="saveFoo")
     def save_foo(self, value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "saveFoo", [value]))
 
     @builtins.property # type: ignore[misc]
@@ -6668,12 +6679,12 @@ class ReturnsPrivateImplementationOfInterface(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ReturnsPrivateImplementationOfInterface",
 ):
-    """Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
+    '''Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
 
     :return: an instance of an un-exported class that extends \`\`ExportedBaseClass\`\`, declared as \`\`IPrivatelyImplemented\`\`.
 
     :see: https://github.com/aws/jsii/issues/320
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(ReturnsPrivateImplementationOfInterface, self, [])
@@ -6696,14 +6707,14 @@ class RootStruct:
         string_prop: builtins.str,
         nested_struct: typing.Optional[NestedStruct] = None,
     ) -> None:
-        """This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
+        '''This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
 
         This is cheating with the (current) declared types, but this is the "more
         idiomatic" way for Pythonists.
 
         :param string_prop: May not be empty.
         :param nested_struct: 
-        """
+        '''
         if isinstance(nested_struct, dict):
             nested_struct = NestedStruct(**nested_struct)
         self._values: typing.Dict[str, typing.Any] = {
@@ -6714,7 +6725,7 @@ class RootStruct:
 
     @builtins.property
     def string_prop(self) -> builtins.str:
-        """May not be empty."""
+        '''May not be empty.'''
         result = self._values.get("string_prop")
         assert result is not None, "Required property 'string_prop' is missing"
         return typing.cast(builtins.str, result)
@@ -6748,10 +6759,10 @@ class RootStructValidator(
         string_prop: builtins.str,
         nested_struct: typing.Optional[NestedStruct] = None,
     ) -> None:
-        """
+        '''
         :param string_prop: May not be empty.
         :param nested_struct: 
-        """
+        '''
         struct = RootStruct(string_prop=string_prop, nested_struct=nested_struct)
 
         return typing.cast(None, jsii.sinvoke(cls, "validate", [struct]))
@@ -6771,18 +6782,18 @@ class RuntimeTypeChecking(
         arg2: typing.Optional[builtins.str] = None,
         arg3: typing.Optional[datetime.datetime] = None,
     ) -> None:
-        """
+        '''
         :param arg1: -
         :param arg2: -
         :param arg3: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "methodWithDefaultedArguments", [arg1, arg2, arg3]))
 
     @jsii.member(jsii_name="methodWithOptionalAnyArgument")
     def method_with_optional_any_argument(self, arg: typing.Any = None) -> None:
-        """
+        '''
         :param arg: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "methodWithOptionalAnyArgument", [arg]))
 
     @jsii.member(jsii_name="methodWithOptionalArguments")
@@ -6792,12 +6803,12 @@ class RuntimeTypeChecking(
         arg2: builtins.str,
         arg3: typing.Optional[datetime.datetime] = None,
     ) -> None:
-        """Used to verify verification of number of method arguments.
+        '''Used to verify verification of number of method arguments.
 
         :param arg1: -
         :param arg2: -
         :param arg3: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "methodWithOptionalArguments", [arg1, arg2, arg3]))
 
 
@@ -6816,10 +6827,10 @@ class SecondLevelStruct:
         deeper_required_prop: builtins.str,
         deeper_optional_prop: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param deeper_required_prop: It's long and required.
         :param deeper_optional_prop: It's long, but you'll almost never pass it.
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "deeper_required_prop": deeper_required_prop,
         }
@@ -6828,14 +6839,14 @@ class SecondLevelStruct:
 
     @builtins.property
     def deeper_required_prop(self) -> builtins.str:
-        """It's long and required."""
+        '''It's long and required.'''
         result = self._values.get("deeper_required_prop")
         assert result is not None, "Required property 'deeper_required_prop' is missing"
         return typing.cast(builtins.str, result)
 
     @builtins.property
     def deeper_optional_prop(self) -> typing.Optional[builtins.str]:
-        """It's long, but you'll almost never pass it."""
+        '''It's long, but you'll almost never pass it.'''
         result = self._values.get("deeper_optional_prop")
         return typing.cast(typing.Optional[builtins.str], result)
 
@@ -6855,12 +6866,12 @@ class SingleInstanceTwoTypes(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.SingleInstanceTwoTypes",
 ):
-    """Test that a single instance can be returned under two different FQNs.
+    '''Test that a single instance can be returned under two different FQNs.
 
     JSII clients can instantiate 2 different strongly-typed wrappers for the same
     object. Unfortunately, this will break object equality, but if we didn't do
     this it would break runtime type checks in the JVM or CLR.
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(SingleInstanceTwoTypes, self, [])
@@ -6875,47 +6886,47 @@ class SingleInstanceTwoTypes(
 
 
 class SingletonInt(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SingletonInt"):
-    """Verifies that singleton enums are handled correctly.
+    '''Verifies that singleton enums are handled correctly.
 
     https://github.com/aws/jsii/issues/231
-    """
+    '''
 
     @jsii.member(jsii_name="isSingletonInt")
     def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonInt", [value]))
 
 
 @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
 class SingletonIntEnum(enum.Enum):
-    """A singleton integer."""
+    '''A singleton integer.'''
 
     SINGLETON_INT = "SINGLETON_INT"
-    """Elite!"""
+    '''Elite!'''
 
 
 class SingletonString(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.SingletonString"):
-    """Verifies that singleton enums are handled correctly.
+    '''Verifies that singleton enums are handled correctly.
 
     https://github.com/aws/jsii/issues/231
-    """
+    '''
 
     @jsii.member(jsii_name="isSingletonString")
     def is_singleton_string(self, value: builtins.str) -> builtins.bool:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonString", [value]))
 
 
 @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
 class SingletonStringEnum(enum.Enum):
-    """A singleton string."""
+    '''A singleton string.'''
 
     SINGLETON_STRING = "SINGLETON_STRING"
-    """1337."""
+    '''1337.'''
 
 
 @jsii.data_type(
@@ -6930,10 +6941,10 @@ class SmellyStruct:
         property: builtins.str,
         yet_anoter_one: builtins.bool,
     ) -> None:
-        """
+        '''
         :param property: 
         :param yet_anoter_one: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "property": property,
             "yet_anoter_one": yet_anoter_one,
@@ -6984,10 +6995,10 @@ class StableClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StableClass"):
         readonly_string: builtins.str,
         mutable_number: typing.Optional[jsii.Number] = None,
     ) -> None:
-        """
+        '''
         :param readonly_string: -
         :param mutable_number: -
-        """
+        '''
         jsii.create(StableClass, self, [readonly_string, mutable_number])
 
     @jsii.member(jsii_name="method")
@@ -7022,9 +7033,9 @@ class StableEnum(enum.Enum):
 )
 class StableStruct:
     def __init__(self, *, readonly_property: builtins.str) -> None:
-        """
+        '''
         :param readonly_property: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "readonly_property": readonly_property,
         }
@@ -7048,10 +7059,10 @@ class StableStruct:
 
 
 class StaticContext(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StaticContext"):
-    """This is used to validate the ability to use \`\`this\`\` from within a static context.
+    '''This is used to validate the ability to use \`\`this\`\` from within a static context.
 
     https://github.com/awslabs/aws-cdk/issues/2304
-    """
+    '''
 
     @jsii.member(jsii_name="canAccessStaticContext") # type: ignore[misc]
     @builtins.classmethod
@@ -7072,12 +7083,12 @@ class StaticHelloParent(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.StaticHelloParent",
 ):
-    """Static methods that override parent class are technically overrides (the inheritance of statics is part of the ES6 specification), but certain other languages such as Java do not carry statics in the inheritance chain at all, so they cannot be overridden, only hidden.
+    '''Static methods that override parent class are technically overrides (the inheritance of statics is part of the ES6 specification), but certain other languages such as Java do not carry statics in the inheritance chain at all, so they cannot be overridden, only hidden.
 
     The difference is fairly minor (for typical use-cases, the end result is the
     same), however this has implications on what the generated code should look
     like.
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(StaticHelloParent, self, [])
@@ -7095,18 +7106,18 @@ class StaticHelloParent(
 
 class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
     def __init__(self, value: builtins.str) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         jsii.create(Statics, self, [value])
 
     @jsii.member(jsii_name="staticMethod") # type: ignore[misc]
     @builtins.classmethod
     def static_method(cls, name: builtins.str) -> builtins.str:
-        """Jsdocs for static method.
+        '''Jsdocs for static method.
 
         :param name: The name of the person to say hello to.
-        """
+        '''
         return typing.cast(builtins.str, jsii.sinvoke(cls, "staticMethod", [name]))
 
     @jsii.member(jsii_name="justMethod")
@@ -7116,7 +7127,7 @@ class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="BAR")
     def BAR(cls) -> jsii.Number:
-        """Constants may also use all-caps."""
+        '''Constants may also use all-caps.'''
         return typing.cast(jsii.Number, jsii.sget(cls, "BAR"))
 
     @jsii.python.classproperty # type: ignore[misc]
@@ -7127,22 +7138,22 @@ class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="Foo")
     def FOO(cls) -> builtins.str:
-        """Jsdocs for static property."""
+        '''Jsdocs for static property.'''
         return typing.cast(builtins.str, jsii.sget(cls, "Foo"))
 
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="zooBar")
     def ZOO_BAR(cls) -> typing.Mapping[builtins.str, builtins.str]:
-        """Constants can also use camelCase."""
+        '''Constants can also use camelCase.'''
         return typing.cast(typing.Mapping[builtins.str, builtins.str], jsii.sget(cls, "zooBar"))
 
     @jsii.python.classproperty # type: ignore[misc]
     @jsii.member(jsii_name="instance")
     def instance(cls) -> "Statics":
-        """Jsdocs for static getter.
+        '''Jsdocs for static getter.
 
         Jsdocs for static setter.
-        """
+        '''
         return typing.cast("Statics", jsii.sget(cls, "instance"))
 
     @instance.setter # type: ignore[no-redef]
@@ -7202,12 +7213,12 @@ class StructA:
         optional_number: typing.Optional[jsii.Number] = None,
         optional_string: typing.Optional[builtins.str] = None,
     ) -> None:
-        """We can serialize and deserialize structs without silently ignoring optional fields.
+        '''We can serialize and deserialize structs without silently ignoring optional fields.
 
         :param required_string: 
         :param optional_number: 
         :param optional_string: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "required_string": required_string,
         }
@@ -7261,12 +7272,12 @@ class StructB:
         optional_boolean: typing.Optional[builtins.bool] = None,
         optional_struct_a: typing.Optional[StructA] = None,
     ) -> None:
-        """This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
+        '''This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
 
         :param required_string: 
         :param optional_boolean: 
         :param optional_struct_a: 
-        """
+        '''
         if isinstance(optional_struct_a, dict):
             optional_struct_a = StructA(**optional_struct_a)
         self._values: typing.Dict[str, typing.Any] = {
@@ -7317,13 +7328,13 @@ class StructParameterType:
         scope: builtins.str,
         props: typing.Optional[builtins.bool] = None,
     ) -> None:
-        """Verifies that, in languages that do keyword lifting (e.g: Python), having a struct member with the same name as a positional parameter results in the correct code being emitted.
+        '''Verifies that, in languages that do keyword lifting (e.g: Python), having a struct member with the same name as a positional parameter results in the correct code being emitted.
 
         See: https://github.com/aws/aws-cdk/issues/4302
 
         :param scope: 
         :param props: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "scope": scope,
         }
@@ -7354,7 +7365,7 @@ class StructParameterType:
 
 
 class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"):
-    """Just because we can."""
+    '''Just because we can.'''
 
     def __init__(self) -> None:
         jsii.create(StructPassing, self, [])
@@ -7366,10 +7377,10 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         _positional: jsii.Number,
         *inputs: "TopLevelStruct",
     ) -> jsii.Number:
-        """
+        '''
         :param _positional: -
         :param inputs: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs]))
 
     @jsii.member(jsii_name="roundTrip") # type: ignore[misc]
@@ -7382,12 +7393,12 @@ class StructPassing(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.StructPassing"
         second_level: typing.Union[jsii.Number, SecondLevelStruct],
         optional: typing.Optional[builtins.str] = None,
     ) -> "TopLevelStruct":
-        """
+        '''
         :param _positional: -
         :param required: This is a required field.
         :param second_level: A union to really stress test our serialization.
         :param optional: You don't have to pass this.
-        """
+        '''
         input = TopLevelStruct(
             required=required, second_level=second_level, optional=optional
         )
@@ -7402,17 +7413,17 @@ class StructUnionConsumer(
     @jsii.member(jsii_name="isStructA") # type: ignore[misc]
     @builtins.classmethod
     def is_struct_a(cls, struct: typing.Union[StructA, StructB]) -> builtins.bool:
-        """
+        '''
         :param struct: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructA", [struct]))
 
     @jsii.member(jsii_name="isStructB") # type: ignore[misc]
     @builtins.classmethod
     def is_struct_b(cls, struct: typing.Union[StructA, StructB]) -> builtins.bool:
-        """
+        '''
         :param struct: -
-        """
+        '''
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructB", [struct]))
 
 
@@ -7435,12 +7446,12 @@ class StructWithJavaReservedWords:
         result: typing.Optional[builtins.str] = None,
         that: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param default: 
         :param assert_: 
         :param result: 
         :param that: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "default": default,
         }
@@ -7489,7 +7500,7 @@ class Sum(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Sum",
 ):
-    """An operation that sums multiple values."""
+    '''An operation that sums multiple values.'''
 
     def __init__(self) -> None:
         jsii.create(Sum, self, [])
@@ -7497,16 +7508,16 @@ class Sum(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.NumericValue:
-        """The expression that this operation consists of.
+        '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
-        """
+        '''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="parts")
     def parts(self) -> typing.List[scope.jsii_calc_lib.NumericValue]:
-        """The parts to sum."""
+        '''The parts to sum.'''
         return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "parts"))
 
     @parts.setter
@@ -7526,10 +7537,10 @@ class SupportsNiceJavaBuilderProps:
         bar: jsii.Number,
         id: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param bar: Some number, like 42.
         :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "bar": bar,
         }
@@ -7538,17 +7549,17 @@ class SupportsNiceJavaBuilderProps:
 
     @builtins.property
     def bar(self) -> jsii.Number:
-        """Some number, like 42."""
+        '''Some number, like 42.'''
         result = self._values.get("bar")
         assert result is not None, "Required property 'bar' is missing"
         return typing.cast(jsii.Number, result)
 
     @builtins.property
     def id(self) -> typing.Optional[builtins.str]:
-        """An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`.
+        '''An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`.
 
         But here we are, doing it like we didn't care.
-        """
+        '''
         result = self._values.get("id")
         return typing.cast(typing.Optional[builtins.str], result)
 
@@ -7568,7 +7579,7 @@ class SupportsNiceJavaBuilderWithRequiredProps(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
 ):
-    """We can generate fancy builders in Java for classes which take a mix of positional & struct parameters."""
+    '''We can generate fancy builders in Java for classes which take a mix of positional & struct parameters.'''
 
     def __init__(
         self,
@@ -7577,11 +7588,11 @@ class SupportsNiceJavaBuilderWithRequiredProps(
         bar: jsii.Number,
         id: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param id_: some identifier of your choice.
         :param bar: Some number, like 42.
         :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
-        """
+        '''
         props = SupportsNiceJavaBuilderProps(bar=bar, id=id)
 
         jsii.create(SupportsNiceJavaBuilderWithRequiredProps, self, [id_, props])
@@ -7594,7 +7605,7 @@ class SupportsNiceJavaBuilderWithRequiredProps(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="id")
     def id(self) -> jsii.Number:
-        """some identifier of your choice."""
+        '''some identifier of your choice.'''
         return typing.cast(jsii.Number, jsii.get(self, "id"))
 
     @builtins.property # type: ignore[misc]
@@ -7620,16 +7631,16 @@ class SyncVirtualMethods(
 
     @jsii.member(jsii_name="modifyOtherProperty")
     def modify_other_property(self, value: builtins.str) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "modifyOtherProperty", [value]))
 
     @jsii.member(jsii_name="modifyValueOfTheProperty")
     def modify_value_of_the_property(self, value: builtins.str) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "modifyValueOfTheProperty", [value]))
 
     @jsii.member(jsii_name="readA")
@@ -7650,16 +7661,16 @@ class SyncVirtualMethods(
 
     @jsii.member(jsii_name="virtualMethod")
     def virtual_method(self, n: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param n: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "virtualMethod", [n]))
 
     @jsii.member(jsii_name="writeA")
     def write_a(self, value: jsii.Number) -> None:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(None, jsii.invoke(self, "writeA", [value]))
 
     @builtins.property # type: ignore[misc]
@@ -7739,11 +7750,11 @@ class TopLevelStruct:
         second_level: typing.Union[jsii.Number, SecondLevelStruct],
         optional: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param required: This is a required field.
         :param second_level: A union to really stress test our serialization.
         :param optional: You don't have to pass this.
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "required": required,
             "second_level": second_level,
@@ -7753,21 +7764,21 @@ class TopLevelStruct:
 
     @builtins.property
     def required(self) -> builtins.str:
-        """This is a required field."""
+        '''This is a required field.'''
         result = self._values.get("required")
         assert result is not None, "Required property 'required' is missing"
         return typing.cast(builtins.str, result)
 
     @builtins.property
     def second_level(self) -> typing.Union[jsii.Number, SecondLevelStruct]:
-        """A union to really stress test our serialization."""
+        '''A union to really stress test our serialization.'''
         result = self._values.get("second_level")
         assert result is not None, "Required property 'second_level' is missing"
         return typing.cast(typing.Union[jsii.Number, SecondLevelStruct], result)
 
     @builtins.property
     def optional(self) -> typing.Optional[builtins.str]:
-        """You don't have to pass this."""
+        '''You don't have to pass this.'''
         result = self._values.get("optional")
         return typing.cast(typing.Optional[builtins.str], result)
 
@@ -7784,15 +7795,15 @@ class TopLevelStruct:
 
 
 class UmaskCheck(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UmaskCheck"):
-    """Checks the current file permissions are cool (no funky UMASK down-scoping happened).
+    '''Checks the current file permissions are cool (no funky UMASK down-scoping happened).
 
     :see: https://github.com/aws/jsii/issues/1765
-    """
+    '''
 
     @jsii.member(jsii_name="mode") # type: ignore[misc]
     @builtins.classmethod
     def mode(cls) -> jsii.Number:
-        """This should return 0o644 (-rw-r--r--)."""
+        '''This should return 0o644 (-rw-r--r--).'''
         return typing.cast(jsii.Number, jsii.sinvoke(cls, "mode", []))
 
 
@@ -7801,16 +7812,16 @@ class UnaryOperation(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.UnaryOperation",
 ):
-    """An operation on a single operand."""
+    '''An operation on a single operand.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_UnaryOperationProxy"]:
         return _UnaryOperationProxy
 
     def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
-        """
+        '''
         :param operand: -
-        """
+        '''
         jsii.create(UnaryOperation, self, [operand])
 
     @builtins.property # type: ignore[misc]
@@ -7837,10 +7848,10 @@ class UnionProperties:
         bar: typing.Union[builtins.str, jsii.Number, AllTypes],
         foo: typing.Optional[typing.Union[builtins.str, jsii.Number]] = None,
     ) -> None:
-        """
+        '''
         :param bar: 
         :param foo: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "bar": bar,
         }
@@ -7875,12 +7886,12 @@ class UpcasingReflectable(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.UpcasingReflectable",
 ):
-    """Ensures submodule-imported types from dependencies can be used correctly."""
+    '''Ensures submodule-imported types from dependencies can be used correctly.'''
 
     def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
-        """
+        '''
         :param delegate: -
-        """
+        '''
         jsii.create(UpcasingReflectable, self, [delegate])
 
     @jsii.python.classproperty # type: ignore[misc]
@@ -7909,7 +7920,7 @@ class UseBundledDependency(
 
 
 class UseCalcBase(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UseCalcBase"):
-    """Depend on a type from jsii-calc-base as a test for awslabs/jsii#128."""
+    '''Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.'''
 
     def __init__(self) -> None:
         jsii.create(UseCalcBase, self, [])
@@ -7924,9 +7935,9 @@ class UsesInterfaceWithProperties(
     jsii_type="jsii-calc.UsesInterfaceWithProperties",
 ):
     def __init__(self, obj: IInterfaceWithProperties) -> None:
-        """
+        '''
         :param obj: -
-        """
+        '''
         jsii.create(UsesInterfaceWithProperties, self, [obj])
 
     @jsii.member(jsii_name="justRead")
@@ -7938,16 +7949,16 @@ class UsesInterfaceWithProperties(
         self,
         ext: IInterfaceWithPropertiesExtension,
     ) -> builtins.str:
-        """
+        '''
         :param ext: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
 
     @jsii.member(jsii_name="writeAndRead")
     def write_and_read(self, value: builtins.str) -> builtins.str:
-        """
+        '''
         :param value: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "writeAndRead", [value]))
 
     @builtins.property # type: ignore[misc]
@@ -7958,24 +7969,24 @@ class UsesInterfaceWithProperties(
 
 class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
     def __init__(self, method: "VariadicMethod") -> None:
-        """
+        '''
         :param method: -
-        """
+        '''
         jsii.create(VariadicInvoker, self, [method])
 
     @jsii.member(jsii_name="asArray")
     def as_array(self, *values: jsii.Number) -> typing.List[jsii.Number]:
-        """
+        '''
         :param values: -
-        """
+        '''
         return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [*values]))
 
 
 class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMethod"):
     def __init__(self, *prefix: jsii.Number) -> None:
-        """
+        '''
         :param prefix: a prefix that will be use for all values returned by \`\`#asArray\`\`.
-        """
+        '''
         jsii.create(VariadicMethod, self, [*prefix])
 
     @jsii.member(jsii_name="asArray")
@@ -7984,10 +7995,10 @@ class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMetho
         first: jsii.Number,
         *others: jsii.Number,
     ) -> typing.List[jsii.Number]:
-        """
+        '''
         :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
         :param others: other elements to be included in the array.
-        """
+        '''
         return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
 
 
@@ -8000,37 +8011,37 @@ class VirtualMethodPlayground(
 
     @jsii.member(jsii_name="overrideMeAsync")
     def override_me_async(self, index: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param index: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeAsync", [index]))
 
     @jsii.member(jsii_name="overrideMeSync")
     def override_me_sync(self, index: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param index: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "overrideMeSync", [index]))
 
     @jsii.member(jsii_name="parallelSumAsync")
     def parallel_sum_async(self, count: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param count: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "parallelSumAsync", [count]))
 
     @jsii.member(jsii_name="serialSumAsync")
     def serial_sum_async(self, count: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param count: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.ainvoke(self, "serialSumAsync", [count]))
 
     @jsii.member(jsii_name="sumSync")
     def sum_sync(self, count: jsii.Number) -> jsii.Number:
-        """
+        '''
         :param count: -
-        """
+        '''
         return typing.cast(jsii.Number, jsii.invoke(self, "sumSync", [count]))
 
 
@@ -8038,12 +8049,12 @@ class VoidCallback(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.VoidCallback",
 ):
-    """This test is used to validate the runtimes can return correctly from a void callback.
+    '''This test is used to validate the runtimes can return correctly from a void callback.
 
     - Implement \`\`overrideMe\`\` (method does not have to do anything).
     - Invoke \`\`callMe\`\`
     - Verify that \`\`methodWasCalled\`\` is \`\`true\`\`.
-    """
+    '''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_VoidCallbackProxy"]:
@@ -8077,12 +8088,12 @@ class WithPrivatePropertyInConstructor(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.WithPrivatePropertyInConstructor",
 ):
-    """Verifies that private property declarations in constructor arguments are hidden."""
+    '''Verifies that private property declarations in constructor arguments are hidden.'''
 
     def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
-        """
+        '''
         :param private_field: -
-        """
+        '''
         jsii.create(WithPrivatePropertyInConstructor, self, [private_field])
 
     @builtins.property # type: ignore[misc]
@@ -8107,9 +8118,9 @@ class AbstractClass(
     @jsii.member(jsii_name="abstractMethod") # type: ignore[misc]
     @abc.abstractmethod
     def abstract_method(self, name: builtins.str) -> builtins.str:
-        """
+        '''
         :param name: -
-        """
+        '''
         ...
 
     @jsii.member(jsii_name="nonAbstractMethod")
@@ -8127,36 +8138,36 @@ class _AbstractClassProxy(
 ):
     @jsii.member(jsii_name="abstractMethod")
     def abstract_method(self, name: builtins.str) -> builtins.str:
-        """
+        '''
         :param name: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self, "abstractMethod", [name]))
 
 
 class Add(BinaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Add"):
-    """The "+" binary operation."""
+    '''The "+" binary operation.'''
 
     def __init__(
         self,
         lhs: scope.jsii_calc_lib.NumericValue,
         rhs: scope.jsii_calc_lib.NumericValue,
     ) -> None:
-        """Creates a BinaryOperation.
+        '''Creates a BinaryOperation.
 
         :param lhs: Left-hand side operand.
         :param rhs: Right-hand side operand.
-        """
+        '''
         jsii.create(Add, self, [lhs, rhs])
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value."""
+        '''(deprecated) String representation of the value.'''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The value."""
+        '''(deprecated) The value.'''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
 
@@ -8203,10 +8214,10 @@ class Bell(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Bell"):
 )
 class ChildStruct982(ParentStruct982):
     def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
-        """
+        '''
         :param foo: 
         :param bar: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
             "bar": bar,
@@ -8331,7 +8342,7 @@ class ClassWithPrivateConstructorAndAutomaticProperties(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
 ):
-    """Class that implements interface properties automatically, but using a private constructor."""
+    '''Class that implements interface properties automatically, but using a private constructor.'''
 
     @jsii.member(jsii_name="create") # type: ignore[misc]
     @builtins.classmethod
@@ -8340,10 +8351,10 @@ class ClassWithPrivateConstructorAndAutomaticProperties(
         read_only_string: builtins.str,
         read_write_string: builtins.str,
     ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
-        """
+        '''
         :param read_only_string: -
         :param read_write_string: -
-        """
+        '''
         return typing.cast("ClassWithPrivateConstructorAndAutomaticProperties", jsii.sinvoke(cls, "create", [read_only_string, read_write_string]))
 
     @builtins.property # type: ignore[misc]
@@ -8385,7 +8396,7 @@ class IInterfaceThatShouldNotBeADataType(
     IInterfaceWithMethods,
     typing_extensions.Protocol,
 ):
-    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."""
+    '''Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_IInterfaceThatShouldNotBeADataTypeProxy"]:
@@ -8400,7 +8411,7 @@ class IInterfaceThatShouldNotBeADataType(
 class _IInterfaceThatShouldNotBeADataTypeProxy(
     jsii.proxy_for(IInterfaceWithMethods) # type: ignore[misc]
 ):
-    """Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype."""
+    '''Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.'''
 
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IInterfaceThatShouldNotBeADataType"
 
@@ -8469,9 +8480,9 @@ class JSII417Derived(
     jsii_type="jsii-calc.JSII417Derived",
 ):
     def __init__(self, property: builtins.str) -> None:
-        """
+        '''
         :param property: -
-        """
+        '''
         jsii.create(JSII417Derived, self, [property])
 
     @jsii.member(jsii_name="bar")
@@ -8490,38 +8501,38 @@ class JSII417Derived(
 
 @jsii.implements(IFriendlier)
 class Negate(UnaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Negate"):
-    """The negation operation ("-value")."""
+    '''The negation operation ("-value").'''
 
     def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
-        """
+        '''
         :param operand: -
-        """
+        '''
         jsii.create(Negate, self, [operand])
 
     @jsii.member(jsii_name="farewell")
     def farewell(self) -> builtins.str:
-        """Say farewell."""
+        '''Say farewell.'''
         return typing.cast(builtins.str, jsii.invoke(self, "farewell", []))
 
     @jsii.member(jsii_name="goodbye")
     def goodbye(self) -> builtins.str:
-        """Say goodbye."""
+        '''Say goodbye.'''
         return typing.cast(builtins.str, jsii.invoke(self, "goodbye", []))
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> builtins.str:
-        """(deprecated) Say hello!"""
+        '''(deprecated) Say hello!'''
         return typing.cast(builtins.str, jsii.invoke(self, "hello", []))
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value."""
+        '''(deprecated) String representation of the value.'''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The value."""
+        '''(deprecated) The value.'''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
 
@@ -8553,18 +8564,18 @@ class SupportsNiceJavaBuilder(
         props: typing.Optional[SupportsNiceJavaBuilderProps] = None,
         *rest: builtins.str,
     ) -> None:
-        """
+        '''
         :param id: some identifier.
         :param default_bar: the default value of \`\`bar\`\`.
         :param props: some props once can provide.
         :param rest: a variadic continuation.
-        """
+        '''
         jsii.create(SupportsNiceJavaBuilder, self, [id, default_bar, props, *rest])
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="id")
     def id(self) -> jsii.Number:
-        """some identifier."""
+        '''some identifier.'''
         return typing.cast(jsii.Number, jsii.get(self, "id"))
 
     @builtins.property # type: ignore[misc]
@@ -8580,12 +8591,12 @@ class DoubleTrouble(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DoubleTrouble"
 
     @jsii.member(jsii_name="hello")
     def hello(self) -> builtins.str:
-        """(deprecated) Say hello!"""
+        '''(deprecated) Say hello!'''
         return typing.cast(builtins.str, jsii.invoke(self, "hello", []))
 
     @jsii.member(jsii_name="next")
     def next(self) -> jsii.Number:
-        """Returns another random number."""
+        '''Returns another random number.'''
         return typing.cast(jsii.Number, jsii.invoke(self, "next", []))
 
 
@@ -8858,7 +8869,7 @@ class CompositeOperation(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.composition.CompositeOperation",
 ):
-    """Abstract operation composed from an expression of other operations."""
+    '''Abstract operation composed from an expression of other operations.'''
 
     @builtins.staticmethod
     def __jsii_proxy_class__() -> typing.Type["_CompositeOperationProxy"]:
@@ -8869,29 +8880,29 @@ class CompositeOperation(
 
     @jsii.member(jsii_name="toString")
     def to_string(self) -> builtins.str:
-        """(deprecated) String representation of the value."""
+        '''(deprecated) String representation of the value.'''
         return typing.cast(builtins.str, jsii.invoke(self, "toString", []))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="expression")
     @abc.abstractmethod
     def expression(self) -> scope.jsii_calc_lib.NumericValue:
-        """The expression that this operation consists of.
+        '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
-        """
+        '''
         ...
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="value")
     def value(self) -> jsii.Number:
-        """(deprecated) The value."""
+        '''(deprecated) The value.'''
         return typing.cast(jsii.Number, jsii.get(self, "value"))
 
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="decorationPostfixes")
     def decoration_postfixes(self) -> typing.List[builtins.str]:
-        """A set of postfixes to include in a decorated .toString()."""
+        '''A set of postfixes to include in a decorated .toString().'''
         return typing.cast(typing.List[builtins.str], jsii.get(self, "decorationPostfixes"))
 
     @decoration_postfixes.setter
@@ -8901,7 +8912,7 @@ class CompositeOperation(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="decorationPrefixes")
     def decoration_prefixes(self) -> typing.List[builtins.str]:
-        """A set of prefixes to include in a decorated .toString()."""
+        '''A set of prefixes to include in a decorated .toString().'''
         return typing.cast(typing.List[builtins.str], jsii.get(self, "decorationPrefixes"))
 
     @decoration_prefixes.setter
@@ -8911,7 +8922,7 @@ class CompositeOperation(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="stringStyle")
     def string_style(self) -> "CompositeOperation.CompositionStringStyle":
-        """The .toString() style."""
+        '''The .toString() style.'''
         return typing.cast("CompositeOperation.CompositionStringStyle", jsii.get(self, "stringStyle"))
 
     @string_style.setter
@@ -8922,12 +8933,12 @@ class CompositeOperation(
         jsii_type="jsii-calc.composition.CompositeOperation.CompositionStringStyle"
     )
     class CompositionStringStyle(enum.Enum):
-        """Style of .toString() output for CompositeOperation."""
+        '''Style of .toString() output for CompositeOperation.'''
 
         NORMAL = "NORMAL"
-        """Normal string expression."""
+        '''Normal string expression.'''
         DECORATED = "DECORATED"
-        """Decorated string expression."""
+        '''Decorated string expression.'''
 
 
 class _CompositeOperationProxy(
@@ -8937,10 +8948,10 @@ class _CompositeOperationProxy(
     @builtins.property # type: ignore[misc]
     @jsii.member(jsii_name="expression")
     def expression(self) -> scope.jsii_calc_lib.NumericValue:
-        """The expression that this operation consists of.
+        '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
-        """
+        '''
         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
 
 
@@ -9039,9 +9050,9 @@ class Foo(
 )
 class Hello:
     def __init__(self, *, foo: jsii.Number) -> None:
-        """
+        '''
         :param foo: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
         }
@@ -9094,9 +9105,9 @@ from .._jsii import *
 )
 class Hello:
     def __init__(self, *, foo: jsii.Number) -> None:
-        """
+        '''
         :param foo: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
         }
@@ -9151,16 +9162,16 @@ class ClassWithSelf(
     jsii_type="jsii-calc.PythonSelf.ClassWithSelf",
 ):
     def __init__(self_, self: builtins.str) -> None:
-        """
+        '''
         :param self: -
-        """
+        '''
         jsii.create(ClassWithSelf, self_, [self])
 
     @jsii.member(jsii_name="method")
     def method(self_, self: jsii.Number) -> builtins.str:
-        """
+        '''
         :param self: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
 
     @builtins.property # type: ignore[misc]
@@ -9174,9 +9185,9 @@ class ClassWithSelfKwarg(
     jsii_type="jsii-calc.PythonSelf.ClassWithSelfKwarg",
 ):
     def __init__(self_, *, self: builtins.str) -> None:
-        """
+        '''
         :param self: 
-        """
+        '''
         props = StructWithSelf(self=self)
 
         jsii.create(ClassWithSelfKwarg, self_, [props])
@@ -9195,9 +9206,9 @@ class IInterfaceWithSelf(typing_extensions.Protocol):
 
     @jsii.member(jsii_name="method")
     def method(self_, self: jsii.Number) -> builtins.str:
-        """
+        '''
         :param self: -
-        """
+        '''
         ...
 
 
@@ -9206,9 +9217,9 @@ class _IInterfaceWithSelfProxy:
 
     @jsii.member(jsii_name="method")
     def method(self_, self: jsii.Number) -> builtins.str:
-        """
+        '''
         :param self: -
-        """
+        '''
         return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
 
 
@@ -9219,9 +9230,9 @@ class _IInterfaceWithSelfProxy:
 )
 class StructWithSelf:
     def __init__(self_, *, self: builtins.str) -> None:
-        """
+        '''
         :param self: 
-        """
+        '''
         self_._values: typing.Dict[str, typing.Any] = {
             "self": self,
         }
@@ -9282,18 +9293,18 @@ from .param import SpecialParameter as _SpecialParameter_5bbf34a2
 @jsii.implements(_INamespaced_e2f386ad)
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.MyClass"):
     def __init__(self, *, prop: _SomeEnum_b2e41d92) -> None:
-        """
+        '''
         :param prop: 
-        """
+        '''
         props = _SomeStruct_91627123(prop=prop)
 
         jsii.create(MyClass, self, [props])
 
     @jsii.member(jsii_name="methodWithSpecialParam")
     def method_with_special_param(self, *, value: builtins.str) -> builtins.str:
-        """
+        '''
         :param value: 
-        """
+        '''
         param = _SpecialParameter_5bbf34a2(value=value)
 
         return typing.cast(builtins.str, jsii.invoke(self, "methodWithSpecialParam", [param]))
@@ -9359,9 +9370,9 @@ from .. import MyClass as _MyClass_a2fdc0b6
 )
 class MyClassReference:
     def __init__(self, *, reference: _MyClass_a2fdc0b6) -> None:
-        """
+        '''
         :param reference: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "reference": reference,
         }
@@ -9409,17 +9420,17 @@ from ..._jsii import *
 @jsii.enum(jsii_type="jsii-calc.submodule.child.Awesomeness")
 class Awesomeness(enum.Enum):
     AWESOME = "AWESOME"
-    """It was awesome!"""
+    '''It was awesome!'''
 
 
 @jsii.enum(jsii_type="jsii-calc.submodule.child.Goodness")
 class Goodness(enum.Enum):
     PRETTY_GOOD = "PRETTY_GOOD"
-    """It's pretty good."""
+    '''It's pretty good.'''
     REALLY_GOOD = "REALLY_GOOD"
-    """It's really good."""
+    '''It's really good.'''
     AMAZINGLY_GOOD = "AMAZINGLY_GOOD"
-    """It's amazingly good."""
+    '''It's amazingly good.'''
 
 
 class InnerClass(
@@ -9439,10 +9450,10 @@ class OuterClass(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.submodule.child.OuterClass",
 ):
-    """Checks that classes can self-reference during initialization.
+    '''Checks that classes can self-reference during initialization.
 
     :see: : https://github.com/aws/jsii/pull/1706
-    """
+    '''
 
     def __init__(self) -> None:
         jsii.create(OuterClass, self, [])
@@ -9465,9 +9476,9 @@ class SomeEnum(enum.Enum):
 )
 class SomeStruct:
     def __init__(self, *, prop: SomeEnum) -> None:
-        """
+        '''
         :param prop: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "prop": prop,
         }
@@ -9497,9 +9508,9 @@ class SomeStruct:
 )
 class Structure:
     def __init__(self, *, bool: builtins.bool) -> None:
-        """
+        '''
         :param bool: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "bool": bool,
         }
@@ -9534,10 +9545,10 @@ class KwargsProps(SomeStruct):
         prop: SomeEnum,
         extra: typing.Optional[builtins.str] = None,
     ) -> None:
-        """
+        '''
         :param prop: 
         :param extra: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "prop": prop,
         }
@@ -9601,7 +9612,7 @@ from ..child import (
 
 
 class Kwargs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.isolated.Kwargs"):
-    """Ensures imports are correctly registered for kwargs lifted properties from super-structs."""
+    '''Ensures imports are correctly registered for kwargs lifted properties from super-structs.'''
 
     @jsii.member(jsii_name="method") # type: ignore[misc]
     @builtins.classmethod
@@ -9611,10 +9622,10 @@ class Kwargs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.isolated.Kw
         extra: typing.Optional[builtins.str] = None,
         prop: _SomeEnum_b2e41d92,
     ) -> builtins.bool:
-        """
+        '''
         :param extra: 
         :param prop: 
-        """
+        '''
         props = _KwargsProps_c7855dcf(extra=extra, prop=prop)
 
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "method", [props]))
@@ -9747,9 +9758,9 @@ from ..._jsii import *
 )
 class SpecialParameter:
     def __init__(self, *, value: builtins.str) -> None:
-        """
+        '''
         :param value: 
-        """
+        '''
         self._values: typing.Dict[str, typing.Any] = {
             "value": value,
         }


### PR DESCRIPTION
Since docstrings are now rendered inside single-quoted multiline strings to allow the docstring itself to include example code with double-quoted multiline string literals. Those are the ones produced by rosetta for python.

Fixes #2569



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
