### PR TITLE
chore: remove CodeBuild PR validation

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -28,7 +28,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - '#review-requested=0'
       - '#changes-requested-reviews-by=0'
-      - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
       - status-success=jsii/superchain
@@ -80,7 +79,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - '#review-requested=0'
       - '#changes-requested-reviews-by=0'
-      - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
       - status-success=jsii/superchain
@@ -132,7 +130,6 @@ pull_request_rules:
       - '#approved-reviews-by>=1'
       - '#review-requested=0'
       - '#changes-requested-reviews-by=0'
-      - status-success~=AWS CodeBuild us-east-1
       - status-success=Semantic Pull Request
       # Docker image validation
       - status-success=jsii/superchain


### PR DESCRIPTION
Our GitHub Actions test suite is superior, and the CodeBuild validation was redundant.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
