### PR TITLE
feat(go): emit indirect dependencies in go.mod

### DIFF
--- a/packages/@jsii/go-runtime/build-tools/gen-calc.ts
+++ b/packages/@jsii/go-runtime/build-tools/gen-calc.ts
@@ -55,6 +55,7 @@ for (const localPath of Object.values(genModules)) {
     [
       goMod.trim(),
       '',
+      '// Injected by "yarn gen:calc", aka build-tools/gen-calc.ts',
       'replace (',
       ...replaces
         .map(

--- a/packages/@jsii/go-runtime/build-tools/gen-calc.ts
+++ b/packages/@jsii/go-runtime/build-tools/gen-calc.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env npx ts-node
 
-import { removeSync } from 'fs-extra';
-import { join, resolve } from 'path';
+import { readFileSync, removeSync, writeFileSync } from 'fs-extra';
+import { join, relative, resolve } from 'path';
 
+import { runtimeModules } from '../lib';
+import { localRuntimeModules } from '../lib/local-runtime-modules';
 import { runCommand } from './_constants';
 
 const genRoot = join(__dirname, '..', 'jsii-calc');
@@ -22,3 +24,45 @@ runCommand(
   ],
   { stdio: 'inherit' },
 );
+
+// Inject "replaces" in the go.mod files so IDEs do not struggle too much...
+const genModules = localRuntimeModules(genRoot);
+const localModules = {
+  ...genModules,
+  ...runtimeModules,
+};
+for (const localPath of Object.values(genModules)) {
+  const goModFile = join(localPath, 'go.mod');
+  const goMod = readFileSync(goModFile, 'utf8');
+
+  const replaces = new Array<{
+    readonly dep: string;
+    readonly depPath: string;
+  }>();
+
+  let matches: ReturnType<RegExp['exec']>;
+  const depRegex = /([a-z0-9._~/-]+)\s+v\d/gi;
+  while ((matches = depRegex.exec(goMod)) != null) {
+    const [, dep] = matches;
+    if (dep in localModules) {
+      const depPath = localModules[dep];
+      replaces.push({ dep, depPath });
+    }
+  }
+
+  writeFileSync(
+    goModFile,
+    [
+      goMod.trim(),
+      '',
+      'replace (',
+      ...replaces
+        .map(
+          ({ dep, depPath }) => `\t${dep} => ${relative(localPath, depPath)}`,
+        )
+        .sort(),
+      ')',
+      '',
+    ].join('\n'),
+  );
+}

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -3,6 +3,7 @@ import { Assembly, Type, Submodule as JsiiSubmodule } from 'jsii-reflect';
 import { basename, dirname, join } from 'path';
 import * as semver from 'semver';
 
+import { VERSION } from '../../version';
 import { EmitContext } from './emit-context';
 import { ReadmeFile } from './readme-file';
 import {
@@ -253,17 +254,38 @@ export class RootPackage extends Package {
     code.line();
     code.open('require (');
     // Strip " (build abcdef)" from the jsii version
-    code.line(
-      `${JSII_RT_MODULE_NAME} v${this.assembly.jsiiVersion.replace(
-        / .*$/,
-        '',
-      )}`,
-    );
-    for (const dep of this.packageDependencies) {
+    code.line(`${JSII_RT_MODULE_NAME} v${VERSION}`);
+    const dependencies = this.packageDependencies;
+    for (const dep of dependencies) {
       code.line(`${dep.goModuleName} v${dep.version}`);
     }
+    indirectDependencies(
+      dependencies,
+      new Set(dependencies.map((dep) => dep.goModuleName)),
+    );
     code.close(')');
     code.closeFile(GOMOD_FILENAME);
+
+    /**
+     * Emits indirect dependency declarations, which are helpful to make IDEs at
+     * ease with the codebase.
+     */
+    function indirectDependencies(
+      pkgs: RootPackage[],
+      alreadyEmitted: Set<string>,
+    ): void {
+      for (const pkg of pkgs) {
+        const deps = pkg.packageDependencies;
+        for (const dep of deps) {
+          if (alreadyEmitted.has(dep.goModuleName)) {
+            continue;
+          }
+          alreadyEmitted.add(dep.goModuleName);
+          code.line(`${dep.goModuleName} v${dep.version} // indirect`);
+        }
+        indirectDependencies(deps, alreadyEmitted);
+      }
+    }
   }
 
   /*

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -130,7 +130,7 @@ module foo
 go 1.15
 
 require (
-	github.com/aws/jsii-runtime-go v1337.42.1337
+	github.com/aws/jsii-runtime-go v0.0.0
 	bar/v2 v2.0.0-rc.42
 )
 
@@ -636,7 +636,7 @@ module foo
 go 1.15
 
 require (
-	github.com/aws/jsii-runtime-go v1337.42.1337
+	github.com/aws/jsii-runtime-go v0.0.0
 	bar/v4 v4.5.6-pre.1337
 )
 
@@ -1140,7 +1140,7 @@ module foo/v2
 go 1.15
 
 require (
-	github.com/aws/jsii-runtime-go v1337.42.1337
+	github.com/aws/jsii-runtime-go v0.0.0
 )
 
 `;
@@ -1622,7 +1622,7 @@ module foo/v4
 go 1.15
 
 require (
-	github.com/aws/jsii-runtime-go v1337.42.1337
+	github.com/aws/jsii-runtime-go v0.0.0
 )
 
 `;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -1695,6 +1695,7 @@ require (
 	github.com/aws/jsii-runtime-go v0.0.0
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1 // indirect
 )
 
 `;


### PR DESCRIPTION
This helps IDEs (eg: GoLand from JetBrains, etc..) be more comfortable
with the codebase, as indirect dependencies are correctly mapped. This
generates code more in line with what `go mod` would have generated if
one had tried to manually generate those packages.

This was manually confirmed to have a fully working experience in GoLand,
where even generated code modules are completely browsable, compiling,
and IntelliSense-able in this configuration; while previously it would be
unable to build and check the generated code, resulting in an extremely
poor experience (with UIs jumping around as the IDE failed to resolve modules).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
