### PR TITLE
chore: copy golang runtime to dist for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -456,36 +456,3 @@ jobs:
           path: |-
             ${{ github.workspace }}/aws-cdk/dist/
             ${{ github.workspace }}/aws-cdk/**/dist/
-
-  push-go-runtime:
-    needs: build
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Node 12
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: '12'
-      - name: Download Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: built-tree
-          path: ${{ github.workspace }}/jsii-built-tree
-      - name: Extract Artifact
-        working-directory: ${{ github.workspace }}/jsii-built-tree
-        run: |-
-          tar zxvf built-tree.tgz
-          rm built-tree.tgz
-      - name: Release
-        working-directory: ${{ github.workspace }}/jsii-built-tree
-        if: github.ref == 'refs/head/release'
-        run: |-
-          VERSION=$(node -p 'require("./lerna.json").version')
-          cd ./packages/@jsii/go-runtime/jsii-runtime-go
-          echo ${VERSION} > version
-          npx -p jsii-release@latest jsii-release-golang .
-        env:
-          GIT_USER_NAME: AWS CDK Team
-          GIT_USER_EMAIL: aws-cdk-dev@amazon.com
-          GITHUB_TOKEN: ${{ secrets.GO_PUBLISHING_TOKEN }}
-

--- a/packages/@jsii/go-runtime/build-tools/package.sh
+++ b/packages/@jsii/go-runtime/build-tools/package.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+cd ${scriptdir}/..
+
+rm -fr dist
+mkdir -p dist/go
+rsync -av jsii-runtime-go/* dist/go/

--- a/packages/@jsii/go-runtime/package.json
+++ b/packages/@jsii/go-runtime/package.json
@@ -10,6 +10,7 @@
     "gen:calc": "node build-tools/gen-calc.js",
     "gen:rt": "node build-tools/gen.js",
     "generate": "npm run gen:rt && npm run gen:calc",
+    "package": "build-tools/package.sh",
     "lint": "node build-tools/all-go.js vet ./...",
     "test": "npm run gen:calc && node build-tools/all-go.js test ./..."
   },


### PR DESCRIPTION
The publisher expects golang code to reside under the `go` directory in the build artifact. To that end, add a "package" script to the `@jsii/go-runtime` module which copies the go runtime code to `dist/go`. This is then collected during mono-repo packaging.

Remove the go publishing step from the github workflow as it is now handled by the delivlib pipeline.

Fixes #2579



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
