### PR TITLE
chore: use GitHub Actions to auto-approve PR

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,9 +5,13 @@ on: pull_request
 
 jobs:
   auto-approve:
-    if: contains(github.event.pull_request.labels.*.name, 'pr/auto-approve')
+    if: >
+       contains(github.event.pull_request.labels.*.name, 'pr/auto-approve') && 
+       (github.event.pull_request.user.login == 'aws-cdk-automation' 
+        || github.event.pull_request.user.login == 'dependabot[bot]' 
+        || github.event.pull_request.user.login == 'dependabot-preview[bot]')
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/auto-approve-action@v2.0.0
       with:
-        github-token: "${{ secrets.AUTO_APPROVE_GITHUB_TOKEN }}"
+        github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
We were using the `aws-cdk-automation` user credentials to automatically approve PRs, but that would fail for PRs created by that user itself.

In the CDK repository, we approve using GitHub Actions' credentials and that seems to work fine, so do the same here.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
