### PR TITLE
fix(pacmak): go 1.16 requires running "go mod download" explicitly

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -40,7 +40,9 @@ export class Golang extends Target {
     // write `local.go.mod` with "replace" directives for local modules
     const localGoMod = await this.writeLocalGoMod(pkgDir);
 
-    // run `go build` with local.go.mod
+    // run `go build` with local.go.mod, go 1.16 requires that we download
+    // modules explicit so go.sum is updated.
+    await go('mod', ['download', '-modfile', localGoMod], { cwd: pkgDir });
     await go('build', ['-modfile', localGoMod], { cwd: pkgDir });
 
     // delete local.go.mod and local.go.sum from the output directory so it doesn't get published
@@ -229,5 +231,11 @@ function tryFindLocalRuntime():
  */
 async function go(command: string, args: string[], options: { cwd: string }) {
   const { cwd } = options;
-  return shell('go', [command, ...args], { cwd });
+  return shell('go', [command, ...args], {
+    cwd,
+    env: {
+      // disable the use of sumdb to reduce eventual consistency issues when new modules are published
+      GOSUMDB: 'off',
+    },
+  });
 }


### PR DESCRIPTION
Starting go 1.16, `go build` does not download modules and updates go.sum automatically. To that end, we now execute this before we execute `go build` during pacmak.

Additionally, set `GOSUMDB` to `off` in order to reduce the chance for eventual consistency issues when new modules are published.

Fixes #2615



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
