### PR TITLE
fix(go-runtime): enums are not encoded/decoded correctly

### DIFF
--- a/gh-pages/content/specification/2-type-system.md
+++ b/gh-pages/content/specification/2-type-system.md
@@ -230,10 +230,10 @@ value:
 
 In **JavaScript**, `enum` entries are represented by their value equivalent. In order to support statically typed
 representations in other languages, these are serialized using a dedicated wrapper object, using a single key
-(`$jsii.enum`) with the fully qualified name of the `enum` entry:
+(`$jsii.enum`) with the fully qualified name of the `enum` entry (formatted as `<enum type fqn>/<entry name>`):
 
 ```json
-{ "$jsii.enum": "@scope/module.EnumType.ENTRY_NAME" }
+{ "$jsii.enum": "@scope/module.EnumType/ENTRY_NAME" }
 ```
 
 ### Identity Serialization

--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -157,6 +157,46 @@ func TestAllTypes(t *testing.T) {
 	})
 }
 
+func TestEnumUnmarshal(t *testing.T) {
+	actual := calc.EnumDispenser_RandomStringLikeEnum()
+	if actual != calc.StringEnumB {
+		t.Errorf("Expected StringEnum.B. Actual: %s", actual)
+	}
+}
+
+func TestEnumRoundtrip(t *testing.T) {
+	allTypes := calc.NewAllTypes()
+	actual := allTypes.EnumMethod(calc.StringEnumA)
+	if actual != calc.StringEnumA {
+		t.Errorf("Expected StringEnum.A. Actual: %s", actual)
+	}
+
+	actual = allTypes.EnumMethod(calc.StringEnumC)
+	if actual != calc.StringEnumC {
+		t.Errorf("Expected StringEnum.C. Actual: %s", actual)
+	}
+}
+
+func TestOptionalEnums(t *testing.T) {
+	allTypes := calc.NewAllTypes()
+	actual := allTypes.GetOptionalEnumValue()
+	if actual != "" {
+		t.Error("Expected value to be nil")
+	}
+
+	allTypes.SetOptionalEnumValue(calc.StringEnumB)
+	actual = allTypes.GetOptionalEnumValue()
+	if actual != calc.StringEnumB {
+		t.Errorf("Expected StringEnum.B. Actual: %s", actual)
+	}
+
+	allTypes.SetOptionalEnumValue("")
+	actual = allTypes.GetOptionalEnumValue()
+	if actual != "" {
+		t.Error("Expected value to be nil")
+	}
+}
+
 func TestReturnsSpecialParam(t *testing.T) {
 	retSpecialParam := returnsParam.NewReturnsSpecialParameter()
 	val := retSpecialParam.ReturnsSpecialParam()

--- a/packages/@jsii/go-runtime/jsii-runtime-go/api.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/api.go
@@ -89,6 +89,10 @@ type objref struct {
 	InstanceID string `json:"$jsii.byref"`
 }
 
+type enumref struct {
+	MemberFQN string `json:"$jsii.enum"`
+}
+
 type loadRequest struct {
 	kernelRequester
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/api.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/api.go
@@ -85,11 +85,11 @@ func (r kernelResponder) isResponse() {
 	return
 }
 
-type objref struct {
+type objectRef struct {
 	InstanceID string `json:"$jsii.byref"`
 }
 
-type enumref struct {
+type enumRef struct {
 	MemberFQN string `json:"$jsii.enum"`
 }
 
@@ -130,7 +130,7 @@ type delRequest struct {
 	kernelRequester
 
 	API    string `json:"api"`
-	ObjRef objref `json:"objref"`
+	ObjRef objectRef `json:"objref"`
 }
 
 type delResponse struct {
@@ -142,7 +142,7 @@ type getRequest struct {
 
 	API      string `json:"api"`
 	Property string `json:"property"`
-	ObjRef   objref `json:"objref"`
+	ObjRef   objectRef `json:"objref"`
 }
 
 type staticGetRequest struct {
@@ -165,7 +165,7 @@ type setRequest struct {
 	API      string      `json:"api"`
 	Property string      `json:"property"`
 	Value    interface{} `json:"value"`
-	ObjRef   objref      `json:"objref"`
+	ObjRef   objectRef      `json:"objref"`
 }
 
 type staticSetRequest struct {
@@ -196,7 +196,7 @@ type invokeRequest struct {
 	API       string        `json:"api"`
 	Method    string        `json:"method"`
 	Arguments []interface{} `json:"args"`
-	ObjRef    objref        `json:"objref"`
+	ObjRef    objectRef        `json:"objref"`
 }
 
 type invokeResponse struct {
@@ -211,7 +211,7 @@ type beginRequest struct {
 	API       string        `json:"api"`
 	Method    *string       `json:"method"`
 	Arguments []interface{} `json:"args"`
-	ObjRef    objref        `json:"objref"`
+	ObjRef    objectRef        `json:"objref"`
 }
 
 type beginResponse struct {

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
@@ -262,6 +262,27 @@ func castValToRef(data interface{}) (objref, bool) {
 	return ref, ok
 }
 
+func castValToEnumRef(data interface{}) (enum enumref, ok bool) {
+	dataVal := reflect.ValueOf(data)
+	ok = false
+
+	if dataVal.Kind() == reflect.Map {
+		for _, k := range dataVal.MapKeys() {
+			// Finding values type requires extracting from reflect.Value
+			// otherwise .Kind() returns `interface{}`
+			v := reflect.ValueOf(dataVal.MapIndex(k).Interface())
+
+			if k.Kind() == reflect.String && k.String() == "$jsii.enum" && v.Kind() == reflect.String {
+				enum.MemberFQN = v.String()
+				ok = true
+				return
+			}
+		}
+	}
+
+	return
+}
+
 // Accepts pointers to structs that implement interfaces and searches for an
 // existing object reference in the client. If it exists, it casts it to an
 // objref for the runtime. Recursively casts types that may contain nested
@@ -274,6 +295,11 @@ func castPtrToRef(data interface{}) interface{} {
 		valref, valHasRef := client.findObjectRef(data)
 		if valHasRef {
 			return objref{InstanceID: valref}
+		}
+	} else if dataVal.Kind() == reflect.String {
+		enumRef, isEnumRef := client.types.tryRenderEnumRef(dataVal)
+		if isEnumRef {
+			return enumRef
 		}
 	} else if dataVal.Kind() == reflect.Slice {
 		refs := make([]interface{}, dataVal.Len())
@@ -308,7 +334,29 @@ func (c *client) castAndSetToPtr(ptr interface{}, data interface{}) {
 	dataVal := reflect.ValueOf(data)
 
 	ref, isRef := castValToRef(data)
+	if isRef {
+		// If return data is JSII object references, add to objects table.
+		concreteType, err := c.types.concreteTypeFor(ptrVal.Type())
+		if err != nil {
+			panic(err)
+		}
+		ptrVal.Set(reflect.New(concreteType))
+		c.objects[ptrVal.Interface()] = ref.InstanceID
+		return
+	}
 
+	enumref, isEnum := castValToEnumRef(data)
+	if isEnum {
+		member, err := c.types.enumMemberForEnumRef(enumref)
+		if err != nil {
+			panic(err)
+		}
+
+		ptrVal.Set(reflect.ValueOf(member))
+		return
+	}
+
+	// arrays
 	if ptrVal.Kind() == reflect.Slice && dataVal.Kind() == reflect.Slice {
 		// If return type is a slice, recursively cast elements
 		for i := 0; i < dataVal.Len(); i++ {
@@ -318,15 +366,13 @@ func (c *client) castAndSetToPtr(ptr interface{}, data interface{}) {
 			c.castAndSetToPtr(inner.Interface(), dataVal.Index(i).Interface())
 			ptrVal.Set(reflect.Append(ptrVal, inner.Elem()))
 		}
-	} else if isRef {
-		// If return data is JSII object references, add to objects table.
-		concreteType, err := c.types.concreteTypeFor(ptrVal.Type())
-		if err != nil {
-			panic(err)
-		}
-		ptrVal.Set(reflect.New(concreteType))
-		c.objects[ptrVal.Interface()] = ref.InstanceID
-	} else {
+
+		return
+	}
+
+	// TODO: maps
+
+	if data != nil {
 		val := reflect.ValueOf(data)
 		ptrVal.Set(val)
 	}


### PR DESCRIPTION
Enum values are represented in the jsii kernel as `{ "$jsii.enum": "fqn/member" }`, so we need to marshal/unmarshall them based on this encoding.

Change the type registry to capture a mapping between FQN to enum member consts and type to enum FQNs.

Fixes #2534
Co-authored-by: Romain Marcadier <rmuller@amazon.com>

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
