### PR TITLE
chore: add "version" file to go dist directory

### DIFF
--- a/packages/@jsii/go-runtime/build-tools/package.sh
+++ b/packages/@jsii/go-runtime/build-tools/package.sh
@@ -6,3 +6,7 @@ cd ${scriptdir}/..
 rm -fr dist
 mkdir -p dist/go
 rsync -av jsii-runtime-go/* dist/go/
+
+# create a "version" file which is needed by jsii-release
+version=$(node -p "require('./package.json').version")
+echo ${version} > dist/go/version


### PR DESCRIPTION
jsii-release requires a file called "version" so it will know the go-runtime version.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
