### PR TITLE
refactor(go): hide API fields from the kernel API

### DIFF
--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/begin.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/begin.go
@@ -1,23 +1,25 @@
 package kernel
 
-import "github.com/aws/jsii-runtime-go/api"
+import (
+	"github.com/aws/jsii-runtime-go/api"
+)
 
-type BeginRequest struct {
-	kernelRequester
-
-	API       string        `json:"api"`
+type BeginProps struct {
 	Method    *string       `json:"method"`
 	Arguments []interface{} `json:"args"`
 	ObjRef    api.ObjectRef `json:"objref"`
 }
 
 type BeginResponse struct {
-	kernelResponder
-
+	kernelResponse
 	PromiseID *string `json:"promise_id"`
 }
 
-func (c *client) Begin(request BeginRequest) (response BeginResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Begin(props BeginProps) (response BeginResponse, err error) {
+	type request struct {
+		kernelRequest
+		BeginProps
+	}
+	err = c.request(request{kernelRequest{"begin"}, props}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/callbacks.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/callbacks.go
@@ -1,20 +1,15 @@
 package kernel
 
-import "github.com/aws/jsii-runtime-go/api"
-
-type callbacksRequest struct {
-	kernelRequester
-
-	API string `json:"api"`
-}
+import (
+	"github.com/aws/jsii-runtime-go/api"
+)
 
 type CallbacksResponse struct {
-	kernelResponder
-
+	kernelResponse
 	Callbacks []api.Callback `json:"callbacks"`
 }
 
 func (c *client) Callbacks() (response CallbacksResponse, err error) {
-	err = c.request(callbacksRequest{API: "callbacks"}, &response)
+	err = c.request(kernelRequest{"callbacks"}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/client.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/client.go
@@ -208,7 +208,7 @@ func (c *client) RegisterInstance(instance interface{}, instanceID string) error
 	return nil
 }
 
-func (c *client) request(req kernelRequest, res kernelResponse) error {
+func (c *client) request(req kernelRequester, res kernelResponder) error {
 	err := c.writer.Encode(req)
 	if err != nil {
 		return err
@@ -217,7 +217,7 @@ func (c *client) request(req kernelRequest, res kernelResponse) error {
 	return c.response(res)
 }
 
-func (c *client) response(res kernelResponse) error {
+func (c *client) response(res kernelResponder) error {
 	if c.reader.More() {
 		return c.reader.Decode(res)
 	}

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/client_test.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/client_test.go
@@ -18,8 +18,7 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("Client Load Error", func(t *testing.T) {
-		request := LoadRequest{
-			API:     "load",
+		request := LoadProps{
 			Name:    "jsii-calc",
 			Version: "0.0.0",
 			Tarball: "jsii-calc-tarball.tgz",

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/complete.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/complete.go
@@ -1,21 +1,21 @@
 package kernel
 
-type CompleteRequest struct {
-	kernelRequester
-
-	API        string      `json:"api"`
+type CompleteProps struct {
 	CallbackID *string     `json:"cbid"`
 	Error      *string     `json:"err"`
 	Result     interface{} `json:"result"`
 }
 
 type CompleteResponse struct {
-	kernelResponder
-
+	kernelResponse
 	CallbackID *string `json:"cbid"`
 }
 
-func (c *client) Complete(request CompleteRequest) (response CompleteResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Complete(props CompleteProps) (response CompleteResponse, err error) {
+	type request struct {
+		kernelRequest
+		CompleteProps
+	}
+	err = c.request(request{kernelRequest{"complete"}, props}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/create.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/create.go
@@ -2,10 +2,7 @@ package kernel
 
 import "github.com/aws/jsii-runtime-go/api"
 
-type CreateRequest struct {
-	kernelRequester
-
-	API        string         `json:"api"`
+type CreateProps struct {
 	FQN        api.FQN        `json:"fqn"`
 	Interfaces []api.FQN      `json:"interfaces"`
 	Arguments  []interface{}  `json:"args"`
@@ -14,13 +11,16 @@ type CreateRequest struct {
 
 // TODO extends AnnotatedObjRef?
 type CreateResponse struct {
-	kernelResponder
-
+	kernelResponse
 	InstanceID string `json:"$jsii.byref"`
 }
 
-func (c *client) Create(request CreateRequest) (response CreateResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Create(props CreateProps) (response CreateResponse, err error) {
+	type request struct {
+		kernelRequest
+		CreateProps
+	}
+	err = c.request(request{kernelRequest{"create"}, props}, &response)
 	return
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/del.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/del.go
@@ -2,18 +2,19 @@ package kernel
 
 import "github.com/aws/jsii-runtime-go/api"
 
-type DelRequest struct {
-	kernelRequester
-
-	API    string        `json:"api"`
+type DelProps struct {
 	ObjRef api.ObjectRef `json:"objref"`
 }
 
 type DelResponse struct {
-	kernelResponder
+	kernelResponse
 }
 
-func (c *client) Del(request DelRequest) (response DelResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Del(props DelProps) (response DelResponse, err error) {
+	type request struct {
+		kernelRequest
+		DelProps
+	}
+	err = c.request(request{kernelRequest{"del"}, props}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/end.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/end.go
@@ -1,19 +1,19 @@
 package kernel
 
-type EndRequest struct {
-	kernelRequester
-
-	API       string  `json:"api"`
+type EndProps struct {
 	PromiseID *string `json:"promise_id"`
 }
 
 type EndResponse struct {
-	kernelResponder
-
+	kernelResponse
 	Result interface{} `json:"result"`
 }
 
-func (c *client) End(request EndRequest) (response EndResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) End(props EndProps) (response EndResponse, err error) {
+	type request struct {
+		kernelRequest
+		EndProps
+	}
+	err = c.request(request{kernelRequest{"end"}, props}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/get.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/get.go
@@ -2,35 +2,36 @@ package kernel
 
 import "github.com/aws/jsii-runtime-go/api"
 
-type GetRequest struct {
-	kernelRequester
-
-	API      string        `json:"api"`
+type GetProps struct {
 	Property string        `json:"property"`
 	ObjRef   api.ObjectRef `json:"objref"`
 }
 
-type StaticGetRequest struct {
-	kernelRequester
-
-	API      string  `json:"api"`
+type StaticGetProps struct {
 	FQN      api.FQN `json:"fqn"`
 	Property string  `json:"property"`
 }
 
 type GetResponse struct {
-	kernelResponder
-
+	kernelResponse
 	Value interface{} `json:"value"`
 }
 
-func (c *client) Get(request GetRequest) (response GetResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Get(props GetProps) (response GetResponse, err error) {
+	type request struct {
+		kernelRequest
+		GetProps
+	}
+	err = c.request(request{kernelRequest{"get"}, props}, &response)
 	return
 }
 
-func (c *client) SGet(request StaticGetRequest) (response GetResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) SGet(props StaticGetProps) (response GetResponse, err error) {
+	type request struct {
+		kernelRequest
+		StaticGetProps
+	}
+	err = c.request(request{kernelRequest{"sget"}, props}, &response)
 	return
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/hello.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/hello.go
@@ -3,7 +3,7 @@ package kernel
 import "regexp"
 
 type HelloMessage struct {
-	kernelResponder
+	kernelResponse
 
 	Hello string `json:"hello"`
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/invoke.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/invoke.go
@@ -2,37 +2,38 @@ package kernel
 
 import "github.com/aws/jsii-runtime-go/api"
 
-type InvokeRequest struct {
-	kernelRequester
-
-	API       string        `json:"api"`
+type InvokeProps struct {
 	Method    string        `json:"method"`
 	Arguments []interface{} `json:"args"`
 	ObjRef    api.ObjectRef `json:"objref"`
 }
 
-type StaticInvokeRequest struct {
-	kernelRequester
-
-	API       string        `json:"api"`
+type StaticInvokeProps struct {
 	FQN       api.FQN       `json:"fqn"`
 	Method    string        `json:"method"`
 	Arguments []interface{} `json:"args"`
 }
 
 type InvokeResponse struct {
-	kernelResponder
-
+	kernelResponse
 	Result interface{} `json:"result"`
 }
 
-func (c *client) Invoke(request InvokeRequest) (response InvokeResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Invoke(props InvokeProps) (response InvokeResponse, err error) {
+	type request struct {
+		kernelRequest
+		InvokeProps
+	}
+	err = c.request(request{kernelRequest{"invoke"}, props}, &response)
 	return
 }
 
-func (c *client) SInvoke(request StaticInvokeRequest) (response InvokeResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) SInvoke(props StaticInvokeProps) (response InvokeResponse, err error) {
+	type request struct {
+		kernelRequest
+		StaticInvokeProps
+	}
+	err = c.request(request{kernelRequest{"sinvoke"}, props}, &response)
 	return
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/load.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/load.go
@@ -1,11 +1,8 @@
 package kernel
 
-// LoadRequest holds the necessary information to load a library into the
+// LoadProps holds the necessary information to load a library into the
 // @jsii/kernel process through the Load method.
-type LoadRequest struct {
-	kernelRequester
-
-	API     string `json:"api"`
+type LoadProps struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 	Tarball string `json:"tarball"`
@@ -14,14 +11,17 @@ type LoadRequest struct {
 // LoadResponse contains the data returned by the @jsii/kernel process in
 // response to a load request.
 type LoadResponse struct {
-	kernelResponder
-
+	kernelResponse
 	Assembly string  `json:"assembly"`
 	Types    float64 `json:"types"`
 }
 
-func (c *client) Load(request LoadRequest) (response LoadResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Load(props LoadProps) (response LoadResponse, err error) {
+	type request struct {
+		kernelRequest
+		LoadProps
+	}
+	err = c.request(request{kernelRequest{"load"}, props}, &response)
 	return
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/naming.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/naming.go
@@ -1,20 +1,21 @@
 package kernel
 
-type NamingRequest struct {
-	kernelRequester
-
-	API      string `json:"api"`
+type NamingProps struct {
 	Assembly string `json:"assembly"`
 }
 
 type NamingResponse struct {
-	kernelResponder
+	kernelResponse
 	// readonly naming: {
 	//   readonly [language: string]: { readonly [key: string]: any } | undefined;
 	// };
 }
 
-func (c *client) Naming(request NamingRequest) (response NamingResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Naming(props NamingProps) (response NamingResponse, err error) {
+	type request struct {
+		kernelRequest
+		NamingProps
+	}
+	err = c.request(request{kernelRequest{"naming"}, props}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/request-response-markers.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/request-response-markers.go
@@ -1,39 +1,40 @@
 package kernel
 
-// kernelRequest allows creating a union of kernelRequest and kernelResponse
+// kernelRequester allows creating a union of kernelRequester and kernelResponder
 // types by defining private method implemented by a private custom type, which
 // is embedded in all relevant types.
-type kernelRequest interface {
+type kernelRequester interface {
 	// isRequest is a marker method that is intended to ensure no external type
 	// can implement this interface.
 	isRequest() kernelBrand
 }
 
-// kernelRequester is a 0-width marker struct embedded to make another type be
-// usable as a kernelRequest.
-type kernelRequester struct{}
+// kernelRequest is the standard implementation for kernelRequester.
+type kernelRequest struct {
+	API string `json:"api"`
+}
 
-func (r kernelRequester) isRequest() kernelBrand {
+func (r kernelRequest) isRequest() kernelBrand {
 	return kernelBrand{}
 }
 
-// kenrelResponse allows creating a union of kernelResponse and kernelRequest
+// kernelResponder allows creating a union of kernelResponder and kernelRequester
 // types by defining private method implemented by a private custom type, which
 // is embedded in all relevant types.
-type kernelResponse interface {
+type kernelResponder interface {
 	// isResponse is a marker method that is intended to ensure no external type
 	// can implement this interface.
 	isResponse() kernelBrand
 }
 
-// kernelResponder is a 0-width marker struc tembedded to make another type be
-// usable as a kernelResponse.
-type kernelResponder struct{}
+// kernelResponse is a 0-width marker struc tembedded to make another type be
+// usable as a kernelResponder.
+type kernelResponse struct{}
 
-func (r kernelResponder) isResponse() kernelBrand {
+func (r kernelResponse) isResponse() kernelBrand {
 	return kernelBrand{}
 }
 
-// kernelBrand is a private type used to ensure the kernelRequest and
-// kernelResponse cannot be implemented outside of this package.
+// kernelBrand is a private type used to ensure the kernelRequester and
+// kernelResponder cannot be implemented outside of this package.
 type kernelBrand struct{}

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/set.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/set.go
@@ -2,35 +2,37 @@ package kernel
 
 import "github.com/aws/jsii-runtime-go/api"
 
-type SetRequest struct {
-	kernelRequester
-
-	API      string        `json:"api"`
+type SetProps struct {
 	Property string        `json:"property"`
 	Value    interface{}   `json:"value"`
 	ObjRef   api.ObjectRef `json:"objref"`
 }
 
-type StaticSetRequest struct {
-	kernelRequester
-
-	API      string      `json:"api"`
+type StaticSetProps struct {
 	FQN      api.FQN     `json:"fqn"`
 	Property string      `json:"property"`
 	Value    interface{} `json:"value"`
 }
 
 type SetResponse struct {
-	kernelResponder
+	kernelResponse
 }
 
-func (c *client) Set(request SetRequest) (response SetResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) Set(props SetProps) (response SetResponse, err error) {
+	type request struct {
+		kernelRequest
+		SetProps
+	}
+	err = c.request(request{kernelRequest{"set"}, props}, &response)
 	return
 }
 
-func (c *client) SSet(request StaticSetRequest) (response SetResponse, err error) {
-	err = c.request(request, &response)
+func (c *client) SSet(props StaticSetProps) (response SetResponse, err error) {
+	type request struct {
+		kernelRequest
+		StaticSetProps
+	}
+	err = c.request(request{kernelRequest{"sset"}, props}, &response)
 	return
 }
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/stats.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/stats.go
@@ -1,18 +1,11 @@
 package kernel
 
-type statsRequest struct {
-	kernelRequester
-
-	API string `json:"api"`
-}
-
 type StatsResponse struct {
-	kernelResponder
-
+	kernelResponse
 	ObjectCount float64 `json:"object_count"`
 }
 
 func (c *client) Stats() (response StatsResponse, err error) {
-	err = c.request(statsRequest{API: "stats"}, &response)
+	err = c.request(kernelRequest{"stats"}, &response)
 	return
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
@@ -36,8 +36,7 @@ func Load(name string, version string, tarball []byte) {
 	}
 	tmpfile.Close()
 
-	_, err = c.Load(kernel.LoadRequest{
-		API:     "load",
+	_, err = c.Load(kernel.LoadProps{
 		Name:    name,
 		Version: version,
 		Tarball: tmpfile.Name(),
@@ -105,8 +104,7 @@ func Create(fqn FQN, args []interface{}, interfaces []FQN, overrides []Override,
 		apiOverrides = append(apiOverrides, override)
 	}
 
-	res, err := client.Create(kernel.CreateRequest{
-		API:        "create",
+	res, err := client.Create(kernel.CreateProps{
 		FQN:        api.FQN(fqn),
 		Arguments:  castPtrsToRef(args),
 		Interfaces: interfaceFQNs,
@@ -134,8 +132,7 @@ func Invoke(obj interface{}, method string, args []interface{}, hasReturn bool, 
 		panic("No Object Found")
 	}
 
-	res, err := client.Invoke(kernel.InvokeRequest{
-		API:       "invoke",
+	res, err := client.Invoke(kernel.InvokeProps{
 		Method:    method,
 		Arguments: castPtrsToRef(args),
 		ObjRef: api.ObjectRef{
@@ -157,8 +154,7 @@ func Invoke(obj interface{}, method string, args []interface{}, hasReturn bool, 
 func StaticInvoke(fqn FQN, method string, args []interface{}, hasReturn bool, ret interface{}) {
 	client := kernel.GetClient()
 
-	res, err := client.SInvoke(kernel.StaticInvokeRequest{
-		API:       "sinvoke",
+	res, err := client.SInvoke(kernel.StaticInvokeProps{
 		FQN:       api.FQN(fqn),
 		Method:    method,
 		Arguments: castPtrsToRef(args),
@@ -185,8 +181,7 @@ func Get(obj interface{}, property string, ret interface{}) {
 		panic("No Object Found")
 	}
 
-	res, err := client.Get(kernel.GetRequest{
-		API:      "get",
+	res, err := client.Get(kernel.GetProps{
 		Property: property,
 		ObjRef: api.ObjectRef{
 			InstanceID: refid,
@@ -205,8 +200,7 @@ func Get(obj interface{}, property string, ret interface{}) {
 func StaticGet(fqn FQN, property string, ret interface{}) {
 	client := kernel.GetClient()
 
-	res, err := client.SGet(kernel.StaticGetRequest{
-		API:      "sget",
+	res, err := client.SGet(kernel.StaticGetProps{
 		FQN:      api.FQN(fqn),
 		Property: property,
 	})
@@ -230,8 +224,7 @@ func Set(obj interface{}, property string, value interface{}) {
 		panic("No Object Found")
 	}
 
-	_, err := client.Set(kernel.SetRequest{
-		API:      "set",
+	_, err := client.Set(kernel.SetProps{
 		Property: property,
 		Value:    castPtrToRef(value),
 		ObjRef: api.ObjectRef{
@@ -249,8 +242,7 @@ func Set(obj interface{}, property string, value interface{}) {
 func StaticSet(fqn FQN, property string, value interface{}) {
 	client := kernel.GetClient()
 
-	_, err := client.SSet(kernel.StaticSetRequest{
-		API:      "sset",
+	_, err := client.SSet(kernel.StaticSetProps{
 		FQN:      api.FQN(fqn),
 		Property: property,
 		Value:    value,


### PR DESCRIPTION
Those need not be set on each site that makes a kernel call. This leads
to possible errors. Instead, the API call name is no centralized by the
`kernel` package, which sets it "behind the covers".

In order for the naming to make sense with respects to go naming
conventions, I renamed:
- `type kernelRequester struct` to `kernelRequest`
- `type kernelRequest interface` to `kernelRequester`
- `type kernelResponder struct` to `kernelResponse`
- `type kernelResponse interface` to `kernelResponder`

The `kernelRequest` struct now contains the `API` field definition, and
all the client APIs that end up calling `client.request` compose a
`kernelRequest` and their "request properties type" into a single
struct, for easy and straight-forward marshaling.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
