### PR TITLE
refactor(go): stop emitting unused fields in go structs

### DIFF
--- a/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
+++ b/packages/@jsii/go-runtime/jsii-calc-test/main_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 
 // Only uses first argument as initial value. This is just a convenience for
 // tests that want to assert against the initialValue
-func initCalculator(initialValue float64) calc.CalculatorIface {
+func initCalculator(initialValue float64) calc.Calculator {
 	return calc.NewCalculator(calc.CalculatorProps{
 		InitialValue: initialValue,
 		MaximumValue: math.MaxFloat64,
@@ -43,7 +43,7 @@ func TestCalculator(t *testing.T) {
 	t.Run("Property access", func(t *testing.T) {
 		expected := float64(10)
 		calculator := initCalculator(expected)
-		actual := calculator.GetValue()
+		actual := calculator.Value()
 		if actual != expected {
 			t.Errorf("Expected: %f; Actual %f;", expected, actual)
 		}
@@ -54,7 +54,7 @@ func TestCalculator(t *testing.T) {
 		var newVal float64 = 12345
 		currentProps := calclib.NewNumber(newVal)
 		calculator.SetCurr(currentProps)
-		actual := calculator.GetValue()
+		actual := calculator.Value()
 		if newVal != actual {
 			t.Errorf("Expected: %f; Actual %f;", newVal, actual)
 		}
@@ -65,7 +65,7 @@ func TestCalculator(t *testing.T) {
 		calculator := initCalculator(initial)
 		calculator.Mul(factor)
 		expectedProduct := initial * factor
-		actualProduct := calculator.GetValue()
+		actualProduct := calculator.Value()
 		if actualProduct != expectedProduct {
 			t.Errorf("Expected quotient: %f; Actual %f;", expectedProduct, actualProduct)
 		}
@@ -108,7 +108,7 @@ func TestUpcasingReflectable(t *testing.T) {
 	key, val := "key1", "value1"
 	delegate[key] = val
 	upReflectable := calc.NewUpcasingReflectable(delegate)
-	entries := upReflectable.GetEntries()
+	entries := upReflectable.Entries()
 
 	if len(entries) != 1 {
 		t.Errorf("Entries expected to have length of: 1; Actual: %d", len(entries))
@@ -127,7 +127,7 @@ func TestAllTypes(t *testing.T) {
 	t.Run("Array property", func(t *testing.T) {
 		expected1, expected2 := "val1", "val2"
 		allTypes.SetArrayProperty([]string{expected1, expected2})
-		actual := allTypes.GetArrayProperty()
+		actual := allTypes.ArrayProperty()
 		actual1, actual2 := actual[0], actual[1]
 
 		if actual1 != expected1 || actual2 != expected2 {
@@ -141,7 +141,7 @@ func TestAllTypes(t *testing.T) {
 		expected[key] = val
 		allTypes.SetAnyProperty(expected)
 
-		actual := allTypes.GetAnyProperty()
+		actual := allTypes.AnyProperty()
 		actualVal := reflect.ValueOf(actual)
 		switch actualVal.Kind() {
 		case reflect.Map:
@@ -177,19 +177,19 @@ func TestEnumRoundtrip(t *testing.T) {
 
 func TestOptionalEnums(t *testing.T) {
 	allTypes := calc.NewAllTypes()
-	actual := allTypes.GetOptionalEnumValue()
+	actual := allTypes.OptionalEnumValue()
 	if actual != "" {
 		t.Error("Expected value to be nil")
 	}
 
 	allTypes.SetOptionalEnumValue(calc.StringEnum_B)
-	actual = allTypes.GetOptionalEnumValue()
+	actual = allTypes.OptionalEnumValue()
 	if actual != calc.StringEnum_B {
 		t.Errorf("Expected StringEnum.B. Actual: %s", actual)
 	}
 
 	allTypes.SetOptionalEnumValue("")
-	actual = allTypes.GetOptionalEnumValue()
+	actual = allTypes.OptionalEnumValue()
 	if actual != "" {
 		t.Error("Expected value to be nil")
 	}
@@ -207,21 +207,21 @@ func TestReturnsSpecialParam(t *testing.T) {
 
 func TestMaps(t *testing.T) {
 	allTypes := calc.NewAllTypes()
-	actual := allTypes.GetMapProperty()
+	actual := allTypes.MapProperty()
 	if len(actual) != 0 {
 		t.Errorf("Expected length of empty map to be 0. Got: %d", len(actual))
 	}
 
 	question := "The answer to the ultimate question of life, the universe, and everything"
 	answer := calclib.NewNumber(42)
-	allTypes.SetMapProperty(map[string]calclib.NumberIface{
+	allTypes.SetMapProperty(map[string]calclib.Number{
 		question: answer,
 	})
-	actual = allTypes.GetMapProperty()
+	actual = allTypes.MapProperty()
 	if len(actual) != 1 {
 		t.Errorf("Expected length of empty map to be 1. Got: %d", len(actual))
 	}
-	if actual[question].GetValue() != answer.GetValue() {
+	if actual[question].Value() != answer.Value() {
 		t.Errorf("Expected to have the value %v in there, got: %v", answer, actual[question])
 	}
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/kernel/conversions.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/kernel/conversions.go
@@ -19,9 +19,9 @@ func (c *client) CastAndSetToPtr(ptr interface{}, data interface{}) {
 		if fields, isStruct := c.Types().StructFields(ptrVal.Type()); isStruct {
 			for _, field := range fields {
 				got, err := c.Get(GetRequest{
-					API:             "get",
-					Property:        field.Tag.Get("json"),
-					ObjRef:          ref,
+					API:      "get",
+					Property: field.Tag.Get("json"),
+					ObjRef:   ref,
 				})
 				if err != nil {
 					panic(err)
@@ -33,9 +33,8 @@ func (c *client) CastAndSetToPtr(ptr interface{}, data interface{}) {
 		}
 
 		// If return data is jsii object references, add to objects table.
-		if concreteType, err := c.Types().ConcreteTypeFor(ptrVal.Type()); err == nil {
-			ptrVal.Set(reflect.New(concreteType))
-			if err = c.RegisterInstance(ptrVal.Interface(), ref.InstanceID); err != nil {
+		if err := c.Types().InitJsiiProxy(ptrVal); err == nil {
+			if err = c.RegisterInstance(ptrVal, ref.InstanceID); err != nil {
 				panic(err)
 			}
 		} else {

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
@@ -47,13 +47,13 @@ func Load(name string, version string, tarball []byte) {
 	}
 }
 
-// RegisterClass associates a class fully qualified name to the specified struct
-// type, and class interface. Panics if class is not a struct, iface is not an
-// interface, or if the provided fqn was already used to register a different
+// RegisterClass associates a class fully qualified name to the specified class
+// interface, and proxy struct. Panics if class is not an go interface, proxy is
+// not a go struct, or if the provided fqn was already used to register a different
 // type.
-func RegisterClass(fqn FQN, class reflect.Type, iface reflect.Type) {
+func RegisterClass(fqn FQN, class reflect.Type, maker func() interface{}) {
 	client := kernel.GetClient()
-	if err := client.Types().RegisterClass(api.FQN(fqn), class, iface); err != nil {
+	if err := client.Types().RegisterClass(api.FQN(fqn), class, maker); err != nil {
 		panic(err)
 	}
 }
@@ -70,12 +70,11 @@ func RegisterEnum(fqn FQN, enum reflect.Type, members map[string]interface{}) {
 }
 
 // RegisterInterface associates an interface's fully qualified name to the
-// specified interface type, and proxy struct. Panics if iface is not an
-// interface, proxy is not a struct, or if the provided fqn was already used to
-// register a different type.
-func RegisterInterface(fqn FQN, iface reflect.Type, proxy reflect.Type) {
+// specified interface type, and proxy maker function. Panics if iface is not an
+// interface, or if the provided fqn was already used to register a different type.
+func RegisterInterface(fqn FQN, iface reflect.Type, maker func() interface{}) {
 	client := kernel.GetClient()
-	if err := client.Types().RegisterInterface(api.FQN(fqn), iface, proxy); err != nil {
+	if err := client.Types().RegisterInterface(api.FQN(fqn), iface, maker); err != nil {
 		panic(err)
 	}
 }
@@ -90,10 +89,49 @@ func RegisterStruct(fqn FQN, strct reflect.Type) {
 	}
 }
 
+// InitJsiiProxy initializes a jsii proxy instance at the provided pointer.
+// Panics if the pointer cannot be initialized to a proxy instance (i.e: the
+// element of it is not a registered jsii interface or class type).
+func InitJsiiProxy(ptr interface{}) {
+	ptrVal := reflect.ValueOf(ptr).Elem()
+	if err := kernel.GetClient().Types().InitJsiiProxy(ptrVal); err != nil {
+		panic(err)
+	}
+}
+
 // Create will construct a new JSII object within the kernel runtime. This is
 // called by jsii object constructors.
-func Create(fqn FQN, args []interface{}, interfaces []FQN, overrides []Override, ret interface{}) {
+func Create(fqn FQN, args []interface{}, interfaces []FQN, overrides []Override, inst interface{}) {
 	client := kernel.GetClient()
+
+	instVal := reflect.ValueOf(inst).Elem()
+	instType := instVal.Type()
+	numField := instType.NumField()
+	for i := 0; i < numField; i++ {
+		field := instType.Field(i)
+		if !field.Anonymous {
+			continue
+		}
+		switch field.Type.Kind() {
+		case reflect.Interface:
+			fieldVal := instVal.Field(i)
+			if !fieldVal.IsNil() {
+				continue
+			}
+			if err := client.Types().InitJsiiProxy(fieldVal); err != nil {
+				panic(err)
+			}
+
+		case reflect.Struct:
+			fieldVal := instVal.Field(i)
+			if !fieldVal.IsZero() {
+				continue
+			}
+			if err := client.Types().InitJsiiProxy(fieldVal); err != nil {
+				panic(err)
+			}
+		}
+	}
 
 	var interfaceFQNs []api.FQN
 	for _, iface := range interfaces {
@@ -116,7 +154,7 @@ func Create(fqn FQN, args []interface{}, interfaces []FQN, overrides []Override,
 		panic(err)
 	}
 
-	if err = client.RegisterInstance(ret, res.InstanceID); err != nil {
+	if err = client.RegisterInstance(instVal, res.InstanceID); err != nil {
 		panic(err)
 	}
 }
@@ -127,7 +165,7 @@ func Invoke(obj interface{}, method string, args []interface{}, hasReturn bool, 
 	client := kernel.GetClient()
 
 	// Find reference to class instance in client
-	refid, found := client.FindObjectRef(obj)
+	refid, found := client.FindObjectRef(reflect.ValueOf(obj))
 
 	if !found {
 		panic("No Object Found")
@@ -178,10 +216,10 @@ func Get(obj interface{}, property string, ret interface{}) {
 	client := kernel.GetClient()
 
 	// Find reference to class instance in client
-	refid, found := client.FindObjectRef(obj)
+	refid, found := client.FindObjectRef(reflect.ValueOf(obj))
 
 	if !found {
-		panic("No Object Found")
+		panic(fmt.Errorf("no object reference found for %v", obj))
 	}
 
 	res, err := client.Get(kernel.GetRequest{
@@ -223,7 +261,7 @@ func Set(obj interface{}, property string, value interface{}) {
 	client := kernel.GetClient()
 
 	// Find reference to class instance in client
-	refid, found := client.FindObjectRef(obj)
+	refid, found := client.FindObjectRef(reflect.ValueOf(obj))
 
 	if !found {
 		panic("No Object Found")
@@ -286,7 +324,7 @@ func castPtrToRef(data interface{}) interface{} {
 		return result
 
 	case reflect.Ptr:
-		valref, valHasRef := client.FindObjectRef(data)
+		valref, valHasRef := client.FindObjectRef(reflect.ValueOf(data))
 		if valHasRef {
 			return api.ObjectRef{InstanceID: valref}
 		}

--- a/packages/@jsii/go-runtime/jsii-runtime-go/typeregistry/type-registry.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/typeregistry/type-registry.go
@@ -15,12 +15,10 @@ type TypeRegistry interface {
 	// StructFields returns the list of fields that make a registered jsii struct.
 	StructFields(typ reflect.Type) (fields []reflect.StructField, found bool)
 
-	// ConcreteTypeFor returns the concrete implementation of the provided struct
-	// or interface type. If typ is a struct, returns typ without futher effort. If
-	// it is an interface, returns the struct associated to this interface type.
-	// Returns an error if the argument is an interface, and no struct was
-	// registered for it using registerClass, registerInterface or registerStruct.
-	ConcreteTypeFor(typ reflect.Type) (structType reflect.Type, err error)
+	// InitJsiiProxy initializes a jsii proxy value at the provided pointer. It
+	// returns an error if the pointer does not have a value of a registered
+	// proxyable type (that is, a class or interface type).
+	InitJsiiProxy(val reflect.Value) error
 
 	// EnumMemberForEnumRef returns the go enum member corresponding to a jsii fully
 	// qualified enum member name (e.g: "jsii-calc.StringEnum/A"). If no enum member
@@ -45,11 +43,6 @@ type typeRegistry struct {
 	// enums are not included
 	fqnToType map[api.FQN]reflect.Type
 
-	// ifaceToStruct provides the go struct that should be used to build a proxy
-	// for interface types, so the correct dynamic type can be returned from a
-	// conversion.
-	ifaceToStruct map[reflect.Type]reflect.Type
-
 	// map enum member FQNs (e.g. "jsii-calc.StringEnum/A") to the corresponding
 	// go const for this member.
 	fqnToEnumMember map[string]interface{}
@@ -60,16 +53,19 @@ type typeRegistry struct {
 
 	// maps registered struct types to all their fields.
 	structFields map[reflect.Type][]reflect.StructField
+
+	// map registered interface types to a proxy maker function
+	proxyMakers map[reflect.Type]func() interface{}
 }
 
 // NewTypeRegistry creates a new type registry.
 func NewTypeRegistry() TypeRegistry {
 	return &typeRegistry{
 		fqnToType:       make(map[api.FQN]reflect.Type),
-		ifaceToStruct:   make(map[reflect.Type]reflect.Type),
 		fqnToEnumMember: make(map[string]interface{}),
 		typeToEnumFQN:   make(map[reflect.Type]api.FQN),
 		structFields:    make(map[reflect.Type][]reflect.StructField),
+		proxyMakers:     make(map[reflect.Type]func() interface{}),
 	}
 }
 
@@ -78,29 +74,50 @@ func (t *typeRegistry) StructFields(typ reflect.Type) (fields []reflect.StructFi
 	var found []reflect.StructField
 	found, ok = t.structFields[typ]
 	if ok {
+		// Returning a copy, to ensure our storage does not get mutated.
 		fields = append(fields, found...)
 	}
 	return
 }
 
-// ConcreteTypeFor returns the concrete implementation of the provided struct
-// or interface type. If typ is a struct, returns typ without futher effort. If
-// it is an interface, returns the struct associated to this interface type.
-// Returns an error if the argument is an interface, and no struct was
-// registered for it using registerClass, registerInterface or registerStruct.
-func (t *typeRegistry) ConcreteTypeFor(typ reflect.Type) (structType reflect.Type, err error) {
-	if typ.Kind() == reflect.Struct {
-		structType = typ
-		err = nil
-	} else if typ.Kind() == reflect.Interface {
-		var ok bool
-		if structType, ok = t.ifaceToStruct[typ]; !ok {
-			err = fmt.Errorf("no concrete type was registered for interface: %v", typ)
+// InitJsiiProxy initializes a jsii proxy value at the provided pointer. It
+// returns an error if the pointer does not have a value of a registered
+// proxyable type (that is, a class or interface type).
+func (t *typeRegistry) InitJsiiProxy(val reflect.Value) error {
+	valType := val.Type()
+
+	switch valType.Kind() {
+	case reflect.Interface:
+		if maker, ok := t.proxyMakers[valType]; ok {
+			made := maker()
+			val.Set(reflect.ValueOf(made))
+			return nil
 		}
-	} else {
-		err = fmt.Errorf("invalid argument: expected a struct or interface type, but got %v", typ)
+		return fmt.Errorf("unable to make an instance of unregistered interface %v", valType)
+
+	case reflect.Struct:
+		if !val.IsZero() {
+			return fmt.Errorf("refusing to initialize non-zero-value struct %v", val)
+		}
+		numField := valType.NumField()
+		for i := 0; i < numField; i++ {
+			field := valType.Field(i)
+			if field.Name == "_" {
+				// Ignore any padding
+				continue
+			}
+			if !field.Anonymous {
+				return fmt.Errorf("refusing to initialize non-anonymous field %s of %v", field.Name, val)
+			}
+			if err := t.InitJsiiProxy(val.Field(i)); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unable to make an instance of %v (neither a struct nor interface)", valType)
 	}
-	return
 }
 
 // EnumMemberForEnumRef returns the go enum member corresponding to a jsii fully

--- a/packages/jsii-pacmak/lib/targets/go/comparators.ts
+++ b/packages/jsii-pacmak/lib/targets/go/comparators.ts
@@ -1,0 +1,4 @@
+type Named = { readonly name: string };
+export function byName(l: Named, r: Named): number {
+  return l.name.localeCompare(r.name);
+}

--- a/packages/jsii-pacmak/lib/targets/go/documentation.ts
+++ b/packages/jsii-pacmak/lib/targets/go/documentation.ts
@@ -18,17 +18,25 @@ export class Documentation {
    * Stability/Deprecation description
    */
   public emit(docs: Docs): void {
+    let firstLine = true;
     if (docs.toString() !== '') {
       this.emitComment(docs.toString());
+      firstLine = false;
     }
 
     if (docs.returns !== '') {
-      this.emitComment();
+      if (!firstLine) {
+        this.emitComment();
+      }
+      firstLine = false;
       this.emitComment(`Returns: ${docs.returns}`);
     }
 
     if (docs.example !== '') {
-      this.emitComment();
+      if (!firstLine) {
+        this.emitComment();
+      }
+      firstLine = false;
       // TODO: Translate code examples to Go with Rosetta (not implemented there yet)
       this.emitComment('TODO: EXAMPLE');
       this.emitComment();
@@ -59,9 +67,10 @@ export class Documentation {
     }
   }
 
-  private shouldMentionStability(docs: Docs): boolean {
-    const s = docs.stability;
+  private shouldMentionStability({ stability }: Docs): boolean {
     // Don't render "stable" or "external", those are both stable by implication
-    return s === Stability.Deprecated || s === Stability.Experimental;
+    return (
+      stability === Stability.Deprecated || stability === Stability.Experimental
+    );
   }
 }

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -13,7 +13,7 @@ import {
   JSII_INIT_FUNC,
   JSII_INIT_ALIAS,
 } from './runtime';
-import { GoClass, GoType, Enum, Interface, Struct } from './types';
+import { GoClass, GoType, Enum, GoInterface, Struct } from './types';
 import { findTypeInTree, goPackageName, flatMap, tarballName } from './util';
 import { VersionFile } from './version-file';
 
@@ -50,7 +50,7 @@ export abstract class Package {
         if (type.isInterfaceType() && type.datatype) {
           return new Struct(this, type);
         } else if (type.isInterfaceType()) {
-          return new Interface(this, type);
+          return new GoInterface(this, type);
         } else if (type.isClassType()) {
           return new GoClass(this, type);
         } else if (type.isEnumType()) {
@@ -217,7 +217,7 @@ export class RootPackage extends Package {
     const moduleName = assembly.targets?.go?.moduleName ?? '';
 
     super(
-      Object.values(assembly.types),
+      assembly.types,
       assembly.submodules,
       packageName,
       filePath,

--- a/packages/jsii-pacmak/lib/targets/go/runtime/class-constructor.ts
+++ b/packages/jsii-pacmak/lib/targets/go/runtime/class-constructor.ts
@@ -11,11 +11,13 @@ export class ClassConstructor {
     emitInitialization(code);
 
     const resultVar = slugify(
-      'self',
+      this.parent.parent.proxyName[0],
       this.parent.parameters.map((p) => p.name),
     );
 
-    code.line(`${resultVar} := ${this.parent.parent.name}{}`);
+    code.line(`${resultVar} := ${this.parent.parent.proxyName}{}`);
+    code.line();
+
     code.open(`${JSII_CREATE_FUNC}(`);
 
     code.line(`"${this.parent.parent.fqn}",`);

--- a/packages/jsii-pacmak/lib/targets/go/types/class.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/class.ts
@@ -1,6 +1,7 @@
 import { CodeMaker, toPascalCase } from 'codemaker';
 import { Method, ClassType, Initializer } from 'jsii-reflect';
 
+import * as comparators from '../comparators';
 import { EmitContext } from '../emit-context';
 import { Package } from '../package';
 import {
@@ -11,44 +12,118 @@ import {
   StaticSetProperty,
 } from '../runtime';
 import { getMemberDependencies, getParamDependencies } from '../util';
-import { GoStruct } from './go-type';
+import { GoType } from './go-type';
+import { GoTypeRef } from './go-type-reference';
+import { GoInterface } from './interface';
 import { GoParameter, GoMethod, GoProperty } from './type-member';
 
 /*
  * GoClass wraps a Typescript class as a Go custom struct type
  */
-export class GoClass extends GoStruct {
-  public readonly methods: ClassMethod[] = [];
-  public readonly staticMethods: StaticMethod[] = [];
-  public readonly staticProperties: GoProperty[] = [];
+export class GoClass extends GoType {
+  public readonly methods: ClassMethod[];
+  public readonly staticMethods: StaticMethod[];
+  public readonly properties: GoProperty[];
+  public readonly staticProperties: GoProperty[];
+
+  private readonly reimplementedMethods?: readonly ClassMethod[];
+  private readonly reimplementedProperties?: readonly GoProperty[];
+
+  private _extends?: GoClass | null;
+  private _implements?: readonly GoInterface[];
 
   private readonly initializer?: GoClassConstructor;
 
   public constructor(pkg: Package, public type: ClassType) {
     super(pkg, type);
 
-    for (const method of Object.values(this.type.getMethods(true))) {
+    const methods = new Array<ClassMethod>();
+    const staticMethods = new Array<StaticMethod>();
+    for (const method of type.ownMethods) {
       if (method.static) {
-        this.staticMethods.push(new StaticMethod(this, method));
+        staticMethods.push(new StaticMethod(this, method));
       } else {
-        this.methods.push(new ClassMethod(this, method));
+        methods.push(new ClassMethod(this, method));
       }
     }
+    // Ensure consistent order, mostly cosmetic.
+    this.methods = methods.sort(comparators.byName);
+    this.staticMethods = staticMethods.sort(comparators.byName);
 
-    for (const prop of Object.values(this.type.getProperties(true))) {
+    const properties = new Array<GoProperty>();
+    const staticProperties = new Array<GoProperty>();
+    for (const prop of type.ownProperties) {
       if (prop.static) {
-        this.staticProperties.push(new GoProperty(this, prop));
+        staticProperties.push(new GoProperty(this, prop));
+      } else {
+        properties.push(new GoProperty(this, prop));
       }
     }
+    // Ensure consistent order, mostly cosmetic.
+    this.properties = properties.sort(comparators.byName);
+    this.staticProperties = staticProperties.sort(comparators.byName);
 
-    if (this.type.initializer) {
-      this.initializer = new GoClassConstructor(this, this.type.initializer);
+    // If there is more than one base, and any ancestor (including transitive)
+    // comes from a different assembly, we will re-implement all members on the
+    // proxy struct, as otherwise we run the risk of un-promotable methods
+    // caused by inheriting the same interface via multiple paths (since we have
+    // to represent those as embedded types).
+    const hasMultipleBases = type.interfaces.length > (type.base ? 0 : 1);
+    if (
+      hasMultipleBases &&
+      type
+        .getAncestors()
+        .some((ancestor) => ancestor.assembly.fqn !== type.assembly.fqn)
+    ) {
+      this.reimplementedMethods = type.allMethods
+        .filter((method) => !method.static && method.definingType !== type)
+        .map((method) => new ClassMethod(this, method))
+        .sort(comparators.byName);
+
+      this.reimplementedProperties = type.allProperties
+        .filter(
+          (property) => !property.static && property.definingType !== type,
+        )
+        .map((property) => new GoProperty(this, property))
+        .sort(comparators.byName);
+    }
+
+    if (type.initializer) {
+      this.initializer = new GoClassConstructor(this, type.initializer);
     }
   }
 
+  public get extends(): GoClass | undefined {
+    // Cannot compute in constructor, as dependencies may not have finished
+    // resolving just yet.
+    if (this._extends === undefined) {
+      this._extends = this.type.base
+        ? (this.pkg.root.findType(this.type.base.fqn) as GoClass)
+        : null;
+    }
+    return this._extends == null ? undefined : this._extends;
+  }
+
+  public get implements(): readonly GoInterface[] {
+    // Cannot compute in constructor, as dependencies may not have finished
+    // resolving just yet.
+    if (this._implements === undefined) {
+      this._implements = this.type.interfaces
+        .map((iface) => this.pkg.root.findType(iface.fqn) as GoInterface)
+        // Ensure consistent order, mostly cosmetic.
+        .sort((l, r) => l.fqn.localeCompare(r.fqn));
+    }
+    return this._implements;
+  }
+
+  public get baseTypes(): ReadonlyArray<GoClass | GoInterface> {
+    return [...(this.extends ? [this.extends] : []), ...this.implements];
+  }
+
   public emit(context: EmitContext): void {
-    // emits interface, struct proxy, and instance methods
-    super.emit(context);
+    this.emitInterface(context);
+    this.emitStruct(context);
+    this.emitGetters(context);
 
     if (this.initializer) {
       this.initializer.emit(context);
@@ -67,13 +142,17 @@ export class GoClass extends GoStruct {
     for (const method of this.methods) {
       method.emit(context);
     }
+
+    for (const method of this.reimplementedMethods ?? []) {
+      method.emit(context);
+    }
   }
 
   public emitRegistration(code: CodeMaker): void {
     code.open(`${JSII_RT_ALIAS}.RegisterClass(`);
     code.line(`"${this.fqn}",`);
     code.line(`reflect.TypeOf((*${this.name})(nil)).Elem(),`);
-    code.line(`reflect.TypeOf((*${this.interfaceName})(nil)).Elem(),`);
+    this.emitProxyMakerFunction(code, this.baseTypes);
     code.close(')');
   }
 
@@ -94,13 +173,25 @@ export class GoClass extends GoStruct {
   }
 
   protected emitInterface(context: EmitContext): void {
-    const { code } = context;
-    code.line('// Class interface'); // FIXME for debugging
-    code.openBlock(`type ${this.interfaceName} interface`);
+    const { code, documenter } = context;
+    documenter.emit(this.type.docs);
+    code.openBlock(`type ${this.name} interface`);
 
     // embed extended interfaces
-    for (const iface of this.extends) {
-      code.line(iface.scopedInterfaceName(this.pkg));
+    if (this.extends) {
+      code.line(
+        new GoTypeRef(
+          this.pkg.root,
+          this.extends.type.reference,
+        ).scopedInterfaceName(this.pkg),
+      );
+    }
+    for (const iface of this.implements) {
+      code.line(
+        new GoTypeRef(this.pkg.root, iface.type.reference).scopedInterfaceName(
+          this.pkg,
+        ),
+      );
     }
 
     for (const property of this.properties) {
@@ -112,6 +203,51 @@ export class GoClass extends GoStruct {
       method.emitDecl(context);
     }
 
+    code.closeBlock();
+    code.line();
+  }
+
+  private emitGetters(context: EmitContext) {
+    if (this.properties.length === 0) {
+      return;
+    }
+    for (const property of this.properties) {
+      property.emitGetterProxy(context);
+    }
+    for (const property of this.reimplementedProperties ?? []) {
+      property.emitGetterProxy(context);
+    }
+    context.code.line();
+  }
+
+  private emitStruct({ code }: EmitContext): void {
+    code.line(`// The jsii proxy struct for ${this.name}`);
+    code.openBlock(`type ${this.proxyName} struct`);
+    if (this.extends == null && this.implements.length === 0) {
+      // Make sure this is not 0-width
+      code.line('_ byte // padding');
+    } else {
+      if (this.extends) {
+        const embed =
+          this.extends.pkg === this.pkg
+            ? this.extends.proxyName
+            : new GoTypeRef(
+                this.pkg.root,
+                this.extends.type.reference,
+              ).scopedInterfaceName(this.pkg);
+        code.line(`${embed} // extends ${this.extends.fqn}`);
+      }
+      for (const iface of this.implements) {
+        const embed =
+          iface.pkg === this.pkg
+            ? iface.proxyName
+            : new GoTypeRef(
+                this.pkg.root,
+                iface.type.reference,
+              ).scopedInterfaceName(this.pkg);
+        code.line(`${embed} // implements ${iface.fqn}`);
+      }
+    }
     code.closeBlock();
     code.line();
   }
@@ -141,17 +277,19 @@ export class GoClass extends GoStruct {
 
   // emits the implementation of the setters for the struct
   private emitSetters(context: EmitContext): void {
-    if (this.properties.length !== 0) {
-      for (const property of this.properties) {
-        property.emitSetterImpl(context);
-      }
+    for (const property of this.properties) {
+      property.emitSetterProxy(context);
+    }
+    for (const property of this.reimplementedProperties ?? []) {
+      property.emitSetterProxy(context);
     }
   }
 
   public get dependencies(): Package[] {
     // need to add dependencies of method arguments and constructor arguments
     return [
-      ...super.dependencies,
+      ...this.baseTypes.map((ref) => ref.pkg),
+      ...getMemberDependencies(this.properties),
       ...getMemberDependencies(this.methods),
       ...getParamDependencies(this.methods),
     ];
@@ -174,7 +312,7 @@ export class GoClassConstructor {
     private readonly type: Initializer,
   ) {
     this.constructorRuntimeCall = new ClassConstructor(this);
-    this.parameters = Object.values(this.type.parameters).map(
+    this.parameters = this.type.parameters.map(
       (param) => new GoParameter(parent, param),
     );
   }
@@ -193,9 +331,7 @@ export class GoClassConstructor {
       code.line(`// ${docstring}`);
     }
 
-    code.openBlock(
-      `func ${constr}(${paramString}) ${this.parent.interfaceName}`,
-    );
+    code.openBlock(`func ${constr}(${paramString}) ${this.parent.name}`);
 
     this.constructorRuntimeCall.emit(code);
     code.closeBlock();
@@ -217,13 +353,14 @@ export class ClassMethod extends GoMethod {
   }
 
   /* emit generates method implementation on the class */
-  public emit({ code }: EmitContext) {
+  public emit({ code, documenter }: EmitContext) {
     const name = this.name;
     const returnTypeString = this.reference?.void ? '' : ` ${this.returnType}`;
 
+    documenter.emit(this.method.docs);
     code.openBlock(
       `func (${this.instanceArg} *${
-        this.parent.name
+        this.parent.proxyName
       }) ${name}(${this.paramString()})${returnTypeString}`,
     );
 
@@ -262,10 +399,11 @@ export class StaticMethod extends ClassMethod {
     super(parent, method);
   }
 
-  public emit({ code }: EmitContext) {
+  public emit({ code, documenter }: EmitContext) {
     const name = `${this.parent.name}_${this.name}`;
     const returnTypeString = this.reference?.void ? '' : ` ${this.returnType}`;
 
+    documenter.emit(this.method.docs);
     code.openBlock(`func ${name}(${this.paramString()})${returnTypeString}`);
 
     this.runtimeCall.emit(code);

--- a/packages/jsii-pacmak/lib/targets/go/types/go-type-reference.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/go-type-reference.ts
@@ -68,10 +68,6 @@ export class GoTypeRef {
     return undefined;
   }
 
-  public get interfaceName() {
-    return this.type?.interfaceName;
-  }
-
   public get name() {
     return this.type?.name;
   }
@@ -149,9 +145,7 @@ export class GoTypeRef {
       return `${prefix}${innerName}`;
     } else if (typeMap.type === 'interface') {
       const prefix = asRef ? '*' : '';
-      const baseName = asInterface
-        ? typeMap.value.interfaceName
-        : typeMap.value.name;
+      const baseName = typeMap.value.name;
       // type is defined in the same scope as the current one, no namespace required
       if (scope.packageName === typeMap.value.namespace && baseName) {
         // if the current scope is the same as the types scope, return without a namespace

--- a/packages/jsii-pacmak/lib/targets/go/types/interface.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/interface.ts
@@ -1,51 +1,70 @@
 import { CodeMaker } from 'codemaker';
 import { InterfaceType, Method, Property } from 'jsii-reflect';
 
+import * as comparators from '../comparators';
 import { EmitContext } from '../emit-context';
 import { Package } from '../package';
 import { JSII_RT_ALIAS, MethodCall } from '../runtime';
 import { getMemberDependencies, getParamDependencies } from '../util';
-import { GoType, INTERFACE_TYPE_SUFFIX } from './go-type';
+import { GoType } from './go-type';
 import { GoTypeRef } from './go-type-reference';
 import { GoMethod, GoProperty } from './type-member';
 
-export class Interface extends GoType {
+export class GoInterface extends GoType {
   public readonly methods: InterfaceMethod[];
-  public readonly inheritedMethods: InterfaceMethod[];
+  public readonly reimplementedMethods?: readonly InterfaceMethod[];
   public readonly properties: InterfaceProperty[];
-  public readonly inheritedProperties: InterfaceProperty[];
-  public readonly interfaceName: string;
+  public readonly reimplementedProperties?: readonly InterfaceProperty[];
 
   public constructor(pkg: Package, public type: InterfaceType) {
     super(pkg, type);
-    this.methods = Object.values(type.getMethods()).map(
-      (method) => new InterfaceMethod(this, method),
-    );
 
-    this.inheritedMethods = Object.values(type.getMethods(true)).map(
-      (method) => new InterfaceMethod(this, method),
-    );
+    this.methods = type.ownMethods
+      .map((method) => new InterfaceMethod(this, method))
+      .sort(comparators.byName);
 
-    this.properties = Object.values(type.getProperties()).map(
-      (prop) => new InterfaceProperty(this, prop),
-    );
+    this.properties = type.ownProperties
+      .map((prop) => new InterfaceProperty(this, prop))
+      .sort(comparators.byName);
 
-    this.inheritedProperties = Object.values(type.getProperties(true)).map(
-      (prop) => new InterfaceProperty(this, prop),
-    );
+    // If there is more than one base, and any ancestor (including transitive)
+    // comes from a different assembly, we will re-implement all members on the
+    // proxy struct, as otherwise we run the risk of un-promotable methods
+    // caused by inheriting the same interface via multiple paths (since we have
+    // to represent those as embedded types).
+    if (
+      type.interfaces.length > 1 &&
+      type
+        .getInterfaces(true)
+        .some((ancestor) => ancestor.assembly.fqn !== type.assembly.fqn)
+    ) {
+      this.reimplementedMethods = type.allMethods
+        .filter((method) => !method.static && method.definingType !== type)
+        .map((method) => new InterfaceMethod(this, method))
+        .sort(comparators.byName);
 
-    this.interfaceName = `${this.name}${INTERFACE_TYPE_SUFFIX}`;
+      this.reimplementedProperties = type.allProperties
+        .filter(
+          (property) => !property.static && property.definingType !== type,
+        )
+        .map((property) => new InterfaceProperty(this, property))
+        .sort(comparators.byName);
+    }
   }
 
   public emit(context: EmitContext) {
     this.emitDocs(context);
 
     const { code } = context;
-    code.openBlock(`type ${this.interfaceName} interface`);
+    code.openBlock(`type ${this.name} interface`);
 
     // embed extended interfaces
     for (const iface of this.extends) {
-      code.line(iface.scopedInterfaceName(this.pkg));
+      code.line(
+        new GoTypeRef(this.pkg.root, iface.type.reference).scopedInterfaceName(
+          this.pkg,
+        ),
+      );
     }
 
     for (const method of this.methods) {
@@ -59,18 +78,47 @@ export class Interface extends GoType {
     code.closeBlock();
     code.line();
 
-    code.line(`type ${this.name} struct {}`);
+    code.line(`// The jsii proxy for ${this.name}`);
+    code.openBlock(`type ${this.proxyName} struct`);
+    if (this.extends.length === 0) {
+      // Ensure this is not 0-width
+      code.line('_ byte // padding');
+    } else {
+      for (const base of this.extends) {
+        const embed =
+          base.pkg === this.pkg
+            ? base.proxyName
+            : new GoTypeRef(
+                this.pkg.root,
+                base.type.reference,
+              ).scopedInterfaceName(this.pkg);
+        code.line(`${embed} // extends ${base.fqn}`);
+      }
+    }
+    code.closeBlock();
     code.line();
 
-    for (const method of this.inheritedMethods) {
+    for (const method of this.methods) {
       method.emit(context);
     }
 
-    for (const prop of this.inheritedProperties) {
-      prop.emitGetterImpl(context);
+    for (const method of this.reimplementedMethods ?? []) {
+      method.emit(context);
+    }
+
+    for (const prop of this.properties) {
+      prop.emitGetterProxy(context);
 
       if (!prop.immutable) {
-        prop.emitSetterImpl(context);
+        prop.emitSetterProxy(context);
+      }
+    }
+
+    for (const prop of this.reimplementedProperties ?? []) {
+      prop.emitGetterProxy(context);
+
+      if (!prop.immutable) {
+        prop.emitSetterProxy(context);
       }
     }
   }
@@ -78,8 +126,8 @@ export class Interface extends GoType {
   public emitRegistration(code: CodeMaker): void {
     code.open(`${JSII_RT_ALIAS}.RegisterInterface(`);
     code.line(`"${this.fqn}",`);
-    code.line(`reflect.TypeOf((*${this.interfaceName})(nil)).Elem(),`);
     code.line(`reflect.TypeOf((*${this.name})(nil)).Elem(),`);
+    this.emitProxyMakerFunction(code, this.extends);
     code.close(')');
   }
 
@@ -97,16 +145,16 @@ export class Interface extends GoType {
     );
   }
 
-  public get extends(): GoTypeRef[] {
-    return this.type.getInterfaces(true).map((iface) => {
-      return new GoTypeRef(this.pkg.root, iface.reference);
-    });
+  public get extends(): GoInterface[] {
+    return this.type.interfaces
+      .map((iface) => this.pkg.root.findType(iface.fqn) as GoInterface)
+      .sort(comparators.byName);
   }
 
   public get extendsDependencies(): Package[] {
     const packages: Package[] = [];
     for (const ifaceRef of this.extends) {
-      const pkg = ifaceRef.type?.pkg;
+      const pkg = ifaceRef.pkg;
       if (pkg) {
         packages.push(pkg);
       }
@@ -129,7 +177,7 @@ class InterfaceProperty extends GoProperty {
   public readonly reference?: GoTypeRef;
 
   public constructor(
-    public readonly parent: Interface,
+    public readonly parent: GoInterface,
     public readonly property: Property,
   ) {
     super(parent, property);
@@ -142,14 +190,9 @@ class InterfaceProperty extends GoProperty {
     );
   }
 
-  public emit(context: EmitContext) {
-    const docs = this.property.docs;
-    if (docs) {
-      context.documenter.emit(docs);
-    }
-
-    const { code } = context;
-    code.line(`${this.getter}() ${this.returnType}`);
+  public emit({ code, documenter }: EmitContext) {
+    documenter.emit(this.property.docs);
+    code.line(`${this.name}() ${this.returnType}`);
   }
 }
 
@@ -159,7 +202,7 @@ class InterfaceMethod extends GoMethod {
   public readonly usesRuntimePackage = true;
 
   public constructor(
-    public readonly parent: Interface,
+    public readonly parent: GoInterface,
     public readonly method: Method,
   ) {
     super(parent, method);
@@ -179,7 +222,7 @@ class InterfaceMethod extends GoMethod {
     const name = this.name;
     code.openBlock(
       `func (${this.instanceArg} *${
-        this.parent.name
+        this.parent.proxyName
       }) ${name}(${this.paramString()})${this.returnTypeString}`,
     );
 

--- a/packages/jsii-pacmak/lib/targets/go/types/type-member.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/type-member.ts
@@ -5,7 +5,7 @@ import { EmitContext } from '../emit-context';
 import { GetProperty, SetProperty } from '../runtime';
 import { substituteReservedWords } from '../util';
 
-import { GoClass, GoType, Interface, GoTypeRef } from './index';
+import { GoClass, GoType, GoInterface, GoTypeRef } from './index';
 
 /*
  * Structure for Class and Interface methods. Useful for sharing logic for dependency resolution
@@ -26,7 +26,6 @@ export interface GoTypeMember {
 */
 export class GoProperty implements GoTypeMember {
   public readonly name: string;
-  public readonly getter: string;
   public readonly reference?: GoTypeRef;
   public readonly immutable: boolean;
 
@@ -35,7 +34,6 @@ export class GoProperty implements GoTypeMember {
     public readonly property: Property,
   ) {
     this.name = toPascalCase(this.property.name);
-    this.getter = `Get${this.name}`;
     this.immutable = property.immutable;
 
     if (property.type) {
@@ -63,7 +61,7 @@ export class GoProperty implements GoTypeMember {
   }
 
   public get instanceArg(): string {
-    return this.parent.name.substring(0, 1).toLowerCase();
+    return this.parent.proxyName.substring(0, 1).toLowerCase();
   }
 
   public emitStructMember({ code, documenter }: EmitContext) {
@@ -80,7 +78,19 @@ export class GoProperty implements GoTypeMember {
 
   public emitGetterDecl(context: EmitContext) {
     const { code } = context;
-    code.line(`${this.getter}() ${this.returnType}`);
+    code.line(`${this.name}() ${this.returnType}`);
+  }
+
+  public emitGetter({ code, documenter }: EmitContext): void {
+    const receiver = this.parent.name;
+    const instanceArg = receiver.substring(0, 1).toLowerCase();
+
+    documenter.emit(this.property.docs);
+    code.openBlock(
+      `func (${instanceArg} *${receiver}) Get${this.name}() ${this.returnType}`,
+    );
+    code.line(`return ${instanceArg}.${this.name}`);
+    code.closeBlock();
   }
 
   public emitSetterDecl(context: EmitContext) {
@@ -91,13 +101,13 @@ export class GoProperty implements GoTypeMember {
   }
 
   // Emits getter methods on the struct for each property
-  public emitGetterImpl(context: EmitContext) {
+  public emitGetterProxy(context: EmitContext) {
     const { code } = context;
-    const receiver = this.parent.name;
+    const receiver = this.parent.proxyName;
     const instanceArg = receiver.substring(0, 1).toLowerCase();
 
     code.openBlock(
-      `func (${instanceArg} *${receiver}) ${this.getter}() ${this.returnType}`,
+      `func (${instanceArg} *${receiver}) ${this.name}() ${this.returnType}`,
     );
 
     new GetProperty(this).emit(code);
@@ -106,10 +116,10 @@ export class GoProperty implements GoTypeMember {
     code.line();
   }
 
-  public emitSetterImpl(context: EmitContext) {
+  public emitSetterProxy(context: EmitContext) {
     if (!this.immutable) {
       const { code } = context;
-      const receiver = this.parent.name;
+      const receiver = this.parent.proxyName;
       const instanceArg = receiver.substring(0, 1).toLowerCase();
 
       code.openBlock(
@@ -130,7 +140,7 @@ export abstract class GoMethod implements GoTypeMember {
   public readonly parameters: GoParameter[];
 
   public constructor(
-    public readonly parent: GoClass | Interface,
+    public readonly parent: GoClass | GoInterface,
     public readonly method: Method,
   ) {
     this.name = toPascalCase(method.name);
@@ -138,7 +148,7 @@ export abstract class GoMethod implements GoTypeMember {
     if (method.returns.type) {
       this.reference = new GoTypeRef(parent.pkg.root, method.returns.type);
     }
-    this.parameters = Object.values(this.method.parameters).map(
+    this.parameters = this.method.parameters.map(
       (param) => new GoParameter(parent, param),
     );
   }
@@ -195,7 +205,7 @@ export class GoParameter {
   public readonly reference: GoTypeRef;
 
   public constructor(
-    public parent: GoClass | Interface,
+    public parent: GoClass | GoInterface,
     public readonly parameter: Parameter,
   ) {
     this.name = substituteReservedWords(parameter.name);

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -281,30 +281,32 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 )
 
-// Class interface
-type BaseIface interface {
+// A base class.
+type Base interface {
 	TypeName() interface{}
 }
 
-// A base class.
-// Struct proxy
-type Base struct {
+// The jsii proxy struct for Base
+type base struct {
+	_ byte // padding
 }
 
-func NewBase() BaseIface {
+func NewBase() Base {
 	_init_.Initialize()
-	self := Base{}
+	b := base{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-base.Base",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-func (b *Base) TypeName() interface{} {
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (b *base) TypeName() interface{} {
 	var returns interface{}
 	_jsii_.Invoke(
 		b,
@@ -317,7 +319,7 @@ func (b *Base) TypeName() interface{} {
 }
 
 type BaseProps struct {
-	Foo scopejsiicalcbaseofbase.VeryIface \`json:"foo"\`
+	Foo scopejsiicalcbaseofbase.Very \`json:"foo"\`
 	Bar string \`json:"bar"\`
 }
 
@@ -328,25 +330,17 @@ func (b *BaseProps) ToVeryBaseProps() scopejsiicalcbaseofbase.VeryBaseProps {
 	}
 }
 
-type IBaseInterfaceIface interface {
-	scopejsiicalcbaseofbase.IVeryBaseInterfaceIface
+type IBaseInterface interface {
+	scopejsiicalcbaseofbase.IVeryBaseInterface
 	Bar()
 }
 
-type IBaseInterface struct {}
-
-func (i *IBaseInterface) Foo() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"foo",
-		[]interface{}{},
-		false,
-		&returns,
-	)
+// The jsii proxy for IBaseInterface
+type iBaseInterface struct {
+	scopejsiicalcbaseofbase.IVeryBaseInterface // extends @scope/jsii-calc-base-of-base.IVeryBaseInterface
 }
 
-func (i *IBaseInterface) Bar() {
+func (i *iBaseInterface) Bar() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -357,26 +351,27 @@ func (i *IBaseInterface) Bar() {
 	)
 }
 
-// Class interface
-type StaticConsumerIface interface {
-}
-
 // Hides the transitive dependency of base-of-base.
-// Struct proxy
-type StaticConsumer struct {
+type StaticConsumer interface {
 }
 
-func NewStaticConsumer() StaticConsumerIface {
+// The jsii proxy struct for StaticConsumer
+type staticConsumer struct {
+	_ byte // padding
+}
+
+func NewStaticConsumer() StaticConsumer {
 	_init_.Initialize()
-	self := StaticConsumer{}
+	s := staticConsumer{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-base.StaticConsumer",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
 func StaticConsumer_Consume(args interface{}) {
@@ -407,7 +402,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-base.Base",
 		reflect.TypeOf((*Base)(nil)).Elem(),
-		reflect.TypeOf((*BaseIface)(nil)).Elem(),
+		func() interface{} {
+			return &base{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-base.BaseProps",
@@ -415,13 +412,19 @@ func init() {
 	)
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-base.IBaseInterface",
-		reflect.TypeOf((*IBaseInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IBaseInterface)(nil)).Elem(),
+		func() interface{} {
+			i := iBaseInterface{}
+			_jsii_.InitJsiiProxy(&i.IVeryBaseInterface)
+			return &i
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-base.StaticConsumer",
 		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
-		reflect.TypeOf((*StaticConsumerIface)(nil)).Elem(),
+		func() interface{} {
+			return &staticConsumer{}
+		},
 	)
 }
 
@@ -705,13 +708,16 @@ import (
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 )
 
-type IVeryBaseInterfaceIface interface {
+type IVeryBaseInterface interface {
 	Foo()
 }
 
-type IVeryBaseInterface struct {}
+// The jsii proxy for IVeryBaseInterface
+type iVeryBaseInterface struct {
+	_ byte // padding
+}
 
-func (i *IVeryBaseInterface) Foo() {
+func (i *iVeryBaseInterface) Foo() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -722,12 +728,12 @@ func (i *IVeryBaseInterface) Foo() {
 	)
 }
 
-// Class interface
-type StaticConsumerIface interface {
+type StaticConsumer interface {
 }
 
-// Struct proxy
-type StaticConsumer struct {
+// The jsii proxy struct for StaticConsumer
+type staticConsumer struct {
+	_ byte // padding
 }
 
 func StaticConsumer_Consume(_args interface{}) {
@@ -742,31 +748,33 @@ func StaticConsumer_Consume(_args interface{}) {
 	)
 }
 
-// Class interface
-type VeryIface interface {
+// Something here.
+// Experimental.
+type Very interface {
 	Hey() float64
 }
 
-// Something here.
-// Experimental.
-// Struct proxy
-type Very struct {
+// The jsii proxy struct for Very
+type very struct {
+	_ byte // padding
 }
 
-func NewVery() VeryIface {
+func NewVery() Very {
 	_init_.Initialize()
-	self := Very{}
+	v := very{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-base-of-base.Very",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&v,
 	)
-	return &self
+	return &v
 }
 
-func (v *Very) Hey() float64 {
+// Experimental.
+func (v *very) Hey() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -779,7 +787,7 @@ func (v *Very) Hey() float64 {
 }
 
 type VeryBaseProps struct {
-	Foo VeryIface \`json:"foo"\`
+	Foo Very \`json:"foo"\`
 }
 
 
@@ -797,18 +805,24 @@ import (
 func init() {
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-base-of-base.IVeryBaseInterface",
-		reflect.TypeOf((*IVeryBaseInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IVeryBaseInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iVeryBaseInterface{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-base-of-base.StaticConsumer",
 		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
-		reflect.TypeOf((*StaticConsumerIface)(nil)).Elem(),
+		func() interface{} {
+			return &staticConsumer{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-base-of-base.Very",
 		reflect.TypeOf((*Very)(nil)).Elem(),
-		reflect.TypeOf((*VeryIface)(nil)).Elem(),
+		func() interface{} {
+			return &very{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-base-of-base.VeryBaseProps",
@@ -1108,7 +1122,6 @@ import (
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 )
 
 // Deprecated.
@@ -1140,14 +1153,17 @@ const (
 
 // The general contract for a concrete number.
 // Deprecated.
-type IDoublableIface interface {
+type IDoublable interface {
 	// Deprecated.
-	GetDoubleValue() float64
+	DoubleValue() float64
 }
 
-type IDoublable struct {}
+// The jsii proxy for IDoublable
+type iDoublable struct {
+	_ byte // padding
+}
 
-func (i *IDoublable) GetDoubleValue() float64 {
+func (i *iDoublable) DoubleValue() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -1162,15 +1178,18 @@ func (i *IDoublable) GetDoubleValue() float64 {
 // These classes can be greeted with
 // a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
 // Deprecated.
-type IFriendlyIface interface {
+type IFriendly interface {
 	// Say hello!
 	// Deprecated.
 	Hello() string
 }
 
-type IFriendly struct {}
+// The jsii proxy for IFriendly
+type iFriendly struct {
+	_ byte // padding
+}
 
-func (i *IFriendly) Hello() string {
+func (i *iFriendly) Hello() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -1187,38 +1206,18 @@ func (i *IFriendly) Hello() string {
 // Their presence validates that .NET/Java/jsii-reflect can track all fields
 // far enough up the tree.
 // Deprecated.
-type IThreeLevelsInterfaceIface interface {
-	scopejsiicalcbaseofbase.IVeryBaseInterfaceIface
-	scopejsiicalcbase.IBaseInterfaceIface
+type IThreeLevelsInterface interface {
+	scopejsiicalcbase.IBaseInterface
 	// Deprecated.
 	Baz()
 }
 
-type IThreeLevelsInterface struct {}
-
-func (i *IThreeLevelsInterface) Foo() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"foo",
-		[]interface{}{},
-		false,
-		&returns,
-	)
+// The jsii proxy for IThreeLevelsInterface
+type iThreeLevelsInterface struct {
+	scopejsiicalcbase.IBaseInterface // extends @scope/jsii-calc-base.IBaseInterface
 }
 
-func (i *IThreeLevelsInterface) Bar() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"bar",
-		[]interface{}{},
-		false,
-		&returns,
-	)
-}
-
-func (i *IThreeLevelsInterface) Baz() {
+func (i *iThreeLevelsInterface) Baz() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -1242,38 +1241,22 @@ type MyFirstStruct struct {
 	FirstOptional []string \`json:"firstOptional"\`
 }
 
-// Class interface
-type NumberIface interface {
-	IDoublableIface
-	GetValue() float64
-	GetDoubleValue() float64
-	TypeName() interface{}
-	ToString() string
-}
-
 // Represents a concrete number.
 // Deprecated.
-// Struct proxy
-type Number struct {
-	// The number.
-	// Deprecated.
-	Value float64 \`json:"value"\`
-	// The number multiplied by 2.
-	// Deprecated.
-	DoubleValue float64 \`json:"doubleValue"\`
+type Number interface {
+	NumericValue
+	IDoublable
+	DoubleValue() float64
+	Value() float64
 }
 
-func (n *Number) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		n,
-		"value",
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for Number
+type number struct {
+	numericValue // extends @scope/jsii-calc-lib.NumericValue
+	iDoublable // implements @scope/jsii-calc-lib.IDoublable
 }
 
-func (n *Number) GetDoubleValue() float64 {
+func (n *number) DoubleValue() float64 {
 	var returns float64
 	_jsii_.Get(
 		n,
@@ -1283,34 +1266,35 @@ func (n *Number) GetDoubleValue() float64 {
 	return returns
 }
 
+func (n *number) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		n,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
 
 // Creates a Number object.
-func NewNumber(value float64) NumberIface {
+func NewNumber(value float64) Number {
 	_init_.Initialize()
-	self := Number{}
+	n := number{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-lib.Number",
 		[]interface{}{value},
 		[]_jsii_.FQN{"@scope/jsii-calc-lib.IDoublable"},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *Number) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (n *Number) ToString() string {
+// String representation of the value.
+// Deprecated.
+func (n *number) ToString() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -1322,23 +1306,34 @@ func (n *Number) ToString() string {
 	return returns
 }
 
-// Class interface
-type NumericValueIface interface {
-	GetValue() float64
-	TypeName() interface{}
-	ToString() string
+// Returns: the name of the class (to verify native type names are created for derived classes).
+// Deprecated.
+func (n *number) TypeName() interface{} {
+	var returns interface{}
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
 }
 
 // Abstract class which represents a numeric value.
 // Deprecated.
-// Struct proxy
-type NumericValue struct {
-	// The value.
-	// Deprecated.
-	Value float64 \`json:"value"\`
+type NumericValue interface {
+	scopejsiicalcbase.Base
+	Value() float64
+	ToString() string
 }
 
-func (n *NumericValue) GetValue() float64 {
+// The jsii proxy struct for NumericValue
+type numericValue struct {
+	scopejsiicalcbase.Base // extends @scope/jsii-calc-base.Base
+}
+
+func (n *numericValue) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		n,
@@ -1349,32 +1344,23 @@ func (n *NumericValue) GetValue() float64 {
 }
 
 
-func NewNumericValue() NumericValueIface {
+func NewNumericValue() NumericValue {
 	_init_.Initialize()
-	self := NumericValue{}
+	n := numericValue{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-lib.NumericValue",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *NumericValue) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (n *NumericValue) ToString() string {
+// String representation of the value.
+// Deprecated.
+func (n *numericValue) ToString() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -1386,59 +1372,35 @@ func (n *NumericValue) ToString() string {
 	return returns
 }
 
-// Class interface
-type OperationIface interface {
-	GetValue() float64
-	TypeName() interface{}
+// Represents an operation on values.
+// Deprecated.
+type Operation interface {
+	NumericValue
 	ToString() string
 }
 
-// Represents an operation on values.
-// Deprecated.
-// Struct proxy
-type Operation struct {
-	// The value.
-	// Deprecated.
-	Value float64 \`json:"value"\`
+// The jsii proxy struct for Operation
+type operation struct {
+	numericValue // extends @scope/jsii-calc-lib.NumericValue
 }
 
-func (o *Operation) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		o,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewOperation() OperationIface {
+func NewOperation() Operation {
 	_init_.Initialize()
-	self := Operation{}
+	o := operation{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-lib.Operation",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *Operation) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		o,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (o *Operation) ToString() string {
+// String representation of the value.
+// Deprecated.
+func (o *operation) ToString() string {
 	var returns string
 	_jsii_.Invoke(
 		o,
@@ -1493,18 +1455,26 @@ func init() {
 	)
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-lib.IDoublable",
-		reflect.TypeOf((*IDoublableIface)(nil)).Elem(),
 		reflect.TypeOf((*IDoublable)(nil)).Elem(),
+		func() interface{} {
+			return &iDoublable{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-lib.IFriendly",
-		reflect.TypeOf((*IFriendlyIface)(nil)).Elem(),
 		reflect.TypeOf((*IFriendly)(nil)).Elem(),
+		func() interface{} {
+			return &iFriendly{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-lib.IThreeLevelsInterface",
-		reflect.TypeOf((*IThreeLevelsInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IThreeLevelsInterface)(nil)).Elem(),
+		func() interface{} {
+			i := iThreeLevelsInterface{}
+			_jsii_.InitJsiiProxy(&i.IBaseInterface)
+			return &i
+		},
 	)
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-lib.MyFirstStruct",
@@ -1513,17 +1483,30 @@ func init() {
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.Number",
 		reflect.TypeOf((*Number)(nil)).Elem(),
-		reflect.TypeOf((*NumberIface)(nil)).Elem(),
+		func() interface{} {
+			n := number{}
+			_jsii_.InitJsiiProxy(&n.numericValue)
+			_jsii_.InitJsiiProxy(&n.iDoublable)
+			return &n
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.NumericValue",
 		reflect.TypeOf((*NumericValue)(nil)).Elem(),
-		reflect.TypeOf((*NumericValueIface)(nil)).Elem(),
+		func() interface{} {
+			n := numericValue{}
+			_jsii_.InitJsiiProxy(&n.Base)
+			return &n
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.Operation",
 		reflect.TypeOf((*Operation)(nil)).Elem(),
-		reflect.TypeOf((*OperationIface)(nil)).Elem(),
+		func() interface{} {
+			o := operation{}
+			_jsii_.InitJsiiProxy(&o.numericValue)
+			return &o
+		},
 	)
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-lib.StructWithOnlyOptionals",
@@ -1542,14 +1525,17 @@ import (
 )
 
 // Deprecated.
-type IReflectableIface interface {
+type IReflectable interface {
 	// Deprecated.
-	GetEntries() []ReflectableEntry
+	Entries() []ReflectableEntry
 }
 
-type IReflectable struct {}
+// The jsii proxy for IReflectable
+type iReflectable struct {
+	_ byte // padding
+}
 
-func (i *IReflectable) GetEntries() []ReflectableEntry {
+func (i *iReflectable) Entries() []ReflectableEntry {
 	var returns []ReflectableEntry
 	_jsii_.Get(
 		i,
@@ -1559,30 +1545,28 @@ func (i *IReflectable) GetEntries() []ReflectableEntry {
 	return returns
 }
 
-// Class interface
-type NestingClassIface interface {
+// This class is here to show we can use nested classes across module boundaries.
+// Deprecated.
+type NestingClass interface {
+}
+
+// The jsii proxy struct for NestingClass
+type nestingClass struct {
+	_ byte // padding
 }
 
 // This class is here to show we can use nested classes across module boundaries.
 // Deprecated.
-// Struct proxy
-type NestingClass struct {
+type NestedClass interface {
+	Property() string
 }
 
-// Class interface
-type NestedClassIface interface {
-	GetProperty() string
+// The jsii proxy struct for NestedClass
+type nestedClass struct {
+	_ byte // padding
 }
 
-// This class is here to show we can use nested classes across module boundaries.
-// Deprecated.
-// Struct proxy
-type NestedClass struct {
-	// Deprecated.
-	Property string \`json:"property"\`
-}
-
-func (n *NestedClass) GetProperty() string {
+func (n *nestedClass) Property() string {
 	var returns string
 	_jsii_.Get(
 		n,
@@ -1593,17 +1577,18 @@ func (n *NestedClass) GetProperty() string {
 }
 
 
-func NewNestedClass() NestedClassIface {
+func NewNestedClass() NestedClass {
 	_init_.Initialize()
-	self := NestedClass{}
+	n := nestedClass{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
 // This is a struct, nested within a class.
@@ -1623,30 +1608,32 @@ type ReflectableEntry struct {
 	Value interface{} \`json:"value"\`
 }
 
-// Class interface
-type ReflectorIface interface {
-	AsMap(reflectable IReflectableIface) map[string]interface{}
-}
-
 // Deprecated.
-// Struct proxy
-type Reflector struct {
+type Reflector interface {
+	AsMap(reflectable IReflectable) map[string]interface{}
 }
 
-func NewReflector() ReflectorIface {
+// The jsii proxy struct for Reflector
+type reflector struct {
+	_ byte // padding
+}
+
+func NewReflector() Reflector {
 	_init_.Initialize()
-	self := Reflector{}
+	r := reflector{}
+
 	_jsii_.Create(
 		"@scope/jsii-calc-lib.submodule.Reflector",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&r,
 	)
-	return &self
+	return &r
 }
 
-func (r *Reflector) AsMap(reflectable IReflectableIface) map[string]interface{} {
+// Deprecated.
+func (r *reflector) AsMap(reflectable IReflectable) map[string]interface{} {
 	var returns map[string]interface{}
 	_jsii_.Invoke(
 		r,
@@ -1673,18 +1660,24 @@ import (
 func init() {
 	_jsii_.RegisterInterface(
 		"@scope/jsii-calc-lib.submodule.IReflectable",
-		reflect.TypeOf((*IReflectableIface)(nil)).Elem(),
 		reflect.TypeOf((*IReflectable)(nil)).Elem(),
+		func() interface{} {
+			return &iReflectable{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.submodule.NestingClass",
 		reflect.TypeOf((*NestingClass)(nil)).Elem(),
-		reflect.TypeOf((*NestingClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &nestingClass{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
 		reflect.TypeOf((*NestedClass)(nil)).Elem(),
-		reflect.TypeOf((*NestedClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &nestedClass{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-lib.submodule.NestingClass.NestedStruct",
@@ -1697,7 +1690,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"@scope/jsii-calc-lib.submodule.Reflector",
 		reflect.TypeOf((*Reflector)(nil)).Elem(),
-		reflect.TypeOf((*ReflectorIface)(nil)).Elem(),
+		func() interface{} {
+			return &reflector{}
+		},
 	)
 }
 
@@ -2014,58 +2009,26 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 )
 
-// Class interface
-type CompositeOperationIface interface {
-	GetValue() float64
-	GetExpression() scopejsiicalclib.NumericValueIface
-	GetDecorationPostfixes() []string
+// Abstract operation composed from an expression of other operations.
+type CompositeOperation interface {
+	scopejsiicalclib.Operation
+	DecorationPostfixes() []string
 	SetDecorationPostfixes(val []string)
-	GetDecorationPrefixes() []string
+	DecorationPrefixes() []string
 	SetDecorationPrefixes(val []string)
-	GetStringStyle() CompositionStringStyle
+	Expression() scopejsiicalclib.NumericValue
+	StringStyle() CompositionStringStyle
 	SetStringStyle(val CompositionStringStyle)
-	TypeName() interface{}
+	Value() float64
 	ToString() string
 }
 
-// Abstract operation composed from an expression of other operations.
-// Struct proxy
-type CompositeOperation struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// The expression that this operation consists of.
-	//
-	// Must be implemented by derived classes.
-	Expression scopejsiicalclib.NumericValueIface \`json:"expression"\`
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes []string \`json:"decorationPostfixes"\`
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes []string \`json:"decorationPrefixes"\`
-	// The .toString() style.
-	StringStyle CompositionStringStyle \`json:"stringStyle"\`
+// The jsii proxy struct for CompositeOperation
+type compositeOperation struct {
+	scopejsiicalclib.Operation // extends @scope/jsii-calc-lib.Operation
 }
 
-func (c *CompositeOperation) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		c,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-func (c *CompositeOperation) GetExpression() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		c,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (c *CompositeOperation) GetDecorationPostfixes() []string {
+func (c *compositeOperation) DecorationPostfixes() []string {
 	var returns []string
 	_jsii_.Get(
 		c,
@@ -2075,7 +2038,7 @@ func (c *CompositeOperation) GetDecorationPostfixes() []string {
 	return returns
 }
 
-func (c *CompositeOperation) GetDecorationPrefixes() []string {
+func (c *compositeOperation) DecorationPrefixes() []string {
 	var returns []string
 	_jsii_.Get(
 		c,
@@ -2085,7 +2048,17 @@ func (c *CompositeOperation) GetDecorationPrefixes() []string {
 	return returns
 }
 
-func (c *CompositeOperation) GetStringStyle() CompositionStringStyle {
+func (c *compositeOperation) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		c,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (c *compositeOperation) StringStyle() CompositionStringStyle {
 	var returns CompositionStringStyle
 	_jsii_.Get(
 		c,
@@ -2095,21 +2068,32 @@ func (c *CompositeOperation) GetStringStyle() CompositionStringStyle {
 	return returns
 }
 
+func (c *compositeOperation) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		c,
+		"value",
+		&returns,
+	)
+	return returns
+}
 
-func NewCompositeOperation() CompositeOperationIface {
+
+func NewCompositeOperation() CompositeOperation {
 	_init_.Initialize()
-	self := CompositeOperation{}
+	c := compositeOperation{}
+
 	_jsii_.Create(
 		"jsii-calc.composition.CompositeOperation",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *CompositeOperation) SetDecorationPostfixes(val []string) {
+func (c *compositeOperation) SetDecorationPostfixes(val []string) {
 	_jsii_.Set(
 		c,
 		"decorationPostfixes",
@@ -2117,7 +2101,7 @@ func (c *CompositeOperation) SetDecorationPostfixes(val []string) {
 	)
 }
 
-func (c *CompositeOperation) SetDecorationPrefixes(val []string) {
+func (c *compositeOperation) SetDecorationPrefixes(val []string) {
 	_jsii_.Set(
 		c,
 		"decorationPrefixes",
@@ -2125,7 +2109,7 @@ func (c *CompositeOperation) SetDecorationPrefixes(val []string) {
 	)
 }
 
-func (c *CompositeOperation) SetStringStyle(val CompositionStringStyle) {
+func (c *compositeOperation) SetStringStyle(val CompositionStringStyle) {
 	_jsii_.Set(
 		c,
 		"stringStyle",
@@ -2133,19 +2117,8 @@ func (c *CompositeOperation) SetStringStyle(val CompositionStringStyle) {
 	)
 }
 
-func (c *CompositeOperation) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		c,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (c *CompositeOperation) ToString() string {
+// (deprecated) String representation of the value.
+func (c *compositeOperation) ToString() string {
 	var returns string
 	_jsii_.Invoke(
 		c,
@@ -2181,7 +2154,11 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.composition.CompositeOperation",
 		reflect.TypeOf((*CompositeOperation)(nil)).Elem(),
-		reflect.TypeOf((*CompositeOperationIface)(nil)).Elem(),
+		func() interface{} {
+			c := compositeOperation{}
+			_jsii_.InitJsiiProxy(&c.Operation)
+			return &c
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.composition.CompositeOperation.CompositionStringStyle",
@@ -2203,18 +2180,17 @@ import (
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 )
 
-// Class interface
-type BaseIface interface {
-	GetProp() string
+type Base interface {
+	Prop() string
 	SetProp(val string)
 }
 
-// Struct proxy
-type Base struct {
-	Prop string \`json:"prop"\`
+// The jsii proxy struct for Base
+type base struct {
+	_ byte // padding
 }
 
-func (b *Base) GetProp() string {
+func (b *base) Prop() string {
 	var returns string
 	_jsii_.Get(
 		b,
@@ -2225,20 +2201,21 @@ func (b *Base) GetProp() string {
 }
 
 
-func NewBase() BaseIface {
+func NewBase() Base {
 	_init_.Initialize()
-	self := Base{}
+	b := base{}
+
 	_jsii_.Create(
 		"jsii-calc.DerivedClassHasNoProperties.Base",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-func (b *Base) SetProp(val string) {
+func (b *base) SetProp(val string) {
 	_jsii_.Set(
 		b,
 		"prop",
@@ -2246,47 +2223,27 @@ func (b *Base) SetProp(val string) {
 	)
 }
 
-// Class interface
-type DerivedIface interface {
-	GetProp() string
-	SetProp(val string)
+type Derived interface {
+	Base
 }
 
-// Struct proxy
-type Derived struct {
-	Prop string \`json:"prop"\`
+// The jsii proxy struct for Derived
+type derived struct {
+	base // extends jsii-calc.DerivedClassHasNoProperties.Base
 }
 
-func (d *Derived) GetProp() string {
-	var returns string
-	_jsii_.Get(
-		d,
-		"prop",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewDerived() DerivedIface {
+func NewDerived() Derived {
 	_init_.Initialize()
-	self := Derived{}
+	d := derived{}
+
 	_jsii_.Create(
 		"jsii-calc.DerivedClassHasNoProperties.Derived",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
-}
-
-func (d *Derived) SetProp(val string) {
-	_jsii_.Set(
-		d,
-		"prop",
-		val,
-	)
+	return &d
 }
 
 
@@ -2305,12 +2262,18 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.DerivedClassHasNoProperties.Base",
 		reflect.TypeOf((*Base)(nil)).Elem(),
-		reflect.TypeOf((*BaseIface)(nil)).Elem(),
+		func() interface{} {
+			return &base{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DerivedClassHasNoProperties.Derived",
 		reflect.TypeOf((*Derived)(nil)).Elem(),
-		reflect.TypeOf((*DerivedIface)(nil)).Elem(),
+		func() interface{} {
+			d := derived{}
+			_jsii_.InitJsiiProxy(&d.base)
+			return &d
+		},
 	)
 }
 
@@ -2338,18 +2301,17 @@ import (
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 )
 
-// Class interface
-type FooIface interface {
-	GetBar() string
+type Foo interface {
+	Bar() string
 	SetBar(val string)
 }
 
-// Struct proxy
-type Foo struct {
-	Bar string \`json:"bar"\`
+// The jsii proxy struct for Foo
+type foo struct {
+	_ byte // padding
 }
 
-func (f *Foo) GetBar() string {
+func (f *foo) Bar() string {
 	var returns string
 	_jsii_.Get(
 		f,
@@ -2360,20 +2322,21 @@ func (f *Foo) GetBar() string {
 }
 
 
-func NewFoo() FooIface {
+func NewFoo() Foo {
 	_init_.Initialize()
-	self := Foo{}
+	f := foo{}
+
 	_jsii_.Create(
 		"jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&f,
 	)
-	return &self
+	return &f
 }
 
-func (f *Foo) SetBar(val string) {
+func (f *foo) SetBar(val string) {
 	_jsii_.Set(
 		f,
 		"bar",
@@ -2401,7 +2364,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
 		reflect.TypeOf((*Foo)(nil)).Elem(),
-		reflect.TypeOf((*FooIface)(nil)).Elem(),
+		func() interface{} {
+			return &foo{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
@@ -2489,32 +2454,21 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
 )
 
-// Class interface
-type AbstractClassIface interface {
-	IInterfaceImplementedByAbstractClassIface
-	GetAbstractProperty() string
-	GetPropFromInterface() string
+type AbstractClass interface {
+	AbstractClassBase
+	IInterfaceImplementedByAbstractClass
+	PropFromInterface() string
 	AbstractMethod(name string) string
 	NonAbstractMethod() float64
 }
 
-// Struct proxy
-type AbstractClass struct {
-	AbstractProperty string \`json:"abstractProperty"\`
-	PropFromInterface string \`json:"propFromInterface"\`
+// The jsii proxy struct for AbstractClass
+type abstractClass struct {
+	abstractClassBase // extends jsii-calc.AbstractClassBase
+	iInterfaceImplementedByAbstractClass // implements jsii-calc.IInterfaceImplementedByAbstractClass
 }
 
-func (a *AbstractClass) GetAbstractProperty() string {
-	var returns string
-	_jsii_.Get(
-		a,
-		"abstractProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AbstractClass) GetPropFromInterface() string {
+func (a *abstractClass) PropFromInterface() string {
 	var returns string
 	_jsii_.Get(
 		a,
@@ -2525,20 +2479,21 @@ func (a *AbstractClass) GetPropFromInterface() string {
 }
 
 
-func NewAbstractClass() AbstractClassIface {
+func NewAbstractClass() AbstractClass {
 	_init_.Initialize()
-	self := AbstractClass{}
+	a := abstractClass{}
+
 	_jsii_.Create(
 		"jsii-calc.AbstractClass",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IInterfaceImplementedByAbstractClass"},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AbstractClass) AbstractMethod(name string) string {
+func (a *abstractClass) AbstractMethod(name string) string {
 	var returns string
 	_jsii_.Invoke(
 		a,
@@ -2550,7 +2505,7 @@ func (a *AbstractClass) AbstractMethod(name string) string {
 	return returns
 }
 
-func (a *AbstractClass) NonAbstractMethod() float64 {
+func (a *abstractClass) NonAbstractMethod() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -2562,17 +2517,16 @@ func (a *AbstractClass) NonAbstractMethod() float64 {
 	return returns
 }
 
-// Class interface
-type AbstractClassBaseIface interface {
-	GetAbstractProperty() string
+type AbstractClassBase interface {
+	AbstractProperty() string
 }
 
-// Struct proxy
-type AbstractClassBase struct {
-	AbstractProperty string \`json:"abstractProperty"\`
+// The jsii proxy struct for AbstractClassBase
+type abstractClassBase struct {
+	_ byte // padding
 }
 
-func (a *AbstractClassBase) GetAbstractProperty() string {
+func (a *abstractClassBase) AbstractProperty() string {
 	var returns string
 	_jsii_.Get(
 		a,
@@ -2583,33 +2537,33 @@ func (a *AbstractClassBase) GetAbstractProperty() string {
 }
 
 
-func NewAbstractClassBase() AbstractClassBaseIface {
+func NewAbstractClassBase() AbstractClassBase {
 	_init_.Initialize()
-	self := AbstractClassBase{}
+	a := abstractClassBase{}
+
 	_jsii_.Create(
 		"jsii-calc.AbstractClassBase",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-// Class interface
-type AbstractClassReturnerIface interface {
-	GetReturnAbstractFromProperty() AbstractClassBaseIface
-	GiveMeAbstract() AbstractClassIface
-	GiveMeInterface() IInterfaceImplementedByAbstractClassIface
+type AbstractClassReturner interface {
+	ReturnAbstractFromProperty() AbstractClassBase
+	GiveMeAbstract() AbstractClass
+	GiveMeInterface() IInterfaceImplementedByAbstractClass
 }
 
-// Struct proxy
-type AbstractClassReturner struct {
-	ReturnAbstractFromProperty AbstractClassBaseIface \`json:"returnAbstractFromProperty"\`
+// The jsii proxy struct for AbstractClassReturner
+type abstractClassReturner struct {
+	_ byte // padding
 }
 
-func (a *AbstractClassReturner) GetReturnAbstractFromProperty() AbstractClassBaseIface {
-	var returns AbstractClassBaseIface
+func (a *abstractClassReturner) ReturnAbstractFromProperty() AbstractClassBase {
+	var returns AbstractClassBase
 	_jsii_.Get(
 		a,
 		"returnAbstractFromProperty",
@@ -2619,21 +2573,22 @@ func (a *AbstractClassReturner) GetReturnAbstractFromProperty() AbstractClassBas
 }
 
 
-func NewAbstractClassReturner() AbstractClassReturnerIface {
+func NewAbstractClassReturner() AbstractClassReturner {
 	_init_.Initialize()
-	self := AbstractClassReturner{}
+	a := abstractClassReturner{}
+
 	_jsii_.Create(
 		"jsii-calc.AbstractClassReturner",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AbstractClassReturner) GiveMeAbstract() AbstractClassIface {
-	var returns AbstractClassIface
+func (a *abstractClassReturner) GiveMeAbstract() AbstractClass {
+	var returns AbstractClass
 	_jsii_.Invoke(
 		a,
 		"giveMeAbstract",
@@ -2644,8 +2599,8 @@ func (a *AbstractClassReturner) GiveMeAbstract() AbstractClassIface {
 	return returns
 }
 
-func (a *AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstractClassIface {
-	var returns IInterfaceImplementedByAbstractClassIface
+func (a *abstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstractClass {
+	var returns IInterfaceImplementedByAbstractClass
 	_jsii_.Invoke(
 		a,
 		"giveMeInterface",
@@ -2656,20 +2611,19 @@ func (a *AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstrac
 	return returns
 }
 
-// Class interface
-type AbstractSuiteIface interface {
-	GetProperty() string
+// Ensures abstract members implementations correctly register overrides in various languages.
+type AbstractSuite interface {
+	Property() string
 	SomeMethod(str string) string
 	WorkItAll(seed string) string
 }
 
-// Ensures abstract members implementations correctly register overrides in various languages.
-// Struct proxy
-type AbstractSuite struct {
-	Property string \`json:"property"\`
+// The jsii proxy struct for AbstractSuite
+type abstractSuite struct {
+	_ byte // padding
 }
 
-func (a *AbstractSuite) GetProperty() string {
+func (a *abstractSuite) Property() string {
 	var returns string
 	_jsii_.Get(
 		a,
@@ -2680,20 +2634,21 @@ func (a *AbstractSuite) GetProperty() string {
 }
 
 
-func NewAbstractSuite() AbstractSuiteIface {
+func NewAbstractSuite() AbstractSuite {
 	_init_.Initialize()
-	self := AbstractSuite{}
+	a := abstractSuite{}
+
 	_jsii_.Create(
 		"jsii-calc.AbstractSuite",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AbstractSuite) SetProperty(val string) {
+func (a *abstractSuite) SetProperty(val string) {
 	_jsii_.Set(
 		a,
 		"property",
@@ -2701,7 +2656,7 @@ func (a *AbstractSuite) SetProperty(val string) {
 	)
 }
 
-func (a *AbstractSuite) SomeMethod(str string) string {
+func (a *abstractSuite) SomeMethod(str string) string {
 	var returns string
 	_jsii_.Invoke(
 		a,
@@ -2713,7 +2668,8 @@ func (a *AbstractSuite) SomeMethod(str string) string {
 	return returns
 }
 
-func (a *AbstractSuite) WorkItAll(seed string) string {
+// Sets \`seed\` to \`this.property\`, then calls \`someMethod\` with \`this.property\` and returns the result.
+func (a *abstractSuite) WorkItAll(seed string) string {
 	var returns string
 	_jsii_.Invoke(
 		a,
@@ -2725,29 +2681,19 @@ func (a *AbstractSuite) WorkItAll(seed string) string {
 	return returns
 }
 
-// Class interface
-type AddIface interface {
-	scopejsiicalclib.IFriendlyIface
-	GetValue() float64
-	GetLhs() scopejsiicalclib.NumericValueIface
-	GetRhs() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
-	Hello() string
-}
-
 // The "+" binary operation.
-// Struct proxy
-type Add struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// Left-hand side operand.
-	Lhs scopejsiicalclib.NumericValueIface \`json:"lhs"\`
-	// Right-hand side operand.
-	Rhs scopejsiicalclib.NumericValueIface \`json:"rhs"\`
+type Add interface {
+	BinaryOperation
+	Value() float64
+	ToString() string
 }
 
-func (a *Add) GetValue() float64 {
+// The jsii proxy struct for Add
+type add struct {
+	binaryOperation // extends jsii-calc.BinaryOperation
+}
+
+func (a *add) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		a,
@@ -2757,54 +2703,24 @@ func (a *Add) GetValue() float64 {
 	return returns
 }
 
-func (a *Add) GetLhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		a,
-		"lhs",
-		&returns,
-	)
-	return returns
-}
-
-func (a *Add) GetRhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		a,
-		"rhs",
-		&returns,
-	)
-	return returns
-}
-
 
 // Creates a BinaryOperation.
-func NewAdd(lhs scopejsiicalclib.NumericValueIface, rhs scopejsiicalclib.NumericValueIface) AddIface {
+func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Add {
 	_init_.Initialize()
-	self := Add{}
+	a := add{}
+
 	_jsii_.Create(
 		"jsii-calc.Add",
 		[]interface{}{lhs, rhs},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *Add) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		a,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (a *Add) ToString() string {
+// (deprecated) String representation of the value.
+func (a *add) ToString() string {
 	var returns string
 	_jsii_.Invoke(
 		a,
@@ -2816,100 +2732,59 @@ func (a *Add) ToString() string {
 	return returns
 }
 
-func (a *Add) Hello() string {
-	var returns string
-	_jsii_.Invoke(
-		a,
-		"hello",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-// Class interface
-type AllTypesIface interface {
-	GetEnumPropertyValue() float64
-	GetAnyArrayProperty() []interface{}
+// This class includes property for all types supported by jsii.
+//
+// The setters will validate
+// that the value set is of the expected type and throw otherwise.
+type AllTypes interface {
+	AnyArrayProperty() []interface{}
 	SetAnyArrayProperty(val []interface{})
-	GetAnyMapProperty() map[string]interface{}
+	AnyMapProperty() map[string]interface{}
 	SetAnyMapProperty(val map[string]interface{})
-	GetAnyProperty() interface{}
+	AnyProperty() interface{}
 	SetAnyProperty(val interface{})
-	GetArrayProperty() []string
+	ArrayProperty() []string
 	SetArrayProperty(val []string)
-	GetBooleanProperty() bool
+	BooleanProperty() bool
 	SetBooleanProperty(val bool)
-	GetDateProperty() string
+	DateProperty() string
 	SetDateProperty(val string)
-	GetEnumProperty() AllTypesEnum
+	EnumProperty() AllTypesEnum
 	SetEnumProperty(val AllTypesEnum)
-	GetJsonProperty() map[string]interface{}
+	EnumPropertyValue() float64
+	JsonProperty() map[string]interface{}
 	SetJsonProperty(val map[string]interface{})
-	GetMapProperty() map[string]scopejsiicalclib.NumberIface
-	SetMapProperty(val map[string]scopejsiicalclib.NumberIface)
-	GetNumberProperty() float64
+	MapProperty() map[string]scopejsiicalclib.Number
+	SetMapProperty(val map[string]scopejsiicalclib.Number)
+	NumberProperty() float64
 	SetNumberProperty(val float64)
-	GetStringProperty() string
-	SetStringProperty(val string)
-	GetUnionArrayProperty() []interface{}
-	SetUnionArrayProperty(val []interface{})
-	GetUnionMapProperty() map[string]interface{}
-	SetUnionMapProperty(val map[string]interface{})
-	GetUnionProperty() interface{}
-	SetUnionProperty(val interface{})
-	GetUnknownArrayProperty() []interface{}
-	SetUnknownArrayProperty(val []interface{})
-	GetUnknownMapProperty() map[string]interface{}
-	SetUnknownMapProperty(val map[string]interface{})
-	GetUnknownProperty() interface{}
-	SetUnknownProperty(val interface{})
-	GetOptionalEnumValue() StringEnum
+	OptionalEnumValue() StringEnum
 	SetOptionalEnumValue(val StringEnum)
+	StringProperty() string
+	SetStringProperty(val string)
+	UnionArrayProperty() []interface{}
+	SetUnionArrayProperty(val []interface{})
+	UnionMapProperty() map[string]interface{}
+	SetUnionMapProperty(val map[string]interface{})
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
+	UnknownArrayProperty() []interface{}
+	SetUnknownArrayProperty(val []interface{})
+	UnknownMapProperty() map[string]interface{}
+	SetUnknownMapProperty(val map[string]interface{})
+	UnknownProperty() interface{}
+	SetUnknownProperty(val interface{})
 	AnyIn(inp interface{})
 	AnyOut() interface{}
 	EnumMethod(value StringEnum) StringEnum
 }
 
-// This class includes property for all types supported by jsii.
-//
-// The setters will validate
-// that the value set is of the expected type and throw otherwise.
-// Struct proxy
-type AllTypes struct {
-	EnumPropertyValue float64 \`json:"enumPropertyValue"\`
-	AnyArrayProperty []interface{} \`json:"anyArrayProperty"\`
-	AnyMapProperty map[string]interface{} \`json:"anyMapProperty"\`
-	AnyProperty interface{} \`json:"anyProperty"\`
-	ArrayProperty []string \`json:"arrayProperty"\`
-	BooleanProperty bool \`json:"booleanProperty"\`
-	DateProperty string \`json:"dateProperty"\`
-	EnumProperty AllTypesEnum \`json:"enumProperty"\`
-	JsonProperty map[string]interface{} \`json:"jsonProperty"\`
-	MapProperty map[string]scopejsiicalclib.NumberIface \`json:"mapProperty"\`
-	NumberProperty float64 \`json:"numberProperty"\`
-	StringProperty string \`json:"stringProperty"\`
-	UnionArrayProperty []interface{} \`json:"unionArrayProperty"\`
-	UnionMapProperty map[string]interface{} \`json:"unionMapProperty"\`
-	UnionProperty interface{} \`json:"unionProperty"\`
-	UnknownArrayProperty []interface{} \`json:"unknownArrayProperty"\`
-	UnknownMapProperty map[string]interface{} \`json:"unknownMapProperty"\`
-	UnknownProperty interface{} \`json:"unknownProperty"\`
-	OptionalEnumValue StringEnum \`json:"optionalEnumValue"\`
+// The jsii proxy struct for AllTypes
+type allTypes struct {
+	_ byte // padding
 }
 
-func (a *AllTypes) GetEnumPropertyValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		a,
-		"enumPropertyValue",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetAnyArrayProperty() []interface{} {
+func (a *allTypes) AnyArrayProperty() []interface{} {
 	var returns []interface{}
 	_jsii_.Get(
 		a,
@@ -2919,7 +2794,7 @@ func (a *AllTypes) GetAnyArrayProperty() []interface{} {
 	return returns
 }
 
-func (a *AllTypes) GetAnyMapProperty() map[string]interface{} {
+func (a *allTypes) AnyMapProperty() map[string]interface{} {
 	var returns map[string]interface{}
 	_jsii_.Get(
 		a,
@@ -2929,7 +2804,7 @@ func (a *AllTypes) GetAnyMapProperty() map[string]interface{} {
 	return returns
 }
 
-func (a *AllTypes) GetAnyProperty() interface{} {
+func (a *allTypes) AnyProperty() interface{} {
 	var returns interface{}
 	_jsii_.Get(
 		a,
@@ -2939,7 +2814,7 @@ func (a *AllTypes) GetAnyProperty() interface{} {
 	return returns
 }
 
-func (a *AllTypes) GetArrayProperty() []string {
+func (a *allTypes) ArrayProperty() []string {
 	var returns []string
 	_jsii_.Get(
 		a,
@@ -2949,7 +2824,7 @@ func (a *AllTypes) GetArrayProperty() []string {
 	return returns
 }
 
-func (a *AllTypes) GetBooleanProperty() bool {
+func (a *allTypes) BooleanProperty() bool {
 	var returns bool
 	_jsii_.Get(
 		a,
@@ -2959,7 +2834,7 @@ func (a *AllTypes) GetBooleanProperty() bool {
 	return returns
 }
 
-func (a *AllTypes) GetDateProperty() string {
+func (a *allTypes) DateProperty() string {
 	var returns string
 	_jsii_.Get(
 		a,
@@ -2969,7 +2844,7 @@ func (a *AllTypes) GetDateProperty() string {
 	return returns
 }
 
-func (a *AllTypes) GetEnumProperty() AllTypesEnum {
+func (a *allTypes) EnumProperty() AllTypesEnum {
 	var returns AllTypesEnum
 	_jsii_.Get(
 		a,
@@ -2979,7 +2854,17 @@ func (a *AllTypes) GetEnumProperty() AllTypesEnum {
 	return returns
 }
 
-func (a *AllTypes) GetJsonProperty() map[string]interface{} {
+func (a *allTypes) EnumPropertyValue() float64 {
+	var returns float64
+	_jsii_.Get(
+		a,
+		"enumPropertyValue",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) JsonProperty() map[string]interface{} {
 	var returns map[string]interface{}
 	_jsii_.Get(
 		a,
@@ -2989,8 +2874,8 @@ func (a *AllTypes) GetJsonProperty() map[string]interface{} {
 	return returns
 }
 
-func (a *AllTypes) GetMapProperty() map[string]scopejsiicalclib.NumberIface {
-	var returns map[string]scopejsiicalclib.NumberIface
+func (a *allTypes) MapProperty() map[string]scopejsiicalclib.Number {
+	var returns map[string]scopejsiicalclib.Number
 	_jsii_.Get(
 		a,
 		"mapProperty",
@@ -2999,7 +2884,7 @@ func (a *AllTypes) GetMapProperty() map[string]scopejsiicalclib.NumberIface {
 	return returns
 }
 
-func (a *AllTypes) GetNumberProperty() float64 {
+func (a *allTypes) NumberProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		a,
@@ -3009,77 +2894,7 @@ func (a *AllTypes) GetNumberProperty() float64 {
 	return returns
 }
 
-func (a *AllTypes) GetStringProperty() string {
-	var returns string
-	_jsii_.Get(
-		a,
-		"stringProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnionArrayProperty() []interface{} {
-	var returns []interface{}
-	_jsii_.Get(
-		a,
-		"unionArrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnionMapProperty() map[string]interface{} {
-	var returns map[string]interface{}
-	_jsii_.Get(
-		a,
-		"unionMapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnionProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		a,
-		"unionProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnknownArrayProperty() []interface{} {
-	var returns []interface{}
-	_jsii_.Get(
-		a,
-		"unknownArrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnknownMapProperty() map[string]interface{} {
-	var returns map[string]interface{}
-	_jsii_.Get(
-		a,
-		"unknownMapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetUnknownProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		a,
-		"unknownProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (a *AllTypes) GetOptionalEnumValue() StringEnum {
+func (a *allTypes) OptionalEnumValue() StringEnum {
 	var returns StringEnum
 	_jsii_.Get(
 		a,
@@ -3089,21 +2904,92 @@ func (a *AllTypes) GetOptionalEnumValue() StringEnum {
 	return returns
 }
 
+func (a *allTypes) StringProperty() string {
+	var returns string
+	_jsii_.Get(
+		a,
+		"stringProperty",
+		&returns,
+	)
+	return returns
+}
 
-func NewAllTypes() AllTypesIface {
+func (a *allTypes) UnionArrayProperty() []interface{} {
+	var returns []interface{}
+	_jsii_.Get(
+		a,
+		"unionArrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) UnionMapProperty() map[string]interface{} {
+	var returns map[string]interface{}
+	_jsii_.Get(
+		a,
+		"unionMapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) UnionProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		a,
+		"unionProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) UnknownArrayProperty() []interface{} {
+	var returns []interface{}
+	_jsii_.Get(
+		a,
+		"unknownArrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) UnknownMapProperty() map[string]interface{} {
+	var returns map[string]interface{}
+	_jsii_.Get(
+		a,
+		"unknownMapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (a *allTypes) UnknownProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		a,
+		"unknownProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAllTypes() AllTypes {
 	_init_.Initialize()
-	self := AllTypes{}
+	a := allTypes{}
+
 	_jsii_.Create(
 		"jsii-calc.AllTypes",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AllTypes) SetAnyArrayProperty(val []interface{}) {
+func (a *allTypes) SetAnyArrayProperty(val []interface{}) {
 	_jsii_.Set(
 		a,
 		"anyArrayProperty",
@@ -3111,7 +2997,7 @@ func (a *AllTypes) SetAnyArrayProperty(val []interface{}) {
 	)
 }
 
-func (a *AllTypes) SetAnyMapProperty(val map[string]interface{}) {
+func (a *allTypes) SetAnyMapProperty(val map[string]interface{}) {
 	_jsii_.Set(
 		a,
 		"anyMapProperty",
@@ -3119,7 +3005,7 @@ func (a *AllTypes) SetAnyMapProperty(val map[string]interface{}) {
 	)
 }
 
-func (a *AllTypes) SetAnyProperty(val interface{}) {
+func (a *allTypes) SetAnyProperty(val interface{}) {
 	_jsii_.Set(
 		a,
 		"anyProperty",
@@ -3127,7 +3013,7 @@ func (a *AllTypes) SetAnyProperty(val interface{}) {
 	)
 }
 
-func (a *AllTypes) SetArrayProperty(val []string) {
+func (a *allTypes) SetArrayProperty(val []string) {
 	_jsii_.Set(
 		a,
 		"arrayProperty",
@@ -3135,7 +3021,7 @@ func (a *AllTypes) SetArrayProperty(val []string) {
 	)
 }
 
-func (a *AllTypes) SetBooleanProperty(val bool) {
+func (a *allTypes) SetBooleanProperty(val bool) {
 	_jsii_.Set(
 		a,
 		"booleanProperty",
@@ -3143,7 +3029,7 @@ func (a *AllTypes) SetBooleanProperty(val bool) {
 	)
 }
 
-func (a *AllTypes) SetDateProperty(val string) {
+func (a *allTypes) SetDateProperty(val string) {
 	_jsii_.Set(
 		a,
 		"dateProperty",
@@ -3151,7 +3037,7 @@ func (a *AllTypes) SetDateProperty(val string) {
 	)
 }
 
-func (a *AllTypes) SetEnumProperty(val AllTypesEnum) {
+func (a *allTypes) SetEnumProperty(val AllTypesEnum) {
 	_jsii_.Set(
 		a,
 		"enumProperty",
@@ -3159,7 +3045,7 @@ func (a *AllTypes) SetEnumProperty(val AllTypesEnum) {
 	)
 }
 
-func (a *AllTypes) SetJsonProperty(val map[string]interface{}) {
+func (a *allTypes) SetJsonProperty(val map[string]interface{}) {
 	_jsii_.Set(
 		a,
 		"jsonProperty",
@@ -3167,7 +3053,7 @@ func (a *AllTypes) SetJsonProperty(val map[string]interface{}) {
 	)
 }
 
-func (a *AllTypes) SetMapProperty(val map[string]scopejsiicalclib.NumberIface) {
+func (a *allTypes) SetMapProperty(val map[string]scopejsiicalclib.Number) {
 	_jsii_.Set(
 		a,
 		"mapProperty",
@@ -3175,7 +3061,7 @@ func (a *AllTypes) SetMapProperty(val map[string]scopejsiicalclib.NumberIface) {
 	)
 }
 
-func (a *AllTypes) SetNumberProperty(val float64) {
+func (a *allTypes) SetNumberProperty(val float64) {
 	_jsii_.Set(
 		a,
 		"numberProperty",
@@ -3183,63 +3069,7 @@ func (a *AllTypes) SetNumberProperty(val float64) {
 	)
 }
 
-func (a *AllTypes) SetStringProperty(val string) {
-	_jsii_.Set(
-		a,
-		"stringProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnionArrayProperty(val []interface{}) {
-	_jsii_.Set(
-		a,
-		"unionArrayProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnionMapProperty(val map[string]interface{}) {
-	_jsii_.Set(
-		a,
-		"unionMapProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnionProperty(val interface{}) {
-	_jsii_.Set(
-		a,
-		"unionProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnknownArrayProperty(val []interface{}) {
-	_jsii_.Set(
-		a,
-		"unknownArrayProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnknownMapProperty(val map[string]interface{}) {
-	_jsii_.Set(
-		a,
-		"unknownMapProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetUnknownProperty(val interface{}) {
-	_jsii_.Set(
-		a,
-		"unknownProperty",
-		val,
-	)
-}
-
-func (a *AllTypes) SetOptionalEnumValue(val StringEnum) {
+func (a *allTypes) SetOptionalEnumValue(val StringEnum) {
 	_jsii_.Set(
 		a,
 		"optionalEnumValue",
@@ -3247,7 +3077,63 @@ func (a *AllTypes) SetOptionalEnumValue(val StringEnum) {
 	)
 }
 
-func (a *AllTypes) AnyIn(inp interface{}) {
+func (a *allTypes) SetStringProperty(val string) {
+	_jsii_.Set(
+		a,
+		"stringProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnionArrayProperty(val []interface{}) {
+	_jsii_.Set(
+		a,
+		"unionArrayProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnionMapProperty(val map[string]interface{}) {
+	_jsii_.Set(
+		a,
+		"unionMapProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnionProperty(val interface{}) {
+	_jsii_.Set(
+		a,
+		"unionProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnknownArrayProperty(val []interface{}) {
+	_jsii_.Set(
+		a,
+		"unknownArrayProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnknownMapProperty(val map[string]interface{}) {
+	_jsii_.Set(
+		a,
+		"unknownMapProperty",
+		val,
+	)
+}
+
+func (a *allTypes) SetUnknownProperty(val interface{}) {
+	_jsii_.Set(
+		a,
+		"unknownProperty",
+		val,
+	)
+}
+
+func (a *allTypes) AnyIn(inp interface{}) {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3258,7 +3144,7 @@ func (a *AllTypes) AnyIn(inp interface{}) {
 	)
 }
 
-func (a *AllTypes) AnyOut() interface{} {
+func (a *allTypes) AnyOut() interface{} {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3270,7 +3156,7 @@ func (a *AllTypes) AnyOut() interface{} {
 	return returns
 }
 
-func (a *AllTypes) EnumMethod(value StringEnum) StringEnum {
+func (a *allTypes) EnumMethod(value StringEnum) StringEnum {
 	var returns StringEnum
 	_jsii_.Invoke(
 		a,
@@ -3290,32 +3176,33 @@ const (
 	AllTypesEnum_THIS_IS_GREAT AllTypesEnum = "THIS_IS_GREAT"
 )
 
-// Class interface
-type AllowedMethodNamesIface interface {
+type AllowedMethodNames interface {
 	GetBar(_p1 string, _p2 float64)
 	GetFoo(withParam string) string
 	SetBar(_x string, _y float64, _z bool)
 	SetFoo(_x string, _y float64)
 }
 
-// Struct proxy
-type AllowedMethodNames struct {
+// The jsii proxy struct for AllowedMethodNames
+type allowedMethodNames struct {
+	_ byte // padding
 }
 
-func NewAllowedMethodNames() AllowedMethodNamesIface {
+func NewAllowedMethodNames() AllowedMethodNames {
 	_init_.Initialize()
-	self := AllowedMethodNames{}
+	a := allowedMethodNames{}
+
 	_jsii_.Create(
 		"jsii-calc.AllowedMethodNames",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AllowedMethodNames) GetBar(_p1 string, _p2 float64) {
+func (a *allowedMethodNames) GetBar(_p1 string, _p2 float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3326,7 +3213,8 @@ func (a *AllowedMethodNames) GetBar(_p1 string, _p2 float64) {
 	)
 }
 
-func (a *AllowedMethodNames) GetFoo(withParam string) string {
+// getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
+func (a *allowedMethodNames) GetFoo(withParam string) string {
 	var returns string
 	_jsii_.Invoke(
 		a,
@@ -3338,7 +3226,7 @@ func (a *AllowedMethodNames) GetFoo(withParam string) string {
 	return returns
 }
 
-func (a *AllowedMethodNames) SetBar(_x string, _y float64, _z bool) {
+func (a *allowedMethodNames) SetBar(_x string, _y float64, _z bool) {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3349,7 +3237,8 @@ func (a *AllowedMethodNames) SetBar(_x string, _y float64, _z bool) {
 	)
 }
 
-func (a *AllowedMethodNames) SetFoo(_x string, _y float64) {
+// setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
+func (a *allowedMethodNames) SetFoo(_x string, _y float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3360,19 +3249,17 @@ func (a *AllowedMethodNames) SetFoo(_x string, _y float64) {
 	)
 }
 
-// Class interface
-type AmbiguousParametersIface interface {
-	GetProps() StructParameterType
-	GetScope() BellIface
+type AmbiguousParameters interface {
+	Props() StructParameterType
+	Scope() Bell
 }
 
-// Struct proxy
-type AmbiguousParameters struct {
-	Props StructParameterType \`json:"props"\`
-	Scope BellIface \`json:"scope"\`
+// The jsii proxy struct for AmbiguousParameters
+type ambiguousParameters struct {
+	_ byte // padding
 }
 
-func (a *AmbiguousParameters) GetProps() StructParameterType {
+func (a *ambiguousParameters) Props() StructParameterType {
 	var returns StructParameterType
 	_jsii_.Get(
 		a,
@@ -3382,8 +3269,8 @@ func (a *AmbiguousParameters) GetProps() StructParameterType {
 	return returns
 }
 
-func (a *AmbiguousParameters) GetScope() BellIface {
-	var returns BellIface
+func (a *ambiguousParameters) Scope() Bell {
+	var returns Bell
 	_jsii_.Get(
 		a,
 		"scope",
@@ -3393,45 +3280,47 @@ func (a *AmbiguousParameters) GetScope() BellIface {
 }
 
 
-func NewAmbiguousParameters(scope BellIface, props StructParameterType) AmbiguousParametersIface {
+func NewAmbiguousParameters(scope Bell, props StructParameterType) AmbiguousParameters {
 	_init_.Initialize()
-	self := AmbiguousParameters{}
+	a := ambiguousParameters{}
+
 	_jsii_.Create(
 		"jsii-calc.AmbiguousParameters",
 		[]interface{}{scope, props},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-// Class interface
-type AnonymousImplementationProviderIface interface {
-	IAnonymousImplementationProviderIface
-	ProvideAsClass() ImplementationIface
-	ProvideAsInterface() IAnonymouslyImplementMeIface
+type AnonymousImplementationProvider interface {
+	IAnonymousImplementationProvider
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
 }
 
-// Struct proxy
-type AnonymousImplementationProvider struct {
+// The jsii proxy struct for AnonymousImplementationProvider
+type anonymousImplementationProvider struct {
+	iAnonymousImplementationProvider // implements jsii-calc.IAnonymousImplementationProvider
 }
 
-func NewAnonymousImplementationProvider() AnonymousImplementationProviderIface {
+func NewAnonymousImplementationProvider() AnonymousImplementationProvider {
 	_init_.Initialize()
-	self := AnonymousImplementationProvider{}
+	a := anonymousImplementationProvider{}
+
 	_jsii_.Create(
 		"jsii-calc.AnonymousImplementationProvider",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IAnonymousImplementationProvider"},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AnonymousImplementationProvider) ProvideAsClass() ImplementationIface {
-	var returns ImplementationIface
+func (a *anonymousImplementationProvider) ProvideAsClass() Implementation {
+	var returns Implementation
 	_jsii_.Invoke(
 		a,
 		"provideAsClass",
@@ -3442,8 +3331,8 @@ func (a *AnonymousImplementationProvider) ProvideAsClass() ImplementationIface {
 	return returns
 }
 
-func (a *AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMeIface {
-	var returns IAnonymouslyImplementMeIface
+func (a *anonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
+	var returns IAnonymouslyImplementMe
 	_jsii_.Invoke(
 		a,
 		"provideAsInterface",
@@ -3454,8 +3343,7 @@ func (a *AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImple
 	return returns
 }
 
-// Class interface
-type AsyncVirtualMethodsIface interface {
+type AsyncVirtualMethods interface {
 	CallMe() float64
 	CallMe2() float64
 	CallMeDoublePromise() float64
@@ -3464,24 +3352,26 @@ type AsyncVirtualMethodsIface interface {
 	OverrideMeToo() float64
 }
 
-// Struct proxy
-type AsyncVirtualMethods struct {
+// The jsii proxy struct for AsyncVirtualMethods
+type asyncVirtualMethods struct {
+	_ byte // padding
 }
 
-func NewAsyncVirtualMethods() AsyncVirtualMethodsIface {
+func NewAsyncVirtualMethods() AsyncVirtualMethods {
 	_init_.Initialize()
-	self := AsyncVirtualMethods{}
+	a := asyncVirtualMethods{}
+
 	_jsii_.Create(
 		"jsii-calc.AsyncVirtualMethods",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AsyncVirtualMethods) CallMe() float64 {
+func (a *asyncVirtualMethods) CallMe() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3493,7 +3383,8 @@ func (a *AsyncVirtualMethods) CallMe() float64 {
 	return returns
 }
 
-func (a *AsyncVirtualMethods) CallMe2() float64 {
+// Just calls "overrideMeToo".
+func (a *asyncVirtualMethods) CallMe2() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3505,7 +3396,12 @@ func (a *AsyncVirtualMethods) CallMe2() float64 {
 	return returns
 }
 
-func (a *AsyncVirtualMethods) CallMeDoublePromise() float64 {
+// This method calls the "callMe" async method indirectly, which will then invoke a virtual method.
+//
+// This is a "double promise" situation, which
+// means that callbacks are not going to be available immediate, but only
+// after an "immediates" cycle.
+func (a *asyncVirtualMethods) CallMeDoublePromise() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3517,7 +3413,7 @@ func (a *AsyncVirtualMethods) CallMeDoublePromise() float64 {
 	return returns
 }
 
-func (a *AsyncVirtualMethods) DontOverrideMe() float64 {
+func (a *asyncVirtualMethods) DontOverrideMe() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3529,7 +3425,7 @@ func (a *AsyncVirtualMethods) DontOverrideMe() float64 {
 	return returns
 }
 
-func (a *AsyncVirtualMethods) OverrideMe(mult float64) float64 {
+func (a *asyncVirtualMethods) OverrideMe(mult float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3541,7 +3437,7 @@ func (a *AsyncVirtualMethods) OverrideMe(mult float64) float64 {
 	return returns
 }
 
-func (a *AsyncVirtualMethods) OverrideMeToo() float64 {
+func (a *asyncVirtualMethods) OverrideMeToo() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		a,
@@ -3553,30 +3449,31 @@ func (a *AsyncVirtualMethods) OverrideMeToo() float64 {
 	return returns
 }
 
-// Class interface
-type AugmentableClassIface interface {
+type AugmentableClass interface {
 	MethodOne()
 	MethodTwo()
 }
 
-// Struct proxy
-type AugmentableClass struct {
+// The jsii proxy struct for AugmentableClass
+type augmentableClass struct {
+	_ byte // padding
 }
 
-func NewAugmentableClass() AugmentableClassIface {
+func NewAugmentableClass() AugmentableClass {
 	_init_.Initialize()
-	self := AugmentableClass{}
+	a := augmentableClass{}
+
 	_jsii_.Create(
 		"jsii-calc.AugmentableClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&a,
 	)
-	return &self
+	return &a
 }
 
-func (a *AugmentableClass) MethodOne() {
+func (a *augmentableClass) MethodOne() {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3587,7 +3484,7 @@ func (a *AugmentableClass) MethodOne() {
 	)
 }
 
-func (a *AugmentableClass) MethodTwo() {
+func (a *augmentableClass) MethodTwo() {
 	var returns interface{}
 	_jsii_.Invoke(
 		a,
@@ -3598,41 +3495,41 @@ func (a *AugmentableClass) MethodTwo() {
 	)
 }
 
-// Class interface
-type BaseJsii976Iface interface {
+type BaseJsii976 interface {
 }
 
-// Struct proxy
-type BaseJsii976 struct {
+// The jsii proxy struct for BaseJsii976
+type baseJsii976 struct {
+	_ byte // padding
 }
 
-func NewBaseJsii976() BaseJsii976Iface {
+func NewBaseJsii976() BaseJsii976 {
 	_init_.Initialize()
-	self := BaseJsii976{}
+	b := baseJsii976{}
+
 	_jsii_.Create(
 		"jsii-calc.BaseJsii976",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-// Class interface
-type BellIface interface {
-	IBellIface
-	GetRung() bool
+type Bell interface {
+	IBell
+	Rung() bool
 	SetRung(val bool)
 	Ring()
 }
 
-// Struct proxy
-type Bell struct {
-	Rung bool \`json:"rung"\`
+// The jsii proxy struct for Bell
+type bell struct {
+	iBell // implements jsii-calc.IBell
 }
 
-func (b *Bell) GetRung() bool {
+func (b *bell) Rung() bool {
 	var returns bool
 	_jsii_.Get(
 		b,
@@ -3643,20 +3540,21 @@ func (b *Bell) GetRung() bool {
 }
 
 
-func NewBell() BellIface {
+func NewBell() Bell {
 	_init_.Initialize()
-	self := Bell{}
+	b := bell{}
+
 	_jsii_.Create(
 		"jsii-calc.Bell",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IBell"},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-func (b *Bell) SetRung(val bool) {
+func (b *bell) SetRung(val bool) {
 	_jsii_.Set(
 		b,
 		"rung",
@@ -3664,7 +3562,7 @@ func (b *Bell) SetRung(val bool) {
 	)
 }
 
-func (b *Bell) Ring() {
+func (b *bell) Ring() {
 	var returns interface{}
 	_jsii_.Invoke(
 		b,
@@ -3675,30 +3573,42 @@ func (b *Bell) Ring() {
 	)
 }
 
-// Class interface
-type BinaryOperationIface interface {
-	scopejsiicalclib.IFriendlyIface
-	GetValue() float64
-	GetLhs() scopejsiicalclib.NumericValueIface
-	GetRhs() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
+// Represents an operation with two operands.
+type BinaryOperation interface {
+	scopejsiicalclib.Operation
+	scopejsiicalclib.IFriendly
+	Lhs() scopejsiicalclib.NumericValue
+	Rhs() scopejsiicalclib.NumericValue
 	Hello() string
 }
 
-// Represents an operation with two operands.
-// Struct proxy
-type BinaryOperation struct {
-	// The value.
-	// Deprecated.
-	Value float64 \`json:"value"\`
-	// Left-hand side operand.
-	Lhs scopejsiicalclib.NumericValueIface \`json:"lhs"\`
-	// Right-hand side operand.
-	Rhs scopejsiicalclib.NumericValueIface \`json:"rhs"\`
+// The jsii proxy struct for BinaryOperation
+type binaryOperation struct {
+	scopejsiicalclib.Operation // extends @scope/jsii-calc-lib.Operation
+	scopejsiicalclib.IFriendly // implements @scope/jsii-calc-lib.IFriendly
 }
 
-func (b *BinaryOperation) GetValue() float64 {
+func (b *binaryOperation) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		b,
+		"lhs",
+		&returns,
+	)
+	return returns
+}
+
+func (b *binaryOperation) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		b,
+		"rhs",
+		&returns,
+	)
+	return returns
+}
+
+func (b *binaryOperation) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		b,
@@ -3708,66 +3618,24 @@ func (b *BinaryOperation) GetValue() float64 {
 	return returns
 }
 
-func (b *BinaryOperation) GetLhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		b,
-		"lhs",
-		&returns,
-	)
-	return returns
-}
-
-func (b *BinaryOperation) GetRhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		b,
-		"rhs",
-		&returns,
-	)
-	return returns
-}
-
 
 // Creates a BinaryOperation.
-func NewBinaryOperation(lhs scopejsiicalclib.NumericValueIface, rhs scopejsiicalclib.NumericValueIface) BinaryOperationIface {
+func NewBinaryOperation(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) BinaryOperation {
 	_init_.Initialize()
-	self := BinaryOperation{}
+	b := binaryOperation{}
+
 	_jsii_.Create(
 		"jsii-calc.BinaryOperation",
 		[]interface{}{lhs, rhs},
 		[]_jsii_.FQN{"@scope/jsii-calc-lib.IFriendly"},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-func (b *BinaryOperation) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		b,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (b *BinaryOperation) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		b,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (b *BinaryOperation) Hello() string {
+// (deprecated) Say hello!
+func (b *binaryOperation) Hello() string {
 	var returns string
 	_jsii_.Invoke(
 		b,
@@ -3779,31 +3647,59 @@ func (b *BinaryOperation) Hello() string {
 	return returns
 }
 
-// Class interface
-type BurriedAnonymousObjectIface interface {
+// String representation of the value.
+// Deprecated.
+func (b *binaryOperation) ToString() string {
+	var returns string
+	_jsii_.Invoke(
+		b,
+		"toString",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (b *binaryOperation) TypeName() interface{} {
+	var returns interface{}
+	_jsii_.Invoke(
+		b,
+		"typeName",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
+}
+
+// See https://github.com/aws/aws-cdk/issues/7977.
+type BurriedAnonymousObject interface {
 	Check() bool
 	GiveItBack(value interface{}) interface{}
 }
 
-// See https://github.com/aws/aws-cdk/issues/7977.
-// Struct proxy
-type BurriedAnonymousObject struct {
+// The jsii proxy struct for BurriedAnonymousObject
+type burriedAnonymousObject struct {
+	_ byte // padding
 }
 
-func NewBurriedAnonymousObject() BurriedAnonymousObjectIface {
+func NewBurriedAnonymousObject() BurriedAnonymousObject {
 	_init_.Initialize()
-	self := BurriedAnonymousObject{}
+	b := burriedAnonymousObject{}
+
 	_jsii_.Create(
 		"jsii-calc.BurriedAnonymousObject",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&b,
 	)
-	return &self
+	return &b
 }
 
-func (b *BurriedAnonymousObject) Check() bool {
+func (b *burriedAnonymousObject) Check() bool {
 	var returns bool
 	_jsii_.Invoke(
 		b,
@@ -3815,7 +3711,10 @@ func (b *BurriedAnonymousObject) Check() bool {
 	return returns
 }
 
-func (b *BurriedAnonymousObject) GiveItBack(value interface{}) interface{} {
+// Implement this method and have it return it's parameter.
+//
+// Returns: \`value\`
+func (b *burriedAnonymousObject) GiveItBack(value interface{}) interface{} {
 	var returns interface{}
 	_jsii_.Invoke(
 		b,
@@ -3825,33 +3724,6 @@ func (b *BurriedAnonymousObject) GiveItBack(value interface{}) interface{} {
 		&returns,
 	)
 	return returns
-}
-
-// Class interface
-type CalculatorIface interface {
-	GetValue() float64
-	GetExpression() scopejsiicalclib.NumericValueIface
-	GetDecorationPostfixes() []string
-	SetDecorationPostfixes(val []string)
-	GetDecorationPrefixes() []string
-	SetDecorationPrefixes(val []string)
-	GetStringStyle() composition.CompositionStringStyle
-	SetStringStyle(val composition.CompositionStringStyle)
-	GetOperationsLog() []scopejsiicalclib.NumericValueIface
-	GetOperationsMap() map[string][]scopejsiicalclib.NumericValueIface
-	GetCurr() scopejsiicalclib.NumericValueIface
-	SetCurr(val scopejsiicalclib.NumericValueIface)
-	GetMaxValue() float64
-	SetMaxValue(val float64)
-	GetUnionProperty() interface{}
-	SetUnionProperty(val interface{})
-	TypeName() interface{}
-	ToString() string
-	Add(value float64)
-	Mul(value float64)
-	Neg()
-	Pow(value float64)
-	ReadUnionValue() float64
 }
 
 // A calculator which maintains a current value and allows adding operations.
@@ -3869,102 +3741,31 @@ type CalculatorIface interface {
 //
 // TODO: EXAMPLE
 //
-// Struct proxy
-type Calculator struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// Returns the expression.
-	Expression scopejsiicalclib.NumericValueIface \`json:"expression"\`
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes []string \`json:"decorationPostfixes"\`
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes []string \`json:"decorationPrefixes"\`
-	// The .toString() style.
-	StringStyle composition.CompositionStringStyle \`json:"stringStyle"\`
-	// A log of all operations.
-	OperationsLog []scopejsiicalclib.NumericValueIface \`json:"operationsLog"\`
-	// A map of per operation name of all operations performed.
-	OperationsMap map[string][]scopejsiicalclib.NumericValueIface \`json:"operationsMap"\`
-	// The current value.
-	Curr scopejsiicalclib.NumericValueIface \`json:"curr"\`
-	// The maximum value allows in this calculator.
-	MaxValue float64 \`json:"maxValue"\`
-	// Example of a property that accepts a union of types.
-	UnionProperty interface{} \`json:"unionProperty"\`
+type Calculator interface {
+	composition.CompositeOperation
+	Curr() scopejsiicalclib.NumericValue
+	SetCurr(val scopejsiicalclib.NumericValue)
+	Expression() scopejsiicalclib.NumericValue
+	MaxValue() float64
+	SetMaxValue(val float64)
+	OperationsLog() []scopejsiicalclib.NumericValue
+	OperationsMap() map[string][]scopejsiicalclib.NumericValue
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
+	Add(value float64)
+	Mul(value float64)
+	Neg()
+	Pow(value float64)
+	ReadUnionValue() float64
 }
 
-func (c *Calculator) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		c,
-		"value",
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for Calculator
+type calculator struct {
+	composition.CompositeOperation // extends jsii-calc.composition.CompositeOperation
 }
 
-func (c *Calculator) GetExpression() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		c,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetDecorationPostfixes() []string {
-	var returns []string
-	_jsii_.Get(
-		c,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetDecorationPrefixes() []string {
-	var returns []string
-	_jsii_.Get(
-		c,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetStringStyle() composition.CompositionStringStyle {
-	var returns composition.CompositionStringStyle
-	_jsii_.Get(
-		c,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetOperationsLog() []scopejsiicalclib.NumericValueIface {
-	var returns []scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		c,
-		"operationsLog",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetOperationsMap() map[string][]scopejsiicalclib.NumericValueIface {
-	var returns map[string][]scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		c,
-		"operationsMap",
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) GetCurr() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (c *calculator) Curr() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		c,
 		"curr",
@@ -3973,7 +3774,17 @@ func (c *Calculator) GetCurr() scopejsiicalclib.NumericValueIface {
 	return returns
 }
 
-func (c *Calculator) GetMaxValue() float64 {
+func (c *calculator) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		c,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (c *calculator) MaxValue() float64 {
 	var returns float64
 	_jsii_.Get(
 		c,
@@ -3983,7 +3794,27 @@ func (c *Calculator) GetMaxValue() float64 {
 	return returns
 }
 
-func (c *Calculator) GetUnionProperty() interface{} {
+func (c *calculator) OperationsLog() []scopejsiicalclib.NumericValue {
+	var returns []scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		c,
+		"operationsLog",
+		&returns,
+	)
+	return returns
+}
+
+func (c *calculator) OperationsMap() map[string][]scopejsiicalclib.NumericValue {
+	var returns map[string][]scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		c,
+		"operationsMap",
+		&returns,
+	)
+	return returns
+}
+
+func (c *calculator) UnionProperty() interface{} {
 	var returns interface{}
 	_jsii_.Get(
 		c,
@@ -3995,44 +3826,21 @@ func (c *Calculator) GetUnionProperty() interface{} {
 
 
 // Creates a Calculator object.
-func NewCalculator(props CalculatorProps) CalculatorIface {
+func NewCalculator(props CalculatorProps) Calculator {
 	_init_.Initialize()
-	self := Calculator{}
+	c := calculator{}
+
 	_jsii_.Create(
 		"jsii-calc.Calculator",
 		[]interface{}{props},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *Calculator) SetDecorationPostfixes(val []string) {
-	_jsii_.Set(
-		c,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (c *Calculator) SetDecorationPrefixes(val []string) {
-	_jsii_.Set(
-		c,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (c *Calculator) SetStringStyle(val composition.CompositionStringStyle) {
-	_jsii_.Set(
-		c,
-		"stringStyle",
-		val,
-	)
-}
-
-func (c *Calculator) SetCurr(val scopejsiicalclib.NumericValueIface) {
+func (c *calculator) SetCurr(val scopejsiicalclib.NumericValue) {
 	_jsii_.Set(
 		c,
 		"curr",
@@ -4040,7 +3848,7 @@ func (c *Calculator) SetCurr(val scopejsiicalclib.NumericValueIface) {
 	)
 }
 
-func (c *Calculator) SetMaxValue(val float64) {
+func (c *calculator) SetMaxValue(val float64) {
 	_jsii_.Set(
 		c,
 		"maxValue",
@@ -4048,7 +3856,7 @@ func (c *Calculator) SetMaxValue(val float64) {
 	)
 }
 
-func (c *Calculator) SetUnionProperty(val interface{}) {
+func (c *calculator) SetUnionProperty(val interface{}) {
 	_jsii_.Set(
 		c,
 		"unionProperty",
@@ -4056,31 +3864,8 @@ func (c *Calculator) SetUnionProperty(val interface{}) {
 	)
 }
 
-func (c *Calculator) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		c,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		c,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (c *Calculator) Add(value float64) {
+// Adds a number to the current value.
+func (c *calculator) Add(value float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		c,
@@ -4091,7 +3876,8 @@ func (c *Calculator) Add(value float64) {
 	)
 }
 
-func (c *Calculator) Mul(value float64) {
+// Multiplies the current value by a number.
+func (c *calculator) Mul(value float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		c,
@@ -4102,7 +3888,8 @@ func (c *Calculator) Mul(value float64) {
 	)
 }
 
-func (c *Calculator) Neg() {
+// Negates the current value.
+func (c *calculator) Neg() {
 	var returns interface{}
 	_jsii_.Invoke(
 		c,
@@ -4113,7 +3900,8 @@ func (c *Calculator) Neg() {
 	)
 }
 
-func (c *Calculator) Pow(value float64) {
+// Raises the current value by a power.
+func (c *calculator) Pow(value float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		c,
@@ -4124,7 +3912,8 @@ func (c *Calculator) Pow(value float64) {
 	)
 }
 
-func (c *Calculator) ReadUnionValue() float64 {
+// Returns teh value of the union property (if defined).
+func (c *calculator) ReadUnionValue() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		c,
@@ -4158,29 +3947,24 @@ func (c *ChildStruct982) ToParentStruct982() ParentStruct982 {
 	}
 }
 
-// Class interface
-type ClassThatImplementsTheInternalInterfaceIface interface {
-	INonInternalInterfaceIface
-	IAnotherPublicInterfaceIface
-	GetA() string
+type ClassThatImplementsTheInternalInterface interface {
+	INonInternalInterface
+	A() string
 	SetA(val string)
-	GetB() string
+	B() string
 	SetB(val string)
-	GetC() string
+	C() string
 	SetC(val string)
-	GetD() string
+	D() string
 	SetD(val string)
 }
 
-// Struct proxy
-type ClassThatImplementsTheInternalInterface struct {
-	A string \`json:"a"\`
-	B string \`json:"b"\`
-	C string \`json:"c"\`
-	D string \`json:"d"\`
+// The jsii proxy struct for ClassThatImplementsTheInternalInterface
+type classThatImplementsTheInternalInterface struct {
+	iNonInternalInterface // implements jsii-calc.INonInternalInterface
 }
 
-func (c *ClassThatImplementsTheInternalInterface) GetA() string {
+func (c *classThatImplementsTheInternalInterface) A() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4190,7 +3974,7 @@ func (c *ClassThatImplementsTheInternalInterface) GetA() string {
 	return returns
 }
 
-func (c *ClassThatImplementsTheInternalInterface) GetB() string {
+func (c *classThatImplementsTheInternalInterface) B() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4200,7 +3984,7 @@ func (c *ClassThatImplementsTheInternalInterface) GetB() string {
 	return returns
 }
 
-func (c *ClassThatImplementsTheInternalInterface) GetC() string {
+func (c *classThatImplementsTheInternalInterface) C() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4210,7 +3994,7 @@ func (c *ClassThatImplementsTheInternalInterface) GetC() string {
 	return returns
 }
 
-func (c *ClassThatImplementsTheInternalInterface) GetD() string {
+func (c *classThatImplementsTheInternalInterface) D() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4221,20 +4005,21 @@ func (c *ClassThatImplementsTheInternalInterface) GetD() string {
 }
 
 
-func NewClassThatImplementsTheInternalInterface() ClassThatImplementsTheInternalInterfaceIface {
+func NewClassThatImplementsTheInternalInterface() ClassThatImplementsTheInternalInterface {
 	_init_.Initialize()
-	self := ClassThatImplementsTheInternalInterface{}
+	c := classThatImplementsTheInternalInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassThatImplementsTheInternalInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.INonInternalInterface"},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ClassThatImplementsTheInternalInterface) SetA(val string) {
+func (c *classThatImplementsTheInternalInterface) SetA(val string) {
 	_jsii_.Set(
 		c,
 		"a",
@@ -4242,7 +4027,7 @@ func (c *ClassThatImplementsTheInternalInterface) SetA(val string) {
 	)
 }
 
-func (c *ClassThatImplementsTheInternalInterface) SetB(val string) {
+func (c *classThatImplementsTheInternalInterface) SetB(val string) {
 	_jsii_.Set(
 		c,
 		"b",
@@ -4250,7 +4035,7 @@ func (c *ClassThatImplementsTheInternalInterface) SetB(val string) {
 	)
 }
 
-func (c *ClassThatImplementsTheInternalInterface) SetC(val string) {
+func (c *classThatImplementsTheInternalInterface) SetC(val string) {
 	_jsii_.Set(
 		c,
 		"c",
@@ -4258,7 +4043,7 @@ func (c *ClassThatImplementsTheInternalInterface) SetC(val string) {
 	)
 }
 
-func (c *ClassThatImplementsTheInternalInterface) SetD(val string) {
+func (c *classThatImplementsTheInternalInterface) SetD(val string) {
 	_jsii_.Set(
 		c,
 		"d",
@@ -4266,29 +4051,24 @@ func (c *ClassThatImplementsTheInternalInterface) SetD(val string) {
 	)
 }
 
-// Class interface
-type ClassThatImplementsThePrivateInterfaceIface interface {
-	INonInternalInterfaceIface
-	IAnotherPublicInterfaceIface
-	GetA() string
+type ClassThatImplementsThePrivateInterface interface {
+	INonInternalInterface
+	A() string
 	SetA(val string)
-	GetB() string
+	B() string
 	SetB(val string)
-	GetC() string
+	C() string
 	SetC(val string)
-	GetE() string
+	E() string
 	SetE(val string)
 }
 
-// Struct proxy
-type ClassThatImplementsThePrivateInterface struct {
-	A string \`json:"a"\`
-	B string \`json:"b"\`
-	C string \`json:"c"\`
-	E string \`json:"e"\`
+// The jsii proxy struct for ClassThatImplementsThePrivateInterface
+type classThatImplementsThePrivateInterface struct {
+	iNonInternalInterface // implements jsii-calc.INonInternalInterface
 }
 
-func (c *ClassThatImplementsThePrivateInterface) GetA() string {
+func (c *classThatImplementsThePrivateInterface) A() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4298,7 +4078,7 @@ func (c *ClassThatImplementsThePrivateInterface) GetA() string {
 	return returns
 }
 
-func (c *ClassThatImplementsThePrivateInterface) GetB() string {
+func (c *classThatImplementsThePrivateInterface) B() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4308,7 +4088,7 @@ func (c *ClassThatImplementsThePrivateInterface) GetB() string {
 	return returns
 }
 
-func (c *ClassThatImplementsThePrivateInterface) GetC() string {
+func (c *classThatImplementsThePrivateInterface) C() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4318,7 +4098,7 @@ func (c *ClassThatImplementsThePrivateInterface) GetC() string {
 	return returns
 }
 
-func (c *ClassThatImplementsThePrivateInterface) GetE() string {
+func (c *classThatImplementsThePrivateInterface) E() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4329,20 +4109,21 @@ func (c *ClassThatImplementsThePrivateInterface) GetE() string {
 }
 
 
-func NewClassThatImplementsThePrivateInterface() ClassThatImplementsThePrivateInterfaceIface {
+func NewClassThatImplementsThePrivateInterface() ClassThatImplementsThePrivateInterface {
 	_init_.Initialize()
-	self := ClassThatImplementsThePrivateInterface{}
+	c := classThatImplementsThePrivateInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassThatImplementsThePrivateInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.INonInternalInterface"},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ClassThatImplementsThePrivateInterface) SetA(val string) {
+func (c *classThatImplementsThePrivateInterface) SetA(val string) {
 	_jsii_.Set(
 		c,
 		"a",
@@ -4350,7 +4131,7 @@ func (c *ClassThatImplementsThePrivateInterface) SetA(val string) {
 	)
 }
 
-func (c *ClassThatImplementsThePrivateInterface) SetB(val string) {
+func (c *classThatImplementsThePrivateInterface) SetB(val string) {
 	_jsii_.Set(
 		c,
 		"b",
@@ -4358,7 +4139,7 @@ func (c *ClassThatImplementsThePrivateInterface) SetB(val string) {
 	)
 }
 
-func (c *ClassThatImplementsThePrivateInterface) SetC(val string) {
+func (c *classThatImplementsThePrivateInterface) SetC(val string) {
 	_jsii_.Set(
 		c,
 		"c",
@@ -4366,7 +4147,7 @@ func (c *ClassThatImplementsThePrivateInterface) SetC(val string) {
 	)
 }
 
-func (c *ClassThatImplementsThePrivateInterface) SetE(val string) {
+func (c *classThatImplementsThePrivateInterface) SetE(val string) {
 	_jsii_.Set(
 		c,
 		"e",
@@ -4374,21 +4155,19 @@ func (c *ClassThatImplementsThePrivateInterface) SetE(val string) {
 	)
 }
 
-// Class interface
-type ClassWithCollectionsIface interface {
-	GetArray() []string
+type ClassWithCollections interface {
+	Array() []string
 	SetArray(val []string)
-	GetMap() map[string]string
+	Map() map[string]string
 	SetMap(val map[string]string)
 }
 
-// Struct proxy
-type ClassWithCollections struct {
-	Array []string \`json:"array"\`
-	Map map[string]string \`json:"map"\`
+// The jsii proxy struct for ClassWithCollections
+type classWithCollections struct {
+	_ byte // padding
 }
 
-func (c *ClassWithCollections) GetArray() []string {
+func (c *classWithCollections) Array() []string {
 	var returns []string
 	_jsii_.Get(
 		c,
@@ -4398,7 +4177,7 @@ func (c *ClassWithCollections) GetArray() []string {
 	return returns
 }
 
-func (c *ClassWithCollections) GetMap() map[string]string {
+func (c *classWithCollections) Map() map[string]string {
 	var returns map[string]string
 	_jsii_.Get(
 		c,
@@ -4409,20 +4188,21 @@ func (c *ClassWithCollections) GetMap() map[string]string {
 }
 
 
-func NewClassWithCollections(map_ map[string]string, array []string) ClassWithCollectionsIface {
+func NewClassWithCollections(map_ map[string]string, array []string) ClassWithCollections {
 	_init_.Initialize()
-	self := ClassWithCollections{}
+	c := classWithCollections{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassWithCollections",
 		[]interface{}{map_, array},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ClassWithCollections) SetArray(val []string) {
+func (c *classWithCollections) SetArray(val []string) {
 	_jsii_.Set(
 		c,
 		"array",
@@ -4430,7 +4210,7 @@ func (c *ClassWithCollections) SetArray(val []string) {
 	)
 }
 
-func (c *ClassWithCollections) SetMap(val map[string]string) {
+func (c *classWithCollections) SetMap(val map[string]string) {
 	_jsii_.Set(
 		c,
 		"map",
@@ -4504,10 +4284,6 @@ func ClassWithCollections_SetStaticMap(val map[string]string) {
 	)
 }
 
-// Class interface
-type ClassWithDocsIface interface {
-}
-
 // This class has docs.
 //
 // The docs are great. They're a bunch of tags.
@@ -4516,35 +4292,39 @@ type ClassWithDocsIface interface {
 //
 // See: https://aws.amazon.com/
 //
-// Struct proxy
-type ClassWithDocs struct {
+type ClassWithDocs interface {
 }
 
-func NewClassWithDocs() ClassWithDocsIface {
+// The jsii proxy struct for ClassWithDocs
+type classWithDocs struct {
+	_ byte // padding
+}
+
+func NewClassWithDocs() ClassWithDocs {
 	_init_.Initialize()
-	self := ClassWithDocs{}
+	c := classWithDocs{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassWithDocs",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-// Class interface
-type ClassWithJavaReservedWordsIface interface {
-	GetInt() string
+type ClassWithJavaReservedWords interface {
+	Int() string
 	Import(assert string) string
 }
 
-// Struct proxy
-type ClassWithJavaReservedWords struct {
-	Int string \`json:"int"\`
+// The jsii proxy struct for ClassWithJavaReservedWords
+type classWithJavaReservedWords struct {
+	_ byte // padding
 }
 
-func (c *ClassWithJavaReservedWords) GetInt() string {
+func (c *classWithJavaReservedWords) Int() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4555,20 +4335,21 @@ func (c *ClassWithJavaReservedWords) GetInt() string {
 }
 
 
-func NewClassWithJavaReservedWords(int string) ClassWithJavaReservedWordsIface {
+func NewClassWithJavaReservedWords(int string) ClassWithJavaReservedWords {
 	_init_.Initialize()
-	self := ClassWithJavaReservedWords{}
+	c := classWithJavaReservedWords{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassWithJavaReservedWords",
 		[]interface{}{int},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ClassWithJavaReservedWords) Import(assert string) string {
+func (c *classWithJavaReservedWords) Import(assert string) string {
 	var returns string
 	_jsii_.Invoke(
 		c,
@@ -4580,19 +4361,18 @@ func (c *ClassWithJavaReservedWords) Import(assert string) string {
 	return returns
 }
 
-// Class interface
-type ClassWithMutableObjectLiteralPropertyIface interface {
-	GetMutableObject() IMutableObjectLiteralIface
-	SetMutableObject(val IMutableObjectLiteralIface)
+type ClassWithMutableObjectLiteralProperty interface {
+	MutableObject() IMutableObjectLiteral
+	SetMutableObject(val IMutableObjectLiteral)
 }
 
-// Struct proxy
-type ClassWithMutableObjectLiteralProperty struct {
-	MutableObject IMutableObjectLiteralIface \`json:"mutableObject"\`
+// The jsii proxy struct for ClassWithMutableObjectLiteralProperty
+type classWithMutableObjectLiteralProperty struct {
+	_ byte // padding
 }
 
-func (c *ClassWithMutableObjectLiteralProperty) GetMutableObject() IMutableObjectLiteralIface {
-	var returns IMutableObjectLiteralIface
+func (c *classWithMutableObjectLiteralProperty) MutableObject() IMutableObjectLiteral {
+	var returns IMutableObjectLiteral
 	_jsii_.Get(
 		c,
 		"mutableObject",
@@ -4602,20 +4382,21 @@ func (c *ClassWithMutableObjectLiteralProperty) GetMutableObject() IMutableObjec
 }
 
 
-func NewClassWithMutableObjectLiteralProperty() ClassWithMutableObjectLiteralPropertyIface {
+func NewClassWithMutableObjectLiteralProperty() ClassWithMutableObjectLiteralProperty {
 	_init_.Initialize()
-	self := ClassWithMutableObjectLiteralProperty{}
+	c := classWithMutableObjectLiteralProperty{}
+
 	_jsii_.Create(
 		"jsii-calc.ClassWithMutableObjectLiteralProperty",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObjectLiteralIface) {
+func (c *classWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObjectLiteral) {
 	_jsii_.Set(
 		c,
 		"mutableObject",
@@ -4623,22 +4404,20 @@ func (c *ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObj
 	)
 }
 
-// Class interface
-type ClassWithPrivateConstructorAndAutomaticPropertiesIface interface {
-	IInterfaceWithPropertiesIface
-	GetReadOnlyString() string
-	GetReadWriteString() string
+// Class that implements interface properties automatically, but using a private constructor.
+type ClassWithPrivateConstructorAndAutomaticProperties interface {
+	IInterfaceWithProperties
+	ReadOnlyString() string
+	ReadWriteString() string
 	SetReadWriteString(val string)
 }
 
-// Class that implements interface properties automatically, but using a private constructor.
-// Struct proxy
-type ClassWithPrivateConstructorAndAutomaticProperties struct {
-	ReadOnlyString string \`json:"readOnlyString"\`
-	ReadWriteString string \`json:"readWriteString"\`
+// The jsii proxy struct for ClassWithPrivateConstructorAndAutomaticProperties
+type classWithPrivateConstructorAndAutomaticProperties struct {
+	iInterfaceWithProperties // implements jsii-calc.IInterfaceWithProperties
 }
 
-func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadOnlyString() string {
+func (c *classWithPrivateConstructorAndAutomaticProperties) ReadOnlyString() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4648,7 +4427,7 @@ func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadOnlyString() 
 	return returns
 }
 
-func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadWriteString() string {
+func (c *classWithPrivateConstructorAndAutomaticProperties) ReadWriteString() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -4659,7 +4438,7 @@ func (c *ClassWithPrivateConstructorAndAutomaticProperties) GetReadWriteString()
 }
 
 
-func (c *ClassWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(val string) {
+func (c *classWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(val string) {
 	_jsii_.Set(
 		c,
 		"readWriteString",
@@ -4667,9 +4446,9 @@ func (c *ClassWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(v
 	)
 }
 
-func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString string, readWriteString string) ClassWithPrivateConstructorAndAutomaticPropertiesIface {
+func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString string, readWriteString string) ClassWithPrivateConstructorAndAutomaticProperties {
 	_init_.Initialize()
-	var returns ClassWithPrivateConstructorAndAutomaticPropertiesIface
+	var returns ClassWithPrivateConstructorAndAutomaticProperties
 	_jsii_.StaticInvoke(
 		"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
 		"create",
@@ -4680,21 +4459,20 @@ func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString str
 	return returns
 }
 
-// Class interface
-type ConfusingToJacksonIface interface {
-	GetUnionProperty() interface{}
-	SetUnionProperty(val interface{})
-}
-
 // This tries to confuse Jackson by having overloaded property setters.
 // See: https://github.com/aws/aws-cdk/issues/4080
 //
-// Struct proxy
-type ConfusingToJackson struct {
-	UnionProperty interface{} \`json:"unionProperty"\`
+type ConfusingToJackson interface {
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
 }
 
-func (c *ConfusingToJackson) GetUnionProperty() interface{} {
+// The jsii proxy struct for ConfusingToJackson
+type confusingToJackson struct {
+	_ byte // padding
+}
+
+func (c *confusingToJackson) UnionProperty() interface{} {
 	var returns interface{}
 	_jsii_.Get(
 		c,
@@ -4705,7 +4483,7 @@ func (c *ConfusingToJackson) GetUnionProperty() interface{} {
 }
 
 
-func (c *ConfusingToJackson) SetUnionProperty(val interface{}) {
+func (c *confusingToJackson) SetUnionProperty(val interface{}) {
 	_jsii_.Set(
 		c,
 		"unionProperty",
@@ -4713,9 +4491,9 @@ func (c *ConfusingToJackson) SetUnionProperty(val interface{}) {
 	)
 }
 
-func ConfusingToJackson_MakeInstance() ConfusingToJacksonIface {
+func ConfusingToJackson_MakeInstance() ConfusingToJackson {
 	_init_.Initialize()
-	var returns ConfusingToJacksonIface
+	var returns ConfusingToJackson
 	_jsii_.StaticInvoke(
 		"jsii-calc.ConfusingToJackson",
 		"makeInstance",
@@ -4743,51 +4521,53 @@ type ConfusingToJacksonStruct struct {
 	UnionProperty interface{} \`json:"unionProperty"\`
 }
 
-// Class interface
-type ConstructorPassesThisOutIface interface {
+type ConstructorPassesThisOut interface {
 }
 
-// Struct proxy
-type ConstructorPassesThisOut struct {
+// The jsii proxy struct for ConstructorPassesThisOut
+type constructorPassesThisOut struct {
+	_ byte // padding
 }
 
-func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumerIface) ConstructorPassesThisOutIface {
+func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumer) ConstructorPassesThisOut {
 	_init_.Initialize()
-	self := ConstructorPassesThisOut{}
+	c := constructorPassesThisOut{}
+
 	_jsii_.Create(
 		"jsii-calc.ConstructorPassesThisOut",
 		[]interface{}{consumer},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-// Class interface
-type ConstructorsIface interface {
+type Constructors interface {
 }
 
-// Struct proxy
-type Constructors struct {
+// The jsii proxy struct for Constructors
+type constructors struct {
+	_ byte // padding
 }
 
-func NewConstructors() ConstructorsIface {
+func NewConstructors() Constructors {
 	_init_.Initialize()
-	self := Constructors{}
+	c := constructors{}
+
 	_jsii_.Create(
 		"jsii-calc.Constructors",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func Constructors_HiddenInterface() IPublicInterfaceIface {
+func Constructors_HiddenInterface() IPublicInterface {
 	_init_.Initialize()
-	var returns IPublicInterfaceIface
+	var returns IPublicInterface
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"hiddenInterface",
@@ -4798,9 +4578,9 @@ func Constructors_HiddenInterface() IPublicInterfaceIface {
 	return returns
 }
 
-func Constructors_HiddenInterfaces() []IPublicInterfaceIface {
+func Constructors_HiddenInterfaces() []IPublicInterface {
 	_init_.Initialize()
-	var returns []IPublicInterfaceIface
+	var returns []IPublicInterface
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"hiddenInterfaces",
@@ -4811,9 +4591,9 @@ func Constructors_HiddenInterfaces() []IPublicInterfaceIface {
 	return returns
 }
 
-func Constructors_HiddenSubInterfaces() []IPublicInterfaceIface {
+func Constructors_HiddenSubInterfaces() []IPublicInterface {
 	_init_.Initialize()
-	var returns []IPublicInterfaceIface
+	var returns []IPublicInterface
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"hiddenSubInterfaces",
@@ -4824,9 +4604,9 @@ func Constructors_HiddenSubInterfaces() []IPublicInterfaceIface {
 	return returns
 }
 
-func Constructors_MakeClass() PublicClassIface {
+func Constructors_MakeClass() PublicClass {
 	_init_.Initialize()
-	var returns PublicClassIface
+	var returns PublicClass
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"makeClass",
@@ -4837,9 +4617,9 @@ func Constructors_MakeClass() PublicClassIface {
 	return returns
 }
 
-func Constructors_MakeInterface() IPublicInterfaceIface {
+func Constructors_MakeInterface() IPublicInterface {
 	_init_.Initialize()
-	var returns IPublicInterfaceIface
+	var returns IPublicInterface
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"makeInterface",
@@ -4850,9 +4630,9 @@ func Constructors_MakeInterface() IPublicInterfaceIface {
 	return returns
 }
 
-func Constructors_MakeInterface2() IPublicInterface2Iface {
+func Constructors_MakeInterface2() IPublicInterface2 {
 	_init_.Initialize()
-	var returns IPublicInterface2Iface
+	var returns IPublicInterface2
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"makeInterface2",
@@ -4863,9 +4643,9 @@ func Constructors_MakeInterface2() IPublicInterface2Iface {
 	return returns
 }
 
-func Constructors_MakeInterfaces() []IPublicInterfaceIface {
+func Constructors_MakeInterfaces() []IPublicInterface {
 	_init_.Initialize()
-	var returns []IPublicInterfaceIface
+	var returns []IPublicInterface
 	_jsii_.StaticInvoke(
 		"jsii-calc.Constructors",
 		"makeInterfaces",
@@ -4876,29 +4656,30 @@ func Constructors_MakeInterfaces() []IPublicInterfaceIface {
 	return returns
 }
 
-// Class interface
-type ConsumePureInterfaceIface interface {
+type ConsumePureInterface interface {
 	WorkItBaby() StructB
 }
 
-// Struct proxy
-type ConsumePureInterface struct {
+// The jsii proxy struct for ConsumePureInterface
+type consumePureInterface struct {
+	_ byte // padding
 }
 
-func NewConsumePureInterface(delegate IStructReturningDelegateIface) ConsumePureInterfaceIface {
+func NewConsumePureInterface(delegate IStructReturningDelegate) ConsumePureInterface {
 	_init_.Initialize()
-	self := ConsumePureInterface{}
+	c := consumePureInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ConsumePureInterface",
 		[]interface{}{delegate},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ConsumePureInterface) WorkItBaby() StructB {
+func (c *consumePureInterface) WorkItBaby() StructB {
 	var returns StructB
 	_jsii_.Invoke(
 		c,
@@ -4910,36 +4691,40 @@ func (c *ConsumePureInterface) WorkItBaby() StructB {
 	return returns
 }
 
-// Class interface
-type ConsumerCanRingBellIface interface {
-	ImplementedByObjectLiteral(ringer IBellRingerIface) bool
-	ImplementedByPrivateClass(ringer IBellRingerIface) bool
-	ImplementedByPublicClass(ringer IBellRingerIface) bool
-	WhenTypedAsClass(ringer IConcreteBellRingerIface) bool
-}
-
 // Test calling back to consumers that implement interfaces.
 //
 // Check that if a JSII consumer implements IConsumerWithInterfaceParam, they can call
 // the method on the argument that they're passed...
-// Struct proxy
-type ConsumerCanRingBell struct {
+type ConsumerCanRingBell interface {
+	ImplementedByObjectLiteral(ringer IBellRinger) bool
+	ImplementedByPrivateClass(ringer IBellRinger) bool
+	ImplementedByPublicClass(ringer IBellRinger) bool
+	WhenTypedAsClass(ringer IConcreteBellRinger) bool
 }
 
-func NewConsumerCanRingBell() ConsumerCanRingBellIface {
+// The jsii proxy struct for ConsumerCanRingBell
+type consumerCanRingBell struct {
+	_ byte // padding
+}
+
+func NewConsumerCanRingBell() ConsumerCanRingBell {
 	_init_.Initialize()
-	self := ConsumerCanRingBell{}
+	c := consumerCanRingBell{}
+
 	_jsii_.Create(
 		"jsii-calc.ConsumerCanRingBell",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using an object literal.
+//
+// Returns whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRinger) bool {
 	_init_.Initialize()
 	var returns bool
 	_jsii_.StaticInvoke(
@@ -4952,7 +4737,10 @@ func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRingerIfac
 	return returns
 }
 
-func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using a private class.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRinger) bool {
 	_init_.Initialize()
 	var returns bool
 	_jsii_.StaticInvoke(
@@ -4965,7 +4753,10 @@ func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRingerIface
 	return returns
 }
 
-func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using a public class.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRinger) bool {
 	_init_.Initialize()
 	var returns bool
 	_jsii_.StaticInvoke(
@@ -4978,7 +4769,10 @@ func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRingerIface)
 	return returns
 }
 
-func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRingerIface) bool {
+// If the parameter is a concrete class instead of an interface.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRinger) bool {
 	_init_.Initialize()
 	var returns bool
 	_jsii_.StaticInvoke(
@@ -4991,7 +4785,10 @@ func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRingerIface)
 	return returns
 }
 
-func (c *ConsumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using an object literal.
+//
+// Returns whether the bell was rung.
+func (c *consumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRinger) bool {
 	var returns bool
 	_jsii_.Invoke(
 		c,
@@ -5003,7 +4800,10 @@ func (c *ConsumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRingerIface
 	return returns
 }
 
-func (c *ConsumerCanRingBell) ImplementedByPrivateClass(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using a private class.
+//
+// Return whether the bell was rung.
+func (c *consumerCanRingBell) ImplementedByPrivateClass(ringer IBellRinger) bool {
 	var returns bool
 	_jsii_.Invoke(
 		c,
@@ -5015,7 +4815,10 @@ func (c *ConsumerCanRingBell) ImplementedByPrivateClass(ringer IBellRingerIface)
 	return returns
 }
 
-func (c *ConsumerCanRingBell) ImplementedByPublicClass(ringer IBellRingerIface) bool {
+// ...if the interface is implemented using a public class.
+//
+// Return whether the bell was rung.
+func (c *consumerCanRingBell) ImplementedByPublicClass(ringer IBellRinger) bool {
 	var returns bool
 	_jsii_.Invoke(
 		c,
@@ -5027,7 +4830,10 @@ func (c *ConsumerCanRingBell) ImplementedByPublicClass(ringer IBellRingerIface) 
 	return returns
 }
 
-func (c *ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRingerIface) bool {
+// If the parameter is a concrete class instead of an interface.
+//
+// Return whether the bell was rung.
+func (c *consumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRinger) bool {
 	var returns bool
 	_jsii_.Invoke(
 		c,
@@ -5039,30 +4845,31 @@ func (c *ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRingerIface) 
 	return returns
 }
 
-// Class interface
-type ConsumersOfThisCrazyTypeSystemIface interface {
-	ConsumeAnotherPublicInterface(obj IAnotherPublicInterfaceIface) string
-	ConsumeNonInternalInterface(obj INonInternalInterfaceIface) interface{}
+type ConsumersOfThisCrazyTypeSystem interface {
+	ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) string
+	ConsumeNonInternalInterface(obj INonInternalInterface) interface{}
 }
 
-// Struct proxy
-type ConsumersOfThisCrazyTypeSystem struct {
+// The jsii proxy struct for ConsumersOfThisCrazyTypeSystem
+type consumersOfThisCrazyTypeSystem struct {
+	_ byte // padding
 }
 
-func NewConsumersOfThisCrazyTypeSystem() ConsumersOfThisCrazyTypeSystemIface {
+func NewConsumersOfThisCrazyTypeSystem() ConsumersOfThisCrazyTypeSystem {
 	_init_.Initialize()
-	self := ConsumersOfThisCrazyTypeSystem{}
+	c := consumersOfThisCrazyTypeSystem{}
+
 	_jsii_.Create(
 		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-func (c *ConsumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnotherPublicInterfaceIface) string {
+func (c *consumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) string {
 	var returns string
 	_jsii_.Invoke(
 		c,
@@ -5074,7 +4881,7 @@ func (c *ConsumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnot
 	return returns
 }
 
-func (c *ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInternalInterfaceIface) interface{} {
+func (c *consumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInternalInterface) interface{} {
 	var returns interface{}
 	_jsii_.Invoke(
 		c,
@@ -5086,32 +4893,33 @@ func (c *ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInt
 	return returns
 }
 
-// Class interface
-type DataRendererIface interface {
+// Verifies proper type handling through dynamic overrides.
+type DataRenderer interface {
 	Render(data scopejsiicalclib.MyFirstStruct) string
 	RenderArbitrary(data map[string]interface{}) string
 	RenderMap(map_ map[string]interface{}) string
 }
 
-// Verifies proper type handling through dynamic overrides.
-// Struct proxy
-type DataRenderer struct {
+// The jsii proxy struct for DataRenderer
+type dataRenderer struct {
+	_ byte // padding
 }
 
-func NewDataRenderer() DataRendererIface {
+func NewDataRenderer() DataRenderer {
 	_init_.Initialize()
-	self := DataRenderer{}
+	d := dataRenderer{}
+
 	_jsii_.Create(
 		"jsii-calc.DataRenderer",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DataRenderer) Render(data scopejsiicalclib.MyFirstStruct) string {
+func (d *dataRenderer) Render(data scopejsiicalclib.MyFirstStruct) string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5123,7 +4931,7 @@ func (d *DataRenderer) Render(data scopejsiicalclib.MyFirstStruct) string {
 	return returns
 }
 
-func (d *DataRenderer) RenderArbitrary(data map[string]interface{}) string {
+func (d *dataRenderer) RenderArbitrary(data map[string]interface{}) string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5135,7 +4943,7 @@ func (d *DataRenderer) RenderArbitrary(data map[string]interface{}) string {
 	return returns
 }
 
-func (d *DataRenderer) RenderMap(map_ map[string]interface{}) string {
+func (d *dataRenderer) RenderMap(map_ map[string]interface{}) string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5147,21 +4955,18 @@ func (d *DataRenderer) RenderMap(map_ map[string]interface{}) string {
 	return returns
 }
 
-// Class interface
-type DefaultedConstructorArgumentIface interface {
-	GetArg1() float64
-	GetArg3() string
-	GetArg2() string
+type DefaultedConstructorArgument interface {
+	Arg1() float64
+	Arg2() string
+	Arg3() string
 }
 
-// Struct proxy
-type DefaultedConstructorArgument struct {
-	Arg1 float64 \`json:"arg1"\`
-	Arg3 string \`json:"arg3"\`
-	Arg2 string \`json:"arg2"\`
+// The jsii proxy struct for DefaultedConstructorArgument
+type defaultedConstructorArgument struct {
+	_ byte // padding
 }
 
-func (d *DefaultedConstructorArgument) GetArg1() float64 {
+func (d *defaultedConstructorArgument) Arg1() float64 {
 	var returns float64
 	_jsii_.Get(
 		d,
@@ -5171,17 +4976,7 @@ func (d *DefaultedConstructorArgument) GetArg1() float64 {
 	return returns
 }
 
-func (d *DefaultedConstructorArgument) GetArg3() string {
-	var returns string
-	_jsii_.Get(
-		d,
-		"arg3",
-		&returns,
-	)
-	return returns
-}
-
-func (d *DefaultedConstructorArgument) GetArg2() string {
+func (d *defaultedConstructorArgument) Arg2() string {
 	var returns string
 	_jsii_.Get(
 		d,
@@ -5191,45 +4986,58 @@ func (d *DefaultedConstructorArgument) GetArg2() string {
 	return returns
 }
 
+func (d *defaultedConstructorArgument) Arg3() string {
+	var returns string
+	_jsii_.Get(
+		d,
+		"arg3",
+		&returns,
+	)
+	return returns
+}
 
-func NewDefaultedConstructorArgument(arg1 float64, arg2 string, arg3 string) DefaultedConstructorArgumentIface {
+
+func NewDefaultedConstructorArgument(arg1 float64, arg2 string, arg3 string) DefaultedConstructorArgument {
 	_init_.Initialize()
-	self := DefaultedConstructorArgument{}
+	d := defaultedConstructorArgument{}
+
 	_jsii_.Create(
 		"jsii-calc.DefaultedConstructorArgument",
 		[]interface{}{arg1, arg2, arg3},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
-}
-
-// Class interface
-type Demonstrate982Iface interface {
+	return &d
 }
 
 // 1.
 //
 // call #takeThis() -> An ObjectRef will be provisioned for the value (it'll be re-used!)
 // 2. call #takeThisToo() -> The ObjectRef from before will need to be down-cased to the ParentStruct982 type
-// Struct proxy
-type Demonstrate982 struct {
+type Demonstrate982 interface {
 }
 
-func NewDemonstrate982() Demonstrate982Iface {
+// The jsii proxy struct for Demonstrate982
+type demonstrate982 struct {
+	_ byte // padding
+}
+
+func NewDemonstrate982() Demonstrate982 {
 	_init_.Initialize()
-	self := Demonstrate982{}
+	d := demonstrate982{}
+
 	_jsii_.Create(
 		"jsii-calc.Demonstrate982",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
+// It's dangerous to go alone!
 func Demonstrate982_TakeThis() ChildStruct982 {
 	_init_.Initialize()
 	var returns ChildStruct982
@@ -5243,6 +5051,7 @@ func Demonstrate982_TakeThis() ChildStruct982 {
 	return returns
 }
 
+// It's dangerous to go alone!
 func Demonstrate982_TakeThisToo() ParentStruct982 {
 	_init_.Initialize()
 	var returns ParentStruct982
@@ -5256,34 +5065,20 @@ func Demonstrate982_TakeThisToo() ParentStruct982 {
 	return returns
 }
 
-// Class interface
-type DeprecatedClassIface interface {
-	GetReadonlyProperty() string
-	GetMutableProperty() float64
+// Deprecated: a pretty boring class
+type DeprecatedClass interface {
+	MutableProperty() float64
 	SetMutableProperty(val float64)
+	ReadonlyProperty() string
 	Method()
 }
 
-// Deprecated: a pretty boring class
-// Struct proxy
-type DeprecatedClass struct {
-	// Deprecated: this is not always "wazoo", be ready to be disappointed
-	ReadonlyProperty string \`json:"readonlyProperty"\`
-	// Deprecated: shouldn't have been mutable
-	MutableProperty float64 \`json:"mutableProperty"\`
+// The jsii proxy struct for DeprecatedClass
+type deprecatedClass struct {
+	_ byte // padding
 }
 
-func (d *DeprecatedClass) GetReadonlyProperty() string {
-	var returns string
-	_jsii_.Get(
-		d,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (d *DeprecatedClass) GetMutableProperty() float64 {
+func (d *deprecatedClass) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		d,
@@ -5293,21 +5088,32 @@ func (d *DeprecatedClass) GetMutableProperty() float64 {
 	return returns
 }
 
+func (d *deprecatedClass) ReadonlyProperty() string {
+	var returns string
+	_jsii_.Get(
+		d,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
 
-func NewDeprecatedClass(readonlyString string, mutableNumber float64) DeprecatedClassIface {
+
+func NewDeprecatedClass(readonlyString string, mutableNumber float64) DeprecatedClass {
 	_init_.Initialize()
-	self := DeprecatedClass{}
+	d := deprecatedClass{}
+
 	_jsii_.Create(
 		"jsii-calc.DeprecatedClass",
 		[]interface{}{readonlyString, mutableNumber},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DeprecatedClass) SetMutableProperty(val float64) {
+func (d *deprecatedClass) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		d,
 		"mutableProperty",
@@ -5315,7 +5121,8 @@ func (d *DeprecatedClass) SetMutableProperty(val float64) {
 	)
 }
 
-func (d *DeprecatedClass) Method() {
+// Deprecated: it was a bad idea
+func (d *deprecatedClass) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		d,
@@ -5353,9 +5160,9 @@ type DerivedStruct struct {
 	AnotherRequired string \`json:"anotherRequired"\`
 	Bool bool \`json:"bool"\`
 	// An example of a non primitive property.
-	NonPrimitive DoubleTroubleIface \`json:"nonPrimitive"\`
+	NonPrimitive DoubleTrouble \`json:"nonPrimitive"\`
 	// This is optional.
-	AnotherOptional map[string]scopejsiicalclib.NumericValueIface \`json:"anotherOptional"\`
+	AnotherOptional map[string]scopejsiicalclib.NumericValue \`json:"anotherOptional"\`
 	OptionalAny interface{} \`json:"optionalAny"\`
 	OptionalArray []string \`json:"optionalArray"\`
 }
@@ -5453,15 +5260,15 @@ func (d *DiamondInheritanceTopLevelStruct) ToDiamondInheritanceSecondMidLevelStr
 	}
 }
 
-// Class interface
-type DisappointingCollectionSourceIface interface {
-}
-
 // Verifies that null/undefined can be returned for optional collections.
 //
 // This source of collections is disappointing - it'll always give you nothing :(
-// Struct proxy
-type DisappointingCollectionSource struct {
+type DisappointingCollectionSource interface {
+}
+
+// The jsii proxy struct for DisappointingCollectionSource
+type disappointingCollectionSource struct {
+	_ byte // padding
 }
 
 func DisappointingCollectionSource_MaybeList() []string {
@@ -5486,31 +5293,32 @@ func DisappointingCollectionSource_MaybeMap() map[string]float64 {
 	return returns
 }
 
-// Class interface
-type DoNotOverridePrivatesIface interface {
+type DoNotOverridePrivates interface {
 	ChangePrivatePropertyValue(newValue string)
 	PrivateMethodValue() string
 	PrivatePropertyValue() string
 }
 
-// Struct proxy
-type DoNotOverridePrivates struct {
+// The jsii proxy struct for DoNotOverridePrivates
+type doNotOverridePrivates struct {
+	_ byte // padding
 }
 
-func NewDoNotOverridePrivates() DoNotOverridePrivatesIface {
+func NewDoNotOverridePrivates() DoNotOverridePrivates {
 	_init_.Initialize()
-	self := DoNotOverridePrivates{}
+	d := doNotOverridePrivates{}
+
 	_jsii_.Create(
 		"jsii-calc.DoNotOverridePrivates",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DoNotOverridePrivates) ChangePrivatePropertyValue(newValue string) {
+func (d *doNotOverridePrivates) ChangePrivatePropertyValue(newValue string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		d,
@@ -5521,7 +5329,7 @@ func (d *DoNotOverridePrivates) ChangePrivatePropertyValue(newValue string) {
 	)
 }
 
-func (d *DoNotOverridePrivates) PrivateMethodValue() string {
+func (d *doNotOverridePrivates) PrivateMethodValue() string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5533,7 +5341,7 @@ func (d *DoNotOverridePrivates) PrivateMethodValue() string {
 	return returns
 }
 
-func (d *DoNotOverridePrivates) PrivatePropertyValue() string {
+func (d *doNotOverridePrivates) PrivatePropertyValue() string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5545,30 +5353,31 @@ func (d *DoNotOverridePrivates) PrivatePropertyValue() string {
 	return returns
 }
 
-// Class interface
-type DoNotRecognizeAnyAsOptionalIface interface {
+// jsii#284: do not recognize "any" as an optional argument.
+type DoNotRecognizeAnyAsOptional interface {
 	Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString string)
 }
 
-// jsii#284: do not recognize "any" as an optional argument.
-// Struct proxy
-type DoNotRecognizeAnyAsOptional struct {
+// The jsii proxy struct for DoNotRecognizeAnyAsOptional
+type doNotRecognizeAnyAsOptional struct {
+	_ byte // padding
 }
 
-func NewDoNotRecognizeAnyAsOptional() DoNotRecognizeAnyAsOptionalIface {
+func NewDoNotRecognizeAnyAsOptional() DoNotRecognizeAnyAsOptional {
 	_init_.Initialize()
-	self := DoNotRecognizeAnyAsOptional{}
+	d := doNotRecognizeAnyAsOptional{}
+
 	_jsii_.Create(
 		"jsii-calc.DoNotRecognizeAnyAsOptional",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DoNotRecognizeAnyAsOptional) Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString string) {
+func (d *doNotRecognizeAnyAsOptional) Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		d,
@@ -5577,12 +5386,6 @@ func (d *DoNotRecognizeAnyAsOptional) Method(_requiredAny interface{}, _optional
 		false,
 		&returns,
 	)
-}
-
-// Class interface
-type DocumentedClassIface interface {
-	Greet(greetee Greetee) float64
-	Hola()
 }
 
 // Here's the first line of the TSDoc comment.
@@ -5594,24 +5397,37 @@ type DocumentedClassIface interface {
 //
 // TODO: EXAMPLE
 //
-// Struct proxy
-type DocumentedClass struct {
+type DocumentedClass interface {
+	Greet(greetee Greetee) float64
+	Hola()
 }
 
-func NewDocumentedClass() DocumentedClassIface {
+// The jsii proxy struct for DocumentedClass
+type documentedClass struct {
+	_ byte // padding
+}
+
+func NewDocumentedClass() DocumentedClass {
 	_init_.Initialize()
-	self := DocumentedClass{}
+	d := documentedClass{}
+
 	_jsii_.Create(
 		"jsii-calc.DocumentedClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DocumentedClass) Greet(greetee Greetee) float64 {
+// Greet the indicated person.
+//
+// This will print out a friendly greeting intended for the indicated person.
+//
+// Returns: A number that everyone knows very well and represents the answer
+// to the ultimate question
+func (d *documentedClass) Greet(greetee Greetee) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		d,
@@ -5623,7 +5439,9 @@ func (d *DocumentedClass) Greet(greetee Greetee) float64 {
 	return returns
 }
 
-func (d *DocumentedClass) Hola() {
+// Say ¡Hola!
+// Experimental.
+func (d *documentedClass) Hola() {
 	var returns interface{}
 	_jsii_.Invoke(
 		d,
@@ -5634,29 +5452,30 @@ func (d *DocumentedClass) Hola() {
 	)
 }
 
-// Class interface
-type DontComplainAboutVariadicAfterOptionalIface interface {
+type DontComplainAboutVariadicAfterOptional interface {
 	OptionalAndVariadic(optional string, things string) string
 }
 
-// Struct proxy
-type DontComplainAboutVariadicAfterOptional struct {
+// The jsii proxy struct for DontComplainAboutVariadicAfterOptional
+type dontComplainAboutVariadicAfterOptional struct {
+	_ byte // padding
 }
 
-func NewDontComplainAboutVariadicAfterOptional() DontComplainAboutVariadicAfterOptionalIface {
+func NewDontComplainAboutVariadicAfterOptional() DontComplainAboutVariadicAfterOptional {
 	_init_.Initialize()
-	self := DontComplainAboutVariadicAfterOptional{}
+	d := dontComplainAboutVariadicAfterOptional{}
+
 	_jsii_.Create(
 		"jsii-calc.DontComplainAboutVariadicAfterOptional",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional string, things string) string {
+func (d *dontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional string, things string) string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5668,33 +5487,33 @@ func (d *DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional st
 	return returns
 }
 
-// Class interface
-type DoubleTroubleIface interface {
-	IFriendlyRandomGeneratorIface
-	IRandomNumberGeneratorIface
-	scopejsiicalclib.IFriendlyIface
+type DoubleTrouble interface {
+	IFriendlyRandomGenerator
 	Hello() string
 	Next() float64
 }
 
-// Struct proxy
-type DoubleTrouble struct {
+// The jsii proxy struct for DoubleTrouble
+type doubleTrouble struct {
+	iFriendlyRandomGenerator // implements jsii-calc.IFriendlyRandomGenerator
 }
 
-func NewDoubleTrouble() DoubleTroubleIface {
+func NewDoubleTrouble() DoubleTrouble {
 	_init_.Initialize()
-	self := DoubleTrouble{}
+	d := doubleTrouble{}
+
 	_jsii_.Create(
 		"jsii-calc.DoubleTrouble",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IFriendlyRandomGenerator"},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DoubleTrouble) Hello() string {
+// (deprecated) Say hello!
+func (d *doubleTrouble) Hello() string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5706,7 +5525,8 @@ func (d *DoubleTrouble) Hello() string {
 	return returns
 }
 
-func (d *DoubleTrouble) Next() float64 {
+// Returns another random number.
+func (d *doubleTrouble) Next() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		d,
@@ -5718,22 +5538,20 @@ func (d *DoubleTrouble) Next() float64 {
 	return returns
 }
 
-// Class interface
-type DynamicPropertyBearerIface interface {
-	GetDynamicProperty() string
+// Ensures we can override a dynamic property that was inherited.
+type DynamicPropertyBearer interface {
+	DynamicProperty() string
 	SetDynamicProperty(val string)
-	GetValueStore() string
+	ValueStore() string
 	SetValueStore(val string)
 }
 
-// Ensures we can override a dynamic property that was inherited.
-// Struct proxy
-type DynamicPropertyBearer struct {
-	DynamicProperty string \`json:"dynamicProperty"\`
-	ValueStore string \`json:"valueStore"\`
+// The jsii proxy struct for DynamicPropertyBearer
+type dynamicPropertyBearer struct {
+	_ byte // padding
 }
 
-func (d *DynamicPropertyBearer) GetDynamicProperty() string {
+func (d *dynamicPropertyBearer) DynamicProperty() string {
 	var returns string
 	_jsii_.Get(
 		d,
@@ -5743,7 +5561,7 @@ func (d *DynamicPropertyBearer) GetDynamicProperty() string {
 	return returns
 }
 
-func (d *DynamicPropertyBearer) GetValueStore() string {
+func (d *dynamicPropertyBearer) ValueStore() string {
 	var returns string
 	_jsii_.Get(
 		d,
@@ -5754,20 +5572,21 @@ func (d *DynamicPropertyBearer) GetValueStore() string {
 }
 
 
-func NewDynamicPropertyBearer(valueStore string) DynamicPropertyBearerIface {
+func NewDynamicPropertyBearer(valueStore string) DynamicPropertyBearer {
 	_init_.Initialize()
-	self := DynamicPropertyBearer{}
+	d := dynamicPropertyBearer{}
+
 	_jsii_.Create(
 		"jsii-calc.DynamicPropertyBearer",
 		[]interface{}{valueStore},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DynamicPropertyBearer) SetDynamicProperty(val string) {
+func (d *dynamicPropertyBearer) SetDynamicProperty(val string) {
 	_jsii_.Set(
 		d,
 		"dynamicProperty",
@@ -5775,7 +5594,7 @@ func (d *DynamicPropertyBearer) SetDynamicProperty(val string) {
 	)
 }
 
-func (d *DynamicPropertyBearer) SetValueStore(val string) {
+func (d *dynamicPropertyBearer) SetValueStore(val string) {
 	_jsii_.Set(
 		d,
 		"valueStore",
@@ -5783,44 +5602,18 @@ func (d *DynamicPropertyBearer) SetValueStore(val string) {
 	)
 }
 
-// Class interface
-type DynamicPropertyBearerChildIface interface {
-	GetDynamicProperty() string
-	SetDynamicProperty(val string)
-	GetValueStore() string
-	SetValueStore(val string)
-	GetOriginalValue() string
+type DynamicPropertyBearerChild interface {
+	DynamicPropertyBearer
+	OriginalValue() string
 	OverrideValue(newValue string) string
 }
 
-// Struct proxy
-type DynamicPropertyBearerChild struct {
-	DynamicProperty string \`json:"dynamicProperty"\`
-	ValueStore string \`json:"valueStore"\`
-	OriginalValue string \`json:"originalValue"\`
+// The jsii proxy struct for DynamicPropertyBearerChild
+type dynamicPropertyBearerChild struct {
+	dynamicPropertyBearer // extends jsii-calc.DynamicPropertyBearer
 }
 
-func (d *DynamicPropertyBearerChild) GetDynamicProperty() string {
-	var returns string
-	_jsii_.Get(
-		d,
-		"dynamicProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (d *DynamicPropertyBearerChild) GetValueStore() string {
-	var returns string
-	_jsii_.Get(
-		d,
-		"valueStore",
-		&returns,
-	)
-	return returns
-}
-
-func (d *DynamicPropertyBearerChild) GetOriginalValue() string {
+func (d *dynamicPropertyBearerChild) OriginalValue() string {
 	var returns string
 	_jsii_.Get(
 		d,
@@ -5831,36 +5624,24 @@ func (d *DynamicPropertyBearerChild) GetOriginalValue() string {
 }
 
 
-func NewDynamicPropertyBearerChild(originalValue string) DynamicPropertyBearerChildIface {
+func NewDynamicPropertyBearerChild(originalValue string) DynamicPropertyBearerChild {
 	_init_.Initialize()
-	self := DynamicPropertyBearerChild{}
+	d := dynamicPropertyBearerChild{}
+
 	_jsii_.Create(
 		"jsii-calc.DynamicPropertyBearerChild",
 		[]interface{}{originalValue},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&d,
 	)
-	return &self
+	return &d
 }
 
-func (d *DynamicPropertyBearerChild) SetDynamicProperty(val string) {
-	_jsii_.Set(
-		d,
-		"dynamicProperty",
-		val,
-	)
-}
-
-func (d *DynamicPropertyBearerChild) SetValueStore(val string) {
-	_jsii_.Set(
-		d,
-		"valueStore",
-		val,
-	)
-}
-
-func (d *DynamicPropertyBearerChild) OverrideValue(newValue string) string {
+// Sets \`this.dynamicProperty\` to the new value, and returns the old value.
+//
+// Returns: the old value that was set.
+func (d *dynamicPropertyBearerChild) OverrideValue(newValue string) string {
 	var returns string
 	_jsii_.Invoke(
 		d,
@@ -5872,32 +5653,36 @@ func (d *DynamicPropertyBearerChild) OverrideValue(newValue string) string {
 	return returns
 }
 
-// Class interface
-type EntropyIface interface {
+// This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
+type Entropy interface {
 	Increase() string
 	Repeat(word string) string
 }
 
-// This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
-// Struct proxy
-type Entropy struct {
+// The jsii proxy struct for Entropy
+type entropy struct {
+	_ byte // padding
 }
 
 // Creates a new instance of Entropy.
-func NewEntropy(clock IWallClockIface) EntropyIface {
+func NewEntropy(clock IWallClock) Entropy {
 	_init_.Initialize()
-	self := Entropy{}
+	e := entropy{}
+
 	_jsii_.Create(
 		"jsii-calc.Entropy",
 		[]interface{}{clock},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&e,
 	)
-	return &self
+	return &e
 }
 
-func (e *Entropy) Increase() string {
+// Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
+//
+// Returns: the time from the \`WallClock\`.
+func (e *entropy) Increase() string {
 	var returns string
 	_jsii_.Invoke(
 		e,
@@ -5909,7 +5694,10 @@ func (e *Entropy) Increase() string {
 	return returns
 }
 
-func (e *Entropy) Repeat(word string) string {
+// Implement this method such that it returns \`word\`.
+//
+// Returns: \`word\`.
+func (e *entropy) Repeat(word string) string {
 	var returns string
 	_jsii_.Invoke(
 		e,
@@ -5921,12 +5709,12 @@ func (e *Entropy) Repeat(word string) string {
 	return returns
 }
 
-// Class interface
-type EnumDispenserIface interface {
+type EnumDispenser interface {
 }
 
-// Struct proxy
-type EnumDispenser struct {
+// The jsii proxy struct for EnumDispenser
+type enumDispenser struct {
+	_ byte // padding
 }
 
 func EnumDispenser_RandomIntegerLikeEnum() AllTypesEnum {
@@ -5955,27 +5743,32 @@ func EnumDispenser_RandomStringLikeEnum() StringEnum {
 	return returns
 }
 
-// Class interface
-type EraseUndefinedHashValuesIface interface {
+type EraseUndefinedHashValues interface {
 }
 
-// Struct proxy
-type EraseUndefinedHashValues struct {
+// The jsii proxy struct for EraseUndefinedHashValues
+type eraseUndefinedHashValues struct {
+	_ byte // padding
 }
 
-func NewEraseUndefinedHashValues() EraseUndefinedHashValuesIface {
+func NewEraseUndefinedHashValues() EraseUndefinedHashValues {
 	_init_.Initialize()
-	self := EraseUndefinedHashValues{}
+	e := eraseUndefinedHashValues{}
+
 	_jsii_.Create(
 		"jsii-calc.EraseUndefinedHashValues",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&e,
 	)
-	return &self
+	return &e
 }
 
+// Returns \`true\` if \`key\` is defined in \`opts\`.
+//
+// Used to check that undefined/null hash values
+// are being erased when sending values from native code to JS.
 func EraseUndefinedHashValues_DoesKeyExist(opts EraseUndefinedHashValuesOptions, key string) bool {
 	_init_.Initialize()
 	var returns bool
@@ -5989,6 +5782,7 @@ func EraseUndefinedHashValues_DoesKeyExist(opts EraseUndefinedHashValuesOptions,
 	return returns
 }
 
+// We expect "prop1" to be erased.
 func EraseUndefinedHashValues_Prop1IsNull() map[string]interface{} {
 	_init_.Initialize()
 	var returns map[string]interface{}
@@ -6002,6 +5796,7 @@ func EraseUndefinedHashValues_Prop1IsNull() map[string]interface{} {
 	return returns
 }
 
+// We expect "prop2" to be erased.
 func EraseUndefinedHashValues_Prop2IsUndefined() map[string]interface{} {
 	_init_.Initialize()
 	var returns map[string]interface{}
@@ -6020,34 +5815,20 @@ type EraseUndefinedHashValuesOptions struct {
 	Option2 string \`json:"option2"\`
 }
 
-// Class interface
-type ExperimentalClassIface interface {
-	GetReadonlyProperty() string
-	GetMutableProperty() float64
+// Experimental.
+type ExperimentalClass interface {
+	MutableProperty() float64
 	SetMutableProperty(val float64)
+	ReadonlyProperty() string
 	Method()
 }
 
-// Experimental.
-// Struct proxy
-type ExperimentalClass struct {
-	// Experimental.
-	ReadonlyProperty string \`json:"readonlyProperty"\`
-	// Experimental.
-	MutableProperty float64 \`json:"mutableProperty"\`
+// The jsii proxy struct for ExperimentalClass
+type experimentalClass struct {
+	_ byte // padding
 }
 
-func (e *ExperimentalClass) GetReadonlyProperty() string {
-	var returns string
-	_jsii_.Get(
-		e,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (e *ExperimentalClass) GetMutableProperty() float64 {
+func (e *experimentalClass) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		e,
@@ -6057,21 +5838,32 @@ func (e *ExperimentalClass) GetMutableProperty() float64 {
 	return returns
 }
 
+func (e *experimentalClass) ReadonlyProperty() string {
+	var returns string
+	_jsii_.Get(
+		e,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
 
-func NewExperimentalClass(readonlyString string, mutableNumber float64) ExperimentalClassIface {
+
+func NewExperimentalClass(readonlyString string, mutableNumber float64) ExperimentalClass {
 	_init_.Initialize()
-	self := ExperimentalClass{}
+	e := experimentalClass{}
+
 	_jsii_.Create(
 		"jsii-calc.ExperimentalClass",
 		[]interface{}{readonlyString, mutableNumber},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&e,
 	)
-	return &self
+	return &e
 }
 
-func (e *ExperimentalClass) SetMutableProperty(val float64) {
+func (e *experimentalClass) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		e,
 		"mutableProperty",
@@ -6079,7 +5871,8 @@ func (e *ExperimentalClass) SetMutableProperty(val float64) {
 	)
 }
 
-func (e *ExperimentalClass) Method() {
+// Experimental.
+func (e *experimentalClass) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		e,
@@ -6104,17 +5897,16 @@ type ExperimentalStruct struct {
 	ReadonlyProperty string \`json:"readonlyProperty"\`
 }
 
-// Class interface
-type ExportedBaseClassIface interface {
-	GetSuccess() bool
+type ExportedBaseClass interface {
+	Success() bool
 }
 
-// Struct proxy
-type ExportedBaseClass struct {
-	Success bool \`json:"success"\`
+// The jsii proxy struct for ExportedBaseClass
+type exportedBaseClass struct {
+	_ byte // padding
 }
 
-func (e *ExportedBaseClass) GetSuccess() bool {
+func (e *exportedBaseClass) Success() bool {
 	var returns bool
 	_jsii_.Get(
 		e,
@@ -6125,17 +5917,18 @@ func (e *ExportedBaseClass) GetSuccess() bool {
 }
 
 
-func NewExportedBaseClass(success bool) ExportedBaseClassIface {
+func NewExportedBaseClass(success bool) ExportedBaseClass {
 	_init_.Initialize()
-	self := ExportedBaseClass{}
+	e := exportedBaseClass{}
+
 	_jsii_.Create(
 		"jsii-calc.ExportedBaseClass",
 		[]interface{}{success},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&e,
 	)
-	return &self
+	return &e
 }
 
 type ExtendsInternalInterface struct {
@@ -6143,31 +5936,19 @@ type ExtendsInternalInterface struct {
 	Prop string \`json:"prop"\`
 }
 
-// Class interface
-type ExternalClassIface interface {
-	GetReadonlyProperty() string
-	GetMutableProperty() float64
+type ExternalClass interface {
+	MutableProperty() float64
 	SetMutableProperty(val float64)
+	ReadonlyProperty() string
 	Method()
 }
 
-// Struct proxy
-type ExternalClass struct {
-	ReadonlyProperty string \`json:"readonlyProperty"\`
-	MutableProperty float64 \`json:"mutableProperty"\`
+// The jsii proxy struct for ExternalClass
+type externalClass struct {
+	_ byte // padding
 }
 
-func (e *ExternalClass) GetReadonlyProperty() string {
-	var returns string
-	_jsii_.Get(
-		e,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (e *ExternalClass) GetMutableProperty() float64 {
+func (e *externalClass) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		e,
@@ -6177,21 +5958,32 @@ func (e *ExternalClass) GetMutableProperty() float64 {
 	return returns
 }
 
+func (e *externalClass) ReadonlyProperty() string {
+	var returns string
+	_jsii_.Get(
+		e,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
 
-func NewExternalClass(readonlyString string, mutableNumber float64) ExternalClassIface {
+
+func NewExternalClass(readonlyString string, mutableNumber float64) ExternalClass {
 	_init_.Initialize()
-	self := ExternalClass{}
+	e := externalClass{}
+
 	_jsii_.Create(
 		"jsii-calc.ExternalClass",
 		[]interface{}{readonlyString, mutableNumber},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&e,
 	)
-	return &self
+	return &e
 }
 
-func (e *ExternalClass) SetMutableProperty(val float64) {
+func (e *externalClass) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		e,
 		"mutableProperty",
@@ -6199,7 +5991,7 @@ func (e *ExternalClass) SetMutableProperty(val float64) {
 	)
 }
 
-func (e *ExternalClass) Method() {
+func (e *externalClass) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		e,
@@ -6221,20 +6013,19 @@ type ExternalStruct struct {
 	ReadonlyProperty string \`json:"readonlyProperty"\`
 }
 
-// Class interface
-type GiveMeStructsIface interface {
-	GetStructLiteral() scopejsiicalclib.StructWithOnlyOptionals
+type GiveMeStructs interface {
+	StructLiteral() scopejsiicalclib.StructWithOnlyOptionals
 	DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct
-	ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTroubleIface
+	ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTrouble
 	ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64
 }
 
-// Struct proxy
-type GiveMeStructs struct {
-	StructLiteral scopejsiicalclib.StructWithOnlyOptionals \`json:"structLiteral"\`
+// The jsii proxy struct for GiveMeStructs
+type giveMeStructs struct {
+	_ byte // padding
 }
 
-func (g *GiveMeStructs) GetStructLiteral() scopejsiicalclib.StructWithOnlyOptionals {
+func (g *giveMeStructs) StructLiteral() scopejsiicalclib.StructWithOnlyOptionals {
 	var returns scopejsiicalclib.StructWithOnlyOptionals
 	_jsii_.Get(
 		g,
@@ -6245,20 +6036,22 @@ func (g *GiveMeStructs) GetStructLiteral() scopejsiicalclib.StructWithOnlyOption
 }
 
 
-func NewGiveMeStructs() GiveMeStructsIface {
+func NewGiveMeStructs() GiveMeStructs {
 	_init_.Initialize()
-	self := GiveMeStructs{}
+	g := giveMeStructs{}
+
 	_jsii_.Create(
 		"jsii-calc.GiveMeStructs",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&g,
 	)
-	return &self
+	return &g
 }
 
-func (g *GiveMeStructs) DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct {
+// Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
+func (g *giveMeStructs) DerivedToFirst(derived DerivedStruct) scopejsiicalclib.MyFirstStruct {
 	var returns scopejsiicalclib.MyFirstStruct
 	_jsii_.Invoke(
 		g,
@@ -6270,8 +6063,9 @@ func (g *GiveMeStructs) DerivedToFirst(derived DerivedStruct) scopejsiicalclib.M
 	return returns
 }
 
-func (g *GiveMeStructs) ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTroubleIface {
-	var returns DoubleTroubleIface
+// Returns the boolean from a DerivedStruct struct.
+func (g *giveMeStructs) ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTrouble {
+	var returns DoubleTrouble
 	_jsii_.Invoke(
 		g,
 		"readDerivedNonPrimitive",
@@ -6282,7 +6076,8 @@ func (g *GiveMeStructs) ReadDerivedNonPrimitive(derived DerivedStruct) DoubleTro
 	return returns
 }
 
-func (g *GiveMeStructs) ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64 {
+// Returns the "anumber" from a MyFirstStruct struct;
+func (g *giveMeStructs) ReadFirstNumber(first scopejsiicalclib.MyFirstStruct) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		g,
@@ -6300,29 +6095,30 @@ type Greetee struct {
 	Name string \`json:"name"\`
 }
 
-// Class interface
-type GreetingAugmenterIface interface {
-	BetterGreeting(friendly scopejsiicalclib.IFriendlyIface) string
+type GreetingAugmenter interface {
+	BetterGreeting(friendly scopejsiicalclib.IFriendly) string
 }
 
-// Struct proxy
-type GreetingAugmenter struct {
+// The jsii proxy struct for GreetingAugmenter
+type greetingAugmenter struct {
+	_ byte // padding
 }
 
-func NewGreetingAugmenter() GreetingAugmenterIface {
+func NewGreetingAugmenter() GreetingAugmenter {
 	_init_.Initialize()
-	self := GreetingAugmenter{}
+	g := greetingAugmenter{}
+
 	_jsii_.Create(
 		"jsii-calc.GreetingAugmenter",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&g,
 	)
-	return &self
+	return &g
 }
 
-func (g *GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendlyIface) string {
+func (g *greetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendly) string {
 	var returns string
 	_jsii_.Invoke(
 		g,
@@ -6335,15 +6131,18 @@ func (g *GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendlyIf
 }
 
 // We can return an anonymous interface implementation from an override without losing the interface declarations.
-type IAnonymousImplementationProviderIface interface {
-	ProvideAsClass() ImplementationIface
-	ProvideAsInterface() IAnonymouslyImplementMeIface
+type IAnonymousImplementationProvider interface {
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
 }
 
-type IAnonymousImplementationProvider struct {}
+// The jsii proxy for IAnonymousImplementationProvider
+type iAnonymousImplementationProvider struct {
+	_ byte // padding
+}
 
-func (i *IAnonymousImplementationProvider) ProvideAsClass() ImplementationIface {
-	var returns ImplementationIface
+func (i *iAnonymousImplementationProvider) ProvideAsClass() Implementation {
+	var returns Implementation
 	_jsii_.Invoke(
 		i,
 		"provideAsClass",
@@ -6354,8 +6153,8 @@ func (i *IAnonymousImplementationProvider) ProvideAsClass() ImplementationIface 
 	return returns
 }
 
-func (i *IAnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMeIface {
-	var returns IAnonymouslyImplementMeIface
+func (i *iAnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
+	var returns IAnonymouslyImplementMe
 	_jsii_.Invoke(
 		i,
 		"provideAsInterface",
@@ -6366,14 +6165,17 @@ func (i *IAnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImpl
 	return returns
 }
 
-type IAnonymouslyImplementMeIface interface {
+type IAnonymouslyImplementMe interface {
 	Verb() string
-	GetValue() float64
+	Value() float64
 }
 
-type IAnonymouslyImplementMe struct {}
+// The jsii proxy for IAnonymouslyImplementMe
+type iAnonymouslyImplementMe struct {
+	_ byte // padding
+}
 
-func (i *IAnonymouslyImplementMe) Verb() string {
+func (i *iAnonymouslyImplementMe) Verb() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -6385,7 +6187,7 @@ func (i *IAnonymouslyImplementMe) Verb() string {
 	return returns
 }
 
-func (i *IAnonymouslyImplementMe) GetValue() float64 {
+func (i *iAnonymouslyImplementMe) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -6395,13 +6197,16 @@ func (i *IAnonymouslyImplementMe) GetValue() float64 {
 	return returns
 }
 
-type IAnotherPublicInterfaceIface interface {
-	GetA() string
+type IAnotherPublicInterface interface {
+	A() string
 }
 
-type IAnotherPublicInterface struct {}
+// The jsii proxy for IAnotherPublicInterface
+type iAnotherPublicInterface struct {
+	_ byte // padding
+}
 
-func (i *IAnotherPublicInterface) GetA() string {
+func (i *iAnotherPublicInterface) A() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6411,7 +6216,7 @@ func (i *IAnotherPublicInterface) GetA() string {
 	return returns
 }
 
-func (i *IAnotherPublicInterface) SetA(val string) {
+func (i *iAnotherPublicInterface) SetA(val string) {
 	_jsii_.Set(
 		i,
 		"a",
@@ -6419,13 +6224,16 @@ func (i *IAnotherPublicInterface) SetA(val string) {
 	)
 }
 
-type IBellIface interface {
+type IBell interface {
 	Ring()
 }
 
-type IBell struct {}
+// The jsii proxy for IBell
+type iBell struct {
+	_ byte // padding
+}
 
-func (i *IBell) Ring() {
+func (i *iBell) Ring() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6437,13 +6245,16 @@ func (i *IBell) Ring() {
 }
 
 // Takes the object parameter as an interface.
-type IBellRingerIface interface {
-	YourTurn(bell IBellIface)
+type IBellRinger interface {
+	YourTurn(bell IBell)
 }
 
-type IBellRinger struct {}
+// The jsii proxy for IBellRinger
+type iBellRinger struct {
+	_ byte // padding
+}
 
-func (i *IBellRinger) YourTurn(bell IBellIface) {
+func (i *iBellRinger) YourTurn(bell IBell) {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6455,13 +6266,16 @@ func (i *IBellRinger) YourTurn(bell IBellIface) {
 }
 
 // Takes the object parameter as a calss.
-type IConcreteBellRingerIface interface {
-	YourTurn(bell BellIface)
+type IConcreteBellRinger interface {
+	YourTurn(bell Bell)
 }
 
-type IConcreteBellRinger struct {}
+// The jsii proxy for IConcreteBellRinger
+type iConcreteBellRinger struct {
+	_ byte // padding
+}
 
-func (i *IConcreteBellRinger) YourTurn(bell BellIface) {
+func (i *iConcreteBellRinger) YourTurn(bell Bell) {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6473,16 +6287,19 @@ func (i *IConcreteBellRinger) YourTurn(bell BellIface) {
 }
 
 // Deprecated: useless interface
-type IDeprecatedInterfaceIface interface {
+type IDeprecatedInterface interface {
 	// Deprecated: services no purpose
 	Method()
 	// Deprecated: could be better
-	GetMutableProperty() float64
+	MutableProperty() float64
 }
 
-type IDeprecatedInterface struct {}
+// The jsii proxy for IDeprecatedInterface
+type iDeprecatedInterface struct {
+	_ byte // padding
+}
 
-func (i *IDeprecatedInterface) Method() {
+func (i *iDeprecatedInterface) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6493,7 +6310,7 @@ func (i *IDeprecatedInterface) Method() {
 	)
 }
 
-func (i *IDeprecatedInterface) GetMutableProperty() float64 {
+func (i *iDeprecatedInterface) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -6503,7 +6320,7 @@ func (i *IDeprecatedInterface) GetMutableProperty() float64 {
 	return returns
 }
 
-func (i *IDeprecatedInterface) SetMutableProperty(val float64) {
+func (i *iDeprecatedInterface) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		i,
 		"mutableProperty",
@@ -6512,16 +6329,19 @@ func (i *IDeprecatedInterface) SetMutableProperty(val float64) {
 }
 
 // Experimental.
-type IExperimentalInterfaceIface interface {
+type IExperimentalInterface interface {
 	// Experimental.
 	Method()
 	// Experimental.
-	GetMutableProperty() float64
+	MutableProperty() float64
 }
 
-type IExperimentalInterface struct {}
+// The jsii proxy for IExperimentalInterface
+type iExperimentalInterface struct {
+	_ byte // padding
+}
 
-func (i *IExperimentalInterface) Method() {
+func (i *iExperimentalInterface) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6532,7 +6352,7 @@ func (i *IExperimentalInterface) Method() {
 	)
 }
 
-func (i *IExperimentalInterface) GetMutableProperty() float64 {
+func (i *iExperimentalInterface) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -6542,7 +6362,7 @@ func (i *IExperimentalInterface) GetMutableProperty() float64 {
 	return returns
 }
 
-func (i *IExperimentalInterface) SetMutableProperty(val float64) {
+func (i *iExperimentalInterface) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		i,
 		"mutableProperty",
@@ -6550,14 +6370,17 @@ func (i *IExperimentalInterface) SetMutableProperty(val float64) {
 	)
 }
 
-type IExtendsPrivateInterfaceIface interface {
-	GetMoreThings() []string
-	GetPrivate() string
+type IExtendsPrivateInterface interface {
+	MoreThings() []string
+	Private() string
 }
 
-type IExtendsPrivateInterface struct {}
+// The jsii proxy for IExtendsPrivateInterface
+type iExtendsPrivateInterface struct {
+	_ byte // padding
+}
 
-func (i *IExtendsPrivateInterface) GetMoreThings() []string {
+func (i *iExtendsPrivateInterface) MoreThings() []string {
 	var returns []string
 	_jsii_.Get(
 		i,
@@ -6567,7 +6390,7 @@ func (i *IExtendsPrivateInterface) GetMoreThings() []string {
 	return returns
 }
 
-func (i *IExtendsPrivateInterface) GetPrivate() string {
+func (i *iExtendsPrivateInterface) Private() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6577,7 +6400,7 @@ func (i *IExtendsPrivateInterface) GetPrivate() string {
 	return returns
 }
 
-func (i *IExtendsPrivateInterface) SetPrivate(val string) {
+func (i *iExtendsPrivateInterface) SetPrivate(val string) {
 	_jsii_.Set(
 		i,
 		"private",
@@ -6585,14 +6408,17 @@ func (i *IExtendsPrivateInterface) SetPrivate(val string) {
 	)
 }
 
-type IExternalInterfaceIface interface {
+type IExternalInterface interface {
 	Method()
-	GetMutableProperty() float64
+	MutableProperty() float64
 }
 
-type IExternalInterface struct {}
+// The jsii proxy for IExternalInterface
+type iExternalInterface struct {
+	_ byte // padding
+}
 
-func (i *IExternalInterface) Method() {
+func (i *iExternalInterface) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6603,7 +6429,7 @@ func (i *IExternalInterface) Method() {
 	)
 }
 
-func (i *IExternalInterface) GetMutableProperty() float64 {
+func (i *iExternalInterface) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -6613,7 +6439,7 @@ func (i *IExternalInterface) GetMutableProperty() float64 {
 	return returns
 }
 
-func (i *IExternalInterface) SetMutableProperty(val float64) {
+func (i *iExternalInterface) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		i,
 		"mutableProperty",
@@ -6622,8 +6448,8 @@ func (i *IExternalInterface) SetMutableProperty(val float64) {
 }
 
 // Even friendlier classes can implement this interface.
-type IFriendlierIface interface {
-	scopejsiicalclib.IFriendlyIface
+type IFriendlier interface {
+	scopejsiicalclib.IFriendly
 	// Say farewell.
 	Farewell() string
 	// Say goodbye.
@@ -6632,21 +6458,12 @@ type IFriendlierIface interface {
 	Goodbye() string
 }
 
-type IFriendlier struct {}
-
-func (i *IFriendlier) Hello() string {
-	var returns string
-	_jsii_.Invoke(
-		i,
-		"hello",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
+// The jsii proxy for IFriendlier
+type iFriendlier struct {
+	scopejsiicalclib.IFriendly // extends @scope/jsii-calc-lib.IFriendly
 }
 
-func (i *IFriendlier) Farewell() string {
+func (i *iFriendlier) Farewell() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -6658,7 +6475,7 @@ func (i *IFriendlier) Farewell() string {
 	return returns
 }
 
-func (i *IFriendlier) Goodbye() string {
+func (i *iFriendlier) Goodbye() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -6670,14 +6487,30 @@ func (i *IFriendlier) Goodbye() string {
 	return returns
 }
 
-type IFriendlyRandomGeneratorIface interface {
-	IRandomNumberGeneratorIface
-	scopejsiicalclib.IFriendlyIface
+type IFriendlyRandomGenerator interface {
+	scopejsiicalclib.IFriendly
+	IRandomNumberGenerator
 }
 
-type IFriendlyRandomGenerator struct {}
+// The jsii proxy for IFriendlyRandomGenerator
+type iFriendlyRandomGenerator struct {
+	scopejsiicalclib.IFriendly // extends @scope/jsii-calc-lib.IFriendly
+	iRandomNumberGenerator // extends jsii-calc.IRandomNumberGenerator
+}
 
-func (i *IFriendlyRandomGenerator) Next() float64 {
+func (i *iFriendlyRandomGenerator) Hello() string {
+	var returns string
+	_jsii_.Invoke(
+		i,
+		"hello",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
+}
+
+func (i *iFriendlyRandomGenerator) Next() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		i,
@@ -6689,26 +6522,17 @@ func (i *IFriendlyRandomGenerator) Next() float64 {
 	return returns
 }
 
-func (i *IFriendlyRandomGenerator) Hello() string {
-	var returns string
-	_jsii_.Invoke(
-		i,
-		"hello",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
 // awslabs/jsii#220 Abstract return type.
-type IInterfaceImplementedByAbstractClassIface interface {
-	GetPropFromInterface() string
+type IInterfaceImplementedByAbstractClass interface {
+	PropFromInterface() string
 }
 
-type IInterfaceImplementedByAbstractClass struct {}
+// The jsii proxy for IInterfaceImplementedByAbstractClass
+type iInterfaceImplementedByAbstractClass struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceImplementedByAbstractClass) GetPropFromInterface() string {
+func (i *iInterfaceImplementedByAbstractClass) PropFromInterface() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6719,35 +6543,17 @@ func (i *IInterfaceImplementedByAbstractClass) GetPropFromInterface() string {
 }
 
 // Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
-type IInterfaceThatShouldNotBeADataTypeIface interface {
-	IInterfaceWithMethodsIface
-	GetOtherValue() string
+type IInterfaceThatShouldNotBeADataType interface {
+	IInterfaceWithMethods
+	OtherValue() string
 }
 
-type IInterfaceThatShouldNotBeADataType struct {}
-
-func (i *IInterfaceThatShouldNotBeADataType) DoThings() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"doThings",
-		[]interface{}{},
-		false,
-		&returns,
-	)
+// The jsii proxy for IInterfaceThatShouldNotBeADataType
+type iInterfaceThatShouldNotBeADataType struct {
+	iInterfaceWithMethods // extends jsii-calc.IInterfaceWithMethods
 }
 
-func (i *IInterfaceThatShouldNotBeADataType) GetValue() string {
-	var returns string
-	_jsii_.Get(
-		i,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-func (i *IInterfaceThatShouldNotBeADataType) GetOtherValue() string {
+func (i *iInterfaceThatShouldNotBeADataType) OtherValue() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6757,13 +6563,16 @@ func (i *IInterfaceThatShouldNotBeADataType) GetOtherValue() string {
 	return returns
 }
 
-type IInterfaceWithInternalIface interface {
+type IInterfaceWithInternal interface {
 	Visible()
 }
 
-type IInterfaceWithInternal struct {}
+// The jsii proxy for IInterfaceWithInternal
+type iInterfaceWithInternal struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceWithInternal) Visible() {
+func (i *iInterfaceWithInternal) Visible() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6774,14 +6583,17 @@ func (i *IInterfaceWithInternal) Visible() {
 	)
 }
 
-type IInterfaceWithMethodsIface interface {
+type IInterfaceWithMethods interface {
 	DoThings()
-	GetValue() string
+	Value() string
 }
 
-type IInterfaceWithMethods struct {}
+// The jsii proxy for IInterfaceWithMethods
+type iInterfaceWithMethods struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceWithMethods) DoThings() {
+func (i *iInterfaceWithMethods) DoThings() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6792,7 +6604,7 @@ func (i *IInterfaceWithMethods) DoThings() {
 	)
 }
 
-func (i *IInterfaceWithMethods) GetValue() string {
+func (i *iInterfaceWithMethods) Value() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6803,13 +6615,16 @@ func (i *IInterfaceWithMethods) GetValue() string {
 }
 
 // awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
-type IInterfaceWithOptionalMethodArgumentsIface interface {
+type IInterfaceWithOptionalMethodArguments interface {
 	Hello(arg1 string, arg2 float64)
 }
 
-type IInterfaceWithOptionalMethodArguments struct {}
+// The jsii proxy for IInterfaceWithOptionalMethodArguments
+type iInterfaceWithOptionalMethodArguments struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceWithOptionalMethodArguments) Hello(arg1 string, arg2 float64) {
+func (i *iInterfaceWithOptionalMethodArguments) Hello(arg1 string, arg2 float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6820,14 +6635,17 @@ func (i *IInterfaceWithOptionalMethodArguments) Hello(arg1 string, arg2 float64)
 	)
 }
 
-type IInterfaceWithPropertiesIface interface {
-	GetReadOnlyString() string
-	GetReadWriteString() string
+type IInterfaceWithProperties interface {
+	ReadOnlyString() string
+	ReadWriteString() string
 }
 
-type IInterfaceWithProperties struct {}
+// The jsii proxy for IInterfaceWithProperties
+type iInterfaceWithProperties struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceWithProperties) GetReadOnlyString() string {
+func (i *iInterfaceWithProperties) ReadOnlyString() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6837,7 +6655,7 @@ func (i *IInterfaceWithProperties) GetReadOnlyString() string {
 	return returns
 }
 
-func (i *IInterfaceWithProperties) GetReadWriteString() string {
+func (i *iInterfaceWithProperties) ReadWriteString() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6847,7 +6665,7 @@ func (i *IInterfaceWithProperties) GetReadWriteString() string {
 	return returns
 }
 
-func (i *IInterfaceWithProperties) SetReadWriteString(val string) {
+func (i *iInterfaceWithProperties) SetReadWriteString(val string) {
 	_jsii_.Set(
 		i,
 		"readWriteString",
@@ -6855,42 +6673,17 @@ func (i *IInterfaceWithProperties) SetReadWriteString(val string) {
 	)
 }
 
-type IInterfaceWithPropertiesExtensionIface interface {
-	IInterfaceWithPropertiesIface
-	GetFoo() float64
+type IInterfaceWithPropertiesExtension interface {
+	IInterfaceWithProperties
+	Foo() float64
 }
 
-type IInterfaceWithPropertiesExtension struct {}
-
-func (i *IInterfaceWithPropertiesExtension) GetReadOnlyString() string {
-	var returns string
-	_jsii_.Get(
-		i,
-		"readOnlyString",
-		&returns,
-	)
-	return returns
+// The jsii proxy for IInterfaceWithPropertiesExtension
+type iInterfaceWithPropertiesExtension struct {
+	iInterfaceWithProperties // extends jsii-calc.IInterfaceWithProperties
 }
 
-func (i *IInterfaceWithPropertiesExtension) GetReadWriteString() string {
-	var returns string
-	_jsii_.Get(
-		i,
-		"readWriteString",
-		&returns,
-	)
-	return returns
-}
-
-func (i *IInterfaceWithPropertiesExtension) SetReadWriteString(val string) {
-	_jsii_.Set(
-		i,
-		"readWriteString",
-		val,
-	)
-}
-
-func (i *IInterfaceWithPropertiesExtension) GetFoo() float64 {
+func (i *iInterfaceWithPropertiesExtension) Foo() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -6900,7 +6693,7 @@ func (i *IInterfaceWithPropertiesExtension) GetFoo() float64 {
 	return returns
 }
 
-func (i *IInterfaceWithPropertiesExtension) SetFoo(val float64) {
+func (i *iInterfaceWithPropertiesExtension) SetFoo(val float64) {
 	_jsii_.Set(
 		i,
 		"foo",
@@ -6908,27 +6701,19 @@ func (i *IInterfaceWithPropertiesExtension) SetFoo(val float64) {
 	)
 }
 
-type Ijsii417DerivedIface interface {
-	Ijsii417PublicBaseOfBaseIface
+type Ijsii417Derived interface {
+	Ijsii417PublicBaseOfBase
 	Bar()
 	Baz()
-	GetProperty() string
+	Property() string
 }
 
-type Ijsii417Derived struct {}
-
-func (i *Ijsii417Derived) Foo() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"foo",
-		[]interface{}{},
-		false,
-		&returns,
-	)
+// The jsii proxy for Ijsii417Derived
+type ijsii417Derived struct {
+	ijsii417PublicBaseOfBase // extends jsii-calc.IJSII417PublicBaseOfBase
 }
 
-func (i *Ijsii417Derived) Bar() {
+func (i *ijsii417Derived) Bar() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6939,7 +6724,7 @@ func (i *Ijsii417Derived) Bar() {
 	)
 }
 
-func (i *Ijsii417Derived) Baz() {
+func (i *ijsii417Derived) Baz() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6950,17 +6735,7 @@ func (i *Ijsii417Derived) Baz() {
 	)
 }
 
-func (i *Ijsii417Derived) GetHasRoot() bool {
-	var returns bool
-	_jsii_.Get(
-		i,
-		"hasRoot",
-		&returns,
-	)
-	return returns
-}
-
-func (i *Ijsii417Derived) GetProperty() string {
+func (i *ijsii417Derived) Property() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -6970,14 +6745,17 @@ func (i *Ijsii417Derived) GetProperty() string {
 	return returns
 }
 
-type Ijsii417PublicBaseOfBaseIface interface {
+type Ijsii417PublicBaseOfBase interface {
 	Foo()
-	GetHasRoot() bool
+	HasRoot() bool
 }
 
-type Ijsii417PublicBaseOfBase struct {}
+// The jsii proxy for Ijsii417PublicBaseOfBase
+type ijsii417PublicBaseOfBase struct {
+	_ byte // padding
+}
 
-func (i *Ijsii417PublicBaseOfBase) Foo() {
+func (i *ijsii417PublicBaseOfBase) Foo() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -6988,7 +6766,7 @@ func (i *Ijsii417PublicBaseOfBase) Foo() {
 	)
 }
 
-func (i *Ijsii417PublicBaseOfBase) GetHasRoot() bool {
+func (i *ijsii417PublicBaseOfBase) HasRoot() bool {
 	var returns bool
 	_jsii_.Get(
 		i,
@@ -6998,28 +6776,40 @@ func (i *Ijsii417PublicBaseOfBase) GetHasRoot() bool {
 	return returns
 }
 
-type IJsii487ExternalIface interface {
+type IJsii487External interface {
 }
 
-type IJsii487External struct {}
-
-type IJsii487External2Iface interface {
+// The jsii proxy for IJsii487External
+type iJsii487External struct {
+	_ byte // padding
 }
 
-type IJsii487External2 struct {}
-
-type IJsii496Iface interface {
+type IJsii487External2 interface {
 }
 
-type IJsii496 struct {}
-
-type IMutableObjectLiteralIface interface {
-	GetValue() string
+// The jsii proxy for IJsii487External2
+type iJsii487External2 struct {
+	_ byte // padding
 }
 
-type IMutableObjectLiteral struct {}
+type IJsii496 interface {
+}
 
-func (i *IMutableObjectLiteral) GetValue() string {
+// The jsii proxy for IJsii496
+type iJsii496 struct {
+	_ byte // padding
+}
+
+type IMutableObjectLiteral interface {
+	Value() string
+}
+
+// The jsii proxy for IMutableObjectLiteral
+type iMutableObjectLiteral struct {
+	_ byte // padding
+}
+
+func (i *iMutableObjectLiteral) Value() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7029,7 +6819,7 @@ func (i *IMutableObjectLiteral) GetValue() string {
 	return returns
 }
 
-func (i *IMutableObjectLiteral) SetValue(val string) {
+func (i *iMutableObjectLiteral) SetValue(val string) {
 	_jsii_.Set(
 		i,
 		"value",
@@ -7037,33 +6827,18 @@ func (i *IMutableObjectLiteral) SetValue(val string) {
 	)
 }
 
-type INonInternalInterfaceIface interface {
-	IAnotherPublicInterfaceIface
-	GetB() string
-	GetC() string
+type INonInternalInterface interface {
+	IAnotherPublicInterface
+	B() string
+	C() string
 }
 
-type INonInternalInterface struct {}
-
-func (i *INonInternalInterface) GetA() string {
-	var returns string
-	_jsii_.Get(
-		i,
-		"a",
-		&returns,
-	)
-	return returns
+// The jsii proxy for INonInternalInterface
+type iNonInternalInterface struct {
+	iAnotherPublicInterface // extends jsii-calc.IAnotherPublicInterface
 }
 
-func (i *INonInternalInterface) SetA(val string) {
-	_jsii_.Set(
-		i,
-		"a",
-		val,
-	)
-}
-
-func (i *INonInternalInterface) GetB() string {
+func (i *iNonInternalInterface) B() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7073,7 +6848,7 @@ func (i *INonInternalInterface) GetB() string {
 	return returns
 }
 
-func (i *INonInternalInterface) SetB(val string) {
+func (i *iNonInternalInterface) SetB(val string) {
 	_jsii_.Set(
 		i,
 		"b",
@@ -7081,7 +6856,7 @@ func (i *INonInternalInterface) SetB(val string) {
 	)
 }
 
-func (i *INonInternalInterface) GetC() string {
+func (i *iNonInternalInterface) C() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7091,7 +6866,7 @@ func (i *INonInternalInterface) GetC() string {
 	return returns
 }
 
-func (i *INonInternalInterface) SetC(val string) {
+func (i *iNonInternalInterface) SetC(val string) {
 	_jsii_.Set(
 		i,
 		"c",
@@ -7100,14 +6875,17 @@ func (i *INonInternalInterface) SetC(val string) {
 }
 
 // Make sure that setters are properly called on objects with interfaces.
-type IObjectWithPropertyIface interface {
+type IObjectWithProperty interface {
 	WasSet() bool
-	GetProperty() string
+	Property() string
 }
 
-type IObjectWithProperty struct {}
+// The jsii proxy for IObjectWithProperty
+type iObjectWithProperty struct {
+	_ byte // padding
+}
 
-func (i *IObjectWithProperty) WasSet() bool {
+func (i *iObjectWithProperty) WasSet() bool {
 	var returns bool
 	_jsii_.Invoke(
 		i,
@@ -7119,7 +6897,7 @@ func (i *IObjectWithProperty) WasSet() bool {
 	return returns
 }
 
-func (i *IObjectWithProperty) GetProperty() string {
+func (i *iObjectWithProperty) Property() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7129,7 +6907,7 @@ func (i *IObjectWithProperty) GetProperty() string {
 	return returns
 }
 
-func (i *IObjectWithProperty) SetProperty(val string) {
+func (i *iObjectWithProperty) SetProperty(val string) {
 	_jsii_.Set(
 		i,
 		"property",
@@ -7138,13 +6916,16 @@ func (i *IObjectWithProperty) SetProperty(val string) {
 }
 
 // Checks that optional result from interface method code generates correctly.
-type IOptionalMethodIface interface {
+type IOptionalMethod interface {
 	Optional() string
 }
 
-type IOptionalMethod struct {}
+// The jsii proxy for IOptionalMethod
+type iOptionalMethod struct {
+	_ byte // padding
+}
 
-func (i *IOptionalMethod) Optional() string {
+func (i *iOptionalMethod) Optional() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -7156,13 +6937,16 @@ func (i *IOptionalMethod) Optional() string {
 	return returns
 }
 
-type IPrivatelyImplementedIface interface {
-	GetSuccess() bool
+type IPrivatelyImplemented interface {
+	Success() bool
 }
 
-type IPrivatelyImplemented struct {}
+// The jsii proxy for IPrivatelyImplemented
+type iPrivatelyImplemented struct {
+	_ byte // padding
+}
 
-func (i *IPrivatelyImplemented) GetSuccess() bool {
+func (i *iPrivatelyImplemented) Success() bool {
 	var returns bool
 	_jsii_.Get(
 		i,
@@ -7172,13 +6956,16 @@ func (i *IPrivatelyImplemented) GetSuccess() bool {
 	return returns
 }
 
-type IPublicInterfaceIface interface {
+type IPublicInterface interface {
 	Bye() string
 }
 
-type IPublicInterface struct {}
+// The jsii proxy for IPublicInterface
+type iPublicInterface struct {
+	_ byte // padding
+}
 
-func (i *IPublicInterface) Bye() string {
+func (i *iPublicInterface) Bye() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -7190,13 +6977,16 @@ func (i *IPublicInterface) Bye() string {
 	return returns
 }
 
-type IPublicInterface2Iface interface {
+type IPublicInterface2 interface {
 	Ciao() string
 }
 
-type IPublicInterface2 struct {}
+// The jsii proxy for IPublicInterface2
+type iPublicInterface2 struct {
+	_ byte // padding
+}
 
-func (i *IPublicInterface2) Ciao() string {
+func (i *iPublicInterface2) Ciao() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -7209,16 +6999,19 @@ func (i *IPublicInterface2) Ciao() string {
 }
 
 // Generates random numbers.
-type IRandomNumberGeneratorIface interface {
+type IRandomNumberGenerator interface {
 	// Returns another random number.
 	//
 	// Returns: A random number.
 	Next() float64
 }
 
-type IRandomNumberGenerator struct {}
+// The jsii proxy for IRandomNumberGenerator
+type iRandomNumberGenerator struct {
+	_ byte // padding
+}
 
-func (i *IRandomNumberGenerator) Next() float64 {
+func (i *iRandomNumberGenerator) Next() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		i,
@@ -7231,13 +7024,16 @@ func (i *IRandomNumberGenerator) Next() float64 {
 }
 
 // Returns a subclass of a known class which implements an interface.
-type IReturnJsii976Iface interface {
-	GetFoo() float64
+type IReturnJsii976 interface {
+	Foo() float64
 }
 
-type IReturnJsii976 struct {}
+// The jsii proxy for IReturnJsii976
+type iReturnJsii976 struct {
+	_ byte // padding
+}
 
-func (i *IReturnJsii976) GetFoo() float64 {
+func (i *iReturnJsii976) Foo() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -7247,15 +7043,18 @@ func (i *IReturnJsii976) GetFoo() float64 {
 	return returns
 }
 
-type IReturnsNumberIface interface {
-	ObtainNumber() scopejsiicalclib.IDoublableIface
-	GetNumberProp() scopejsiicalclib.NumberIface
+type IReturnsNumber interface {
+	ObtainNumber() scopejsiicalclib.IDoublable
+	NumberProp() scopejsiicalclib.Number
 }
 
-type IReturnsNumber struct {}
+// The jsii proxy for IReturnsNumber
+type iReturnsNumber struct {
+	_ byte // padding
+}
 
-func (i *IReturnsNumber) ObtainNumber() scopejsiicalclib.IDoublableIface {
-	var returns scopejsiicalclib.IDoublableIface
+func (i *iReturnsNumber) ObtainNumber() scopejsiicalclib.IDoublable {
+	var returns scopejsiicalclib.IDoublable
 	_jsii_.Invoke(
 		i,
 		"obtainNumber",
@@ -7266,8 +7065,8 @@ func (i *IReturnsNumber) ObtainNumber() scopejsiicalclib.IDoublableIface {
 	return returns
 }
 
-func (i *IReturnsNumber) GetNumberProp() scopejsiicalclib.NumberIface {
-	var returns scopejsiicalclib.NumberIface
+func (i *iReturnsNumber) NumberProp() scopejsiicalclib.Number {
+	var returns scopejsiicalclib.Number
 	_jsii_.Get(
 		i,
 		"numberProp",
@@ -7276,14 +7075,17 @@ func (i *IReturnsNumber) GetNumberProp() scopejsiicalclib.NumberIface {
 	return returns
 }
 
-type IStableInterfaceIface interface {
+type IStableInterface interface {
 	Method()
-	GetMutableProperty() float64
+	MutableProperty() float64
 }
 
-type IStableInterface struct {}
+// The jsii proxy for IStableInterface
+type iStableInterface struct {
+	_ byte // padding
+}
 
-func (i *IStableInterface) Method() {
+func (i *iStableInterface) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -7294,7 +7096,7 @@ func (i *IStableInterface) Method() {
 	)
 }
 
-func (i *IStableInterface) GetMutableProperty() float64 {
+func (i *iStableInterface) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -7304,7 +7106,7 @@ func (i *IStableInterface) GetMutableProperty() float64 {
 	return returns
 }
 
-func (i *IStableInterface) SetMutableProperty(val float64) {
+func (i *iStableInterface) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		i,
 		"mutableProperty",
@@ -7313,13 +7115,16 @@ func (i *IStableInterface) SetMutableProperty(val float64) {
 }
 
 // Verifies that a "pure" implementation of an interface works correctly.
-type IStructReturningDelegateIface interface {
+type IStructReturningDelegate interface {
 	ReturnStruct() StructB
 }
 
-type IStructReturningDelegate struct {}
+// The jsii proxy for IStructReturningDelegate
+type iStructReturningDelegate struct {
+	_ byte // padding
+}
 
-func (i *IStructReturningDelegate) ReturnStruct() StructB {
+func (i *iStructReturningDelegate) ReturnStruct() StructB {
 	var returns StructB
 	_jsii_.Invoke(
 		i,
@@ -7332,14 +7137,17 @@ func (i *IStructReturningDelegate) ReturnStruct() StructB {
 }
 
 // Implement this interface.
-type IWallClockIface interface {
+type IWallClock interface {
 	// Returns the current time, formatted as an ISO-8601 string.
 	Iso8601Now() string
 }
 
-type IWallClock struct {}
+// The jsii proxy for IWallClock
+type iWallClock struct {
+	_ byte // padding
+}
 
-func (i *IWallClock) Iso8601Now() string {
+func (i *iWallClock) Iso8601Now() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -7351,18 +7159,17 @@ func (i *IWallClock) Iso8601Now() string {
 	return returns
 }
 
-// Class interface
-type ImplementInternalInterfaceIface interface {
-	GetProp() string
+type ImplementInternalInterface interface {
+	Prop() string
 	SetProp(val string)
 }
 
-// Struct proxy
-type ImplementInternalInterface struct {
-	Prop string \`json:"prop"\`
+// The jsii proxy struct for ImplementInternalInterface
+type implementInternalInterface struct {
+	_ byte // padding
 }
 
-func (i *ImplementInternalInterface) GetProp() string {
+func (i *implementInternalInterface) Prop() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7373,20 +7180,21 @@ func (i *ImplementInternalInterface) GetProp() string {
 }
 
 
-func NewImplementInternalInterface() ImplementInternalInterfaceIface {
+func NewImplementInternalInterface() ImplementInternalInterface {
 	_init_.Initialize()
-	self := ImplementInternalInterface{}
+	i := implementInternalInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ImplementInternalInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *ImplementInternalInterface) SetProp(val string) {
+func (i *implementInternalInterface) SetProp(val string) {
 	_jsii_.Set(
 		i,
 		"prop",
@@ -7394,17 +7202,16 @@ func (i *ImplementInternalInterface) SetProp(val string) {
 	)
 }
 
-// Class interface
-type ImplementationIface interface {
-	GetValue() float64
+type Implementation interface {
+	Value() float64
 }
 
-// Struct proxy
-type Implementation struct {
-	Value float64 \`json:"value"\`
+// The jsii proxy struct for Implementation
+type implementation struct {
+	_ byte // padding
 }
 
-func (i *Implementation) GetValue() float64 {
+func (i *implementation) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		i,
@@ -7415,43 +7222,45 @@ func (i *Implementation) GetValue() float64 {
 }
 
 
-func NewImplementation() ImplementationIface {
+func NewImplementation() Implementation {
 	_init_.Initialize()
-	self := Implementation{}
+	i := implementation{}
+
 	_jsii_.Create(
 		"jsii-calc.Implementation",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-// Class interface
-type ImplementsInterfaceWithInternalIface interface {
-	IInterfaceWithInternalIface
+type ImplementsInterfaceWithInternal interface {
+	IInterfaceWithInternal
 	Visible()
 }
 
-// Struct proxy
-type ImplementsInterfaceWithInternal struct {
+// The jsii proxy struct for ImplementsInterfaceWithInternal
+type implementsInterfaceWithInternal struct {
+	iInterfaceWithInternal // implements jsii-calc.IInterfaceWithInternal
 }
 
-func NewImplementsInterfaceWithInternal() ImplementsInterfaceWithInternalIface {
+func NewImplementsInterfaceWithInternal() ImplementsInterfaceWithInternal {
 	_init_.Initialize()
-	self := ImplementsInterfaceWithInternal{}
+	i := implementsInterfaceWithInternal{}
+
 	_jsii_.Create(
 		"jsii-calc.ImplementsInterfaceWithInternal",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IInterfaceWithInternal"},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *ImplementsInterfaceWithInternal) Visible() {
+func (i *implementsInterfaceWithInternal) Visible() {
 	var returns interface{}
 	_jsii_.Invoke(
 		i,
@@ -7462,52 +7271,40 @@ func (i *ImplementsInterfaceWithInternal) Visible() {
 	)
 }
 
-// Class interface
-type ImplementsInterfaceWithInternalSubclassIface interface {
-	IInterfaceWithInternalIface
-	Visible()
+type ImplementsInterfaceWithInternalSubclass interface {
+	ImplementsInterfaceWithInternal
 }
 
-// Struct proxy
-type ImplementsInterfaceWithInternalSubclass struct {
+// The jsii proxy struct for ImplementsInterfaceWithInternalSubclass
+type implementsInterfaceWithInternalSubclass struct {
+	implementsInterfaceWithInternal // extends jsii-calc.ImplementsInterfaceWithInternal
 }
 
-func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInternalSubclassIface {
+func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInternalSubclass {
 	_init_.Initialize()
-	self := ImplementsInterfaceWithInternalSubclass{}
+	i := implementsInterfaceWithInternalSubclass{}
+
 	_jsii_.Create(
 		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *ImplementsInterfaceWithInternalSubclass) Visible() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"visible",
-		[]interface{}{},
-		false,
-		&returns,
-	)
-}
-
-// Class interface
-type ImplementsPrivateInterfaceIface interface {
-	GetPrivate() string
+type ImplementsPrivateInterface interface {
+	Private() string
 	SetPrivate(val string)
 }
 
-// Struct proxy
-type ImplementsPrivateInterface struct {
-	Private string \`json:"private"\`
+// The jsii proxy struct for ImplementsPrivateInterface
+type implementsPrivateInterface struct {
+	_ byte // padding
 }
 
-func (i *ImplementsPrivateInterface) GetPrivate() string {
+func (i *implementsPrivateInterface) Private() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -7518,20 +7315,21 @@ func (i *ImplementsPrivateInterface) GetPrivate() string {
 }
 
 
-func NewImplementsPrivateInterface() ImplementsPrivateInterfaceIface {
+func NewImplementsPrivateInterface() ImplementsPrivateInterface {
 	_init_.Initialize()
-	self := ImplementsPrivateInterface{}
+	i := implementsPrivateInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ImplementsPrivateInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *ImplementsPrivateInterface) SetPrivate(val string) {
+func (i *implementsPrivateInterface) SetPrivate(val string) {
 	_jsii_.Set(
 		i,
 		"private",
@@ -7540,7 +7338,7 @@ func (i *ImplementsPrivateInterface) SetPrivate(val string) {
 }
 
 type ImplictBaseOfBase struct {
-	Foo scopejsiicalcbaseofbase.VeryIface \`json:"foo"\`
+	Foo scopejsiicalcbaseofbase.Very \`json:"foo"\`
 	Bar string \`json:"bar"\`
 	Goo string \`json:"goo"\`
 }
@@ -7560,42 +7358,33 @@ func (i *ImplictBaseOfBase) ToBaseProps() scopejsiicalcbase.BaseProps {
 	}
 }
 
-// Class interface
-type InbetweenClassIface interface {
-	IPublicInterface2Iface
-	Hello()
+type InbetweenClass interface {
+	PublicClass
+	IPublicInterface2
 	Ciao() string
 }
 
-// Struct proxy
-type InbetweenClass struct {
+// The jsii proxy struct for InbetweenClass
+type inbetweenClass struct {
+	publicClass // extends jsii-calc.PublicClass
+	iPublicInterface2 // implements jsii-calc.IPublicInterface2
 }
 
-func NewInbetweenClass() InbetweenClassIface {
+func NewInbetweenClass() InbetweenClass {
 	_init_.Initialize()
-	self := InbetweenClass{}
+	i := inbetweenClass{}
+
 	_jsii_.Create(
 		"jsii-calc.InbetweenClass",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IPublicInterface2"},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *InbetweenClass) Hello() {
-	var returns interface{}
-	_jsii_.Invoke(
-		i,
-		"hello",
-		[]interface{}{},
-		false,
-		&returns,
-	)
-}
-
-func (i *InbetweenClass) Ciao() string {
+func (i *inbetweenClass) Ciao() string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -7607,20 +7396,20 @@ func (i *InbetweenClass) Ciao() string {
 	return returns
 }
 
-// Class interface
-type InterfaceCollectionsIface interface {
-}
-
 // Verifies that collections of interfaces or structs are correctly handled.
 //
 // See: https://github.com/aws/jsii/issues/1196
-// Struct proxy
-type InterfaceCollections struct {
+type InterfaceCollections interface {
 }
 
-func InterfaceCollections_ListOfInterfaces() []IBellIface {
+// The jsii proxy struct for InterfaceCollections
+type interfaceCollections struct {
+	_ byte // padding
+}
+
+func InterfaceCollections_ListOfInterfaces() []IBell {
 	_init_.Initialize()
-	var returns []IBellIface
+	var returns []IBell
 	_jsii_.StaticInvoke(
 		"jsii-calc.InterfaceCollections",
 		"listOfInterfaces",
@@ -7644,9 +7433,9 @@ func InterfaceCollections_ListOfStructs() []StructA {
 	return returns
 }
 
-func InterfaceCollections_MapOfInterfaces() map[string]IBellIface {
+func InterfaceCollections_MapOfInterfaces() map[string]IBell {
 	_init_.Initialize()
-	var returns map[string]IBellIface
+	var returns map[string]IBell
 	_jsii_.StaticInvoke(
 		"jsii-calc.InterfaceCollections",
 		"mapOfInterfaces",
@@ -7670,18 +7459,18 @@ func InterfaceCollections_MapOfStructs() map[string]StructA {
 	return returns
 }
 
-// Class interface
-type InterfacesMakerIface interface {
-}
-
 // We can return arrays of interfaces See aws/aws-cdk#2362.
-// Struct proxy
-type InterfacesMaker struct {
+type InterfacesMaker interface {
 }
 
-func InterfacesMaker_MakeInterfaces(count float64) []scopejsiicalclib.IDoublableIface {
+// The jsii proxy struct for InterfacesMaker
+type interfacesMaker struct {
+	_ byte // padding
+}
+
+func InterfacesMaker_MakeInterfaces(count float64) []scopejsiicalclib.IDoublable {
 	_init_.Initialize()
-	var returns []scopejsiicalclib.IDoublableIface
+	var returns []scopejsiicalclib.IDoublable
 	_jsii_.StaticInvoke(
 		"jsii-calc.InterfacesMaker",
 		"makeInterfaces",
@@ -7692,34 +7481,35 @@ func InterfacesMaker_MakeInterfaces(count float64) []scopejsiicalclib.IDoublable
 	return returns
 }
 
-// Class interface
-type IsomorphismIface interface {
-	Myself() IsomorphismIface
-}
-
 // Checks the "same instance" isomorphism is preserved within the constructor.
 //
 // Create a subclass of this, and assert that \`this.myself()\` actually returns
 // \`this\` from within the constructor.
-// Struct proxy
-type Isomorphism struct {
+type Isomorphism interface {
+	Myself() Isomorphism
 }
 
-func NewIsomorphism() IsomorphismIface {
+// The jsii proxy struct for Isomorphism
+type isomorphism struct {
+	_ byte // padding
+}
+
+func NewIsomorphism() Isomorphism {
 	_init_.Initialize()
-	self := Isomorphism{}
+	i := isomorphism{}
+
 	_jsii_.Create(
 		"jsii-calc.Isomorphism",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
-func (i *Isomorphism) Myself() IsomorphismIface {
-	var returns IsomorphismIface
+func (i *isomorphism) Myself() Isomorphism {
+	var returns Isomorphism
 	_jsii_.Invoke(
 		i,
 		"myself",
@@ -7730,32 +7520,19 @@ func (i *Isomorphism) Myself() IsomorphismIface {
 	return returns
 }
 
-// Class interface
-type Jsii417DerivedIface interface {
-	GetHasRoot() bool
-	GetProperty() string
-	Foo()
+type Jsii417Derived interface {
+	Jsii417PublicBaseOfBase
+	Property() string
 	Bar()
 	Baz()
 }
 
-// Struct proxy
-type Jsii417Derived struct {
-	HasRoot bool \`json:"hasRoot"\`
-	Property string \`json:"property"\`
+// The jsii proxy struct for Jsii417Derived
+type jsii417Derived struct {
+	jsii417PublicBaseOfBase // extends jsii-calc.JSII417PublicBaseOfBase
 }
 
-func (j *Jsii417Derived) GetHasRoot() bool {
-	var returns bool
-	_jsii_.Get(
-		j,
-		"hasRoot",
-		&returns,
-	)
-	return returns
-}
-
-func (j *Jsii417Derived) GetProperty() string {
+func (j *jsii417Derived) Property() string {
 	var returns string
 	_jsii_.Get(
 		j,
@@ -7766,44 +7543,21 @@ func (j *Jsii417Derived) GetProperty() string {
 }
 
 
-func NewJsii417Derived(property string) Jsii417DerivedIface {
+func NewJsii417Derived(property string) Jsii417Derived {
 	_init_.Initialize()
-	self := Jsii417Derived{}
+	j := jsii417Derived{}
+
 	_jsii_.Create(
 		"jsii-calc.JSII417Derived",
 		[]interface{}{property},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func Jsii417Derived_MakeInstance() Jsii417PublicBaseOfBaseIface {
-	_init_.Initialize()
-	var returns Jsii417PublicBaseOfBaseIface
-	_jsii_.StaticInvoke(
-		"jsii-calc.JSII417Derived",
-		"makeInstance",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (j *Jsii417Derived) Foo() {
-	var returns interface{}
-	_jsii_.Invoke(
-		j,
-		"foo",
-		[]interface{}{},
-		false,
-		&returns,
-	)
-}
-
-func (j *Jsii417Derived) Bar() {
+func (j *jsii417Derived) Bar() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -7814,7 +7568,7 @@ func (j *Jsii417Derived) Bar() {
 	)
 }
 
-func (j *Jsii417Derived) Baz() {
+func (j *jsii417Derived) Baz() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -7825,18 +7579,17 @@ func (j *Jsii417Derived) Baz() {
 	)
 }
 
-// Class interface
-type Jsii417PublicBaseOfBaseIface interface {
-	GetHasRoot() bool
+type Jsii417PublicBaseOfBase interface {
+	HasRoot() bool
 	Foo()
 }
 
-// Struct proxy
-type Jsii417PublicBaseOfBase struct {
-	HasRoot bool \`json:"hasRoot"\`
+// The jsii proxy struct for Jsii417PublicBaseOfBase
+type jsii417PublicBaseOfBase struct {
+	_ byte // padding
 }
 
-func (j *Jsii417PublicBaseOfBase) GetHasRoot() bool {
+func (j *jsii417PublicBaseOfBase) HasRoot() bool {
 	var returns bool
 	_jsii_.Get(
 		j,
@@ -7847,22 +7600,23 @@ func (j *Jsii417PublicBaseOfBase) GetHasRoot() bool {
 }
 
 
-func NewJsii417PublicBaseOfBase() Jsii417PublicBaseOfBaseIface {
+func NewJsii417PublicBaseOfBase() Jsii417PublicBaseOfBase {
 	_init_.Initialize()
-	self := Jsii417PublicBaseOfBase{}
+	j := jsii417PublicBaseOfBase{}
+
 	_jsii_.Create(
 		"jsii-calc.JSII417PublicBaseOfBase",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func Jsii417PublicBaseOfBase_MakeInstance() Jsii417PublicBaseOfBaseIface {
+func Jsii417PublicBaseOfBase_MakeInstance() Jsii417PublicBaseOfBase {
 	_init_.Initialize()
-	var returns Jsii417PublicBaseOfBaseIface
+	var returns Jsii417PublicBaseOfBase
 	_jsii_.StaticInvoke(
 		"jsii-calc.JSII417PublicBaseOfBase",
 		"makeInstance",
@@ -7873,7 +7627,7 @@ func Jsii417PublicBaseOfBase_MakeInstance() Jsii417PublicBaseOfBaseIface {
 	return returns
 }
 
-func (j *Jsii417PublicBaseOfBase) Foo() {
+func (j *jsii417PublicBaseOfBase) Foo() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -7884,31 +7638,32 @@ func (j *Jsii417PublicBaseOfBase) Foo() {
 	)
 }
 
-// Class interface
-type JsObjectLiteralForInterfaceIface interface {
-	GiveMeFriendly() scopejsiicalclib.IFriendlyIface
-	GiveMeFriendlyGenerator() IFriendlyRandomGeneratorIface
+type JsObjectLiteralForInterface interface {
+	GiveMeFriendly() scopejsiicalclib.IFriendly
+	GiveMeFriendlyGenerator() IFriendlyRandomGenerator
 }
 
-// Struct proxy
-type JsObjectLiteralForInterface struct {
+// The jsii proxy struct for JsObjectLiteralForInterface
+type jsObjectLiteralForInterface struct {
+	_ byte // padding
 }
 
-func NewJsObjectLiteralForInterface() JsObjectLiteralForInterfaceIface {
+func NewJsObjectLiteralForInterface() JsObjectLiteralForInterface {
 	_init_.Initialize()
-	self := JsObjectLiteralForInterface{}
+	j := jsObjectLiteralForInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.JSObjectLiteralForInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func (j *JsObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendlyIface {
-	var returns scopejsiicalclib.IFriendlyIface
+func (j *jsObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendly {
+	var returns scopejsiicalclib.IFriendly
 	_jsii_.Invoke(
 		j,
 		"giveMeFriendly",
@@ -7919,8 +7674,8 @@ func (j *JsObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendl
 	return returns
 }
 
-func (j *JsObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomGeneratorIface {
-	var returns IFriendlyRandomGeneratorIface
+func (j *jsObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomGenerator {
+	var returns IFriendlyRandomGenerator
 	_jsii_.Invoke(
 		j,
 		"giveMeFriendlyGenerator",
@@ -7931,30 +7686,31 @@ func (j *JsObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomG
 	return returns
 }
 
-// Class interface
-type JsObjectLiteralToNativeIface interface {
-	ReturnLiteral() JsObjectLiteralToNativeClassIface
+type JsObjectLiteralToNative interface {
+	ReturnLiteral() JsObjectLiteralToNativeClass
 }
 
-// Struct proxy
-type JsObjectLiteralToNative struct {
+// The jsii proxy struct for JsObjectLiteralToNative
+type jsObjectLiteralToNative struct {
+	_ byte // padding
 }
 
-func NewJsObjectLiteralToNative() JsObjectLiteralToNativeIface {
+func NewJsObjectLiteralToNative() JsObjectLiteralToNative {
 	_init_.Initialize()
-	self := JsObjectLiteralToNative{}
+	j := jsObjectLiteralToNative{}
+
 	_jsii_.Create(
 		"jsii-calc.JSObjectLiteralToNative",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func (j *JsObjectLiteralToNative) ReturnLiteral() JsObjectLiteralToNativeClassIface {
-	var returns JsObjectLiteralToNativeClassIface
+func (j *jsObjectLiteralToNative) ReturnLiteral() JsObjectLiteralToNativeClass {
+	var returns JsObjectLiteralToNativeClass
 	_jsii_.Invoke(
 		j,
 		"returnLiteral",
@@ -7965,21 +7721,19 @@ func (j *JsObjectLiteralToNative) ReturnLiteral() JsObjectLiteralToNativeClassIf
 	return returns
 }
 
-// Class interface
-type JsObjectLiteralToNativeClassIface interface {
-	GetPropA() string
+type JsObjectLiteralToNativeClass interface {
+	PropA() string
 	SetPropA(val string)
-	GetPropB() float64
+	PropB() float64
 	SetPropB(val float64)
 }
 
-// Struct proxy
-type JsObjectLiteralToNativeClass struct {
-	PropA string \`json:"propA"\`
-	PropB float64 \`json:"propB"\`
+// The jsii proxy struct for JsObjectLiteralToNativeClass
+type jsObjectLiteralToNativeClass struct {
+	_ byte // padding
 }
 
-func (j *JsObjectLiteralToNativeClass) GetPropA() string {
+func (j *jsObjectLiteralToNativeClass) PropA() string {
 	var returns string
 	_jsii_.Get(
 		j,
@@ -7989,7 +7743,7 @@ func (j *JsObjectLiteralToNativeClass) GetPropA() string {
 	return returns
 }
 
-func (j *JsObjectLiteralToNativeClass) GetPropB() float64 {
+func (j *jsObjectLiteralToNativeClass) PropB() float64 {
 	var returns float64
 	_jsii_.Get(
 		j,
@@ -8000,20 +7754,21 @@ func (j *JsObjectLiteralToNativeClass) GetPropB() float64 {
 }
 
 
-func NewJsObjectLiteralToNativeClass() JsObjectLiteralToNativeClassIface {
+func NewJsObjectLiteralToNativeClass() JsObjectLiteralToNativeClass {
 	_init_.Initialize()
-	self := JsObjectLiteralToNativeClass{}
+	j := jsObjectLiteralToNativeClass{}
+
 	_jsii_.Create(
 		"jsii-calc.JSObjectLiteralToNativeClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func (j *JsObjectLiteralToNativeClass) SetPropA(val string) {
+func (j *jsObjectLiteralToNativeClass) SetPropA(val string) {
 	_jsii_.Set(
 		j,
 		"propA",
@@ -8021,7 +7776,7 @@ func (j *JsObjectLiteralToNativeClass) SetPropA(val string) {
 	)
 }
 
-func (j *JsObjectLiteralToNativeClass) SetPropB(val float64) {
+func (j *jsObjectLiteralToNativeClass) SetPropB(val float64) {
 	_jsii_.Set(
 		j,
 		"propB",
@@ -8029,9 +7784,8 @@ func (j *JsObjectLiteralToNativeClass) SetPropB(val float64) {
 	)
 }
 
-// Class interface
-type JavaReservedWordsIface interface {
-	GetWhile() string
+type JavaReservedWords interface {
+	While() string
 	SetWhile(val string)
 	Abstract()
 	Assert()
@@ -8087,12 +7841,12 @@ type JavaReservedWordsIface interface {
 	Volatile()
 }
 
-// Struct proxy
-type JavaReservedWords struct {
-	While string \`json:"while"\`
+// The jsii proxy struct for JavaReservedWords
+type javaReservedWords struct {
+	_ byte // padding
 }
 
-func (j *JavaReservedWords) GetWhile() string {
+func (j *javaReservedWords) While() string {
 	var returns string
 	_jsii_.Get(
 		j,
@@ -8103,20 +7857,21 @@ func (j *JavaReservedWords) GetWhile() string {
 }
 
 
-func NewJavaReservedWords() JavaReservedWordsIface {
+func NewJavaReservedWords() JavaReservedWords {
 	_init_.Initialize()
-	self := JavaReservedWords{}
+	j := javaReservedWords{}
+
 	_jsii_.Create(
 		"jsii-calc.JavaReservedWords",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-func (j *JavaReservedWords) SetWhile(val string) {
+func (j *javaReservedWords) SetWhile(val string) {
 	_jsii_.Set(
 		j,
 		"while",
@@ -8124,7 +7879,7 @@ func (j *JavaReservedWords) SetWhile(val string) {
 	)
 }
 
-func (j *JavaReservedWords) Abstract() {
+func (j *javaReservedWords) Abstract() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8135,7 +7890,7 @@ func (j *JavaReservedWords) Abstract() {
 	)
 }
 
-func (j *JavaReservedWords) Assert() {
+func (j *javaReservedWords) Assert() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8146,7 +7901,7 @@ func (j *JavaReservedWords) Assert() {
 	)
 }
 
-func (j *JavaReservedWords) Boolean() {
+func (j *javaReservedWords) Boolean() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8157,7 +7912,7 @@ func (j *JavaReservedWords) Boolean() {
 	)
 }
 
-func (j *JavaReservedWords) Break() {
+func (j *javaReservedWords) Break() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8168,7 +7923,7 @@ func (j *JavaReservedWords) Break() {
 	)
 }
 
-func (j *JavaReservedWords) Byte() {
+func (j *javaReservedWords) Byte() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8179,7 +7934,7 @@ func (j *JavaReservedWords) Byte() {
 	)
 }
 
-func (j *JavaReservedWords) Case() {
+func (j *javaReservedWords) Case() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8190,7 +7945,7 @@ func (j *JavaReservedWords) Case() {
 	)
 }
 
-func (j *JavaReservedWords) Catch() {
+func (j *javaReservedWords) Catch() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8201,7 +7956,7 @@ func (j *JavaReservedWords) Catch() {
 	)
 }
 
-func (j *JavaReservedWords) Char() {
+func (j *javaReservedWords) Char() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8212,7 +7967,7 @@ func (j *JavaReservedWords) Char() {
 	)
 }
 
-func (j *JavaReservedWords) Class() {
+func (j *javaReservedWords) Class() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8223,7 +7978,7 @@ func (j *JavaReservedWords) Class() {
 	)
 }
 
-func (j *JavaReservedWords) Const() {
+func (j *javaReservedWords) Const() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8234,7 +7989,7 @@ func (j *JavaReservedWords) Const() {
 	)
 }
 
-func (j *JavaReservedWords) Continue() {
+func (j *javaReservedWords) Continue() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8245,7 +8000,7 @@ func (j *JavaReservedWords) Continue() {
 	)
 }
 
-func (j *JavaReservedWords) Default() {
+func (j *javaReservedWords) Default() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8256,7 +8011,7 @@ func (j *JavaReservedWords) Default() {
 	)
 }
 
-func (j *JavaReservedWords) Do() {
+func (j *javaReservedWords) Do() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8267,7 +8022,7 @@ func (j *JavaReservedWords) Do() {
 	)
 }
 
-func (j *JavaReservedWords) Double() {
+func (j *javaReservedWords) Double() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8278,7 +8033,7 @@ func (j *JavaReservedWords) Double() {
 	)
 }
 
-func (j *JavaReservedWords) Else() {
+func (j *javaReservedWords) Else() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8289,7 +8044,7 @@ func (j *JavaReservedWords) Else() {
 	)
 }
 
-func (j *JavaReservedWords) Enum() {
+func (j *javaReservedWords) Enum() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8300,7 +8055,7 @@ func (j *JavaReservedWords) Enum() {
 	)
 }
 
-func (j *JavaReservedWords) Extends() {
+func (j *javaReservedWords) Extends() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8311,7 +8066,7 @@ func (j *JavaReservedWords) Extends() {
 	)
 }
 
-func (j *JavaReservedWords) False() {
+func (j *javaReservedWords) False() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8322,7 +8077,7 @@ func (j *JavaReservedWords) False() {
 	)
 }
 
-func (j *JavaReservedWords) Final() {
+func (j *javaReservedWords) Final() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8333,7 +8088,7 @@ func (j *JavaReservedWords) Final() {
 	)
 }
 
-func (j *JavaReservedWords) Finally() {
+func (j *javaReservedWords) Finally() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8344,7 +8099,7 @@ func (j *JavaReservedWords) Finally() {
 	)
 }
 
-func (j *JavaReservedWords) Float() {
+func (j *javaReservedWords) Float() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8355,7 +8110,7 @@ func (j *JavaReservedWords) Float() {
 	)
 }
 
-func (j *JavaReservedWords) For() {
+func (j *javaReservedWords) For() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8366,7 +8121,7 @@ func (j *JavaReservedWords) For() {
 	)
 }
 
-func (j *JavaReservedWords) Goto() {
+func (j *javaReservedWords) Goto() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8377,7 +8132,7 @@ func (j *JavaReservedWords) Goto() {
 	)
 }
 
-func (j *JavaReservedWords) If() {
+func (j *javaReservedWords) If() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8388,7 +8143,7 @@ func (j *JavaReservedWords) If() {
 	)
 }
 
-func (j *JavaReservedWords) Implements() {
+func (j *javaReservedWords) Implements() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8399,7 +8154,7 @@ func (j *JavaReservedWords) Implements() {
 	)
 }
 
-func (j *JavaReservedWords) Import() {
+func (j *javaReservedWords) Import() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8410,7 +8165,7 @@ func (j *JavaReservedWords) Import() {
 	)
 }
 
-func (j *JavaReservedWords) Instanceof() {
+func (j *javaReservedWords) Instanceof() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8421,7 +8176,7 @@ func (j *JavaReservedWords) Instanceof() {
 	)
 }
 
-func (j *JavaReservedWords) Int() {
+func (j *javaReservedWords) Int() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8432,7 +8187,7 @@ func (j *JavaReservedWords) Int() {
 	)
 }
 
-func (j *JavaReservedWords) Interface() {
+func (j *javaReservedWords) Interface() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8443,7 +8198,7 @@ func (j *JavaReservedWords) Interface() {
 	)
 }
 
-func (j *JavaReservedWords) Long() {
+func (j *javaReservedWords) Long() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8454,7 +8209,7 @@ func (j *JavaReservedWords) Long() {
 	)
 }
 
-func (j *JavaReservedWords) Native() {
+func (j *javaReservedWords) Native() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8465,7 +8220,7 @@ func (j *JavaReservedWords) Native() {
 	)
 }
 
-func (j *JavaReservedWords) New() {
+func (j *javaReservedWords) New() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8476,7 +8231,7 @@ func (j *JavaReservedWords) New() {
 	)
 }
 
-func (j *JavaReservedWords) Null() {
+func (j *javaReservedWords) Null() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8487,7 +8242,7 @@ func (j *JavaReservedWords) Null() {
 	)
 }
 
-func (j *JavaReservedWords) Package() {
+func (j *javaReservedWords) Package() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8498,7 +8253,7 @@ func (j *JavaReservedWords) Package() {
 	)
 }
 
-func (j *JavaReservedWords) Private() {
+func (j *javaReservedWords) Private() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8509,7 +8264,7 @@ func (j *JavaReservedWords) Private() {
 	)
 }
 
-func (j *JavaReservedWords) Protected() {
+func (j *javaReservedWords) Protected() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8520,7 +8275,7 @@ func (j *JavaReservedWords) Protected() {
 	)
 }
 
-func (j *JavaReservedWords) Public() {
+func (j *javaReservedWords) Public() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8531,7 +8286,7 @@ func (j *JavaReservedWords) Public() {
 	)
 }
 
-func (j *JavaReservedWords) Return() {
+func (j *javaReservedWords) Return() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8542,7 +8297,7 @@ func (j *JavaReservedWords) Return() {
 	)
 }
 
-func (j *JavaReservedWords) Short() {
+func (j *javaReservedWords) Short() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8553,7 +8308,7 @@ func (j *JavaReservedWords) Short() {
 	)
 }
 
-func (j *JavaReservedWords) Static() {
+func (j *javaReservedWords) Static() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8564,7 +8319,7 @@ func (j *JavaReservedWords) Static() {
 	)
 }
 
-func (j *JavaReservedWords) Strictfp() {
+func (j *javaReservedWords) Strictfp() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8575,7 +8330,7 @@ func (j *JavaReservedWords) Strictfp() {
 	)
 }
 
-func (j *JavaReservedWords) Super() {
+func (j *javaReservedWords) Super() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8586,7 +8341,7 @@ func (j *JavaReservedWords) Super() {
 	)
 }
 
-func (j *JavaReservedWords) Switch() {
+func (j *javaReservedWords) Switch() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8597,7 +8352,7 @@ func (j *JavaReservedWords) Switch() {
 	)
 }
 
-func (j *JavaReservedWords) Synchronized() {
+func (j *javaReservedWords) Synchronized() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8608,7 +8363,7 @@ func (j *JavaReservedWords) Synchronized() {
 	)
 }
 
-func (j *JavaReservedWords) This() {
+func (j *javaReservedWords) This() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8619,7 +8374,7 @@ func (j *JavaReservedWords) This() {
 	)
 }
 
-func (j *JavaReservedWords) Throw() {
+func (j *javaReservedWords) Throw() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8630,7 +8385,7 @@ func (j *JavaReservedWords) Throw() {
 	)
 }
 
-func (j *JavaReservedWords) Throws() {
+func (j *javaReservedWords) Throws() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8641,7 +8396,7 @@ func (j *JavaReservedWords) Throws() {
 	)
 }
 
-func (j *JavaReservedWords) Transient() {
+func (j *javaReservedWords) Transient() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8652,7 +8407,7 @@ func (j *JavaReservedWords) Transient() {
 	)
 }
 
-func (j *JavaReservedWords) True() {
+func (j *javaReservedWords) True() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8663,7 +8418,7 @@ func (j *JavaReservedWords) True() {
 	)
 }
 
-func (j *JavaReservedWords) Try() {
+func (j *javaReservedWords) Try() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8674,7 +8429,7 @@ func (j *JavaReservedWords) Try() {
 	)
 }
 
-func (j *JavaReservedWords) Void() {
+func (j *javaReservedWords) Void() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8685,7 +8440,7 @@ func (j *JavaReservedWords) Void() {
 	)
 }
 
-func (j *JavaReservedWords) Volatile() {
+func (j *javaReservedWords) Volatile() {
 	var returns interface{}
 	_jsii_.Invoke(
 		j,
@@ -8696,71 +8451,75 @@ func (j *JavaReservedWords) Volatile() {
 	)
 }
 
-// Class interface
-type Jsii487DerivedIface interface {
-	IJsii487External2Iface
-	IJsii487ExternalIface
+type Jsii487Derived interface {
+	IJsii487External
+	IJsii487External2
 }
 
-// Struct proxy
-type Jsii487Derived struct {
+// The jsii proxy struct for Jsii487Derived
+type jsii487Derived struct {
+	iJsii487External // implements jsii-calc.IJsii487External
+	iJsii487External2 // implements jsii-calc.IJsii487External2
 }
 
-func NewJsii487Derived() Jsii487DerivedIface {
+func NewJsii487Derived() Jsii487Derived {
 	_init_.Initialize()
-	self := Jsii487Derived{}
+	j := jsii487Derived{}
+
 	_jsii_.Create(
 		"jsii-calc.Jsii487Derived",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IJsii487External2", "jsii-calc.IJsii487External"},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
-// Class interface
-type Jsii496DerivedIface interface {
-	IJsii496Iface
+type Jsii496Derived interface {
+	IJsii496
 }
 
-// Struct proxy
-type Jsii496Derived struct {
+// The jsii proxy struct for Jsii496Derived
+type jsii496Derived struct {
+	iJsii496 // implements jsii-calc.IJsii496
 }
 
-func NewJsii496Derived() Jsii496DerivedIface {
+func NewJsii496Derived() Jsii496Derived {
 	_init_.Initialize()
-	self := Jsii496Derived{}
+	j := jsii496Derived{}
+
 	_jsii_.Create(
 		"jsii-calc.Jsii496Derived",
 		[]interface{}{},
 		[]_jsii_.FQN{"jsii-calc.IJsii496"},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
-}
-
-// Class interface
-type JsiiAgentIface interface {
+	return &j
 }
 
 // Host runtime version should be set via JSII_AGENT.
-// Struct proxy
-type JsiiAgent struct {
+type JsiiAgent interface {
 }
 
-func NewJsiiAgent() JsiiAgentIface {
+// The jsii proxy struct for JsiiAgent
+type jsiiAgent struct {
+	_ byte // padding
+}
+
+func NewJsiiAgent() JsiiAgent {
 	_init_.Initialize()
-	self := JsiiAgent{}
+	j := jsiiAgent{}
+
 	_jsii_.Create(
 		"jsii-calc.JsiiAgent",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&j,
 	)
-	return &self
+	return &j
 }
 
 func JsiiAgent_Value() string {
@@ -8774,15 +8533,15 @@ func JsiiAgent_Value() string {
 	return returns
 }
 
-// Class interface
-type JsonFormatterIface interface {
-}
-
 // Make sure structs are un-decorated on the way in.
 // See: https://github.com/aws/aws-cdk/issues/5066
 //
-// Struct proxy
-type JsonFormatter struct {
+type JsonFormatter interface {
+}
+
+// The jsii proxy struct for JsonFormatter
+type jsonFormatter struct {
+	_ byte // padding
 }
 
 func JsonFormatter_AnyArray() interface{} {
@@ -8967,18 +8726,17 @@ func JsonFormatter_Stringify(value interface{}) string {
 	return returns
 }
 
-// Class interface
-type LevelOneIface interface {
-	GetProps() LevelOneProps
-}
-
 // Validates that nested classes get correct code generation for the occasional forward reference.
-// Struct proxy
-type LevelOne struct {
-	Props LevelOneProps \`json:"props"\`
+type LevelOne interface {
+	Props() LevelOneProps
 }
 
-func (l *LevelOne) GetProps() LevelOneProps {
+// The jsii proxy struct for LevelOne
+type levelOne struct {
+	_ byte // padding
+}
+
+func (l *levelOne) Props() LevelOneProps {
 	var returns LevelOneProps
 	_jsii_.Get(
 		l,
@@ -8989,17 +8747,18 @@ func (l *LevelOne) GetProps() LevelOneProps {
 }
 
 
-func NewLevelOne(props LevelOneProps) LevelOneIface {
+func NewLevelOne(props LevelOneProps) LevelOne {
 	_init_.Initialize()
-	self := LevelOne{}
+	l := levelOne{}
+
 	_jsii_.Create(
 		"jsii-calc.LevelOne",
 		[]interface{}{props},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&l,
 	)
-	return &self
+	return &l
 }
 
 type PropBooleanValue struct {
@@ -9054,18 +8813,17 @@ type LoadBalancedFargateServiceProps struct {
 	PublicTasks bool \`json:"publicTasks"\`
 }
 
-// Class interface
-type MethodNamedPropertyIface interface {
-	GetElite() float64
+type MethodNamedProperty interface {
+	Elite() float64
 	Property() string
 }
 
-// Struct proxy
-type MethodNamedProperty struct {
-	Elite float64 \`json:"elite"\`
+// The jsii proxy struct for MethodNamedProperty
+type methodNamedProperty struct {
+	_ byte // padding
 }
 
-func (m *MethodNamedProperty) GetElite() float64 {
+func (m *methodNamedProperty) Elite() float64 {
 	var returns float64
 	_jsii_.Get(
 		m,
@@ -9076,20 +8834,21 @@ func (m *MethodNamedProperty) GetElite() float64 {
 }
 
 
-func NewMethodNamedProperty() MethodNamedPropertyIface {
+func NewMethodNamedProperty() MethodNamedProperty {
 	_init_.Initialize()
-	self := MethodNamedProperty{}
+	m := methodNamedProperty{}
+
 	_jsii_.Create(
 		"jsii-calc.MethodNamedProperty",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&m,
 	)
-	return &self
+	return &m
 }
 
-func (m *MethodNamedProperty) Property() string {
+func (m *methodNamedProperty) Property() string {
 	var returns string
 	_jsii_.Invoke(
 		m,
@@ -9101,35 +8860,26 @@ func (m *MethodNamedProperty) Property() string {
 	return returns
 }
 
-// Class interface
-type MultiplyIface interface {
-	scopejsiicalclib.IFriendlyIface
-	IFriendlierIface
-	scopejsiicalclib.IFriendlyIface
-	IRandomNumberGeneratorIface
-	GetValue() float64
-	GetLhs() scopejsiicalclib.NumericValueIface
-	GetRhs() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
-	Hello() string
+// The "*" binary operation.
+type Multiply interface {
+	BinaryOperation
+	IFriendlier
+	IRandomNumberGenerator
+	Value() float64
 	Farewell() string
 	Goodbye() string
 	Next() float64
+	ToString() string
 }
 
-// The "*" binary operation.
-// Struct proxy
-type Multiply struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// Left-hand side operand.
-	Lhs scopejsiicalclib.NumericValueIface \`json:"lhs"\`
-	// Right-hand side operand.
-	Rhs scopejsiicalclib.NumericValueIface \`json:"rhs"\`
+// The jsii proxy struct for Multiply
+type multiply struct {
+	binaryOperation // extends jsii-calc.BinaryOperation
+	iFriendlier // implements jsii-calc.IFriendlier
+	iRandomNumberGenerator // implements jsii-calc.IRandomNumberGenerator
 }
 
-func (m *Multiply) GetValue() float64 {
+func (m *multiply) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		m,
@@ -9139,8 +8889,8 @@ func (m *Multiply) GetValue() float64 {
 	return returns
 }
 
-func (m *Multiply) GetLhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (m *multiply) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		m,
 		"lhs",
@@ -9149,8 +8899,8 @@ func (m *Multiply) GetLhs() scopejsiicalclib.NumericValueIface {
 	return returns
 }
 
-func (m *Multiply) GetRhs() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (m *multiply) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		m,
 		"rhs",
@@ -9161,56 +8911,22 @@ func (m *Multiply) GetRhs() scopejsiicalclib.NumericValueIface {
 
 
 // Creates a BinaryOperation.
-func NewMultiply(lhs scopejsiicalclib.NumericValueIface, rhs scopejsiicalclib.NumericValueIface) MultiplyIface {
+func NewMultiply(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Multiply {
 	_init_.Initialize()
-	self := Multiply{}
+	m := multiply{}
+
 	_jsii_.Create(
 		"jsii-calc.Multiply",
 		[]interface{}{lhs, rhs},
 		[]_jsii_.FQN{"jsii-calc.IFriendlier", "jsii-calc.IRandomNumberGenerator"},
 		[]_jsii_.Override{},
-		&self,
+		&m,
 	)
-	return &self
+	return &m
 }
 
-func (m *Multiply) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		m,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (m *Multiply) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		m,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (m *Multiply) Hello() string {
-	var returns string
-	_jsii_.Invoke(
-		m,
-		"hello",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (m *Multiply) Farewell() string {
+// Say farewell.
+func (m *multiply) Farewell() string {
 	var returns string
 	_jsii_.Invoke(
 		m,
@@ -9222,7 +8938,8 @@ func (m *Multiply) Farewell() string {
 	return returns
 }
 
-func (m *Multiply) Goodbye() string {
+// Say goodbye.
+func (m *multiply) Goodbye() string {
 	var returns string
 	_jsii_.Invoke(
 		m,
@@ -9234,7 +8951,8 @@ func (m *Multiply) Goodbye() string {
 	return returns
 }
 
-func (m *Multiply) Next() float64 {
+// Returns another random number.
+func (m *multiply) Next() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		m,
@@ -9246,28 +8964,63 @@ func (m *Multiply) Next() float64 {
 	return returns
 }
 
-// Class interface
-type NegateIface interface {
-	IFriendlierIface
-	scopejsiicalclib.IFriendlyIface
-	GetValue() float64
-	GetOperand() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
-	Farewell() string
-	Goodbye() string
-	Hello() string
+// (deprecated) String representation of the value.
+func (m *multiply) ToString() string {
+	var returns string
+	_jsii_.Invoke(
+		m,
+		"toString",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
+}
+
+// (deprecated) Say hello!
+func (m *multiply) Hello() string {
+	var returns string
+	_jsii_.Invoke(
+		m,
+		"hello",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (m *multiply) TypeName() interface{} {
+	var returns interface{}
+	_jsii_.Invoke(
+		m,
+		"typeName",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
 }
 
 // The negation operation ("-value").
-// Struct proxy
-type Negate struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	Operand scopejsiicalclib.NumericValueIface \`json:"operand"\`
+type Negate interface {
+	UnaryOperation
+	IFriendlier
+	Value() float64
+	Farewell() string
+	Goodbye() string
+	Hello() string
+	ToString() string
 }
 
-func (n *Negate) GetValue() float64 {
+// The jsii proxy struct for Negate
+type negate struct {
+	unaryOperation // extends jsii-calc.UnaryOperation
+	iFriendlier // implements jsii-calc.IFriendlier
+}
+
+func (n *negate) Value() float64 {
 	var returns float64
 	_jsii_.Get(
 		n,
@@ -9277,8 +9030,8 @@ func (n *Negate) GetValue() float64 {
 	return returns
 }
 
-func (n *Negate) GetOperand() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (n *negate) Operand() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		n,
 		"operand",
@@ -9288,44 +9041,22 @@ func (n *Negate) GetOperand() scopejsiicalclib.NumericValueIface {
 }
 
 
-func NewNegate(operand scopejsiicalclib.NumericValueIface) NegateIface {
+func NewNegate(operand scopejsiicalclib.NumericValue) Negate {
 	_init_.Initialize()
-	self := Negate{}
+	n := negate{}
+
 	_jsii_.Create(
 		"jsii-calc.Negate",
 		[]interface{}{operand},
 		[]_jsii_.FQN{"jsii-calc.IFriendlier"},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *Negate) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (n *Negate) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		n,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (n *Negate) Farewell() string {
+// Say farewell.
+func (n *negate) Farewell() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9337,7 +9068,8 @@ func (n *Negate) Farewell() string {
 	return returns
 }
 
-func (n *Negate) Goodbye() string {
+// Say goodbye.
+func (n *negate) Goodbye() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9349,7 +9081,8 @@ func (n *Negate) Goodbye() string {
 	return returns
 }
 
-func (n *Negate) Hello() string {
+// (deprecated) Say hello!
+func (n *negate) Hello() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9361,17 +9094,43 @@ func (n *Negate) Hello() string {
 	return returns
 }
 
-// Class interface
-type NestedClassInstanceIface interface {
+// (deprecated) String representation of the value.
+func (n *negate) ToString() string {
+	var returns string
+	_jsii_.Invoke(
+		n,
+		"toString",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
 }
 
-// Struct proxy
-type NestedClassInstance struct {
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (n *negate) TypeName() interface{} {
+	var returns interface{}
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		[]interface{}{},
+		true,
+		&returns,
+	)
+	return returns
 }
 
-func NestedClassInstance_MakeInstance() submodule.NestedClassIface {
+type NestedClassInstance interface {
+}
+
+// The jsii proxy struct for NestedClassInstance
+type nestedClassInstance struct {
+	_ byte // padding
+}
+
+func NestedClassInstance_MakeInstance() submodule.NestedClass {
 	_init_.Initialize()
-	var returns submodule.NestedClassIface
+	var returns submodule.NestedClass
 	_jsii_.StaticInvoke(
 		"jsii-calc.NestedClassInstance",
 		"makeInstance",
@@ -9387,22 +9146,20 @@ type NestedStruct struct {
 	NumberProp float64 \`json:"numberProp"\`
 }
 
-// Class interface
-type NodeStandardLibraryIface interface {
-	GetOsPlatform() string
+// Test fixture to verify that jsii modules can use the node standard library.
+type NodeStandardLibrary interface {
+	OsPlatform() string
 	CryptoSha256() string
 	FsReadFile() string
 	FsReadFileSync() string
 }
 
-// Test fixture to verify that jsii modules can use the node standard library.
-// Struct proxy
-type NodeStandardLibrary struct {
-	// Returns the current os.platform() from the "os" node module.
-	OsPlatform string \`json:"osPlatform"\`
+// The jsii proxy struct for NodeStandardLibrary
+type nodeStandardLibrary struct {
+	_ byte // padding
 }
 
-func (n *NodeStandardLibrary) GetOsPlatform() string {
+func (n *nodeStandardLibrary) OsPlatform() string {
 	var returns string
 	_jsii_.Get(
 		n,
@@ -9413,20 +9170,24 @@ func (n *NodeStandardLibrary) GetOsPlatform() string {
 }
 
 
-func NewNodeStandardLibrary() NodeStandardLibraryIface {
+func NewNodeStandardLibrary() NodeStandardLibrary {
 	_init_.Initialize()
-	self := NodeStandardLibrary{}
+	n := nodeStandardLibrary{}
+
 	_jsii_.Create(
 		"jsii-calc.NodeStandardLibrary",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *NodeStandardLibrary) CryptoSha256() string {
+// Uses node.js "crypto" module to calculate sha256 of a string.
+//
+// Returns: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50"
+func (n *nodeStandardLibrary) CryptoSha256() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9438,7 +9199,10 @@ func (n *NodeStandardLibrary) CryptoSha256() string {
 	return returns
 }
 
-func (n *NodeStandardLibrary) FsReadFile() string {
+// Reads a local resource file (resource.txt) asynchronously.
+//
+// Returns: "Hello, resource!"
+func (n *nodeStandardLibrary) FsReadFile() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9450,7 +9214,10 @@ func (n *NodeStandardLibrary) FsReadFile() string {
 	return returns
 }
 
-func (n *NodeStandardLibrary) FsReadFileSync() string {
+// Sync version of fsReadFile.
+//
+// Returns: "Hello, resource! SYNC!"
+func (n *nodeStandardLibrary) FsReadFileSync() string {
 	var returns string
 	_jsii_.Invoke(
 		n,
@@ -9462,22 +9229,21 @@ func (n *NodeStandardLibrary) FsReadFileSync() string {
 	return returns
 }
 
-// Class interface
-type NullShouldBeTreatedAsUndefinedIface interface {
-	GetChangeMeToUndefined() string
+// jsii#282, aws-cdk#157: null should be treated as "undefined".
+type NullShouldBeTreatedAsUndefined interface {
+	ChangeMeToUndefined() string
 	SetChangeMeToUndefined(val string)
 	GiveMeUndefined(value interface{})
 	GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData)
 	VerifyPropertyIsUndefined()
 }
 
-// jsii#282, aws-cdk#157: null should be treated as "undefined".
-// Struct proxy
-type NullShouldBeTreatedAsUndefined struct {
-	ChangeMeToUndefined string \`json:"changeMeToUndefined"\`
+// The jsii proxy struct for NullShouldBeTreatedAsUndefined
+type nullShouldBeTreatedAsUndefined struct {
+	_ byte // padding
 }
 
-func (n *NullShouldBeTreatedAsUndefined) GetChangeMeToUndefined() string {
+func (n *nullShouldBeTreatedAsUndefined) ChangeMeToUndefined() string {
 	var returns string
 	_jsii_.Get(
 		n,
@@ -9488,20 +9254,21 @@ func (n *NullShouldBeTreatedAsUndefined) GetChangeMeToUndefined() string {
 }
 
 
-func NewNullShouldBeTreatedAsUndefined(_param1 string, optional interface{}) NullShouldBeTreatedAsUndefinedIface {
+func NewNullShouldBeTreatedAsUndefined(_param1 string, optional interface{}) NullShouldBeTreatedAsUndefined {
 	_init_.Initialize()
-	self := NullShouldBeTreatedAsUndefined{}
+	n := nullShouldBeTreatedAsUndefined{}
+
 	_jsii_.Create(
 		"jsii-calc.NullShouldBeTreatedAsUndefined",
 		[]interface{}{_param1, optional},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *NullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val string) {
+func (n *nullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val string) {
 	_jsii_.Set(
 		n,
 		"changeMeToUndefined",
@@ -9509,7 +9276,7 @@ func (n *NullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val string) {
 	)
 }
 
-func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefined(value interface{}) {
+func (n *nullShouldBeTreatedAsUndefined) GiveMeUndefined(value interface{}) {
 	var returns interface{}
 	_jsii_.Invoke(
 		n,
@@ -9520,7 +9287,7 @@ func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefined(value interface{}) {
 	)
 }
 
-func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData) {
+func (n *nullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input NullShouldBeTreatedAsUndefinedData) {
 	var returns interface{}
 	_jsii_.Invoke(
 		n,
@@ -9531,7 +9298,7 @@ func (n *NullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input Nul
 	)
 }
 
-func (n *NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
+func (n *nullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
 	var returns interface{}
 	_jsii_.Invoke(
 		n,
@@ -9547,22 +9314,21 @@ type NullShouldBeTreatedAsUndefinedData struct {
 	ThisShouldBeUndefined interface{} \`json:"thisShouldBeUndefined"\`
 }
 
-// Class interface
-type NumberGeneratorIface interface {
-	GetGenerator() IRandomNumberGeneratorIface
-	SetGenerator(val IRandomNumberGeneratorIface)
-	IsSameGenerator(gen IRandomNumberGeneratorIface) bool
+// This allows us to test that a reference can be stored for objects that implement interfaces.
+type NumberGenerator interface {
+	Generator() IRandomNumberGenerator
+	SetGenerator(val IRandomNumberGenerator)
+	IsSameGenerator(gen IRandomNumberGenerator) bool
 	NextTimes100() float64
 }
 
-// This allows us to test that a reference can be stored for objects that implement interfaces.
-// Struct proxy
-type NumberGenerator struct {
-	Generator IRandomNumberGeneratorIface \`json:"generator"\`
+// The jsii proxy struct for NumberGenerator
+type numberGenerator struct {
+	_ byte // padding
 }
 
-func (n *NumberGenerator) GetGenerator() IRandomNumberGeneratorIface {
-	var returns IRandomNumberGeneratorIface
+func (n *numberGenerator) Generator() IRandomNumberGenerator {
+	var returns IRandomNumberGenerator
 	_jsii_.Get(
 		n,
 		"generator",
@@ -9572,20 +9338,21 @@ func (n *NumberGenerator) GetGenerator() IRandomNumberGeneratorIface {
 }
 
 
-func NewNumberGenerator(generator IRandomNumberGeneratorIface) NumberGeneratorIface {
+func NewNumberGenerator(generator IRandomNumberGenerator) NumberGenerator {
 	_init_.Initialize()
-	self := NumberGenerator{}
+	n := numberGenerator{}
+
 	_jsii_.Create(
 		"jsii-calc.NumberGenerator",
 		[]interface{}{generator},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&n,
 	)
-	return &self
+	return &n
 }
 
-func (n *NumberGenerator) SetGenerator(val IRandomNumberGeneratorIface) {
+func (n *numberGenerator) SetGenerator(val IRandomNumberGenerator) {
 	_jsii_.Set(
 		n,
 		"generator",
@@ -9593,7 +9360,7 @@ func (n *NumberGenerator) SetGenerator(val IRandomNumberGeneratorIface) {
 	)
 }
 
-func (n *NumberGenerator) IsSameGenerator(gen IRandomNumberGeneratorIface) bool {
+func (n *numberGenerator) IsSameGenerator(gen IRandomNumberGenerator) bool {
 	var returns bool
 	_jsii_.Invoke(
 		n,
@@ -9605,7 +9372,7 @@ func (n *NumberGenerator) IsSameGenerator(gen IRandomNumberGeneratorIface) bool 
 	return returns
 }
 
-func (n *NumberGenerator) NextTimes100() float64 {
+func (n *numberGenerator) NextTimes100() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		n,
@@ -9617,31 +9384,33 @@ func (n *NumberGenerator) NextTimes100() float64 {
 	return returns
 }
 
-// Class interface
-type ObjectRefsInCollectionsIface interface {
-	SumFromArray(values []scopejsiicalclib.NumericValueIface) float64
-	SumFromMap(values map[string]scopejsiicalclib.NumericValueIface) float64
-}
-
 // Verify that object references can be passed inside collections.
-// Struct proxy
-type ObjectRefsInCollections struct {
+type ObjectRefsInCollections interface {
+	SumFromArray(values []scopejsiicalclib.NumericValue) float64
+	SumFromMap(values map[string]scopejsiicalclib.NumericValue) float64
 }
 
-func NewObjectRefsInCollections() ObjectRefsInCollectionsIface {
+// The jsii proxy struct for ObjectRefsInCollections
+type objectRefsInCollections struct {
+	_ byte // padding
+}
+
+func NewObjectRefsInCollections() ObjectRefsInCollections {
 	_init_.Initialize()
-	self := ObjectRefsInCollections{}
+	o := objectRefsInCollections{}
+
 	_jsii_.Create(
 		"jsii-calc.ObjectRefsInCollections",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *ObjectRefsInCollections) SumFromArray(values []scopejsiicalclib.NumericValueIface) float64 {
+// Returns the sum of all values.
+func (o *objectRefsInCollections) SumFromArray(values []scopejsiicalclib.NumericValue) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		o,
@@ -9653,7 +9422,8 @@ func (o *ObjectRefsInCollections) SumFromArray(values []scopejsiicalclib.Numeric
 	return returns
 }
 
-func (o *ObjectRefsInCollections) SumFromMap(values map[string]scopejsiicalclib.NumericValueIface) float64 {
+// Returns the sum of all values in a map.
+func (o *objectRefsInCollections) SumFromMap(values map[string]scopejsiicalclib.NumericValue) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		o,
@@ -9665,17 +9435,17 @@ func (o *ObjectRefsInCollections) SumFromMap(values map[string]scopejsiicalclib.
 	return returns
 }
 
-// Class interface
-type ObjectWithPropertyProviderIface interface {
+type ObjectWithPropertyProvider interface {
 }
 
-// Struct proxy
-type ObjectWithPropertyProvider struct {
+// The jsii proxy struct for ObjectWithPropertyProvider
+type objectWithPropertyProvider struct {
+	_ byte // padding
 }
 
-func ObjectWithPropertyProvider_Provide() IObjectWithPropertyIface {
+func ObjectWithPropertyProvider_Provide() IObjectWithProperty {
 	_init_.Initialize()
-	var returns IObjectWithPropertyIface
+	var returns IObjectWithProperty
 	_jsii_.StaticInvoke(
 		"jsii-calc.ObjectWithPropertyProvider",
 		"provide",
@@ -9686,32 +9456,36 @@ func ObjectWithPropertyProvider_Provide() IObjectWithPropertyIface {
 	return returns
 }
 
-// Class interface
-type OldIface interface {
-	DoAThing()
-}
-
 // Old class.
 // Deprecated: Use the new class or the old class whatever you want because
 // whatever you like is always the best
-// Struct proxy
-type Old struct {
+type Old interface {
+	DoAThing()
 }
 
-func NewOld() OldIface {
+// The jsii proxy struct for Old
+type old struct {
+	_ byte // padding
+}
+
+func NewOld() Old {
 	_init_.Initialize()
-	self := Old{}
+	o := old{}
+
 	_jsii_.Create(
 		"jsii-calc.Old",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *Old) DoAThing() {
+// Doo wop that thing.
+// Deprecated: Use the new class or the old class whatever you want because
+// whatever you like is always the best
+func (o *old) DoAThing() {
 	var returns interface{}
 	_jsii_.Invoke(
 		o,
@@ -9722,30 +9496,31 @@ func (o *Old) DoAThing() {
 	)
 }
 
-// Class interface
-type OptionalArgumentInvokerIface interface {
+type OptionalArgumentInvoker interface {
 	InvokeWithOptional()
 	InvokeWithoutOptional()
 }
 
-// Struct proxy
-type OptionalArgumentInvoker struct {
+// The jsii proxy struct for OptionalArgumentInvoker
+type optionalArgumentInvoker struct {
+	_ byte // padding
 }
 
-func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArgumentsIface) OptionalArgumentInvokerIface {
+func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArguments) OptionalArgumentInvoker {
 	_init_.Initialize()
-	self := OptionalArgumentInvoker{}
+	o := optionalArgumentInvoker{}
+
 	_jsii_.Create(
 		"jsii-calc.OptionalArgumentInvoker",
 		[]interface{}{delegate},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *OptionalArgumentInvoker) InvokeWithOptional() {
+func (o *optionalArgumentInvoker) InvokeWithOptional() {
 	var returns interface{}
 	_jsii_.Invoke(
 		o,
@@ -9756,7 +9531,7 @@ func (o *OptionalArgumentInvoker) InvokeWithOptional() {
 	)
 }
 
-func (o *OptionalArgumentInvoker) InvokeWithoutOptional() {
+func (o *optionalArgumentInvoker) InvokeWithoutOptional() {
 	var returns interface{}
 	_jsii_.Invoke(
 		o,
@@ -9767,21 +9542,18 @@ func (o *OptionalArgumentInvoker) InvokeWithoutOptional() {
 	)
 }
 
-// Class interface
-type OptionalConstructorArgumentIface interface {
-	GetArg1() float64
-	GetArg2() string
-	GetArg3() string
+type OptionalConstructorArgument interface {
+	Arg1() float64
+	Arg2() string
+	Arg3() string
 }
 
-// Struct proxy
-type OptionalConstructorArgument struct {
-	Arg1 float64 \`json:"arg1"\`
-	Arg2 string \`json:"arg2"\`
-	Arg3 string \`json:"arg3"\`
+// The jsii proxy struct for OptionalConstructorArgument
+type optionalConstructorArgument struct {
+	_ byte // padding
 }
 
-func (o *OptionalConstructorArgument) GetArg1() float64 {
+func (o *optionalConstructorArgument) Arg1() float64 {
 	var returns float64
 	_jsii_.Get(
 		o,
@@ -9791,7 +9563,7 @@ func (o *OptionalConstructorArgument) GetArg1() float64 {
 	return returns
 }
 
-func (o *OptionalConstructorArgument) GetArg2() string {
+func (o *optionalConstructorArgument) Arg2() string {
 	var returns string
 	_jsii_.Get(
 		o,
@@ -9801,7 +9573,7 @@ func (o *OptionalConstructorArgument) GetArg2() string {
 	return returns
 }
 
-func (o *OptionalConstructorArgument) GetArg3() string {
+func (o *optionalConstructorArgument) Arg3() string {
 	var returns string
 	_jsii_.Get(
 		o,
@@ -9812,46 +9584,35 @@ func (o *OptionalConstructorArgument) GetArg3() string {
 }
 
 
-func NewOptionalConstructorArgument(arg1 float64, arg2 string, arg3 string) OptionalConstructorArgumentIface {
+func NewOptionalConstructorArgument(arg1 float64, arg2 string, arg3 string) OptionalConstructorArgument {
 	_init_.Initialize()
-	self := OptionalConstructorArgument{}
+	o := optionalConstructorArgument{}
+
 	_jsii_.Create(
 		"jsii-calc.OptionalConstructorArgument",
 		[]interface{}{arg1, arg2, arg3},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
 type OptionalStruct struct {
 	Field string \`json:"field"\`
 }
 
-// Class interface
-type OptionalStructConsumerIface interface {
-	GetParameterWasUndefined() bool
-	GetFieldValue() string
+type OptionalStructConsumer interface {
+	FieldValue() string
+	ParameterWasUndefined() bool
 }
 
-// Struct proxy
-type OptionalStructConsumer struct {
-	ParameterWasUndefined bool \`json:"parameterWasUndefined"\`
-	FieldValue string \`json:"fieldValue"\`
+// The jsii proxy struct for OptionalStructConsumer
+type optionalStructConsumer struct {
+	_ byte // padding
 }
 
-func (o *OptionalStructConsumer) GetParameterWasUndefined() bool {
-	var returns bool
-	_jsii_.Get(
-		o,
-		"parameterWasUndefined",
-		&returns,
-	)
-	return returns
-}
-
-func (o *OptionalStructConsumer) GetFieldValue() string {
+func (o *optionalStructConsumer) FieldValue() string {
 	var returns string
 	_jsii_.Get(
 		o,
@@ -9861,38 +9622,47 @@ func (o *OptionalStructConsumer) GetFieldValue() string {
 	return returns
 }
 
+func (o *optionalStructConsumer) ParameterWasUndefined() bool {
+	var returns bool
+	_jsii_.Get(
+		o,
+		"parameterWasUndefined",
+		&returns,
+	)
+	return returns
+}
 
-func NewOptionalStructConsumer(optionalStruct OptionalStruct) OptionalStructConsumerIface {
+
+func NewOptionalStructConsumer(optionalStruct OptionalStruct) OptionalStructConsumer {
 	_init_.Initialize()
-	self := OptionalStructConsumer{}
+	o := optionalStructConsumer{}
+
 	_jsii_.Create(
 		"jsii-calc.OptionalStructConsumer",
 		[]interface{}{optionalStruct},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-// Class interface
-type OverridableProtectedMemberIface interface {
-	GetOverrideReadOnly() string
-	GetOverrideReadWrite() string
+// See: https://github.com/aws/jsii/issues/903
+//
+type OverridableProtectedMember interface {
+	OverrideReadOnly() string
+	OverrideReadWrite() string
 	OverrideMe() string
 	SwitchModes()
 	ValueFromProtected() string
 }
 
-// See: https://github.com/aws/jsii/issues/903
-//
-// Struct proxy
-type OverridableProtectedMember struct {
-	OverrideReadOnly string \`json:"overrideReadOnly"\`
-	OverrideReadWrite string \`json:"overrideReadWrite"\`
+// The jsii proxy struct for OverridableProtectedMember
+type overridableProtectedMember struct {
+	_ byte // padding
 }
 
-func (o *OverridableProtectedMember) GetOverrideReadOnly() string {
+func (o *overridableProtectedMember) OverrideReadOnly() string {
 	var returns string
 	_jsii_.Get(
 		o,
@@ -9902,7 +9672,7 @@ func (o *OverridableProtectedMember) GetOverrideReadOnly() string {
 	return returns
 }
 
-func (o *OverridableProtectedMember) GetOverrideReadWrite() string {
+func (o *overridableProtectedMember) OverrideReadWrite() string {
 	var returns string
 	_jsii_.Get(
 		o,
@@ -9913,20 +9683,21 @@ func (o *OverridableProtectedMember) GetOverrideReadWrite() string {
 }
 
 
-func NewOverridableProtectedMember() OverridableProtectedMemberIface {
+func NewOverridableProtectedMember() OverridableProtectedMember {
 	_init_.Initialize()
-	self := OverridableProtectedMember{}
+	o := overridableProtectedMember{}
+
 	_jsii_.Create(
 		"jsii-calc.OverridableProtectedMember",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *OverridableProtectedMember) SetOverrideReadWrite(val string) {
+func (o *overridableProtectedMember) SetOverrideReadWrite(val string) {
 	_jsii_.Set(
 		o,
 		"overrideReadWrite",
@@ -9934,7 +9705,7 @@ func (o *OverridableProtectedMember) SetOverrideReadWrite(val string) {
 	)
 }
 
-func (o *OverridableProtectedMember) OverrideMe() string {
+func (o *overridableProtectedMember) OverrideMe() string {
 	var returns string
 	_jsii_.Invoke(
 		o,
@@ -9946,7 +9717,7 @@ func (o *OverridableProtectedMember) OverrideMe() string {
 	return returns
 }
 
-func (o *OverridableProtectedMember) SwitchModes() {
+func (o *overridableProtectedMember) SwitchModes() {
 	var returns interface{}
 	_jsii_.Invoke(
 		o,
@@ -9957,7 +9728,7 @@ func (o *OverridableProtectedMember) SwitchModes() {
 	)
 }
 
-func (o *OverridableProtectedMember) ValueFromProtected() string {
+func (o *overridableProtectedMember) ValueFromProtected() string {
 	var returns string
 	_jsii_.Invoke(
 		o,
@@ -9969,29 +9740,30 @@ func (o *OverridableProtectedMember) ValueFromProtected() string {
 	return returns
 }
 
-// Class interface
-type OverrideReturnsObjectIface interface {
-	Test(obj IReturnsNumberIface) float64
+type OverrideReturnsObject interface {
+	Test(obj IReturnsNumber) float64
 }
 
-// Struct proxy
-type OverrideReturnsObject struct {
+// The jsii proxy struct for OverrideReturnsObject
+type overrideReturnsObject struct {
+	_ byte // padding
 }
 
-func NewOverrideReturnsObject() OverrideReturnsObjectIface {
+func NewOverrideReturnsObject() OverrideReturnsObject {
 	_init_.Initialize()
-	self := OverrideReturnsObject{}
+	o := overrideReturnsObject{}
+
 	_jsii_.Create(
 		"jsii-calc.OverrideReturnsObject",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
-func (o *OverrideReturnsObject) Test(obj IReturnsNumberIface) float64 {
+func (o *overrideReturnsObject) Test(obj IReturnsNumber) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		o,
@@ -10008,29 +9780,30 @@ type ParentStruct982 struct {
 	Foo string \`json:"foo"\`
 }
 
-// Class interface
-type PartiallyInitializedThisConsumerIface interface {
-	ConsumePartiallyInitializedThis(obj ConstructorPassesThisOutIface, dt string, ev AllTypesEnum) string
+type PartiallyInitializedThisConsumer interface {
+	ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt string, ev AllTypesEnum) string
 }
 
-// Struct proxy
-type PartiallyInitializedThisConsumer struct {
+// The jsii proxy struct for PartiallyInitializedThisConsumer
+type partiallyInitializedThisConsumer struct {
+	_ byte // padding
 }
 
-func NewPartiallyInitializedThisConsumer() PartiallyInitializedThisConsumerIface {
+func NewPartiallyInitializedThisConsumer() PartiallyInitializedThisConsumer {
 	_init_.Initialize()
-	self := PartiallyInitializedThisConsumer{}
+	p := partiallyInitializedThisConsumer{}
+
 	_jsii_.Create(
 		"jsii-calc.PartiallyInitializedThisConsumer",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
+	return &p
 }
 
-func (p *PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj ConstructorPassesThisOutIface, dt string, ev AllTypesEnum) string {
+func (p *partiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt string, ev AllTypesEnum) string {
 	var returns string
 	_jsii_.Invoke(
 		p,
@@ -10042,29 +9815,30 @@ func (p *PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj C
 	return returns
 }
 
-// Class interface
-type PolymorphismIface interface {
-	SayHello(friendly scopejsiicalclib.IFriendlyIface) string
+type Polymorphism interface {
+	SayHello(friendly scopejsiicalclib.IFriendly) string
 }
 
-// Struct proxy
-type Polymorphism struct {
+// The jsii proxy struct for Polymorphism
+type polymorphism struct {
+	_ byte // padding
 }
 
-func NewPolymorphism() PolymorphismIface {
+func NewPolymorphism() Polymorphism {
 	_init_.Initialize()
-	self := Polymorphism{}
+	p := polymorphism{}
+
 	_jsii_.Create(
 		"jsii-calc.Polymorphism",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
+	return &p
 }
 
-func (p *Polymorphism) SayHello(friendly scopejsiicalclib.IFriendlyIface) string {
+func (p *polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) string {
 	var returns string
 	_jsii_.Invoke(
 		p,
@@ -10076,95 +9850,21 @@ func (p *Polymorphism) SayHello(friendly scopejsiicalclib.IFriendlyIface) string
 	return returns
 }
 
-// Class interface
-type PowerIface interface {
-	GetValue() float64
-	GetExpression() scopejsiicalclib.NumericValueIface
-	GetDecorationPostfixes() []string
-	SetDecorationPostfixes(val []string)
-	GetDecorationPrefixes() []string
-	SetDecorationPrefixes(val []string)
-	GetStringStyle() composition.CompositionStringStyle
-	SetStringStyle(val composition.CompositionStringStyle)
-	GetBase() scopejsiicalclib.NumericValueIface
-	GetPow() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
-}
-
 // The power operation.
-// Struct proxy
-type Power struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// The expression that this operation consists of.
-	//
-	// Must be implemented by derived classes.
-	Expression scopejsiicalclib.NumericValueIface \`json:"expression"\`
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes []string \`json:"decorationPostfixes"\`
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes []string \`json:"decorationPrefixes"\`
-	// The .toString() style.
-	StringStyle composition.CompositionStringStyle \`json:"stringStyle"\`
-	// The base of the power.
-	Base scopejsiicalclib.NumericValueIface \`json:"base"\`
-	// The number of times to multiply.
-	Pow scopejsiicalclib.NumericValueIface \`json:"pow"\`
+type Power interface {
+	composition.CompositeOperation
+	Base() scopejsiicalclib.NumericValue
+	Expression() scopejsiicalclib.NumericValue
+	Pow() scopejsiicalclib.NumericValue
 }
 
-func (p *Power) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		p,
-		"value",
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for Power
+type power struct {
+	composition.CompositeOperation // extends jsii-calc.composition.CompositeOperation
 }
 
-func (p *Power) GetExpression() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
-	_jsii_.Get(
-		p,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (p *Power) GetDecorationPostfixes() []string {
-	var returns []string
-	_jsii_.Get(
-		p,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (p *Power) GetDecorationPrefixes() []string {
-	var returns []string
-	_jsii_.Get(
-		p,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (p *Power) GetStringStyle() composition.CompositionStringStyle {
-	var returns composition.CompositionStringStyle
-	_jsii_.Get(
-		p,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (p *Power) GetBase() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (p *power) Base() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		p,
 		"base",
@@ -10173,8 +9873,18 @@ func (p *Power) GetBase() scopejsiicalclib.NumericValueIface {
 	return returns
 }
 
-func (p *Power) GetPow() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (p *power) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		p,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (p *power) Pow() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		p,
 		"pow",
@@ -10185,81 +9895,32 @@ func (p *Power) GetPow() scopejsiicalclib.NumericValueIface {
 
 
 // Creates a Power operation.
-func NewPower(base scopejsiicalclib.NumericValueIface, pow scopejsiicalclib.NumericValueIface) PowerIface {
+func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) Power {
 	_init_.Initialize()
-	self := Power{}
+	p := power{}
+
 	_jsii_.Create(
 		"jsii-calc.Power",
 		[]interface{}{base, pow},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
-}
-
-func (p *Power) SetDecorationPostfixes(val []string) {
-	_jsii_.Set(
-		p,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (p *Power) SetDecorationPrefixes(val []string) {
-	_jsii_.Set(
-		p,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (p *Power) SetStringStyle(val composition.CompositionStringStyle) {
-	_jsii_.Set(
-		p,
-		"stringStyle",
-		val,
-	)
-}
-
-func (p *Power) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		p,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (p *Power) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		p,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-// Class interface
-type PropertyNamedPropertyIface interface {
-	GetProperty() string
-	GetYetAnoterOne() bool
+	return &p
 }
 
 // Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.
-// Struct proxy
-type PropertyNamedProperty struct {
-	Property string \`json:"property"\`
-	YetAnoterOne bool \`json:"yetAnoterOne"\`
+type PropertyNamedProperty interface {
+	Property() string
+	YetAnoterOne() bool
 }
 
-func (p *PropertyNamedProperty) GetProperty() string {
+// The jsii proxy struct for PropertyNamedProperty
+type propertyNamedProperty struct {
+	_ byte // padding
+}
+
+func (p *propertyNamedProperty) Property() string {
 	var returns string
 	_jsii_.Get(
 		p,
@@ -10269,7 +9930,7 @@ func (p *PropertyNamedProperty) GetProperty() string {
 	return returns
 }
 
-func (p *PropertyNamedProperty) GetYetAnoterOne() bool {
+func (p *propertyNamedProperty) YetAnoterOne() bool {
 	var returns bool
 	_jsii_.Get(
 		p,
@@ -10280,42 +9941,44 @@ func (p *PropertyNamedProperty) GetYetAnoterOne() bool {
 }
 
 
-func NewPropertyNamedProperty() PropertyNamedPropertyIface {
+func NewPropertyNamedProperty() PropertyNamedProperty {
 	_init_.Initialize()
-	self := PropertyNamedProperty{}
+	p := propertyNamedProperty{}
+
 	_jsii_.Create(
 		"jsii-calc.PropertyNamedProperty",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
+	return &p
 }
 
-// Class interface
-type PublicClassIface interface {
+type PublicClass interface {
 	Hello()
 }
 
-// Struct proxy
-type PublicClass struct {
+// The jsii proxy struct for PublicClass
+type publicClass struct {
+	_ byte // padding
 }
 
-func NewPublicClass() PublicClassIface {
+func NewPublicClass() PublicClass {
 	_init_.Initialize()
-	self := PublicClass{}
+	p := publicClass{}
+
 	_jsii_.Create(
 		"jsii-calc.PublicClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
+	return &p
 }
 
-func (p *PublicClass) Hello() {
+func (p *publicClass) Hello() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10326,8 +9989,7 @@ func (p *PublicClass) Hello() {
 	)
 }
 
-// Class interface
-type PythonReservedWordsIface interface {
+type PythonReservedWords interface {
 	And()
 	As()
 	Assert()
@@ -10362,24 +10024,26 @@ type PythonReservedWordsIface interface {
 	Yield()
 }
 
-// Struct proxy
-type PythonReservedWords struct {
+// The jsii proxy struct for PythonReservedWords
+type pythonReservedWords struct {
+	_ byte // padding
 }
 
-func NewPythonReservedWords() PythonReservedWordsIface {
+func NewPythonReservedWords() PythonReservedWords {
 	_init_.Initialize()
-	self := PythonReservedWords{}
+	p := pythonReservedWords{}
+
 	_jsii_.Create(
 		"jsii-calc.PythonReservedWords",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&p,
 	)
-	return &self
+	return &p
 }
 
-func (p *PythonReservedWords) And() {
+func (p *pythonReservedWords) And() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10390,7 +10054,7 @@ func (p *PythonReservedWords) And() {
 	)
 }
 
-func (p *PythonReservedWords) As() {
+func (p *pythonReservedWords) As() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10401,7 +10065,7 @@ func (p *PythonReservedWords) As() {
 	)
 }
 
-func (p *PythonReservedWords) Assert() {
+func (p *pythonReservedWords) Assert() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10412,7 +10076,7 @@ func (p *PythonReservedWords) Assert() {
 	)
 }
 
-func (p *PythonReservedWords) Async() {
+func (p *pythonReservedWords) Async() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10423,7 +10087,7 @@ func (p *PythonReservedWords) Async() {
 	)
 }
 
-func (p *PythonReservedWords) Await() {
+func (p *pythonReservedWords) Await() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10434,7 +10098,7 @@ func (p *PythonReservedWords) Await() {
 	)
 }
 
-func (p *PythonReservedWords) Break() {
+func (p *pythonReservedWords) Break() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10445,7 +10109,7 @@ func (p *PythonReservedWords) Break() {
 	)
 }
 
-func (p *PythonReservedWords) Class() {
+func (p *pythonReservedWords) Class() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10456,7 +10120,7 @@ func (p *PythonReservedWords) Class() {
 	)
 }
 
-func (p *PythonReservedWords) Continue() {
+func (p *pythonReservedWords) Continue() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10467,7 +10131,7 @@ func (p *PythonReservedWords) Continue() {
 	)
 }
 
-func (p *PythonReservedWords) Def() {
+func (p *pythonReservedWords) Def() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10478,7 +10142,7 @@ func (p *PythonReservedWords) Def() {
 	)
 }
 
-func (p *PythonReservedWords) Del() {
+func (p *pythonReservedWords) Del() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10489,7 +10153,7 @@ func (p *PythonReservedWords) Del() {
 	)
 }
 
-func (p *PythonReservedWords) Elif() {
+func (p *pythonReservedWords) Elif() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10500,7 +10164,7 @@ func (p *PythonReservedWords) Elif() {
 	)
 }
 
-func (p *PythonReservedWords) Else() {
+func (p *pythonReservedWords) Else() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10511,7 +10175,7 @@ func (p *PythonReservedWords) Else() {
 	)
 }
 
-func (p *PythonReservedWords) Except() {
+func (p *pythonReservedWords) Except() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10522,7 +10186,7 @@ func (p *PythonReservedWords) Except() {
 	)
 }
 
-func (p *PythonReservedWords) Finally() {
+func (p *pythonReservedWords) Finally() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10533,7 +10197,7 @@ func (p *PythonReservedWords) Finally() {
 	)
 }
 
-func (p *PythonReservedWords) For() {
+func (p *pythonReservedWords) For() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10544,7 +10208,7 @@ func (p *PythonReservedWords) For() {
 	)
 }
 
-func (p *PythonReservedWords) From() {
+func (p *pythonReservedWords) From() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10555,7 +10219,7 @@ func (p *PythonReservedWords) From() {
 	)
 }
 
-func (p *PythonReservedWords) Global() {
+func (p *pythonReservedWords) Global() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10566,7 +10230,7 @@ func (p *PythonReservedWords) Global() {
 	)
 }
 
-func (p *PythonReservedWords) If() {
+func (p *pythonReservedWords) If() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10577,7 +10241,7 @@ func (p *PythonReservedWords) If() {
 	)
 }
 
-func (p *PythonReservedWords) Import() {
+func (p *pythonReservedWords) Import() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10588,7 +10252,7 @@ func (p *PythonReservedWords) Import() {
 	)
 }
 
-func (p *PythonReservedWords) In() {
+func (p *pythonReservedWords) In() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10599,7 +10263,7 @@ func (p *PythonReservedWords) In() {
 	)
 }
 
-func (p *PythonReservedWords) Is() {
+func (p *pythonReservedWords) Is() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10610,7 +10274,7 @@ func (p *PythonReservedWords) Is() {
 	)
 }
 
-func (p *PythonReservedWords) Lambda() {
+func (p *pythonReservedWords) Lambda() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10621,7 +10285,7 @@ func (p *PythonReservedWords) Lambda() {
 	)
 }
 
-func (p *PythonReservedWords) Nonlocal() {
+func (p *pythonReservedWords) Nonlocal() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10632,7 +10296,7 @@ func (p *PythonReservedWords) Nonlocal() {
 	)
 }
 
-func (p *PythonReservedWords) Not() {
+func (p *pythonReservedWords) Not() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10643,7 +10307,7 @@ func (p *PythonReservedWords) Not() {
 	)
 }
 
-func (p *PythonReservedWords) Or() {
+func (p *pythonReservedWords) Or() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10654,7 +10318,7 @@ func (p *PythonReservedWords) Or() {
 	)
 }
 
-func (p *PythonReservedWords) Pass() {
+func (p *pythonReservedWords) Pass() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10665,7 +10329,7 @@ func (p *PythonReservedWords) Pass() {
 	)
 }
 
-func (p *PythonReservedWords) Raise() {
+func (p *pythonReservedWords) Raise() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10676,7 +10340,7 @@ func (p *PythonReservedWords) Raise() {
 	)
 }
 
-func (p *PythonReservedWords) Return() {
+func (p *pythonReservedWords) Return() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10687,7 +10351,7 @@ func (p *PythonReservedWords) Return() {
 	)
 }
 
-func (p *PythonReservedWords) Try() {
+func (p *pythonReservedWords) Try() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10698,7 +10362,7 @@ func (p *PythonReservedWords) Try() {
 	)
 }
 
-func (p *PythonReservedWords) While() {
+func (p *pythonReservedWords) While() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10709,7 +10373,7 @@ func (p *PythonReservedWords) While() {
 	)
 }
 
-func (p *PythonReservedWords) With() {
+func (p *pythonReservedWords) With() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10720,7 +10384,7 @@ func (p *PythonReservedWords) With() {
 	)
 }
 
-func (p *PythonReservedWords) Yield() {
+func (p *pythonReservedWords) Yield() {
 	var returns interface{}
 	_jsii_.Invoke(
 		p,
@@ -10731,21 +10395,20 @@ func (p *PythonReservedWords) Yield() {
 	)
 }
 
-// Class interface
-type ReferenceEnumFromScopedPackageIface interface {
-	GetFoo() scopejsiicalclib.EnumFromScopedModule
+// See awslabs/jsii#138.
+type ReferenceEnumFromScopedPackage interface {
+	Foo() scopejsiicalclib.EnumFromScopedModule
 	SetFoo(val scopejsiicalclib.EnumFromScopedModule)
 	LoadFoo() scopejsiicalclib.EnumFromScopedModule
 	SaveFoo(value scopejsiicalclib.EnumFromScopedModule)
 }
 
-// See awslabs/jsii#138.
-// Struct proxy
-type ReferenceEnumFromScopedPackage struct {
-	Foo scopejsiicalclib.EnumFromScopedModule \`json:"foo"\`
+// The jsii proxy struct for ReferenceEnumFromScopedPackage
+type referenceEnumFromScopedPackage struct {
+	_ byte // padding
 }
 
-func (r *ReferenceEnumFromScopedPackage) GetFoo() scopejsiicalclib.EnumFromScopedModule {
+func (r *referenceEnumFromScopedPackage) Foo() scopejsiicalclib.EnumFromScopedModule {
 	var returns scopejsiicalclib.EnumFromScopedModule
 	_jsii_.Get(
 		r,
@@ -10756,20 +10419,21 @@ func (r *ReferenceEnumFromScopedPackage) GetFoo() scopejsiicalclib.EnumFromScope
 }
 
 
-func NewReferenceEnumFromScopedPackage() ReferenceEnumFromScopedPackageIface {
+func NewReferenceEnumFromScopedPackage() ReferenceEnumFromScopedPackage {
 	_init_.Initialize()
-	self := ReferenceEnumFromScopedPackage{}
+	r := referenceEnumFromScopedPackage{}
+
 	_jsii_.Create(
 		"jsii-calc.ReferenceEnumFromScopedPackage",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&r,
 	)
-	return &self
+	return &r
 }
 
-func (r *ReferenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromScopedModule) {
+func (r *referenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromScopedModule) {
 	_jsii_.Set(
 		r,
 		"foo",
@@ -10777,7 +10441,7 @@ func (r *ReferenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromSco
 	)
 }
 
-func (r *ReferenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScopedModule {
+func (r *referenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScopedModule {
 	var returns scopejsiicalclib.EnumFromScopedModule
 	_jsii_.Invoke(
 		r,
@@ -10789,7 +10453,7 @@ func (r *ReferenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScop
 	return returns
 }
 
-func (r *ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFromScopedModule) {
+func (r *referenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFromScopedModule) {
 	var returns interface{}
 	_jsii_.Invoke(
 		r,
@@ -10800,23 +10464,22 @@ func (r *ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFrom
 	)
 }
 
-// Class interface
-type ReturnsPrivateImplementationOfInterfaceIface interface {
-	GetPrivateImplementation() IPrivatelyImplementedIface
-}
-
 // Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
 //
 // Returns: an instance of an un-exported class that extends \`ExportedBaseClass\`, declared as \`IPrivatelyImplemented\`.
 // See: https://github.com/aws/jsii/issues/320
 //
-// Struct proxy
-type ReturnsPrivateImplementationOfInterface struct {
-	PrivateImplementation IPrivatelyImplementedIface \`json:"privateImplementation"\`
+type ReturnsPrivateImplementationOfInterface interface {
+	PrivateImplementation() IPrivatelyImplemented
 }
 
-func (r *ReturnsPrivateImplementationOfInterface) GetPrivateImplementation() IPrivatelyImplementedIface {
-	var returns IPrivatelyImplementedIface
+// The jsii proxy struct for ReturnsPrivateImplementationOfInterface
+type returnsPrivateImplementationOfInterface struct {
+	_ byte // padding
+}
+
+func (r *returnsPrivateImplementationOfInterface) PrivateImplementation() IPrivatelyImplemented {
+	var returns IPrivatelyImplemented
 	_jsii_.Get(
 		r,
 		"privateImplementation",
@@ -10826,17 +10489,18 @@ func (r *ReturnsPrivateImplementationOfInterface) GetPrivateImplementation() IPr
 }
 
 
-func NewReturnsPrivateImplementationOfInterface() ReturnsPrivateImplementationOfInterfaceIface {
+func NewReturnsPrivateImplementationOfInterface() ReturnsPrivateImplementationOfInterface {
 	_init_.Initialize()
-	self := ReturnsPrivateImplementationOfInterface{}
+	r := returnsPrivateImplementationOfInterface{}
+
 	_jsii_.Create(
 		"jsii-calc.ReturnsPrivateImplementationOfInterface",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&r,
 	)
-	return &self
+	return &r
 }
 
 // This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
@@ -10849,12 +10513,12 @@ type RootStruct struct {
 	NestedStruct NestedStruct \`json:"nestedStruct"\`
 }
 
-// Class interface
-type RootStructValidatorIface interface {
+type RootStructValidator interface {
 }
 
-// Struct proxy
-type RootStructValidator struct {
+// The jsii proxy struct for RootStructValidator
+type rootStructValidator struct {
+	_ byte // padding
 }
 
 func RootStructValidator_Validate(struct_ RootStruct) {
@@ -10869,31 +10533,32 @@ func RootStructValidator_Validate(struct_ RootStruct) {
 	)
 }
 
-// Class interface
-type RuntimeTypeCheckingIface interface {
+type RuntimeTypeChecking interface {
 	MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string)
 	MethodWithOptionalAnyArgument(arg interface{})
 	MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string)
 }
 
-// Struct proxy
-type RuntimeTypeChecking struct {
+// The jsii proxy struct for RuntimeTypeChecking
+type runtimeTypeChecking struct {
+	_ byte // padding
 }
 
-func NewRuntimeTypeChecking() RuntimeTypeCheckingIface {
+func NewRuntimeTypeChecking() RuntimeTypeChecking {
 	_init_.Initialize()
-	self := RuntimeTypeChecking{}
+	r := runtimeTypeChecking{}
+
 	_jsii_.Create(
 		"jsii-calc.RuntimeTypeChecking",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&r,
 	)
-	return &self
+	return &r
 }
 
-func (r *RuntimeTypeChecking) MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string) {
+func (r *runtimeTypeChecking) MethodWithDefaultedArguments(arg1 float64, arg2 string, arg3 string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		r,
@@ -10904,7 +10569,7 @@ func (r *RuntimeTypeChecking) MethodWithDefaultedArguments(arg1 float64, arg2 st
 	)
 }
 
-func (r *RuntimeTypeChecking) MethodWithOptionalAnyArgument(arg interface{}) {
+func (r *runtimeTypeChecking) MethodWithOptionalAnyArgument(arg interface{}) {
 	var returns interface{}
 	_jsii_.Invoke(
 		r,
@@ -10915,7 +10580,8 @@ func (r *RuntimeTypeChecking) MethodWithOptionalAnyArgument(arg interface{}) {
 	)
 }
 
-func (r *RuntimeTypeChecking) MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string) {
+// Used to verify verification of number of method arguments.
+func (r *runtimeTypeChecking) MethodWithOptionalArguments(arg1 float64, arg2 string, arg3 string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		r,
@@ -10933,36 +10599,37 @@ type SecondLevelStruct struct {
 	DeeperOptionalProp string \`json:"deeperOptionalProp"\`
 }
 
-// Class interface
-type SingleInstanceTwoTypesIface interface {
-	Interface1() InbetweenClassIface
-	Interface2() IPublicInterfaceIface
-}
-
 // Test that a single instance can be returned under two different FQNs.
 //
 // JSII clients can instantiate 2 different strongly-typed wrappers for the same
 // object. Unfortunately, this will break object equality, but if we didn't do
 // this it would break runtime type checks in the JVM or CLR.
-// Struct proxy
-type SingleInstanceTwoTypes struct {
+type SingleInstanceTwoTypes interface {
+	Interface1() InbetweenClass
+	Interface2() IPublicInterface
 }
 
-func NewSingleInstanceTwoTypes() SingleInstanceTwoTypesIface {
+// The jsii proxy struct for SingleInstanceTwoTypes
+type singleInstanceTwoTypes struct {
+	_ byte // padding
+}
+
+func NewSingleInstanceTwoTypes() SingleInstanceTwoTypes {
 	_init_.Initialize()
-	self := SingleInstanceTwoTypes{}
+	s := singleInstanceTwoTypes{}
+
 	_jsii_.Create(
 		"jsii-calc.SingleInstanceTwoTypes",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-func (s *SingleInstanceTwoTypes) Interface1() InbetweenClassIface {
-	var returns InbetweenClassIface
+func (s *singleInstanceTwoTypes) Interface1() InbetweenClass {
+	var returns InbetweenClass
 	_jsii_.Invoke(
 		s,
 		"interface1",
@@ -10973,8 +10640,8 @@ func (s *SingleInstanceTwoTypes) Interface1() InbetweenClassIface {
 	return returns
 }
 
-func (s *SingleInstanceTwoTypes) Interface2() IPublicInterfaceIface {
-	var returns IPublicInterfaceIface
+func (s *singleInstanceTwoTypes) Interface2() IPublicInterface {
+	var returns IPublicInterface
 	_jsii_.Invoke(
 		s,
 		"interface2",
@@ -10985,19 +10652,19 @@ func (s *SingleInstanceTwoTypes) Interface2() IPublicInterfaceIface {
 	return returns
 }
 
-// Class interface
-type SingletonIntIface interface {
-	IsSingletonInt(value float64) bool
-}
-
 // Verifies that singleton enums are handled correctly.
 //
 // https://github.com/aws/jsii/issues/231
-// Struct proxy
-type SingletonInt struct {
+type SingletonInt interface {
+	IsSingletonInt(value float64) bool
 }
 
-func (s *SingletonInt) IsSingletonInt(value float64) bool {
+// The jsii proxy struct for SingletonInt
+type singletonInt struct {
+	_ byte // padding
+}
+
+func (s *singletonInt) IsSingletonInt(value float64) bool {
 	var returns bool
 	_jsii_.Invoke(
 		s,
@@ -11016,19 +10683,19 @@ const (
 	SingletonIntEnum_SINGLETON_INT SingletonIntEnum = "SINGLETON_INT"
 )
 
-// Class interface
-type SingletonStringIface interface {
-	IsSingletonString(value string) bool
-}
-
 // Verifies that singleton enums are handled correctly.
 //
 // https://github.com/aws/jsii/issues/231
-// Struct proxy
-type SingletonString struct {
+type SingletonString interface {
+	IsSingletonString(value string) bool
 }
 
-func (s *SingletonString) IsSingletonString(value string) bool {
+// The jsii proxy struct for SingletonString
+type singletonString struct {
+	_ byte // padding
+}
+
+func (s *singletonString) IsSingletonString(value string) bool {
 	var returns bool
 	_jsii_.Invoke(
 		s,
@@ -11052,25 +10719,26 @@ type SmellyStruct struct {
 	YetAnoterOne bool \`json:"yetAnoterOne"\`
 }
 
-// Class interface
-type SomeTypeJsii976Iface interface {
+type SomeTypeJsii976 interface {
 }
 
-// Struct proxy
-type SomeTypeJsii976 struct {
+// The jsii proxy struct for SomeTypeJsii976
+type someTypeJsii976 struct {
+	_ byte // padding
 }
 
-func NewSomeTypeJsii976() SomeTypeJsii976Iface {
+func NewSomeTypeJsii976() SomeTypeJsii976 {
 	_init_.Initialize()
-	self := SomeTypeJsii976{}
+	s := someTypeJsii976{}
+
 	_jsii_.Create(
 		"jsii-calc.SomeTypeJsii976",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
 func SomeTypeJsii976_ReturnAnonymous() interface{} {
@@ -11086,9 +10754,9 @@ func SomeTypeJsii976_ReturnAnonymous() interface{} {
 	return returns
 }
 
-func SomeTypeJsii976_ReturnReturn() IReturnJsii976Iface {
+func SomeTypeJsii976_ReturnReturn() IReturnJsii976 {
 	_init_.Initialize()
-	var returns IReturnJsii976Iface
+	var returns IReturnJsii976
 	_jsii_.StaticInvoke(
 		"jsii-calc.SomeTypeJsii976",
 		"returnReturn",
@@ -11099,31 +10767,19 @@ func SomeTypeJsii976_ReturnReturn() IReturnJsii976Iface {
 	return returns
 }
 
-// Class interface
-type StableClassIface interface {
-	GetReadonlyProperty() string
-	GetMutableProperty() float64
+type StableClass interface {
+	MutableProperty() float64
 	SetMutableProperty(val float64)
+	ReadonlyProperty() string
 	Method()
 }
 
-// Struct proxy
-type StableClass struct {
-	ReadonlyProperty string \`json:"readonlyProperty"\`
-	MutableProperty float64 \`json:"mutableProperty"\`
+// The jsii proxy struct for StableClass
+type stableClass struct {
+	_ byte // padding
 }
 
-func (s *StableClass) GetReadonlyProperty() string {
-	var returns string
-	_jsii_.Get(
-		s,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (s *StableClass) GetMutableProperty() float64 {
+func (s *stableClass) MutableProperty() float64 {
 	var returns float64
 	_jsii_.Get(
 		s,
@@ -11133,21 +10789,32 @@ func (s *StableClass) GetMutableProperty() float64 {
 	return returns
 }
 
+func (s *stableClass) ReadonlyProperty() string {
+	var returns string
+	_jsii_.Get(
+		s,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
 
-func NewStableClass(readonlyString string, mutableNumber float64) StableClassIface {
+
+func NewStableClass(readonlyString string, mutableNumber float64) StableClass {
 	_init_.Initialize()
-	self := StableClass{}
+	s := stableClass{}
+
 	_jsii_.Create(
 		"jsii-calc.StableClass",
 		[]interface{}{readonlyString, mutableNumber},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-func (s *StableClass) SetMutableProperty(val float64) {
+func (s *stableClass) SetMutableProperty(val float64) {
 	_jsii_.Set(
 		s,
 		"mutableProperty",
@@ -11155,7 +10822,7 @@ func (s *StableClass) SetMutableProperty(val float64) {
 	)
 }
 
-func (s *StableClass) Method() {
+func (s *stableClass) Method() {
 	var returns interface{}
 	_jsii_.Invoke(
 		s,
@@ -11177,15 +10844,15 @@ type StableStruct struct {
 	ReadonlyProperty string \`json:"readonlyProperty"\`
 }
 
-// Class interface
-type StaticContextIface interface {
-}
-
 // This is used to validate the ability to use \`this\` from within a static context.
 //
 // https://github.com/awslabs/aws-cdk/issues/2304
-// Struct proxy
-type StaticContext struct {
+type StaticContext interface {
+}
+
+// The jsii proxy struct for StaticContext
+type staticContext struct {
+	_ byte // padding
 }
 
 func StaticContext_CanAccessStaticContext() bool {
@@ -11221,12 +10888,13 @@ func StaticContext_SetStaticVariable(val bool) {
 	)
 }
 
-// Class interface
-type StaticHelloChildIface interface {
+type StaticHelloChild interface {
+	StaticHelloParent
 }
 
-// Struct proxy
-type StaticHelloChild struct {
+// The jsii proxy struct for StaticHelloChild
+type staticHelloChild struct {
+	staticHelloParent // extends jsii-calc.StaticHelloParent
 }
 
 func StaticHelloChild_Method() {
@@ -11252,30 +10920,31 @@ func StaticHelloChild_Property() float64 {
 	return returns
 }
 
-// Class interface
-type StaticHelloParentIface interface {
-}
-
 // Static methods that override parent class are technically overrides (the inheritance of statics is part of the ES6 specification), but certain other languages such as Java do not carry statics in the inheritance chain at all, so they cannot be overridden, only hidden.
 //
 // The difference is fairly minor (for typical use-cases, the end result is the
 // same), however this has implications on what the generated code should look
 // like.
-// Struct proxy
-type StaticHelloParent struct {
+type StaticHelloParent interface {
 }
 
-func NewStaticHelloParent() StaticHelloParentIface {
+// The jsii proxy struct for StaticHelloParent
+type staticHelloParent struct {
+	_ byte // padding
+}
+
+func NewStaticHelloParent() StaticHelloParent {
 	_init_.Initialize()
-	self := StaticHelloParent{}
+	s := staticHelloParent{}
+
 	_jsii_.Create(
 		"jsii-calc.StaticHelloParent",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
 func StaticHelloParent_Method() {
@@ -11301,18 +10970,17 @@ func StaticHelloParent_Property() float64 {
 	return returns
 }
 
-// Class interface
-type StaticsIface interface {
-	GetValue() string
+type Statics interface {
+	Value() string
 	JustMethod() string
 }
 
-// Struct proxy
-type Statics struct {
-	Value string \`json:"value"\`
+// The jsii proxy struct for Statics
+type statics struct {
+	_ byte // padding
 }
 
-func (s *Statics) GetValue() string {
+func (s *statics) Value() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -11323,19 +10991,21 @@ func (s *Statics) GetValue() string {
 }
 
 
-func NewStatics(value string) StaticsIface {
+func NewStatics(value string) Statics {
 	_init_.Initialize()
-	self := Statics{}
+	s := statics{}
+
 	_jsii_.Create(
 		"jsii-calc.Statics",
 		[]interface{}{value},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
+// Jsdocs for static method.
 func Statics_StaticMethod(name string) string {
 	_init_.Initialize()
 	var returns string
@@ -11360,9 +11030,9 @@ func Statics_Bar() float64 {
 	return returns
 }
 
-func Statics_ConstObj() DoubleTroubleIface {
+func Statics_ConstObj() DoubleTrouble {
 	_init_.Initialize()
-	var returns DoubleTroubleIface
+	var returns DoubleTrouble
 	_jsii_.StaticGet(
 		"jsii-calc.Statics",
 		"ConstObj",
@@ -11382,20 +11052,9 @@ func Statics_Foo() string {
 	return returns
 }
 
-func Statics_ZooBar() map[string]string {
+func Statics_Instance() Statics {
 	_init_.Initialize()
-	var returns map[string]string
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"zooBar",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_Instance() StaticsIface {
-	_init_.Initialize()
-	var returns StaticsIface
+	var returns Statics
 	_jsii_.StaticGet(
 		"jsii-calc.Statics",
 		"instance",
@@ -11404,7 +11063,7 @@ func Statics_Instance() StaticsIface {
 	return returns
 }
 
-func Statics_SetInstance(val StaticsIface) {
+func Statics_SetInstance(val Statics) {
 	_init_.Initialize()
 	_jsii_.StaticSet(
 		"jsii-calc.Statics",
@@ -11433,7 +11092,18 @@ func Statics_SetNonConstStatic(val float64) {
 	)
 }
 
-func (s *Statics) JustMethod() string {
+func Statics_ZooBar() map[string]string {
+	_init_.Initialize()
+	var returns map[string]string
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"zooBar",
+		&returns,
+	)
+	return returns
+}
+
+func (s *statics) JustMethod() string {
 	var returns string
 	_jsii_.Invoke(
 		s,
@@ -11453,18 +11123,17 @@ const (
 	StringEnum_C StringEnum = "C"
 )
 
-// Class interface
-type StripInternalIface interface {
-	GetYouSeeMe() string
+type StripInternal interface {
+	YouSeeMe() string
 	SetYouSeeMe(val string)
 }
 
-// Struct proxy
-type StripInternal struct {
-	YouSeeMe string \`json:"youSeeMe"\`
+// The jsii proxy struct for StripInternal
+type stripInternal struct {
+	_ byte // padding
 }
 
-func (s *StripInternal) GetYouSeeMe() string {
+func (s *stripInternal) YouSeeMe() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -11475,20 +11144,21 @@ func (s *StripInternal) GetYouSeeMe() string {
 }
 
 
-func NewStripInternal() StripInternalIface {
+func NewStripInternal() StripInternal {
 	_init_.Initialize()
-	self := StripInternal{}
+	s := stripInternal{}
+
 	_jsii_.Create(
 		"jsii-calc.StripInternal",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-func (s *StripInternal) SetYouSeeMe(val string) {
+func (s *stripInternal) SetYouSeeMe(val string) {
 	_jsii_.Set(
 		s,
 		"youSeeMe",
@@ -11518,26 +11188,27 @@ type StructParameterType struct {
 	Props bool \`json:"props"\`
 }
 
-// Class interface
-type StructPassingIface interface {
-}
-
 // Just because we can.
-// Struct proxy
-type StructPassing struct {
+type StructPassing interface {
 }
 
-func NewStructPassing() StructPassingIface {
+// The jsii proxy struct for StructPassing
+type structPassing struct {
+	_ byte // padding
+}
+
+func NewStructPassing() StructPassing {
 	_init_.Initialize()
-	self := StructPassing{}
+	s := structPassing{}
+
 	_jsii_.Create(
 		"jsii-calc.StructPassing",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
 func StructPassing_HowManyVarArgsDidIPass(_positional float64, inputs TopLevelStruct) float64 {
@@ -11566,12 +11237,12 @@ func StructPassing_RoundTrip(_positional float64, input TopLevelStruct) TopLevel
 	return returns
 }
 
-// Class interface
-type StructUnionConsumerIface interface {
+type StructUnionConsumer interface {
 }
 
-// Struct proxy
-type StructUnionConsumer struct {
+// The jsii proxy struct for StructUnionConsumer
+type structUnionConsumer struct {
+	_ byte // padding
 }
 
 func StructUnionConsumer_IsStructA(struct_ interface{}) bool {
@@ -11607,53 +11278,21 @@ type StructWithJavaReservedWords struct {
 	That string \`json:"that"\`
 }
 
-// Class interface
-type SumIface interface {
-	GetValue() float64
-	GetExpression() scopejsiicalclib.NumericValueIface
-	GetDecorationPostfixes() []string
-	SetDecorationPostfixes(val []string)
-	GetDecorationPrefixes() []string
-	SetDecorationPrefixes(val []string)
-	GetStringStyle() composition.CompositionStringStyle
-	SetStringStyle(val composition.CompositionStringStyle)
-	GetParts() []scopejsiicalclib.NumericValueIface
-	SetParts(val []scopejsiicalclib.NumericValueIface)
-	TypeName() interface{}
-	ToString() string
-}
-
 // An operation that sums multiple values.
-// Struct proxy
-type Sum struct {
-	// (deprecated) The value.
-	Value float64 \`json:"value"\`
-	// The expression that this operation consists of.
-	//
-	// Must be implemented by derived classes.
-	Expression scopejsiicalclib.NumericValueIface \`json:"expression"\`
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes []string \`json:"decorationPostfixes"\`
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes []string \`json:"decorationPrefixes"\`
-	// The .toString() style.
-	StringStyle composition.CompositionStringStyle \`json:"stringStyle"\`
-	// The parts to sum.
-	Parts []scopejsiicalclib.NumericValueIface \`json:"parts"\`
+type Sum interface {
+	composition.CompositeOperation
+	Expression() scopejsiicalclib.NumericValue
+	Parts() []scopejsiicalclib.NumericValue
+	SetParts(val []scopejsiicalclib.NumericValue)
 }
 
-func (s *Sum) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		s,
-		"value",
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for Sum
+type sum struct {
+	composition.CompositeOperation // extends jsii-calc.composition.CompositeOperation
 }
 
-func (s *Sum) GetExpression() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (s *sum) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		s,
 		"expression",
@@ -11662,38 +11301,8 @@ func (s *Sum) GetExpression() scopejsiicalclib.NumericValueIface {
 	return returns
 }
 
-func (s *Sum) GetDecorationPostfixes() []string {
-	var returns []string
-	_jsii_.Get(
-		s,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (s *Sum) GetDecorationPrefixes() []string {
-	var returns []string
-	_jsii_.Get(
-		s,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (s *Sum) GetStringStyle() composition.CompositionStringStyle {
-	var returns composition.CompositionStringStyle
-	_jsii_.Get(
-		s,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (s *Sum) GetParts() []scopejsiicalclib.NumericValueIface {
-	var returns []scopejsiicalclib.NumericValueIface
+func (s *sum) Parts() []scopejsiicalclib.NumericValue {
+	var returns []scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		s,
 		"parts",
@@ -11703,44 +11312,21 @@ func (s *Sum) GetParts() []scopejsiicalclib.NumericValueIface {
 }
 
 
-func NewSum() SumIface {
+func NewSum() Sum {
 	_init_.Initialize()
-	self := Sum{}
+	s := sum{}
+
 	_jsii_.Create(
 		"jsii-calc.Sum",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-func (s *Sum) SetDecorationPostfixes(val []string) {
-	_jsii_.Set(
-		s,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (s *Sum) SetDecorationPrefixes(val []string) {
-	_jsii_.Set(
-		s,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (s *Sum) SetStringStyle(val composition.CompositionStringStyle) {
-	_jsii_.Set(
-		s,
-		"stringStyle",
-		val,
-	)
-}
-
-func (s *Sum) SetParts(val []scopejsiicalclib.NumericValueIface) {
+func (s *sum) SetParts(val []scopejsiicalclib.NumericValue) {
 	_jsii_.Set(
 		s,
 		"parts",
@@ -11748,58 +11334,18 @@ func (s *Sum) SetParts(val []scopejsiicalclib.NumericValueIface) {
 	)
 }
 
-func (s *Sum) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		s,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
+type SupportsNiceJavaBuilder interface {
+	SupportsNiceJavaBuilderWithRequiredProps
+	Id() float64
+	Rest() []string
 }
 
-func (s *Sum) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		s,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for SupportsNiceJavaBuilder
+type supportsNiceJavaBuilder struct {
+	supportsNiceJavaBuilderWithRequiredProps // extends jsii-calc.SupportsNiceJavaBuilderWithRequiredProps
 }
 
-// Class interface
-type SupportsNiceJavaBuilderIface interface {
-	GetBar() float64
-	GetId() float64
-	GetPropId() string
-	GetRest() []string
-}
-
-// Struct proxy
-type SupportsNiceJavaBuilder struct {
-	Bar float64 \`json:"bar"\`
-	// some identifier.
-	Id float64 \`json:"id"\`
-	PropId string \`json:"propId"\`
-	Rest []string \`json:"rest"\`
-}
-
-func (s *SupportsNiceJavaBuilder) GetBar() float64 {
-	var returns float64
-	_jsii_.Get(
-		s,
-		"bar",
-		&returns,
-	)
-	return returns
-}
-
-func (s *SupportsNiceJavaBuilder) GetId() float64 {
+func (s *supportsNiceJavaBuilder) Id() float64 {
 	var returns float64
 	_jsii_.Get(
 		s,
@@ -11809,17 +11355,7 @@ func (s *SupportsNiceJavaBuilder) GetId() float64 {
 	return returns
 }
 
-func (s *SupportsNiceJavaBuilder) GetPropId() string {
-	var returns string
-	_jsii_.Get(
-		s,
-		"propId",
-		&returns,
-	)
-	return returns
-}
-
-func (s *SupportsNiceJavaBuilder) GetRest() []string {
+func (s *supportsNiceJavaBuilder) Rest() []string {
 	var returns []string
 	_jsii_.Get(
 		s,
@@ -11830,17 +11366,18 @@ func (s *SupportsNiceJavaBuilder) GetRest() []string {
 }
 
 
-func NewSupportsNiceJavaBuilder(id float64, defaultBar float64, props SupportsNiceJavaBuilderProps, rest string) SupportsNiceJavaBuilderIface {
+func NewSupportsNiceJavaBuilder(id float64, defaultBar float64, props SupportsNiceJavaBuilderProps, rest string) SupportsNiceJavaBuilder {
 	_init_.Initialize()
-	self := SupportsNiceJavaBuilder{}
+	s := supportsNiceJavaBuilder{}
+
 	_jsii_.Create(
 		"jsii-calc.SupportsNiceJavaBuilder",
 		[]interface{}{id, defaultBar, props, rest},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
 type SupportsNiceJavaBuilderProps struct {
@@ -11852,23 +11389,19 @@ type SupportsNiceJavaBuilderProps struct {
 	Id string \`json:"id"\`
 }
 
-// Class interface
-type SupportsNiceJavaBuilderWithRequiredPropsIface interface {
-	GetBar() float64
-	GetId() float64
-	GetPropId() string
-}
-
 // We can generate fancy builders in Java for classes which take a mix of positional & struct parameters.
-// Struct proxy
-type SupportsNiceJavaBuilderWithRequiredProps struct {
-	Bar float64 \`json:"bar"\`
-	// some identifier of your choice.
-	Id float64 \`json:"id"\`
-	PropId string \`json:"propId"\`
+type SupportsNiceJavaBuilderWithRequiredProps interface {
+	Bar() float64
+	Id() float64
+	PropId() string
 }
 
-func (s *SupportsNiceJavaBuilderWithRequiredProps) GetBar() float64 {
+// The jsii proxy struct for SupportsNiceJavaBuilderWithRequiredProps
+type supportsNiceJavaBuilderWithRequiredProps struct {
+	_ byte // padding
+}
+
+func (s *supportsNiceJavaBuilderWithRequiredProps) Bar() float64 {
 	var returns float64
 	_jsii_.Get(
 		s,
@@ -11878,7 +11411,7 @@ func (s *SupportsNiceJavaBuilderWithRequiredProps) GetBar() float64 {
 	return returns
 }
 
-func (s *SupportsNiceJavaBuilderWithRequiredProps) GetId() float64 {
+func (s *supportsNiceJavaBuilderWithRequiredProps) Id() float64 {
 	var returns float64
 	_jsii_.Get(
 		s,
@@ -11888,7 +11421,7 @@ func (s *SupportsNiceJavaBuilderWithRequiredProps) GetId() float64 {
 	return returns
 }
 
-func (s *SupportsNiceJavaBuilderWithRequiredProps) GetPropId() string {
+func (s *supportsNiceJavaBuilderWithRequiredProps) PropId() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -11899,31 +11432,31 @@ func (s *SupportsNiceJavaBuilderWithRequiredProps) GetPropId() string {
 }
 
 
-func NewSupportsNiceJavaBuilderWithRequiredProps(id float64, props SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredPropsIface {
+func NewSupportsNiceJavaBuilderWithRequiredProps(id float64, props SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredProps {
 	_init_.Initialize()
-	self := SupportsNiceJavaBuilderWithRequiredProps{}
+	s := supportsNiceJavaBuilderWithRequiredProps{}
+
 	_jsii_.Create(
 		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
 		[]interface{}{id, props},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-// Class interface
-type SyncVirtualMethodsIface interface {
-	GetReadonlyProperty() string
-	GetA() float64
+type SyncVirtualMethods interface {
+	A() float64
 	SetA(val float64)
-	GetCallerIsProperty() float64
+	CallerIsProperty() float64
 	SetCallerIsProperty(val float64)
-	GetOtherProperty() string
+	OtherProperty() string
 	SetOtherProperty(val string)
-	GetTheProperty() string
+	ReadonlyProperty() string
+	TheProperty() string
 	SetTheProperty(val string)
-	GetValueOfOtherProperty() string
+	ValueOfOtherProperty() string
 	SetValueOfOtherProperty(val string)
 	CallerIsAsync() float64
 	CallerIsMethod() float64
@@ -11937,17 +11470,42 @@ type SyncVirtualMethodsIface interface {
 	WriteA(value float64)
 }
 
-// Struct proxy
-type SyncVirtualMethods struct {
-	ReadonlyProperty string \`json:"readonlyProperty"\`
-	A float64 \`json:"a"\`
-	CallerIsProperty float64 \`json:"callerIsProperty"\`
-	OtherProperty string \`json:"otherProperty"\`
-	TheProperty string \`json:"theProperty"\`
-	ValueOfOtherProperty string \`json:"valueOfOtherProperty"\`
+// The jsii proxy struct for SyncVirtualMethods
+type syncVirtualMethods struct {
+	_ byte // padding
 }
 
-func (s *SyncVirtualMethods) GetReadonlyProperty() string {
+func (s *syncVirtualMethods) A() float64 {
+	var returns float64
+	_jsii_.Get(
+		s,
+		"a",
+		&returns,
+	)
+	return returns
+}
+
+func (s *syncVirtualMethods) CallerIsProperty() float64 {
+	var returns float64
+	_jsii_.Get(
+		s,
+		"callerIsProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (s *syncVirtualMethods) OtherProperty() string {
+	var returns string
+	_jsii_.Get(
+		s,
+		"otherProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (s *syncVirtualMethods) ReadonlyProperty() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -11957,37 +11515,7 @@ func (s *SyncVirtualMethods) GetReadonlyProperty() string {
 	return returns
 }
 
-func (s *SyncVirtualMethods) GetA() float64 {
-	var returns float64
-	_jsii_.Get(
-		s,
-		"a",
-		&returns,
-	)
-	return returns
-}
-
-func (s *SyncVirtualMethods) GetCallerIsProperty() float64 {
-	var returns float64
-	_jsii_.Get(
-		s,
-		"callerIsProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (s *SyncVirtualMethods) GetOtherProperty() string {
-	var returns string
-	_jsii_.Get(
-		s,
-		"otherProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (s *SyncVirtualMethods) GetTheProperty() string {
+func (s *syncVirtualMethods) TheProperty() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -11997,7 +11525,7 @@ func (s *SyncVirtualMethods) GetTheProperty() string {
 	return returns
 }
 
-func (s *SyncVirtualMethods) GetValueOfOtherProperty() string {
+func (s *syncVirtualMethods) ValueOfOtherProperty() string {
 	var returns string
 	_jsii_.Get(
 		s,
@@ -12008,20 +11536,21 @@ func (s *SyncVirtualMethods) GetValueOfOtherProperty() string {
 }
 
 
-func NewSyncVirtualMethods() SyncVirtualMethodsIface {
+func NewSyncVirtualMethods() SyncVirtualMethods {
 	_init_.Initialize()
-	self := SyncVirtualMethods{}
+	s := syncVirtualMethods{}
+
 	_jsii_.Create(
 		"jsii-calc.SyncVirtualMethods",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&s,
 	)
-	return &self
+	return &s
 }
 
-func (s *SyncVirtualMethods) SetA(val float64) {
+func (s *syncVirtualMethods) SetA(val float64) {
 	_jsii_.Set(
 		s,
 		"a",
@@ -12029,7 +11558,7 @@ func (s *SyncVirtualMethods) SetA(val float64) {
 	)
 }
 
-func (s *SyncVirtualMethods) SetCallerIsProperty(val float64) {
+func (s *syncVirtualMethods) SetCallerIsProperty(val float64) {
 	_jsii_.Set(
 		s,
 		"callerIsProperty",
@@ -12037,7 +11566,7 @@ func (s *SyncVirtualMethods) SetCallerIsProperty(val float64) {
 	)
 }
 
-func (s *SyncVirtualMethods) SetOtherProperty(val string) {
+func (s *syncVirtualMethods) SetOtherProperty(val string) {
 	_jsii_.Set(
 		s,
 		"otherProperty",
@@ -12045,7 +11574,7 @@ func (s *SyncVirtualMethods) SetOtherProperty(val string) {
 	)
 }
 
-func (s *SyncVirtualMethods) SetTheProperty(val string) {
+func (s *syncVirtualMethods) SetTheProperty(val string) {
 	_jsii_.Set(
 		s,
 		"theProperty",
@@ -12053,7 +11582,7 @@ func (s *SyncVirtualMethods) SetTheProperty(val string) {
 	)
 }
 
-func (s *SyncVirtualMethods) SetValueOfOtherProperty(val string) {
+func (s *syncVirtualMethods) SetValueOfOtherProperty(val string) {
 	_jsii_.Set(
 		s,
 		"valueOfOtherProperty",
@@ -12061,7 +11590,7 @@ func (s *SyncVirtualMethods) SetValueOfOtherProperty(val string) {
 	)
 }
 
-func (s *SyncVirtualMethods) CallerIsAsync() float64 {
+func (s *syncVirtualMethods) CallerIsAsync() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		s,
@@ -12073,7 +11602,7 @@ func (s *SyncVirtualMethods) CallerIsAsync() float64 {
 	return returns
 }
 
-func (s *SyncVirtualMethods) CallerIsMethod() float64 {
+func (s *syncVirtualMethods) CallerIsMethod() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		s,
@@ -12085,7 +11614,7 @@ func (s *SyncVirtualMethods) CallerIsMethod() float64 {
 	return returns
 }
 
-func (s *SyncVirtualMethods) ModifyOtherProperty(value string) {
+func (s *syncVirtualMethods) ModifyOtherProperty(value string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		s,
@@ -12096,7 +11625,7 @@ func (s *SyncVirtualMethods) ModifyOtherProperty(value string) {
 	)
 }
 
-func (s *SyncVirtualMethods) ModifyValueOfTheProperty(value string) {
+func (s *syncVirtualMethods) ModifyValueOfTheProperty(value string) {
 	var returns interface{}
 	_jsii_.Invoke(
 		s,
@@ -12107,7 +11636,7 @@ func (s *SyncVirtualMethods) ModifyValueOfTheProperty(value string) {
 	)
 }
 
-func (s *SyncVirtualMethods) ReadA() float64 {
+func (s *syncVirtualMethods) ReadA() float64 {
 	var returns float64
 	_jsii_.Invoke(
 		s,
@@ -12119,7 +11648,7 @@ func (s *SyncVirtualMethods) ReadA() float64 {
 	return returns
 }
 
-func (s *SyncVirtualMethods) RetrieveOtherProperty() string {
+func (s *syncVirtualMethods) RetrieveOtherProperty() string {
 	var returns string
 	_jsii_.Invoke(
 		s,
@@ -12131,7 +11660,7 @@ func (s *SyncVirtualMethods) RetrieveOtherProperty() string {
 	return returns
 }
 
-func (s *SyncVirtualMethods) RetrieveReadOnlyProperty() string {
+func (s *syncVirtualMethods) RetrieveReadOnlyProperty() string {
 	var returns string
 	_jsii_.Invoke(
 		s,
@@ -12143,7 +11672,7 @@ func (s *SyncVirtualMethods) RetrieveReadOnlyProperty() string {
 	return returns
 }
 
-func (s *SyncVirtualMethods) RetrieveValueOfTheProperty() string {
+func (s *syncVirtualMethods) RetrieveValueOfTheProperty() string {
 	var returns string
 	_jsii_.Invoke(
 		s,
@@ -12155,7 +11684,7 @@ func (s *SyncVirtualMethods) RetrieveValueOfTheProperty() string {
 	return returns
 }
 
-func (s *SyncVirtualMethods) VirtualMethod(n float64) float64 {
+func (s *syncVirtualMethods) VirtualMethod(n float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		s,
@@ -12167,7 +11696,7 @@ func (s *SyncVirtualMethods) VirtualMethod(n float64) float64 {
 	return returns
 }
 
-func (s *SyncVirtualMethods) WriteA(value float64) {
+func (s *syncVirtualMethods) WriteA(value float64) {
 	var returns interface{}
 	_jsii_.Invoke(
 		s,
@@ -12178,29 +11707,30 @@ func (s *SyncVirtualMethods) WriteA(value float64) {
 	)
 }
 
-// Class interface
-type ThrowerIface interface {
+type Thrower interface {
 	ThrowError()
 }
 
-// Struct proxy
-type Thrower struct {
+// The jsii proxy struct for Thrower
+type thrower struct {
+	_ byte // padding
 }
 
-func NewThrower() ThrowerIface {
+func NewThrower() Thrower {
 	_init_.Initialize()
-	self := Thrower{}
+	t := thrower{}
+
 	_jsii_.Create(
 		"jsii-calc.Thrower",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&t,
 	)
-	return &self
+	return &t
 }
 
-func (t *Thrower) ThrowError() {
+func (t *thrower) ThrowError() {
 	var returns interface{}
 	_jsii_.Invoke(
 		t,
@@ -12220,17 +11750,18 @@ type TopLevelStruct struct {
 	Optional string \`json:"optional"\`
 }
 
-// Class interface
-type UmaskCheckIface interface {
-}
-
 // Checks the current file permissions are cool (no funky UMASK down-scoping happened).
 // See: https://github.com/aws/jsii/issues/1765
 //
-// Struct proxy
-type UmaskCheck struct {
+type UmaskCheck interface {
 }
 
+// The jsii proxy struct for UmaskCheck
+type umaskCheck struct {
+	_ byte // padding
+}
+
+// This should return 0o644 (-rw-r--r--).
 func UmaskCheck_Mode() float64 {
 	_init_.Initialize()
 	var returns float64
@@ -12244,35 +11775,19 @@ func UmaskCheck_Mode() float64 {
 	return returns
 }
 
-// Class interface
-type UnaryOperationIface interface {
-	GetValue() float64
-	GetOperand() scopejsiicalclib.NumericValueIface
-	TypeName() interface{}
-	ToString() string
-}
-
 // An operation on a single operand.
-// Struct proxy
-type UnaryOperation struct {
-	// The value.
-	// Deprecated.
-	Value float64 \`json:"value"\`
-	Operand scopejsiicalclib.NumericValueIface \`json:"operand"\`
+type UnaryOperation interface {
+	scopejsiicalclib.Operation
+	Operand() scopejsiicalclib.NumericValue
 }
 
-func (u *UnaryOperation) GetValue() float64 {
-	var returns float64
-	_jsii_.Get(
-		u,
-		"value",
-		&returns,
-	)
-	return returns
+// The jsii proxy struct for UnaryOperation
+type unaryOperation struct {
+	scopejsiicalclib.Operation // extends @scope/jsii-calc-lib.Operation
 }
 
-func (u *UnaryOperation) GetOperand() scopejsiicalclib.NumericValueIface {
-	var returns scopejsiicalclib.NumericValueIface
+func (u *unaryOperation) Operand() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		u,
 		"operand",
@@ -12282,41 +11797,18 @@ func (u *UnaryOperation) GetOperand() scopejsiicalclib.NumericValueIface {
 }
 
 
-func NewUnaryOperation(operand scopejsiicalclib.NumericValueIface) UnaryOperationIface {
+func NewUnaryOperation(operand scopejsiicalclib.NumericValue) UnaryOperation {
 	_init_.Initialize()
-	self := UnaryOperation{}
+	u := unaryOperation{}
+
 	_jsii_.Create(
 		"jsii-calc.UnaryOperation",
 		[]interface{}{operand},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&u,
 	)
-	return &self
-}
-
-func (u *UnaryOperation) TypeName() interface{} {
-	var returns interface{}
-	_jsii_.Invoke(
-		u,
-		"typeName",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
-}
-
-func (u *UnaryOperation) ToString() string {
-	var returns string
-	_jsii_.Invoke(
-		u,
-		"toString",
-		[]interface{}{},
-		true,
-		&returns,
-	)
-	return returns
+	return &u
 }
 
 type UnionProperties struct {
@@ -12324,19 +11816,18 @@ type UnionProperties struct {
 	Foo interface{} \`json:"foo"\`
 }
 
-// Class interface
-type UpcasingReflectableIface interface {
-	submodule.IReflectableIface
-	GetEntries() []submodule.ReflectableEntry
-}
-
 // Ensures submodule-imported types from dependencies can be used correctly.
-// Struct proxy
-type UpcasingReflectable struct {
-	Entries []submodule.ReflectableEntry \`json:"entries"\`
+type UpcasingReflectable interface {
+	submodule.IReflectable
+	Entries() []submodule.ReflectableEntry
 }
 
-func (u *UpcasingReflectable) GetEntries() []submodule.ReflectableEntry {
+// The jsii proxy struct for UpcasingReflectable
+type upcasingReflectable struct {
+	submodule.IReflectable // implements @scope/jsii-calc-lib.submodule.IReflectable
+}
+
+func (u *upcasingReflectable) Entries() []submodule.ReflectableEntry {
 	var returns []submodule.ReflectableEntry
 	_jsii_.Get(
 		u,
@@ -12347,22 +11838,23 @@ func (u *UpcasingReflectable) GetEntries() []submodule.ReflectableEntry {
 }
 
 
-func NewUpcasingReflectable(delegate map[string]interface{}) UpcasingReflectableIface {
+func NewUpcasingReflectable(delegate map[string]interface{}) UpcasingReflectable {
 	_init_.Initialize()
-	self := UpcasingReflectable{}
+	u := upcasingReflectable{}
+
 	_jsii_.Create(
 		"jsii-calc.UpcasingReflectable",
 		[]interface{}{delegate},
 		[]_jsii_.FQN{"@scope/jsii-calc-lib.submodule.IReflectable"},
 		[]_jsii_.Override{},
-		&self,
+		&u,
 	)
-	return &self
+	return &u
 }
 
-func UpcasingReflectable_Reflector() submodule.ReflectorIface {
+func UpcasingReflectable_Reflector() submodule.Reflector {
 	_init_.Initialize()
-	var returns submodule.ReflectorIface
+	var returns submodule.Reflector
 	_jsii_.StaticGet(
 		"jsii-calc.UpcasingReflectable",
 		"reflector",
@@ -12371,29 +11863,30 @@ func UpcasingReflectable_Reflector() submodule.ReflectorIface {
 	return returns
 }
 
-// Class interface
-type UseBundledDependencyIface interface {
+type UseBundledDependency interface {
 	Value() interface{}
 }
 
-// Struct proxy
-type UseBundledDependency struct {
+// The jsii proxy struct for UseBundledDependency
+type useBundledDependency struct {
+	_ byte // padding
 }
 
-func NewUseBundledDependency() UseBundledDependencyIface {
+func NewUseBundledDependency() UseBundledDependency {
 	_init_.Initialize()
-	self := UseBundledDependency{}
+	u := useBundledDependency{}
+
 	_jsii_.Create(
 		"jsii-calc.UseBundledDependency",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&u,
 	)
-	return &self
+	return &u
 }
 
-func (u *UseBundledDependency) Value() interface{} {
+func (u *useBundledDependency) Value() interface{} {
 	var returns interface{}
 	_jsii_.Invoke(
 		u,
@@ -12405,31 +11898,32 @@ func (u *UseBundledDependency) Value() interface{} {
 	return returns
 }
 
-// Class interface
-type UseCalcBaseIface interface {
-	Hello() scopejsiicalcbase.BaseIface
-}
-
 // Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
-// Struct proxy
-type UseCalcBase struct {
+type UseCalcBase interface {
+	Hello() scopejsiicalcbase.Base
 }
 
-func NewUseCalcBase() UseCalcBaseIface {
+// The jsii proxy struct for UseCalcBase
+type useCalcBase struct {
+	_ byte // padding
+}
+
+func NewUseCalcBase() UseCalcBase {
 	_init_.Initialize()
-	self := UseCalcBase{}
+	u := useCalcBase{}
+
 	_jsii_.Create(
 		"jsii-calc.UseCalcBase",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&u,
 	)
-	return &self
+	return &u
 }
 
-func (u *UseCalcBase) Hello() scopejsiicalcbase.BaseIface {
-	var returns scopejsiicalcbase.BaseIface
+func (u *useCalcBase) Hello() scopejsiicalcbase.Base {
+	var returns scopejsiicalcbase.Base
 	_jsii_.Invoke(
 		u,
 		"hello",
@@ -12440,21 +11934,20 @@ func (u *UseCalcBase) Hello() scopejsiicalcbase.BaseIface {
 	return returns
 }
 
-// Class interface
-type UsesInterfaceWithPropertiesIface interface {
-	GetObj() IInterfaceWithPropertiesIface
+type UsesInterfaceWithProperties interface {
+	Obj() IInterfaceWithProperties
 	JustRead() string
-	ReadStringAndNumber(ext IInterfaceWithPropertiesExtensionIface) string
+	ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) string
 	WriteAndRead(value string) string
 }
 
-// Struct proxy
-type UsesInterfaceWithProperties struct {
-	Obj IInterfaceWithPropertiesIface \`json:"obj"\`
+// The jsii proxy struct for UsesInterfaceWithProperties
+type usesInterfaceWithProperties struct {
+	_ byte // padding
 }
 
-func (u *UsesInterfaceWithProperties) GetObj() IInterfaceWithPropertiesIface {
-	var returns IInterfaceWithPropertiesIface
+func (u *usesInterfaceWithProperties) Obj() IInterfaceWithProperties {
+	var returns IInterfaceWithProperties
 	_jsii_.Get(
 		u,
 		"obj",
@@ -12464,20 +11957,21 @@ func (u *UsesInterfaceWithProperties) GetObj() IInterfaceWithPropertiesIface {
 }
 
 
-func NewUsesInterfaceWithProperties(obj IInterfaceWithPropertiesIface) UsesInterfaceWithPropertiesIface {
+func NewUsesInterfaceWithProperties(obj IInterfaceWithProperties) UsesInterfaceWithProperties {
 	_init_.Initialize()
-	self := UsesInterfaceWithProperties{}
+	u := usesInterfaceWithProperties{}
+
 	_jsii_.Create(
 		"jsii-calc.UsesInterfaceWithProperties",
 		[]interface{}{obj},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&u,
 	)
-	return &self
+	return &u
 }
 
-func (u *UsesInterfaceWithProperties) JustRead() string {
+func (u *usesInterfaceWithProperties) JustRead() string {
 	var returns string
 	_jsii_.Invoke(
 		u,
@@ -12489,7 +11983,7 @@ func (u *UsesInterfaceWithProperties) JustRead() string {
 	return returns
 }
 
-func (u *UsesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithPropertiesExtensionIface) string {
+func (u *usesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) string {
 	var returns string
 	_jsii_.Invoke(
 		u,
@@ -12501,7 +11995,7 @@ func (u *UsesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithProp
 	return returns
 }
 
-func (u *UsesInterfaceWithProperties) WriteAndRead(value string) string {
+func (u *usesInterfaceWithProperties) WriteAndRead(value string) string {
 	var returns string
 	_jsii_.Invoke(
 		u,
@@ -12513,29 +12007,30 @@ func (u *UsesInterfaceWithProperties) WriteAndRead(value string) string {
 	return returns
 }
 
-// Class interface
-type VariadicInvokerIface interface {
+type VariadicInvoker interface {
 	AsArray(values float64) []float64
 }
 
-// Struct proxy
-type VariadicInvoker struct {
+// The jsii proxy struct for VariadicInvoker
+type variadicInvoker struct {
+	_ byte // padding
 }
 
-func NewVariadicInvoker(method VariadicMethodIface) VariadicInvokerIface {
+func NewVariadicInvoker(method VariadicMethod) VariadicInvoker {
 	_init_.Initialize()
-	self := VariadicInvoker{}
+	v := variadicInvoker{}
+
 	_jsii_.Create(
 		"jsii-calc.VariadicInvoker",
 		[]interface{}{method},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&v,
 	)
-	return &self
+	return &v
 }
 
-func (v *VariadicInvoker) AsArray(values float64) []float64 {
+func (v *variadicInvoker) AsArray(values float64) []float64 {
 	var returns []float64
 	_jsii_.Invoke(
 		v,
@@ -12547,29 +12042,30 @@ func (v *VariadicInvoker) AsArray(values float64) []float64 {
 	return returns
 }
 
-// Class interface
-type VariadicMethodIface interface {
+type VariadicMethod interface {
 	AsArray(first float64, others float64) []float64
 }
 
-// Struct proxy
-type VariadicMethod struct {
+// The jsii proxy struct for VariadicMethod
+type variadicMethod struct {
+	_ byte // padding
 }
 
-func NewVariadicMethod(prefix float64) VariadicMethodIface {
+func NewVariadicMethod(prefix float64) VariadicMethod {
 	_init_.Initialize()
-	self := VariadicMethod{}
+	v := variadicMethod{}
+
 	_jsii_.Create(
 		"jsii-calc.VariadicMethod",
 		[]interface{}{prefix},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&v,
 	)
-	return &self
+	return &v
 }
 
-func (v *VariadicMethod) AsArray(first float64, others float64) []float64 {
+func (v *variadicMethod) AsArray(first float64, others float64) []float64 {
 	var returns []float64
 	_jsii_.Invoke(
 		v,
@@ -12581,8 +12077,7 @@ func (v *VariadicMethod) AsArray(first float64, others float64) []float64 {
 	return returns
 }
 
-// Class interface
-type VirtualMethodPlaygroundIface interface {
+type VirtualMethodPlayground interface {
 	OverrideMeAsync(index float64) float64
 	OverrideMeSync(index float64) float64
 	ParallelSumAsync(count float64) float64
@@ -12590,24 +12085,26 @@ type VirtualMethodPlaygroundIface interface {
 	SumSync(count float64) float64
 }
 
-// Struct proxy
-type VirtualMethodPlayground struct {
+// The jsii proxy struct for VirtualMethodPlayground
+type virtualMethodPlayground struct {
+	_ byte // padding
 }
 
-func NewVirtualMethodPlayground() VirtualMethodPlaygroundIface {
+func NewVirtualMethodPlayground() VirtualMethodPlayground {
 	_init_.Initialize()
-	self := VirtualMethodPlayground{}
+	v := virtualMethodPlayground{}
+
 	_jsii_.Create(
 		"jsii-calc.VirtualMethodPlayground",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&v,
 	)
-	return &self
+	return &v
 }
 
-func (v *VirtualMethodPlayground) OverrideMeAsync(index float64) float64 {
+func (v *virtualMethodPlayground) OverrideMeAsync(index float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -12619,7 +12116,7 @@ func (v *VirtualMethodPlayground) OverrideMeAsync(index float64) float64 {
 	return returns
 }
 
-func (v *VirtualMethodPlayground) OverrideMeSync(index float64) float64 {
+func (v *virtualMethodPlayground) OverrideMeSync(index float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -12631,7 +12128,7 @@ func (v *VirtualMethodPlayground) OverrideMeSync(index float64) float64 {
 	return returns
 }
 
-func (v *VirtualMethodPlayground) ParallelSumAsync(count float64) float64 {
+func (v *virtualMethodPlayground) ParallelSumAsync(count float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -12643,7 +12140,7 @@ func (v *VirtualMethodPlayground) ParallelSumAsync(count float64) float64 {
 	return returns
 }
 
-func (v *VirtualMethodPlayground) SerialSumAsync(count float64) float64 {
+func (v *virtualMethodPlayground) SerialSumAsync(count float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -12655,7 +12152,7 @@ func (v *VirtualMethodPlayground) SerialSumAsync(count float64) float64 {
 	return returns
 }
 
-func (v *VirtualMethodPlayground) SumSync(count float64) float64 {
+func (v *virtualMethodPlayground) SumSync(count float64) float64 {
 	var returns float64
 	_jsii_.Invoke(
 		v,
@@ -12667,24 +12164,23 @@ func (v *VirtualMethodPlayground) SumSync(count float64) float64 {
 	return returns
 }
 
-// Class interface
-type VoidCallbackIface interface {
-	GetMethodWasCalled() bool
-	CallMe()
-	OverrideMe()
-}
-
 // This test is used to validate the runtimes can return correctly from a void callback.
 //
 // - Implement \`overrideMe\` (method does not have to do anything).
 // - Invoke \`callMe\`
 // - Verify that \`methodWasCalled\` is \`true\`.
-// Struct proxy
-type VoidCallback struct {
-	MethodWasCalled bool \`json:"methodWasCalled"\`
+type VoidCallback interface {
+	MethodWasCalled() bool
+	CallMe()
+	OverrideMe()
 }
 
-func (v *VoidCallback) GetMethodWasCalled() bool {
+// The jsii proxy struct for VoidCallback
+type voidCallback struct {
+	_ byte // padding
+}
+
+func (v *voidCallback) MethodWasCalled() bool {
 	var returns bool
 	_jsii_.Get(
 		v,
@@ -12695,20 +12191,21 @@ func (v *VoidCallback) GetMethodWasCalled() bool {
 }
 
 
-func NewVoidCallback() VoidCallbackIface {
+func NewVoidCallback() VoidCallback {
 	_init_.Initialize()
-	self := VoidCallback{}
+	v := voidCallback{}
+
 	_jsii_.Create(
 		"jsii-calc.VoidCallback",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&v,
 	)
-	return &self
+	return &v
 }
 
-func (v *VoidCallback) CallMe() {
+func (v *voidCallback) CallMe() {
 	var returns interface{}
 	_jsii_.Invoke(
 		v,
@@ -12719,7 +12216,7 @@ func (v *VoidCallback) CallMe() {
 	)
 }
 
-func (v *VoidCallback) OverrideMe() {
+func (v *voidCallback) OverrideMe() {
 	var returns interface{}
 	_jsii_.Invoke(
 		v,
@@ -12730,18 +12227,17 @@ func (v *VoidCallback) OverrideMe() {
 	)
 }
 
-// Class interface
-type WithPrivatePropertyInConstructorIface interface {
-	GetSuccess() bool
-}
-
 // Verifies that private property declarations in constructor arguments are hidden.
-// Struct proxy
-type WithPrivatePropertyInConstructor struct {
-	Success bool \`json:"success"\`
+type WithPrivatePropertyInConstructor interface {
+	Success() bool
 }
 
-func (w *WithPrivatePropertyInConstructor) GetSuccess() bool {
+// The jsii proxy struct for WithPrivatePropertyInConstructor
+type withPrivatePropertyInConstructor struct {
+	_ byte // padding
+}
+
+func (w *withPrivatePropertyInConstructor) Success() bool {
 	var returns bool
 	_jsii_.Get(
 		w,
@@ -12752,17 +12248,18 @@ func (w *WithPrivatePropertyInConstructor) GetSuccess() bool {
 }
 
 
-func NewWithPrivatePropertyInConstructor(privateField string) WithPrivatePropertyInConstructorIface {
+func NewWithPrivatePropertyInConstructor(privateField string) WithPrivatePropertyInConstructor {
 	_init_.Initialize()
-	self := WithPrivatePropertyInConstructor{}
+	w := withPrivatePropertyInConstructor{}
+
 	_jsii_.Create(
 		"jsii-calc.WithPrivatePropertyInConstructor",
 		[]interface{}{privateField},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&w,
 	)
-	return &self
+	return &w
 }
 
 
@@ -12781,32 +12278,49 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.AbstractClass",
 		reflect.TypeOf((*AbstractClass)(nil)).Elem(),
-		reflect.TypeOf((*AbstractClassIface)(nil)).Elem(),
+		func() interface{} {
+			a := abstractClass{}
+			_jsii_.InitJsiiProxy(&a.abstractClassBase)
+			_jsii_.InitJsiiProxy(&a.iInterfaceImplementedByAbstractClass)
+			return &a
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AbstractClassBase",
 		reflect.TypeOf((*AbstractClassBase)(nil)).Elem(),
-		reflect.TypeOf((*AbstractClassBaseIface)(nil)).Elem(),
+		func() interface{} {
+			return &abstractClassBase{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AbstractClassReturner",
 		reflect.TypeOf((*AbstractClassReturner)(nil)).Elem(),
-		reflect.TypeOf((*AbstractClassReturnerIface)(nil)).Elem(),
+		func() interface{} {
+			return &abstractClassReturner{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AbstractSuite",
 		reflect.TypeOf((*AbstractSuite)(nil)).Elem(),
-		reflect.TypeOf((*AbstractSuiteIface)(nil)).Elem(),
+		func() interface{} {
+			return &abstractSuite{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Add",
 		reflect.TypeOf((*Add)(nil)).Elem(),
-		reflect.TypeOf((*AddIface)(nil)).Elem(),
+		func() interface{} {
+			a := add{}
+			_jsii_.InitJsiiProxy(&a.binaryOperation)
+			return &a
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AllTypes",
 		reflect.TypeOf((*AllTypes)(nil)).Elem(),
-		reflect.TypeOf((*AllTypesIface)(nil)).Elem(),
+		func() interface{} {
+			return &allTypes{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.AllTypesEnum",
@@ -12820,52 +12334,81 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.AllowedMethodNames",
 		reflect.TypeOf((*AllowedMethodNames)(nil)).Elem(),
-		reflect.TypeOf((*AllowedMethodNamesIface)(nil)).Elem(),
+		func() interface{} {
+			return &allowedMethodNames{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AmbiguousParameters",
 		reflect.TypeOf((*AmbiguousParameters)(nil)).Elem(),
-		reflect.TypeOf((*AmbiguousParametersIface)(nil)).Elem(),
+		func() interface{} {
+			return &ambiguousParameters{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AnonymousImplementationProvider",
 		reflect.TypeOf((*AnonymousImplementationProvider)(nil)).Elem(),
-		reflect.TypeOf((*AnonymousImplementationProviderIface)(nil)).Elem(),
+		func() interface{} {
+			a := anonymousImplementationProvider{}
+			_jsii_.InitJsiiProxy(&a.iAnonymousImplementationProvider)
+			return &a
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AsyncVirtualMethods",
 		reflect.TypeOf((*AsyncVirtualMethods)(nil)).Elem(),
-		reflect.TypeOf((*AsyncVirtualMethodsIface)(nil)).Elem(),
+		func() interface{} {
+			return &asyncVirtualMethods{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.AugmentableClass",
 		reflect.TypeOf((*AugmentableClass)(nil)).Elem(),
-		reflect.TypeOf((*AugmentableClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &augmentableClass{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.BaseJsii976",
 		reflect.TypeOf((*BaseJsii976)(nil)).Elem(),
-		reflect.TypeOf((*BaseJsii976Iface)(nil)).Elem(),
+		func() interface{} {
+			return &baseJsii976{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Bell",
 		reflect.TypeOf((*Bell)(nil)).Elem(),
-		reflect.TypeOf((*BellIface)(nil)).Elem(),
+		func() interface{} {
+			b := bell{}
+			_jsii_.InitJsiiProxy(&b.iBell)
+			return &b
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.BinaryOperation",
 		reflect.TypeOf((*BinaryOperation)(nil)).Elem(),
-		reflect.TypeOf((*BinaryOperationIface)(nil)).Elem(),
+		func() interface{} {
+			b := binaryOperation{}
+			_jsii_.InitJsiiProxy(&b.Operation)
+			_jsii_.InitJsiiProxy(&b.IFriendly)
+			return &b
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.BurriedAnonymousObject",
 		reflect.TypeOf((*BurriedAnonymousObject)(nil)).Elem(),
-		reflect.TypeOf((*BurriedAnonymousObjectIface)(nil)).Elem(),
+		func() interface{} {
+			return &burriedAnonymousObject{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Calculator",
 		reflect.TypeOf((*Calculator)(nil)).Elem(),
-		reflect.TypeOf((*CalculatorIface)(nil)).Elem(),
+		func() interface{} {
+			c := calculator{}
+			_jsii_.InitJsiiProxy(&c.CompositeOperation)
+			return &c
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.CalculatorProps",
@@ -12878,42 +12421,64 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassThatImplementsTheInternalInterface",
 		reflect.TypeOf((*ClassThatImplementsTheInternalInterface)(nil)).Elem(),
-		reflect.TypeOf((*ClassThatImplementsTheInternalInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			c := classThatImplementsTheInternalInterface{}
+			_jsii_.InitJsiiProxy(&c.iNonInternalInterface)
+			return &c
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassThatImplementsThePrivateInterface",
 		reflect.TypeOf((*ClassThatImplementsThePrivateInterface)(nil)).Elem(),
-		reflect.TypeOf((*ClassThatImplementsThePrivateInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			c := classThatImplementsThePrivateInterface{}
+			_jsii_.InitJsiiProxy(&c.iNonInternalInterface)
+			return &c
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassWithCollections",
 		reflect.TypeOf((*ClassWithCollections)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithCollectionsIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithCollections{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassWithDocs",
 		reflect.TypeOf((*ClassWithDocs)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithDocsIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithDocs{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassWithJavaReservedWords",
 		reflect.TypeOf((*ClassWithJavaReservedWords)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithJavaReservedWordsIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithJavaReservedWords{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassWithMutableObjectLiteralProperty",
 		reflect.TypeOf((*ClassWithMutableObjectLiteralProperty)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithMutableObjectLiteralPropertyIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithMutableObjectLiteralProperty{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
 		reflect.TypeOf((*ClassWithPrivateConstructorAndAutomaticProperties)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithPrivateConstructorAndAutomaticPropertiesIface)(nil)).Elem(),
+		func() interface{} {
+			c := classWithPrivateConstructorAndAutomaticProperties{}
+			_jsii_.InitJsiiProxy(&c.iInterfaceWithProperties)
+			return &c
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ConfusingToJackson",
 		reflect.TypeOf((*ConfusingToJackson)(nil)).Elem(),
-		reflect.TypeOf((*ConfusingToJacksonIface)(nil)).Elem(),
+		func() interface{} {
+			return &confusingToJackson{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.ConfusingToJacksonStruct",
@@ -12922,47 +12487,65 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.ConstructorPassesThisOut",
 		reflect.TypeOf((*ConstructorPassesThisOut)(nil)).Elem(),
-		reflect.TypeOf((*ConstructorPassesThisOutIface)(nil)).Elem(),
+		func() interface{} {
+			return &constructorPassesThisOut{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Constructors",
 		reflect.TypeOf((*Constructors)(nil)).Elem(),
-		reflect.TypeOf((*ConstructorsIface)(nil)).Elem(),
+		func() interface{} {
+			return &constructors{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ConsumePureInterface",
 		reflect.TypeOf((*ConsumePureInterface)(nil)).Elem(),
-		reflect.TypeOf((*ConsumePureInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			return &consumePureInterface{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ConsumerCanRingBell",
 		reflect.TypeOf((*ConsumerCanRingBell)(nil)).Elem(),
-		reflect.TypeOf((*ConsumerCanRingBellIface)(nil)).Elem(),
+		func() interface{} {
+			return &consumerCanRingBell{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
 		reflect.TypeOf((*ConsumersOfThisCrazyTypeSystem)(nil)).Elem(),
-		reflect.TypeOf((*ConsumersOfThisCrazyTypeSystemIface)(nil)).Elem(),
+		func() interface{} {
+			return &consumersOfThisCrazyTypeSystem{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DataRenderer",
 		reflect.TypeOf((*DataRenderer)(nil)).Elem(),
-		reflect.TypeOf((*DataRendererIface)(nil)).Elem(),
+		func() interface{} {
+			return &dataRenderer{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DefaultedConstructorArgument",
 		reflect.TypeOf((*DefaultedConstructorArgument)(nil)).Elem(),
-		reflect.TypeOf((*DefaultedConstructorArgumentIface)(nil)).Elem(),
+		func() interface{} {
+			return &defaultedConstructorArgument{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Demonstrate982",
 		reflect.TypeOf((*Demonstrate982)(nil)).Elem(),
-		reflect.TypeOf((*Demonstrate982Iface)(nil)).Elem(),
+		func() interface{} {
+			return &demonstrate982{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DeprecatedClass",
 		reflect.TypeOf((*DeprecatedClass)(nil)).Elem(),
-		reflect.TypeOf((*DeprecatedClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &deprecatedClass{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.DeprecatedEnum",
@@ -13003,57 +12586,83 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.DisappointingCollectionSource",
 		reflect.TypeOf((*DisappointingCollectionSource)(nil)).Elem(),
-		reflect.TypeOf((*DisappointingCollectionSourceIface)(nil)).Elem(),
+		func() interface{} {
+			return &disappointingCollectionSource{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DoNotOverridePrivates",
 		reflect.TypeOf((*DoNotOverridePrivates)(nil)).Elem(),
-		reflect.TypeOf((*DoNotOverridePrivatesIface)(nil)).Elem(),
+		func() interface{} {
+			return &doNotOverridePrivates{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DoNotRecognizeAnyAsOptional",
 		reflect.TypeOf((*DoNotRecognizeAnyAsOptional)(nil)).Elem(),
-		reflect.TypeOf((*DoNotRecognizeAnyAsOptionalIface)(nil)).Elem(),
+		func() interface{} {
+			return &doNotRecognizeAnyAsOptional{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DocumentedClass",
 		reflect.TypeOf((*DocumentedClass)(nil)).Elem(),
-		reflect.TypeOf((*DocumentedClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &documentedClass{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DontComplainAboutVariadicAfterOptional",
 		reflect.TypeOf((*DontComplainAboutVariadicAfterOptional)(nil)).Elem(),
-		reflect.TypeOf((*DontComplainAboutVariadicAfterOptionalIface)(nil)).Elem(),
+		func() interface{} {
+			return &dontComplainAboutVariadicAfterOptional{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DoubleTrouble",
 		reflect.TypeOf((*DoubleTrouble)(nil)).Elem(),
-		reflect.TypeOf((*DoubleTroubleIface)(nil)).Elem(),
+		func() interface{} {
+			d := doubleTrouble{}
+			_jsii_.InitJsiiProxy(&d.iFriendlyRandomGenerator)
+			return &d
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DynamicPropertyBearer",
 		reflect.TypeOf((*DynamicPropertyBearer)(nil)).Elem(),
-		reflect.TypeOf((*DynamicPropertyBearerIface)(nil)).Elem(),
+		func() interface{} {
+			return &dynamicPropertyBearer{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.DynamicPropertyBearerChild",
 		reflect.TypeOf((*DynamicPropertyBearerChild)(nil)).Elem(),
-		reflect.TypeOf((*DynamicPropertyBearerChildIface)(nil)).Elem(),
+		func() interface{} {
+			d := dynamicPropertyBearerChild{}
+			_jsii_.InitJsiiProxy(&d.dynamicPropertyBearer)
+			return &d
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Entropy",
 		reflect.TypeOf((*Entropy)(nil)).Elem(),
-		reflect.TypeOf((*EntropyIface)(nil)).Elem(),
+		func() interface{} {
+			return &entropy{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.EnumDispenser",
 		reflect.TypeOf((*EnumDispenser)(nil)).Elem(),
-		reflect.TypeOf((*EnumDispenserIface)(nil)).Elem(),
+		func() interface{} {
+			return &enumDispenser{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.EraseUndefinedHashValues",
 		reflect.TypeOf((*EraseUndefinedHashValues)(nil)).Elem(),
-		reflect.TypeOf((*EraseUndefinedHashValuesIface)(nil)).Elem(),
+		func() interface{} {
+			return &eraseUndefinedHashValues{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.EraseUndefinedHashValuesOptions",
@@ -13062,7 +12671,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.ExperimentalClass",
 		reflect.TypeOf((*ExperimentalClass)(nil)).Elem(),
-		reflect.TypeOf((*ExperimentalClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &experimentalClass{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.ExperimentalEnum",
@@ -13079,7 +12690,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.ExportedBaseClass",
 		reflect.TypeOf((*ExportedBaseClass)(nil)).Elem(),
-		reflect.TypeOf((*ExportedBaseClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &exportedBaseClass{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.ExtendsInternalInterface",
@@ -13088,7 +12701,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.ExternalClass",
 		reflect.TypeOf((*ExternalClass)(nil)).Elem(),
-		reflect.TypeOf((*ExternalClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &externalClass{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.ExternalEnum",
@@ -13105,7 +12720,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.GiveMeStructs",
 		reflect.TypeOf((*GiveMeStructs)(nil)).Elem(),
-		reflect.TypeOf((*GiveMeStructsIface)(nil)).Elem(),
+		func() interface{} {
+			return &giveMeStructs{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.Greetee",
@@ -13114,217 +12731,320 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.GreetingAugmenter",
 		reflect.TypeOf((*GreetingAugmenter)(nil)).Elem(),
-		reflect.TypeOf((*GreetingAugmenterIface)(nil)).Elem(),
+		func() interface{} {
+			return &greetingAugmenter{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IAnonymousImplementationProvider",
-		reflect.TypeOf((*IAnonymousImplementationProviderIface)(nil)).Elem(),
 		reflect.TypeOf((*IAnonymousImplementationProvider)(nil)).Elem(),
+		func() interface{} {
+			return &iAnonymousImplementationProvider{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IAnonymouslyImplementMe",
-		reflect.TypeOf((*IAnonymouslyImplementMeIface)(nil)).Elem(),
 		reflect.TypeOf((*IAnonymouslyImplementMe)(nil)).Elem(),
+		func() interface{} {
+			return &iAnonymouslyImplementMe{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IAnotherPublicInterface",
-		reflect.TypeOf((*IAnotherPublicInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IAnotherPublicInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iAnotherPublicInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IBell",
-		reflect.TypeOf((*IBellIface)(nil)).Elem(),
 		reflect.TypeOf((*IBell)(nil)).Elem(),
+		func() interface{} {
+			return &iBell{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IBellRinger",
-		reflect.TypeOf((*IBellRingerIface)(nil)).Elem(),
 		reflect.TypeOf((*IBellRinger)(nil)).Elem(),
+		func() interface{} {
+			return &iBellRinger{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IConcreteBellRinger",
-		reflect.TypeOf((*IConcreteBellRingerIface)(nil)).Elem(),
 		reflect.TypeOf((*IConcreteBellRinger)(nil)).Elem(),
+		func() interface{} {
+			return &iConcreteBellRinger{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IDeprecatedInterface",
-		reflect.TypeOf((*IDeprecatedInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IDeprecatedInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iDeprecatedInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IExperimentalInterface",
-		reflect.TypeOf((*IExperimentalInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IExperimentalInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iExperimentalInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IExtendsPrivateInterface",
-		reflect.TypeOf((*IExtendsPrivateInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IExtendsPrivateInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iExtendsPrivateInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IExternalInterface",
-		reflect.TypeOf((*IExternalInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IExternalInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iExternalInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IFriendlier",
-		reflect.TypeOf((*IFriendlierIface)(nil)).Elem(),
 		reflect.TypeOf((*IFriendlier)(nil)).Elem(),
+		func() interface{} {
+			i := iFriendlier{}
+			_jsii_.InitJsiiProxy(&i.IFriendly)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IFriendlyRandomGenerator",
-		reflect.TypeOf((*IFriendlyRandomGeneratorIface)(nil)).Elem(),
 		reflect.TypeOf((*IFriendlyRandomGenerator)(nil)).Elem(),
+		func() interface{} {
+			i := iFriendlyRandomGenerator{}
+			_jsii_.InitJsiiProxy(&i.IFriendly)
+			_jsii_.InitJsiiProxy(&i.iRandomNumberGenerator)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceImplementedByAbstractClass",
-		reflect.TypeOf((*IInterfaceImplementedByAbstractClassIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceImplementedByAbstractClass)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceImplementedByAbstractClass{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceThatShouldNotBeADataType",
-		reflect.TypeOf((*IInterfaceThatShouldNotBeADataTypeIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceThatShouldNotBeADataType)(nil)).Elem(),
+		func() interface{} {
+			i := iInterfaceThatShouldNotBeADataType{}
+			_jsii_.InitJsiiProxy(&i.iInterfaceWithMethods)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceWithInternal",
-		reflect.TypeOf((*IInterfaceWithInternalIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithInternal)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceWithInternal{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceWithMethods",
-		reflect.TypeOf((*IInterfaceWithMethodsIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithMethods)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceWithMethods{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceWithOptionalMethodArguments",
-		reflect.TypeOf((*IInterfaceWithOptionalMethodArgumentsIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithOptionalMethodArguments)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceWithOptionalMethodArguments{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceWithProperties",
-		reflect.TypeOf((*IInterfaceWithPropertiesIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithProperties)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceWithProperties{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IInterfaceWithPropertiesExtension",
-		reflect.TypeOf((*IInterfaceWithPropertiesExtensionIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithPropertiesExtension)(nil)).Elem(),
+		func() interface{} {
+			i := iInterfaceWithPropertiesExtension{}
+			_jsii_.InitJsiiProxy(&i.iInterfaceWithProperties)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IJSII417Derived",
-		reflect.TypeOf((*Ijsii417DerivedIface)(nil)).Elem(),
 		reflect.TypeOf((*Ijsii417Derived)(nil)).Elem(),
+		func() interface{} {
+			i := ijsii417Derived{}
+			_jsii_.InitJsiiProxy(&i.ijsii417PublicBaseOfBase)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IJSII417PublicBaseOfBase",
-		reflect.TypeOf((*Ijsii417PublicBaseOfBaseIface)(nil)).Elem(),
 		reflect.TypeOf((*Ijsii417PublicBaseOfBase)(nil)).Elem(),
+		func() interface{} {
+			return &ijsii417PublicBaseOfBase{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IJsii487External",
-		reflect.TypeOf((*IJsii487ExternalIface)(nil)).Elem(),
 		reflect.TypeOf((*IJsii487External)(nil)).Elem(),
+		func() interface{} {
+			return &iJsii487External{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IJsii487External2",
-		reflect.TypeOf((*IJsii487External2Iface)(nil)).Elem(),
 		reflect.TypeOf((*IJsii487External2)(nil)).Elem(),
+		func() interface{} {
+			return &iJsii487External2{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IJsii496",
-		reflect.TypeOf((*IJsii496Iface)(nil)).Elem(),
 		reflect.TypeOf((*IJsii496)(nil)).Elem(),
+		func() interface{} {
+			return &iJsii496{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IMutableObjectLiteral",
-		reflect.TypeOf((*IMutableObjectLiteralIface)(nil)).Elem(),
 		reflect.TypeOf((*IMutableObjectLiteral)(nil)).Elem(),
+		func() interface{} {
+			return &iMutableObjectLiteral{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.INonInternalInterface",
-		reflect.TypeOf((*INonInternalInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*INonInternalInterface)(nil)).Elem(),
+		func() interface{} {
+			i := iNonInternalInterface{}
+			_jsii_.InitJsiiProxy(&i.iAnotherPublicInterface)
+			return &i
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IObjectWithProperty",
-		reflect.TypeOf((*IObjectWithPropertyIface)(nil)).Elem(),
 		reflect.TypeOf((*IObjectWithProperty)(nil)).Elem(),
+		func() interface{} {
+			return &iObjectWithProperty{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IOptionalMethod",
-		reflect.TypeOf((*IOptionalMethodIface)(nil)).Elem(),
 		reflect.TypeOf((*IOptionalMethod)(nil)).Elem(),
+		func() interface{} {
+			return &iOptionalMethod{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IPrivatelyImplemented",
-		reflect.TypeOf((*IPrivatelyImplementedIface)(nil)).Elem(),
 		reflect.TypeOf((*IPrivatelyImplemented)(nil)).Elem(),
+		func() interface{} {
+			return &iPrivatelyImplemented{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IPublicInterface",
-		reflect.TypeOf((*IPublicInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IPublicInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iPublicInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IPublicInterface2",
-		reflect.TypeOf((*IPublicInterface2Iface)(nil)).Elem(),
 		reflect.TypeOf((*IPublicInterface2)(nil)).Elem(),
+		func() interface{} {
+			return &iPublicInterface2{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IRandomNumberGenerator",
-		reflect.TypeOf((*IRandomNumberGeneratorIface)(nil)).Elem(),
 		reflect.TypeOf((*IRandomNumberGenerator)(nil)).Elem(),
+		func() interface{} {
+			return &iRandomNumberGenerator{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IReturnJsii976",
-		reflect.TypeOf((*IReturnJsii976Iface)(nil)).Elem(),
 		reflect.TypeOf((*IReturnJsii976)(nil)).Elem(),
+		func() interface{} {
+			return &iReturnJsii976{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IReturnsNumber",
-		reflect.TypeOf((*IReturnsNumberIface)(nil)).Elem(),
 		reflect.TypeOf((*IReturnsNumber)(nil)).Elem(),
+		func() interface{} {
+			return &iReturnsNumber{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IStableInterface",
-		reflect.TypeOf((*IStableInterfaceIface)(nil)).Elem(),
 		reflect.TypeOf((*IStableInterface)(nil)).Elem(),
+		func() interface{} {
+			return &iStableInterface{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IStructReturningDelegate",
-		reflect.TypeOf((*IStructReturningDelegateIface)(nil)).Elem(),
 		reflect.TypeOf((*IStructReturningDelegate)(nil)).Elem(),
+		func() interface{} {
+			return &iStructReturningDelegate{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.IWallClock",
-		reflect.TypeOf((*IWallClockIface)(nil)).Elem(),
 		reflect.TypeOf((*IWallClock)(nil)).Elem(),
+		func() interface{} {
+			return &iWallClock{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ImplementInternalInterface",
 		reflect.TypeOf((*ImplementInternalInterface)(nil)).Elem(),
-		reflect.TypeOf((*ImplementInternalInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			return &implementInternalInterface{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Implementation",
 		reflect.TypeOf((*Implementation)(nil)).Elem(),
-		reflect.TypeOf((*ImplementationIface)(nil)).Elem(),
+		func() interface{} {
+			return &implementation{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ImplementsInterfaceWithInternal",
 		reflect.TypeOf((*ImplementsInterfaceWithInternal)(nil)).Elem(),
-		reflect.TypeOf((*ImplementsInterfaceWithInternalIface)(nil)).Elem(),
+		func() interface{} {
+			i := implementsInterfaceWithInternal{}
+			_jsii_.InitJsiiProxy(&i.iInterfaceWithInternal)
+			return &i
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
 		reflect.TypeOf((*ImplementsInterfaceWithInternalSubclass)(nil)).Elem(),
-		reflect.TypeOf((*ImplementsInterfaceWithInternalSubclassIface)(nil)).Elem(),
+		func() interface{} {
+			i := implementsInterfaceWithInternalSubclass{}
+			_jsii_.InitJsiiProxy(&i.implementsInterfaceWithInternal)
+			return &i
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ImplementsPrivateInterface",
 		reflect.TypeOf((*ImplementsPrivateInterface)(nil)).Elem(),
-		reflect.TypeOf((*ImplementsPrivateInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			return &implementsPrivateInterface{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.ImplictBaseOfBase",
@@ -13333,77 +13053,117 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.InbetweenClass",
 		reflect.TypeOf((*InbetweenClass)(nil)).Elem(),
-		reflect.TypeOf((*InbetweenClassIface)(nil)).Elem(),
+		func() interface{} {
+			i := inbetweenClass{}
+			_jsii_.InitJsiiProxy(&i.publicClass)
+			_jsii_.InitJsiiProxy(&i.iPublicInterface2)
+			return &i
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.InterfaceCollections",
 		reflect.TypeOf((*InterfaceCollections)(nil)).Elem(),
-		reflect.TypeOf((*InterfaceCollectionsIface)(nil)).Elem(),
+		func() interface{} {
+			return &interfaceCollections{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.InterfacesMaker",
 		reflect.TypeOf((*InterfacesMaker)(nil)).Elem(),
-		reflect.TypeOf((*InterfacesMakerIface)(nil)).Elem(),
+		func() interface{} {
+			return &interfacesMaker{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Isomorphism",
 		reflect.TypeOf((*Isomorphism)(nil)).Elem(),
-		reflect.TypeOf((*IsomorphismIface)(nil)).Elem(),
+		func() interface{} {
+			return &isomorphism{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JSII417Derived",
 		reflect.TypeOf((*Jsii417Derived)(nil)).Elem(),
-		reflect.TypeOf((*Jsii417DerivedIface)(nil)).Elem(),
+		func() interface{} {
+			j := jsii417Derived{}
+			_jsii_.InitJsiiProxy(&j.jsii417PublicBaseOfBase)
+			return &j
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JSII417PublicBaseOfBase",
 		reflect.TypeOf((*Jsii417PublicBaseOfBase)(nil)).Elem(),
-		reflect.TypeOf((*Jsii417PublicBaseOfBaseIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsii417PublicBaseOfBase{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JSObjectLiteralForInterface",
 		reflect.TypeOf((*JsObjectLiteralForInterface)(nil)).Elem(),
-		reflect.TypeOf((*JsObjectLiteralForInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsObjectLiteralForInterface{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JSObjectLiteralToNative",
 		reflect.TypeOf((*JsObjectLiteralToNative)(nil)).Elem(),
-		reflect.TypeOf((*JsObjectLiteralToNativeIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsObjectLiteralToNative{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JSObjectLiteralToNativeClass",
 		reflect.TypeOf((*JsObjectLiteralToNativeClass)(nil)).Elem(),
-		reflect.TypeOf((*JsObjectLiteralToNativeClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsObjectLiteralToNativeClass{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JavaReservedWords",
 		reflect.TypeOf((*JavaReservedWords)(nil)).Elem(),
-		reflect.TypeOf((*JavaReservedWordsIface)(nil)).Elem(),
+		func() interface{} {
+			return &javaReservedWords{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Jsii487Derived",
 		reflect.TypeOf((*Jsii487Derived)(nil)).Elem(),
-		reflect.TypeOf((*Jsii487DerivedIface)(nil)).Elem(),
+		func() interface{} {
+			j := jsii487Derived{}
+			_jsii_.InitJsiiProxy(&j.iJsii487External)
+			_jsii_.InitJsiiProxy(&j.iJsii487External2)
+			return &j
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Jsii496Derived",
 		reflect.TypeOf((*Jsii496Derived)(nil)).Elem(),
-		reflect.TypeOf((*Jsii496DerivedIface)(nil)).Elem(),
+		func() interface{} {
+			j := jsii496Derived{}
+			_jsii_.InitJsiiProxy(&j.iJsii496)
+			return &j
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JsiiAgent",
 		reflect.TypeOf((*JsiiAgent)(nil)).Elem(),
-		reflect.TypeOf((*JsiiAgentIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsiiAgent{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.JsonFormatter",
 		reflect.TypeOf((*JsonFormatter)(nil)).Elem(),
-		reflect.TypeOf((*JsonFormatterIface)(nil)).Elem(),
+		func() interface{} {
+			return &jsonFormatter{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.LevelOne",
 		reflect.TypeOf((*LevelOne)(nil)).Elem(),
-		reflect.TypeOf((*LevelOneIface)(nil)).Elem(),
+		func() interface{} {
+			return &levelOne{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.LevelOne.PropBooleanValue",
@@ -13424,22 +13184,37 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.MethodNamedProperty",
 		reflect.TypeOf((*MethodNamedProperty)(nil)).Elem(),
-		reflect.TypeOf((*MethodNamedPropertyIface)(nil)).Elem(),
+		func() interface{} {
+			return &methodNamedProperty{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Multiply",
 		reflect.TypeOf((*Multiply)(nil)).Elem(),
-		reflect.TypeOf((*MultiplyIface)(nil)).Elem(),
+		func() interface{} {
+			m := multiply{}
+			_jsii_.InitJsiiProxy(&m.binaryOperation)
+			_jsii_.InitJsiiProxy(&m.iFriendlier)
+			_jsii_.InitJsiiProxy(&m.iRandomNumberGenerator)
+			return &m
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Negate",
 		reflect.TypeOf((*Negate)(nil)).Elem(),
-		reflect.TypeOf((*NegateIface)(nil)).Elem(),
+		func() interface{} {
+			n := negate{}
+			_jsii_.InitJsiiProxy(&n.unaryOperation)
+			_jsii_.InitJsiiProxy(&n.iFriendlier)
+			return &n
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.NestedClassInstance",
 		reflect.TypeOf((*NestedClassInstance)(nil)).Elem(),
-		reflect.TypeOf((*NestedClassInstanceIface)(nil)).Elem(),
+		func() interface{} {
+			return &nestedClassInstance{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.NestedStruct",
@@ -13448,12 +13223,16 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.NodeStandardLibrary",
 		reflect.TypeOf((*NodeStandardLibrary)(nil)).Elem(),
-		reflect.TypeOf((*NodeStandardLibraryIface)(nil)).Elem(),
+		func() interface{} {
+			return &nodeStandardLibrary{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.NullShouldBeTreatedAsUndefined",
 		reflect.TypeOf((*NullShouldBeTreatedAsUndefined)(nil)).Elem(),
-		reflect.TypeOf((*NullShouldBeTreatedAsUndefinedIface)(nil)).Elem(),
+		func() interface{} {
+			return &nullShouldBeTreatedAsUndefined{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.NullShouldBeTreatedAsUndefinedData",
@@ -13462,32 +13241,44 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.NumberGenerator",
 		reflect.TypeOf((*NumberGenerator)(nil)).Elem(),
-		reflect.TypeOf((*NumberGeneratorIface)(nil)).Elem(),
+		func() interface{} {
+			return &numberGenerator{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ObjectRefsInCollections",
 		reflect.TypeOf((*ObjectRefsInCollections)(nil)).Elem(),
-		reflect.TypeOf((*ObjectRefsInCollectionsIface)(nil)).Elem(),
+		func() interface{} {
+			return &objectRefsInCollections{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ObjectWithPropertyProvider",
 		reflect.TypeOf((*ObjectWithPropertyProvider)(nil)).Elem(),
-		reflect.TypeOf((*ObjectWithPropertyProviderIface)(nil)).Elem(),
+		func() interface{} {
+			return &objectWithPropertyProvider{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Old",
 		reflect.TypeOf((*Old)(nil)).Elem(),
-		reflect.TypeOf((*OldIface)(nil)).Elem(),
+		func() interface{} {
+			return &old{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.OptionalArgumentInvoker",
 		reflect.TypeOf((*OptionalArgumentInvoker)(nil)).Elem(),
-		reflect.TypeOf((*OptionalArgumentInvokerIface)(nil)).Elem(),
+		func() interface{} {
+			return &optionalArgumentInvoker{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.OptionalConstructorArgument",
 		reflect.TypeOf((*OptionalConstructorArgument)(nil)).Elem(),
-		reflect.TypeOf((*OptionalConstructorArgumentIface)(nil)).Elem(),
+		func() interface{} {
+			return &optionalConstructorArgument{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.OptionalStruct",
@@ -13496,17 +13287,23 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.OptionalStructConsumer",
 		reflect.TypeOf((*OptionalStructConsumer)(nil)).Elem(),
-		reflect.TypeOf((*OptionalStructConsumerIface)(nil)).Elem(),
+		func() interface{} {
+			return &optionalStructConsumer{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.OverridableProtectedMember",
 		reflect.TypeOf((*OverridableProtectedMember)(nil)).Elem(),
-		reflect.TypeOf((*OverridableProtectedMemberIface)(nil)).Elem(),
+		func() interface{} {
+			return &overridableProtectedMember{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.OverrideReturnsObject",
 		reflect.TypeOf((*OverrideReturnsObject)(nil)).Elem(),
-		reflect.TypeOf((*OverrideReturnsObjectIface)(nil)).Elem(),
+		func() interface{} {
+			return &overrideReturnsObject{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.ParentStruct982",
@@ -13515,42 +13312,60 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.PartiallyInitializedThisConsumer",
 		reflect.TypeOf((*PartiallyInitializedThisConsumer)(nil)).Elem(),
-		reflect.TypeOf((*PartiallyInitializedThisConsumerIface)(nil)).Elem(),
+		func() interface{} {
+			return &partiallyInitializedThisConsumer{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Polymorphism",
 		reflect.TypeOf((*Polymorphism)(nil)).Elem(),
-		reflect.TypeOf((*PolymorphismIface)(nil)).Elem(),
+		func() interface{} {
+			return &polymorphism{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Power",
 		reflect.TypeOf((*Power)(nil)).Elem(),
-		reflect.TypeOf((*PowerIface)(nil)).Elem(),
+		func() interface{} {
+			p := power{}
+			_jsii_.InitJsiiProxy(&p.CompositeOperation)
+			return &p
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.PropertyNamedProperty",
 		reflect.TypeOf((*PropertyNamedProperty)(nil)).Elem(),
-		reflect.TypeOf((*PropertyNamedPropertyIface)(nil)).Elem(),
+		func() interface{} {
+			return &propertyNamedProperty{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.PublicClass",
 		reflect.TypeOf((*PublicClass)(nil)).Elem(),
-		reflect.TypeOf((*PublicClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &publicClass{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.PythonReservedWords",
 		reflect.TypeOf((*PythonReservedWords)(nil)).Elem(),
-		reflect.TypeOf((*PythonReservedWordsIface)(nil)).Elem(),
+		func() interface{} {
+			return &pythonReservedWords{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ReferenceEnumFromScopedPackage",
 		reflect.TypeOf((*ReferenceEnumFromScopedPackage)(nil)).Elem(),
-		reflect.TypeOf((*ReferenceEnumFromScopedPackageIface)(nil)).Elem(),
+		func() interface{} {
+			return &referenceEnumFromScopedPackage{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.ReturnsPrivateImplementationOfInterface",
 		reflect.TypeOf((*ReturnsPrivateImplementationOfInterface)(nil)).Elem(),
-		reflect.TypeOf((*ReturnsPrivateImplementationOfInterfaceIface)(nil)).Elem(),
+		func() interface{} {
+			return &returnsPrivateImplementationOfInterface{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.RootStruct",
@@ -13559,12 +13374,16 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.RootStructValidator",
 		reflect.TypeOf((*RootStructValidator)(nil)).Elem(),
-		reflect.TypeOf((*RootStructValidatorIface)(nil)).Elem(),
+		func() interface{} {
+			return &rootStructValidator{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.RuntimeTypeChecking",
 		reflect.TypeOf((*RuntimeTypeChecking)(nil)).Elem(),
-		reflect.TypeOf((*RuntimeTypeCheckingIface)(nil)).Elem(),
+		func() interface{} {
+			return &runtimeTypeChecking{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.SecondLevelStruct",
@@ -13573,12 +13392,16 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.SingleInstanceTwoTypes",
 		reflect.TypeOf((*SingleInstanceTwoTypes)(nil)).Elem(),
-		reflect.TypeOf((*SingleInstanceTwoTypesIface)(nil)).Elem(),
+		func() interface{} {
+			return &singleInstanceTwoTypes{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.SingletonInt",
 		reflect.TypeOf((*SingletonInt)(nil)).Elem(),
-		reflect.TypeOf((*SingletonIntIface)(nil)).Elem(),
+		func() interface{} {
+			return &singletonInt{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.SingletonIntEnum",
@@ -13590,7 +13413,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.SingletonString",
 		reflect.TypeOf((*SingletonString)(nil)).Elem(),
-		reflect.TypeOf((*SingletonStringIface)(nil)).Elem(),
+		func() interface{} {
+			return &singletonString{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.SingletonStringEnum",
@@ -13606,12 +13431,16 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.SomeTypeJsii976",
 		reflect.TypeOf((*SomeTypeJsii976)(nil)).Elem(),
-		reflect.TypeOf((*SomeTypeJsii976Iface)(nil)).Elem(),
+		func() interface{} {
+			return &someTypeJsii976{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.StableClass",
 		reflect.TypeOf((*StableClass)(nil)).Elem(),
-		reflect.TypeOf((*StableClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &stableClass{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.StableEnum",
@@ -13628,22 +13457,32 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.StaticContext",
 		reflect.TypeOf((*StaticContext)(nil)).Elem(),
-		reflect.TypeOf((*StaticContextIface)(nil)).Elem(),
+		func() interface{} {
+			return &staticContext{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.StaticHelloChild",
 		reflect.TypeOf((*StaticHelloChild)(nil)).Elem(),
-		reflect.TypeOf((*StaticHelloChildIface)(nil)).Elem(),
+		func() interface{} {
+			s := staticHelloChild{}
+			_jsii_.InitJsiiProxy(&s.staticHelloParent)
+			return &s
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.StaticHelloParent",
 		reflect.TypeOf((*StaticHelloParent)(nil)).Elem(),
-		reflect.TypeOf((*StaticHelloParentIface)(nil)).Elem(),
+		func() interface{} {
+			return &staticHelloParent{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Statics",
 		reflect.TypeOf((*Statics)(nil)).Elem(),
-		reflect.TypeOf((*StaticsIface)(nil)).Elem(),
+		func() interface{} {
+			return &statics{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.StringEnum",
@@ -13657,7 +13496,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.StripInternal",
 		reflect.TypeOf((*StripInternal)(nil)).Elem(),
-		reflect.TypeOf((*StripInternalIface)(nil)).Elem(),
+		func() interface{} {
+			return &stripInternal{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.StructA",
@@ -13674,12 +13515,16 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.StructPassing",
 		reflect.TypeOf((*StructPassing)(nil)).Elem(),
-		reflect.TypeOf((*StructPassingIface)(nil)).Elem(),
+		func() interface{} {
+			return &structPassing{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.StructUnionConsumer",
 		reflect.TypeOf((*StructUnionConsumer)(nil)).Elem(),
-		reflect.TypeOf((*StructUnionConsumerIface)(nil)).Elem(),
+		func() interface{} {
+			return &structUnionConsumer{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.StructWithJavaReservedWords",
@@ -13688,12 +13533,20 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.Sum",
 		reflect.TypeOf((*Sum)(nil)).Elem(),
-		reflect.TypeOf((*SumIface)(nil)).Elem(),
+		func() interface{} {
+			s := sum{}
+			_jsii_.InitJsiiProxy(&s.CompositeOperation)
+			return &s
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.SupportsNiceJavaBuilder",
 		reflect.TypeOf((*SupportsNiceJavaBuilder)(nil)).Elem(),
-		reflect.TypeOf((*SupportsNiceJavaBuilderIface)(nil)).Elem(),
+		func() interface{} {
+			s := supportsNiceJavaBuilder{}
+			_jsii_.InitJsiiProxy(&s.supportsNiceJavaBuilderWithRequiredProps)
+			return &s
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.SupportsNiceJavaBuilderProps",
@@ -13702,17 +13555,23 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
 		reflect.TypeOf((*SupportsNiceJavaBuilderWithRequiredProps)(nil)).Elem(),
-		reflect.TypeOf((*SupportsNiceJavaBuilderWithRequiredPropsIface)(nil)).Elem(),
+		func() interface{} {
+			return &supportsNiceJavaBuilderWithRequiredProps{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.SyncVirtualMethods",
 		reflect.TypeOf((*SyncVirtualMethods)(nil)).Elem(),
-		reflect.TypeOf((*SyncVirtualMethodsIface)(nil)).Elem(),
+		func() interface{} {
+			return &syncVirtualMethods{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.Thrower",
 		reflect.TypeOf((*Thrower)(nil)).Elem(),
-		reflect.TypeOf((*ThrowerIface)(nil)).Elem(),
+		func() interface{} {
+			return &thrower{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.TopLevelStruct",
@@ -13721,12 +13580,18 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.UmaskCheck",
 		reflect.TypeOf((*UmaskCheck)(nil)).Elem(),
-		reflect.TypeOf((*UmaskCheckIface)(nil)).Elem(),
+		func() interface{} {
+			return &umaskCheck{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.UnaryOperation",
 		reflect.TypeOf((*UnaryOperation)(nil)).Elem(),
-		reflect.TypeOf((*UnaryOperationIface)(nil)).Elem(),
+		func() interface{} {
+			u := unaryOperation{}
+			_jsii_.InitJsiiProxy(&u.Operation)
+			return &u
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.UnionProperties",
@@ -13735,47 +13600,67 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.UpcasingReflectable",
 		reflect.TypeOf((*UpcasingReflectable)(nil)).Elem(),
-		reflect.TypeOf((*UpcasingReflectableIface)(nil)).Elem(),
+		func() interface{} {
+			u := upcasingReflectable{}
+			_jsii_.InitJsiiProxy(&u.IReflectable)
+			return &u
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.UseBundledDependency",
 		reflect.TypeOf((*UseBundledDependency)(nil)).Elem(),
-		reflect.TypeOf((*UseBundledDependencyIface)(nil)).Elem(),
+		func() interface{} {
+			return &useBundledDependency{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.UseCalcBase",
 		reflect.TypeOf((*UseCalcBase)(nil)).Elem(),
-		reflect.TypeOf((*UseCalcBaseIface)(nil)).Elem(),
+		func() interface{} {
+			return &useCalcBase{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.UsesInterfaceWithProperties",
 		reflect.TypeOf((*UsesInterfaceWithProperties)(nil)).Elem(),
-		reflect.TypeOf((*UsesInterfaceWithPropertiesIface)(nil)).Elem(),
+		func() interface{} {
+			return &usesInterfaceWithProperties{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.VariadicInvoker",
 		reflect.TypeOf((*VariadicInvoker)(nil)).Elem(),
-		reflect.TypeOf((*VariadicInvokerIface)(nil)).Elem(),
+		func() interface{} {
+			return &variadicInvoker{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.VariadicMethod",
 		reflect.TypeOf((*VariadicMethod)(nil)).Elem(),
-		reflect.TypeOf((*VariadicMethodIface)(nil)).Elem(),
+		func() interface{} {
+			return &variadicMethod{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.VirtualMethodPlayground",
 		reflect.TypeOf((*VirtualMethodPlayground)(nil)).Elem(),
-		reflect.TypeOf((*VirtualMethodPlaygroundIface)(nil)).Elem(),
+		func() interface{} {
+			return &virtualMethodPlayground{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.VoidCallback",
 		reflect.TypeOf((*VoidCallback)(nil)).Elem(),
-		reflect.TypeOf((*VoidCallbackIface)(nil)).Elem(),
+		func() interface{} {
+			return &voidCallback{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.WithPrivatePropertyInConstructor",
 		reflect.TypeOf((*WithPrivatePropertyInConstructor)(nil)).Elem(),
-		reflect.TypeOf((*WithPrivatePropertyInConstructorIface)(nil)).Elem(),
+		func() interface{} {
+			return &withPrivatePropertyInConstructor{}
+		},
 	)
 }
 
@@ -13789,18 +13674,17 @@ import (
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 )
 
-// Class interface
-type ClassWithSelfIface interface {
-	GetSelf() string
+type ClassWithSelf interface {
+	Self() string
 	Method(self float64) string
 }
 
-// Struct proxy
-type ClassWithSelf struct {
-	Self string \`json:"self"\`
+// The jsii proxy struct for ClassWithSelf
+type classWithSelf struct {
+	_ byte // padding
 }
 
-func (c *ClassWithSelf) GetSelf() string {
+func (c *classWithSelf) Self() string {
 	var returns string
 	_jsii_.Get(
 		c,
@@ -13811,20 +13695,21 @@ func (c *ClassWithSelf) GetSelf() string {
 }
 
 
-func NewClassWithSelf(self string) ClassWithSelfIface {
+func NewClassWithSelf(self string) ClassWithSelf {
 	_init_.Initialize()
-	self_ := ClassWithSelf{}
+	c := classWithSelf{}
+
 	_jsii_.Create(
 		"jsii-calc.PythonSelf.ClassWithSelf",
 		[]interface{}{self},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self_,
+		&c,
 	)
-	return &self_
+	return &c
 }
 
-func (c *ClassWithSelf) Method(self float64) string {
+func (c *classWithSelf) Method(self float64) string {
 	var returns string
 	_jsii_.Invoke(
 		c,
@@ -13836,17 +13721,16 @@ func (c *ClassWithSelf) Method(self float64) string {
 	return returns
 }
 
-// Class interface
-type ClassWithSelfKwargIface interface {
-	GetProps() StructWithSelf
+type ClassWithSelfKwarg interface {
+	Props() StructWithSelf
 }
 
-// Struct proxy
-type ClassWithSelfKwarg struct {
-	Props StructWithSelf \`json:"props"\`
+// The jsii proxy struct for ClassWithSelfKwarg
+type classWithSelfKwarg struct {
+	_ byte // padding
 }
 
-func (c *ClassWithSelfKwarg) GetProps() StructWithSelf {
+func (c *classWithSelfKwarg) Props() StructWithSelf {
 	var returns StructWithSelf
 	_jsii_.Get(
 		c,
@@ -13857,26 +13741,30 @@ func (c *ClassWithSelfKwarg) GetProps() StructWithSelf {
 }
 
 
-func NewClassWithSelfKwarg(props StructWithSelf) ClassWithSelfKwargIface {
+func NewClassWithSelfKwarg(props StructWithSelf) ClassWithSelfKwarg {
 	_init_.Initialize()
-	self := ClassWithSelfKwarg{}
+	c := classWithSelfKwarg{}
+
 	_jsii_.Create(
 		"jsii-calc.PythonSelf.ClassWithSelfKwarg",
 		[]interface{}{props},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&c,
 	)
-	return &self
+	return &c
 }
 
-type IInterfaceWithSelfIface interface {
+type IInterfaceWithSelf interface {
 	Method(self float64) string
 }
 
-type IInterfaceWithSelf struct {}
+// The jsii proxy for IInterfaceWithSelf
+type iInterfaceWithSelf struct {
+	_ byte // padding
+}
 
-func (i *IInterfaceWithSelf) Method(self float64) string {
+func (i *iInterfaceWithSelf) Method(self float64) string {
 	var returns string
 	_jsii_.Invoke(
 		i,
@@ -13908,17 +13796,23 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.PythonSelf.ClassWithSelf",
 		reflect.TypeOf((*ClassWithSelf)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithSelfIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithSelf{}
+		},
 	)
 	_jsii_.RegisterClass(
 		"jsii-calc.PythonSelf.ClassWithSelfKwarg",
 		reflect.TypeOf((*ClassWithSelfKwarg)(nil)).Elem(),
-		reflect.TypeOf((*ClassWithSelfKwargIface)(nil)).Elem(),
+		func() interface{} {
+			return &classWithSelfKwarg{}
+		},
 	)
 	_jsii_.RegisterInterface(
 		"jsii-calc.PythonSelf.IInterfaceWithSelf",
-		reflect.TypeOf((*IInterfaceWithSelfIface)(nil)).Elem(),
 		reflect.TypeOf((*IInterfaceWithSelf)(nil)).Elem(),
+		func() interface{} {
+			return &iInterfaceWithSelf{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.PythonSelf.StructWithSelf",
@@ -13936,7 +13830,7 @@ import (
 )
 
 type MyClassReference struct {
-	Reference submodule.MyClassIface \`json:"reference"\`
+	Reference submodule.MyClass \`json:"reference"\`
 }
 
 
@@ -13982,25 +13876,26 @@ const (
 	Goodness_AMAZINGLY_GOOD Goodness = "AMAZINGLY_GOOD"
 )
 
-// Class interface
-type InnerClassIface interface {
+type InnerClass interface {
 }
 
-// Struct proxy
-type InnerClass struct {
+// The jsii proxy struct for InnerClass
+type innerClass struct {
+	_ byte // padding
 }
 
-func NewInnerClass() InnerClassIface {
+func NewInnerClass() InnerClass {
 	_init_.Initialize()
-	self := InnerClass{}
+	i := innerClass{}
+
 	_jsii_.Create(
 		"jsii-calc.submodule.child.InnerClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&i,
 	)
-	return &self
+	return &i
 }
 
 func InnerClass_StaticProp() SomeStruct {
@@ -14026,21 +13921,20 @@ func (k *KwargsProps) ToSomeStruct() SomeStruct {
 	}
 }
 
-// Class interface
-type OuterClassIface interface {
-	GetInnerClass() InnerClassIface
-}
-
 // Checks that classes can self-reference during initialization.
 // See: : https://github.com/aws/jsii/pull/1706
 //
-// Struct proxy
-type OuterClass struct {
-	InnerClass InnerClassIface \`json:"innerClass"\`
+type OuterClass interface {
+	InnerClass() InnerClass
 }
 
-func (o *OuterClass) GetInnerClass() InnerClassIface {
-	var returns InnerClassIface
+// The jsii proxy struct for OuterClass
+type outerClass struct {
+	_ byte // padding
+}
+
+func (o *outerClass) InnerClass() InnerClass {
+	var returns InnerClass
 	_jsii_.Get(
 		o,
 		"innerClass",
@@ -14050,17 +13944,18 @@ func (o *OuterClass) GetInnerClass() InnerClassIface {
 }
 
 
-func NewOuterClass() OuterClassIface {
+func NewOuterClass() OuterClass {
 	_init_.Initialize()
-	self := OuterClass{}
+	o := outerClass{}
+
 	_jsii_.Create(
 		"jsii-calc.submodule.child.OuterClass",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&o,
 	)
-	return &self
+	return &o
 }
 
 type SomeEnum string
@@ -14109,7 +14004,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.child.InnerClass",
 		reflect.TypeOf((*InnerClass)(nil)).Elem(),
-		reflect.TypeOf((*InnerClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &innerClass{}
+		},
 	)
 	_jsii_.RegisterStruct(
 		"jsii-calc.submodule.child.KwargsProps",
@@ -14118,7 +14015,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.child.OuterClass",
 		reflect.TypeOf((*OuterClass)(nil)).Elem(),
-		reflect.TypeOf((*OuterClassIface)(nil)).Elem(),
+		func() interface{} {
+			return &outerClass{}
+		},
 	)
 	_jsii_.RegisterEnum(
 		"jsii-calc.submodule.child.SomeEnum",
@@ -14143,13 +14042,13 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated
 package isolated
 
 
-// Class interface
-type KwargsIface interface {
+// Ensures imports are correctly registered for kwargs lifted properties from super-structs.
+type Kwargs interface {
 }
 
-// Ensures imports are correctly registered for kwargs lifted properties from super-structs.
-// Struct proxy
-type Kwargs struct {
+// The jsii proxy struct for Kwargs
+type kwargs struct {
+	_ byte // padding
 }
 
 func Kwargs_Method(props child.KwargsProps) bool {
@@ -14181,7 +14080,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.isolated.Kwargs",
 		reflect.TypeOf((*Kwargs)(nil)).Elem(),
-		reflect.TypeOf((*KwargsIface)(nil)).Elem(),
+		func() interface{} {
+			return &kwargs{}
+		},
 	)
 }
 
@@ -14194,13 +14095,16 @@ import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 )
 
-type INamespacedIface interface {
-	GetDefinedAt() string
+type INamespaced interface {
+	DefinedAt() string
 }
 
-type INamespaced struct {}
+// The jsii proxy for INamespaced
+type iNamespaced struct {
+	_ byte // padding
+}
 
-func (i *INamespaced) GetDefinedAt() string {
+func (i *iNamespaced) DefinedAt() string {
 	var returns string
 	_jsii_.Get(
 		i,
@@ -14225,8 +14129,10 @@ import (
 func init() {
 	_jsii_.RegisterInterface(
 		"jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced",
-		reflect.TypeOf((*INamespacedIface)(nil)).Elem(),
 		reflect.TypeOf((*INamespaced)(nil)).Elem(),
+		func() interface{} {
+			return &iNamespaced{}
+		},
 	)
 }
 
@@ -14242,20 +14148,18 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/nestedsubmodule/deeplynested"
 )
 
-// Class interface
-type NamespacedIface interface {
-	deeplynested.INamespacedIface
-	GetDefinedAt() string
-	GetGoodness() child.Goodness
+type Namespaced interface {
+	deeplynested.INamespaced
+	DefinedAt() string
+	Goodness() child.Goodness
 }
 
-// Struct proxy
-type Namespaced struct {
-	DefinedAt string \`json:"definedAt"\`
-	Goodness child.Goodness \`json:"goodness"\`
+// The jsii proxy struct for Namespaced
+type namespaced struct {
+	deeplynested.INamespaced // implements jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced
 }
 
-func (n *Namespaced) GetDefinedAt() string {
+func (n *namespaced) DefinedAt() string {
 	var returns string
 	_jsii_.Get(
 		n,
@@ -14265,7 +14169,7 @@ func (n *Namespaced) GetDefinedAt() string {
 	return returns
 }
 
-func (n *Namespaced) GetGoodness() child.Goodness {
+func (n *namespaced) Goodness() child.Goodness {
 	var returns child.Goodness
 	_jsii_.Get(
 		n,
@@ -14292,7 +14196,11 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.nested_submodule.Namespaced",
 		reflect.TypeOf((*Namespaced)(nil)).Elem(),
-		reflect.TypeOf((*NamespacedIface)(nil)).Elem(),
+		func() interface{} {
+			n := namespaced{}
+			_jsii_.InitJsiiProxy(&n.INamespaced)
+			return &n
+		},
 	)
 }
 
@@ -14337,29 +14245,30 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 )
 
-// Class interface
-type ReturnsSpecialParameterIface interface {
+type ReturnsSpecialParameter interface {
 	ReturnsSpecialParam() param.SpecialParameter
 }
 
-// Struct proxy
-type ReturnsSpecialParameter struct {
+// The jsii proxy struct for ReturnsSpecialParameter
+type returnsSpecialParameter struct {
+	_ byte // padding
 }
 
-func NewReturnsSpecialParameter() ReturnsSpecialParameterIface {
+func NewReturnsSpecialParameter() ReturnsSpecialParameter {
 	_init_.Initialize()
-	self := ReturnsSpecialParameter{}
+	r := returnsSpecialParameter{}
+
 	_jsii_.Create(
 		"jsii-calc.submodule.returnsparam.ReturnsSpecialParameter",
 		[]interface{}{},
 		[]_jsii_.FQN{},
 		[]_jsii_.Override{},
-		&self,
+		&r,
 	)
-	return &self
+	return &r
 }
 
-func (r *ReturnsSpecialParameter) ReturnsSpecialParam() param.SpecialParameter {
+func (r *returnsSpecialParameter) ReturnsSpecialParam() param.SpecialParameter {
 	var returns param.SpecialParameter
 	_jsii_.Invoke(
 		r,
@@ -14387,7 +14296,9 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.returnsparam.ReturnsSpecialParameter",
 		reflect.TypeOf((*ReturnsSpecialParameter)(nil)).Elem(),
-		reflect.TypeOf((*ReturnsSpecialParameterIface)(nil)).Elem(),
+		func() interface{} {
+			return &returnsSpecialParameter{}
+		},
 	)
 }
 
@@ -14406,28 +14317,33 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 )
 
-// Class interface
-type MyClassIface interface {
-	deeplynested.INamespacedIface
-	GetAwesomeness() child.Awesomeness
-	GetDefinedAt() string
-	GetGoodness() child.Goodness
-	GetProps() child.SomeStruct
-	GetAllTypes() jsiicalc.AllTypesIface
-	SetAllTypes(val jsiicalc.AllTypesIface)
+type MyClass interface {
+	deeplynested.INamespaced
+	AllTypes() jsiicalc.AllTypes
+	SetAllTypes(val jsiicalc.AllTypes)
+	Awesomeness() child.Awesomeness
+	DefinedAt() string
+	Goodness() child.Goodness
+	Props() child.SomeStruct
 	MethodWithSpecialParam(param param.SpecialParameter) string
 }
 
-// Struct proxy
-type MyClass struct {
-	Awesomeness child.Awesomeness \`json:"awesomeness"\`
-	DefinedAt string \`json:"definedAt"\`
-	Goodness child.Goodness \`json:"goodness"\`
-	Props child.SomeStruct \`json:"props"\`
-	AllTypes jsiicalc.AllTypesIface \`json:"allTypes"\`
+// The jsii proxy struct for MyClass
+type myClass struct {
+	deeplynested.INamespaced // implements jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced
 }
 
-func (m *MyClass) GetAwesomeness() child.Awesomeness {
+func (m *myClass) AllTypes() jsiicalc.AllTypes {
+	var returns jsiicalc.AllTypes
+	_jsii_.Get(
+		m,
+		"allTypes",
+		&returns,
+	)
+	return returns
+}
+
+func (m *myClass) Awesomeness() child.Awesomeness {
 	var returns child.Awesomeness
 	_jsii_.Get(
 		m,
@@ -14437,7 +14353,7 @@ func (m *MyClass) GetAwesomeness() child.Awesomeness {
 	return returns
 }
 
-func (m *MyClass) GetDefinedAt() string {
+func (m *myClass) DefinedAt() string {
 	var returns string
 	_jsii_.Get(
 		m,
@@ -14447,7 +14363,7 @@ func (m *MyClass) GetDefinedAt() string {
 	return returns
 }
 
-func (m *MyClass) GetGoodness() child.Goodness {
+func (m *myClass) Goodness() child.Goodness {
 	var returns child.Goodness
 	_jsii_.Get(
 		m,
@@ -14457,7 +14373,7 @@ func (m *MyClass) GetGoodness() child.Goodness {
 	return returns
 }
 
-func (m *MyClass) GetProps() child.SomeStruct {
+func (m *myClass) Props() child.SomeStruct {
 	var returns child.SomeStruct
 	_jsii_.Get(
 		m,
@@ -14467,31 +14383,22 @@ func (m *MyClass) GetProps() child.SomeStruct {
 	return returns
 }
 
-func (m *MyClass) GetAllTypes() jsiicalc.AllTypesIface {
-	var returns jsiicalc.AllTypesIface
-	_jsii_.Get(
-		m,
-		"allTypes",
-		&returns,
-	)
-	return returns
-}
 
-
-func NewMyClass(props child.SomeStruct) MyClassIface {
+func NewMyClass(props child.SomeStruct) MyClass {
 	_init_.Initialize()
-	self := MyClass{}
+	m := myClass{}
+
 	_jsii_.Create(
 		"jsii-calc.submodule.MyClass",
 		[]interface{}{props},
 		[]_jsii_.FQN{"jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced"},
 		[]_jsii_.Override{},
-		&self,
+		&m,
 	)
-	return &self
+	return &m
 }
 
-func (m *MyClass) SetAllTypes(val jsiicalc.AllTypesIface) {
+func (m *myClass) SetAllTypes(val jsiicalc.AllTypes) {
 	_jsii_.Set(
 		m,
 		"allTypes",
@@ -14499,7 +14406,7 @@ func (m *MyClass) SetAllTypes(val jsiicalc.AllTypesIface) {
 	)
 }
 
-func (m *MyClass) MethodWithSpecialParam(param param.SpecialParameter) string {
+func (m *myClass) MethodWithSpecialParam(param param.SpecialParameter) string {
 	var returns string
 	_jsii_.Invoke(
 		m,
@@ -14527,7 +14434,11 @@ func init() {
 	_jsii_.RegisterClass(
 		"jsii-calc.submodule.MyClass",
 		reflect.TypeOf((*MyClass)(nil)).Elem(),
-		reflect.TypeOf((*MyClassIface)(nil)).Elem(),
+		func() interface{} {
+			m := myClass{}
+			_jsii_.InitJsiiProxy(&m.INamespaced)
+			return &m
+		},
 	)
 }
 

--- a/packages/jsii-reflect/lib/docs.ts
+++ b/packages/jsii-reflect/lib/docs.ts
@@ -23,14 +23,9 @@ export class Docs {
    * Returns docstring of summary and remarks
    */
   public toString() {
-    const ret = new Array<string>();
-    if (this.docs.summary) {
-      ret.push(this.docs.summary);
-    }
-    if (this.docs.remarks) {
-      ret.push('', this.docs.remarks);
-    }
-    return ret.join('\n');
+    return [this.docs.summary, this.docs.remarks]
+      .filter((txt) => !!txt)
+      .join('\n\n');
   }
 
   public get subclassable(): boolean {


### PR DESCRIPTION
Go struct fields used to be emitted for all properties of any type,
including for go structs merely there to act as a proxy to a JS object.
Those properties were never accessed (neither set not read), and could
have been cause for confusion. They additionally needlessly increased
the memory footprint of such data types.

This changes the code generation to no longer emit fields on go structs
that are intended as proxies to JS objects, instead embedding the base
type(s) (super-class and/or super-interfaces) to properly inherit their
methods without duplicating every declaration; and uses a `byte`
placeholder when needed to ensure no 0-width struct is ever generated
(go would have those take 0 bytes of memory, and as a consequence, any
such vlaue is deemed equal to any other, which is not what we want).

In cases when a type descends from more than one direct parent, and
any of their (transitive) bases belongs to a different assembly, all members,
including inherited, are re-implemented to avoid the risk of a conflict
occurring if two parents bring in the same declaration (then automated
promotion cannot happen anymore).

This implied making a change to the method registration functions, such
that each type (class and interface) registers a proxy `maker`
function that is used by the runtime library to properly initialize jsii
proxy instances  of objects without requiring user intervention. This
makes it safe to operate even when embedding data structures from other
libraries. Additionally, it enables hiding the JS proxy structs from the
exported APIs, which further reduces the risk of mis-use.

These changes were proposed in aws/aws-cdk-rfcs#292.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
