### PR TITLE
feat(go): packageName and versionSuffix

### DIFF
--- a/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
@@ -5,10 +5,11 @@
 
 To enable go package generation, add the `go` key to the jsii targets configuration:
 
-- `packageName` (optional) - The name of the Go package name. If this is not
-  specified, the package name will be derived from the npm module name by
-  filtering non-alphanumeric characters (e.g. `aws-cdk-lib` will be
-  `awscdklib`). You can use this field to set a specific package name.
+- `packageName` (optional) - The name of the Go package name. If not specified,
+  package name will be derived from the JavaScript module name by removing
+  non-alphanumeric characters (e.g. `@aws-cdk/aws-s3` will be `awscdkawss3`). If
+  this is set on a submodule config file, it refers to the submodule package
+  name.
 - `moduleName` (required) - The name of the **target repository** in which this
   module will be published (e.g. `github.com/foo/bar`). The module itself will
   *always* be published under a subdirectory named according to the Go package

--- a/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
@@ -3,15 +3,31 @@
 !!! danger
     The **go** target is currently unstable and not suitable for production use.
 
-To enable go package generation, add the **go** key with an empty object to the jsii targets configuration.
+To enable go package generation, add the `go` key to the jsii targets configuration:
 
-This will add generated go package code to your specified `outDir` for testing and experimentation.
+- `packageName` (optional) - The name of the Go package name. If this is not
+  specified, the package name will be derived from the npm module name by
+  filtering non-alphanumeric characters (e.g. `aws-cdk-lib` will be
+  `awscdklib`). You can use this field to set a specific package name.
+- `moduleName` (required) - The name of the **target repository** in which this
+  module will be published (e.g. `github.com/foo/bar`). The module itself will
+  *always* be published under a subdirectory named according to the Go package
+  name of the module (e.g. `github.com/foo/bar/awscdk`).
+- `versionSuffix` (optional) - Can be provided that will be appended at the end
+  of the module version.
 
-```json
+This will add generated go package code to your specified `outDir` under
+`go/PACKAGE_NAME` (e.g. `dist/go/awscdklib`).
+
+```js
 {
   "jsii": {
     "targets": {
-      "go": {},
+      "go": {
+        "moduleName": "github.com/foo/bar",  // REQUIRED
+        "packageName": "hello",              // OPTIONAL
+        "versionSuffix": "-devprefix"        // OPTIONAL
+      },
       // ...
     },
     // ...

--- a/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/targets/go.md
@@ -8,8 +8,8 @@ To enable go package generation, add the `go` key to the jsii targets configurat
 - `packageName` (optional) - The name of the Go package name. If not specified,
   package name will be derived from the JavaScript module name by removing
   non-alphanumeric characters (e.g. `@aws-cdk/aws-s3` will be `awscdkawss3`). If
-  this is set on a submodule config file, it refers to the submodule package
-  name.
+  this is set on a submodule config file (`.jsiirc.json`), it refers to the
+  submodule package name.
 - `moduleName` (required) - The name of the **target repository** in which this
   module will be published (e.g. `github.com/foo/bar`). The module itself will
   *always* be published under a subdirectory named according to the Go package

--- a/packages/@jsii/go-runtime-test/project/compliance_test.go
+++ b/packages/@jsii/go-runtime-test/project/compliance_test.go
@@ -2,17 +2,18 @@ package tests
 
 import (
 	"fmt"
-	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/child"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
-	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
-	"github.com/stretchr/testify/suite"
 	"math"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/child"
+	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
+	"github.com/stretchr/testify/suite"
 )
 
 func (suite *ComplianceSuite) TestStatics() {
@@ -62,7 +63,7 @@ func (suite *ComplianceSuite) TestPrimitiveTypes() {
 
 func (suite *ComplianceSuite) TestUseNestedStruct() {
 	suite.FailTest("Nested types are not namespaced", "https://github.com/aws/jsii/pull/2650")
-	scopejsiicalcbase.StaticConsumer_Consume(submodule.NestingClass_NestedStruct{
+	jcb.StaticConsumer_Consume(customsubmodulename.NestingClass_NestedStruct{
 		Name: "Bond, James Bond",
 	})
 }
@@ -143,7 +144,7 @@ func (suite *ComplianceSuite) TestCallMethods() {
 	assert.Equal(float64(20), calc.Value())
 
 	calc.Pow(5)
-	assert.Equal(float64(20 * 20 * 20 * 20 * 20), calc.Value())
+	assert.Equal(float64(20*20*20*20*20), calc.Value())
 
 	calc.Neg()
 	assert.Equal(float64(-3200000), calc.Value())
@@ -161,7 +162,7 @@ func (suite *ComplianceSuite) TestNodeStandardLibrary() {
 	assert.Equal("Hello, resource!", obj.FsReadFile())
 }
 
-func (suite* ComplianceSuite) TestDynamicTypes() {
+func (suite *ComplianceSuite) TestDynamicTypes() {
 	assert := suite.Assert()
 	types := calc.NewAllTypes()
 
@@ -204,11 +205,11 @@ func (suite* ComplianceSuite) TestDynamicTypes() {
 	assert.Equal(float64(123), (types.AnyProperty()).([]interface{})[2])
 
 	// map
-	types.SetAnyProperty(map[string]string{ "MapKey": "MapValue" })
+	types.SetAnyProperty(map[string]string{"MapKey": "MapValue"})
 	assert.Equal("MapValue", ((types.AnyProperty()).(map[string]interface{}))["MapKey"])
 
 	// map of any
-	types.SetAnyProperty(map[string]interface{}{ "Goo": 19289812 })
+	types.SetAnyProperty(map[string]interface{}{"Goo": 19289812})
 	assert.Equal(float64(19289812), ((types.AnyProperty()).(map[string]interface{}))["Goo"])
 
 	// classes
@@ -260,14 +261,14 @@ func (suite *ComplianceSuite) TestUseEnumFromScopedModule() {
 	obj.SetFoo(calclib.EnumFromScopedModule_VALUE1)
 	assert.Equal(calclib.EnumFromScopedModule_VALUE1, obj.LoadFoo())
 	obj.SaveFoo(calclib.EnumFromScopedModule_VALUE2)
-	assert.Equal( calclib.EnumFromScopedModule_VALUE2, obj.Foo())
+	assert.Equal(calclib.EnumFromScopedModule_VALUE2, obj.Foo())
 }
 
 func (suite *ComplianceSuite) TestCreateObjectAndCtorOverloads() {
 	suite.NotApplicableTest("Golang does not have overloaded functions so the genearated class only has a single New function")
 }
 
-func (suite* ComplianceSuite) TestGetAndSetEnumValues() {
+func (suite *ComplianceSuite) TestGetAndSetEnumValues() {
 	assert := suite.Assert()
 
 	calc := calc.NewCalculator(calc.CalculatorProps{})
@@ -280,7 +281,7 @@ func (suite* ComplianceSuite) TestGetAndSetEnumValues() {
 	assert.Equal("<<[[{{(((1 * (0 + 9)) * (0 + 9)) * (0 + 9))}}]]>>", calc.ToString())
 }
 
-func (suite* ComplianceSuite) TestListInClassCanBeReadCorrectly() {
+func (suite *ComplianceSuite) TestListInClassCanBeReadCorrectly() {
 	assert := suite.Assert()
 
 	classWithCollections := calc.NewClassWithCollections(map[string]string{}, []string{"one", "two"})
@@ -299,7 +300,7 @@ func newDerivedFromAllTypes() derivedFromAllTypes {
 	}
 }
 
-func (suite* ComplianceSuite) TestTestFluentApiWithDerivedClasses() {
+func (suite *ComplianceSuite) TestTestFluentApiWithDerivedClasses() {
 	assert := suite.Assert()
 
 	obj := newDerivedFromAllTypes()
@@ -309,13 +310,13 @@ func (suite* ComplianceSuite) TestTestFluentApiWithDerivedClasses() {
 	assert.Equal(float64(12), obj.NumberProperty())
 }
 
-func (suite* ComplianceSuite) TestCanLoadEnumValues() {
+func (suite *ComplianceSuite) TestCanLoadEnumValues() {
 	assert := suite.Assert()
 	assert.NotEmpty(calc.EnumDispenser_RandomStringLikeEnum())
 	assert.NotEmpty(calc.EnumDispenser_RandomIntegerLikeEnum())
 }
 
-func (suite* ComplianceSuite) TestCollectionOfInterfaces_ListOfStructs() {
+func (suite *ComplianceSuite) TestCollectionOfInterfaces_ListOfStructs() {
 	assert := suite.Assert()
 
 	list := calc.InterfaceCollections_ListOfStructs()
@@ -332,15 +333,15 @@ func newDoNotOverridePrivates() doNotOverridePrivates {
 	}
 }
 
-func (x* doNotOverridePrivates) PrivateProperty() string {
+func (x *doNotOverridePrivates) PrivateProperty() string {
 	return "privateProperty-Override"
 }
 
-func (x* doNotOverridePrivates) SetPrivateProperty(value string) {
+func (x *doNotOverridePrivates) SetPrivateProperty(value string) {
 	panic("Boom")
 }
 
-func (suite* ComplianceSuite) TestDoNotOverridePrivates_property_getter_public() {
+func (suite *ComplianceSuite) TestDoNotOverridePrivates_property_getter_public() {
 	assert := suite.Assert()
 
 	obj := newDoNotOverridePrivates()
@@ -351,11 +352,11 @@ func (suite* ComplianceSuite) TestDoNotOverridePrivates_property_getter_public()
 	assert.Equal("MyNewValue", obj.PrivatePropertyValue())
 }
 
-func (suite* ComplianceSuite) TestEqualsIsResistantToPropertyShadowingResultVariable() {
+func (suite *ComplianceSuite) TestEqualsIsResistantToPropertyShadowingResultVariable() {
 	assert := suite.Assert()
-	first := calc.StructWithJavaReservedWords{ Default: "one" }
-	second := calc.StructWithJavaReservedWords { Default: "one" }
-	third := calc.StructWithJavaReservedWords { Default: "two" }
+	first := calc.StructWithJavaReservedWords{Default: "one"}
+	second := calc.StructWithJavaReservedWords{Default: "one"}
+	third := calc.StructWithJavaReservedWords{Default: "two"}
 	assert.Equal(first, second)
 	assert.NotEqual(first, third)
 }
@@ -370,15 +371,15 @@ func newOverridableProtectedMemberDerived() overridableProtectedMemberDerived {
 	}
 }
 
-func (x* overridableProtectedMemberDerived) OverrideReadOnly() string {
+func (x *overridableProtectedMemberDerived) OverrideReadOnly() string {
 	return "Cthulhu "
 }
 
-func (x* overridableProtectedMemberDerived) OverrideReadeWrite() string {
+func (x *overridableProtectedMemberDerived) OverrideReadeWrite() string {
 	return "Fhtagn!"
 }
 
-func (suite* ComplianceSuite) TestCanOverrideProtectedGetter() {
+func (suite *ComplianceSuite) TestCanOverrideProtectedGetter() {
 	suite.FailTest("Overrides are not supported yet", "https://github.com/aws/jsii/issues/2048")
 
 	assert := suite.Assert()
@@ -402,10 +403,9 @@ func newImplementsAdditionalInterface(s calc.StructB) implementsAdditionalInterf
 	}
 }
 
-func (suite* ComplianceSuite) TestInterfacesCanBeUsedTransparently_WhenAddedToJsiiType() {
+func (suite *ComplianceSuite) TestInterfacesCanBeUsedTransparently_WhenAddedToJsiiType() {
 	suite.FailTest("Overrides not supported", "https://github.com/aws/jsii/issues/2048")
 	assert := suite.Assert()
-
 
 	expected := calc.StructB{RequiredString: "It's Britney b**ch!"}
 	delegate := newImplementsAdditionalInterface(expected)
@@ -413,7 +413,7 @@ func (suite* ComplianceSuite) TestInterfacesCanBeUsedTransparently_WhenAddedToJs
 	assert.Equal(expected, consumer.WorkItBaby())
 }
 
-func (suite* ComplianceSuite) TestStructs_nonOptionalequals() {
+func (suite *ComplianceSuite) TestStructs_nonOptionalequals() {
 	assert := suite.Assert()
 
 	structA := calc.StableStruct{ReadonlyProperty: "one"}
@@ -423,9 +423,8 @@ func (suite* ComplianceSuite) TestStructs_nonOptionalequals() {
 	assert.NotEqual(structC, structA)
 }
 
-func (suite* ComplianceSuite) TestTestInterfaceParameter() {
+func (suite *ComplianceSuite) TestTestInterfaceParameter() {
 	assert := suite.Assert()
-
 
 	obj := calc.NewJsObjectLiteralForInterface()
 	friendly := obj.GiveMeFriendly()
@@ -436,7 +435,7 @@ func (suite* ComplianceSuite) TestTestInterfaceParameter() {
 	assert.Equal("I am literally friendly! Let me buy you a drink!", betterGreeting)
 }
 
-func (suite* ComplianceSuite) TestLiftedKwargWithSameNameAsPositionalArg() {
+func (suite *ComplianceSuite) TestLiftedKwargWithSameNameAsPositionalArg() {
 	assert := suite.Assert()
 
 	// This is a replication of a test that mostly affects languages with keyword arguments (e.g: Python, Ruby, ...)
@@ -468,7 +467,7 @@ func newMulTen(value float64) mulTen {
 	}
 }
 
-func (suite* ComplianceSuite) TestCreationOfNativeObjectsFromJavaScriptObjects() {
+func (suite *ComplianceSuite) TestCreationOfNativeObjectsFromJavaScriptObjects() {
 	assert := suite.Assert()
 
 	types := calc.NewAllTypes()
@@ -479,7 +478,6 @@ func (suite* ComplianceSuite) TestCreationOfNativeObjectsFromJavaScriptObjects()
 	assert.True(ok)
 
 	suite.FailTest("??", "??")
-
 
 	nativeObj := newAddTen(10)
 	types.SetAnyProperty(nativeObj)
@@ -558,7 +556,7 @@ func (suite *ComplianceSuite) TestPropertyOverrides_Interfaces() {
 	assert.Equal("READ_ONLY_STRING", interact.JustRead())
 
 	suite.FailTest("Not sure. Most likely related to the missing setters on interfaces", "https://github.com/aws/jsii/issues/2665")
-	assert.Equal( "Hello!?", interact.WriteAndRead("Hello"))
+	assert.Equal("Hello!?", interact.WriteAndRead("Hello"))
 }
 
 type TestPropertyOverridesInterfacesIInterfaceWithProperties struct {
@@ -677,7 +675,7 @@ func (suite *ComplianceSuite) TestStructs_containsNullChecks() {
 	suite.FailTest("No validation of required fields in structs", "https://github.com/aws/jsii/issues/2672")
 
 	// we expect a failure here when we pass the struct to js
-	assert.PanicsWithError("", func() {obj.ReadFirstNumber(s)})
+	assert.PanicsWithError("", func() { obj.ReadFirstNumber(s) })
 }
 
 func (suite *ComplianceSuite) TestUnionPropertiesWithBuilder() {
@@ -776,9 +774,9 @@ func (suite *ComplianceSuite) TestReturnAbstract() {
 	obj := calc.NewAbstractClassReturner()
 	obj2 := obj.GiveMeAbstract()
 
-	assert.Equal("Hello, John!!", obj2.AbstractMethod("John"));
-	assert.Equal("propFromInterfaceValue", obj2.PropFromInterface());
-	assert.Equal(float64(42), obj2.NonAbstractMethod());
+	assert.Equal("Hello, John!!", obj2.AbstractMethod("John"))
+	assert.Equal("propFromInterfaceValue", obj2.PropFromInterface())
+	assert.Equal(float64(42), obj2.NonAbstractMethod())
 
 	iface := obj.GiveMeInterface()
 	assert.Equal("propFromInterfaceValue", iface.PropFromInterface())
@@ -795,22 +793,22 @@ func (suite *ComplianceSuite) TestCollectionOfInterfaces_MapOfInterfaces() {
 func (suite *ComplianceSuite) TestStructs_multiplePropertiesEquals() {
 	assert := suite.Assert()
 	structA := calc.DiamondInheritanceTopLevelStruct{
-		BaseLevelProperty: "one",
-		FirstMidLevelProperty: "two",
+		BaseLevelProperty:      "one",
+		FirstMidLevelProperty:  "two",
 		SecondMidLevelProperty: "three",
-		TopLevelProperty: "four",
+		TopLevelProperty:       "four",
 	}
 	structB := calc.DiamondInheritanceTopLevelStruct{
-		BaseLevelProperty: "one",
-		FirstMidLevelProperty: "two",
+		BaseLevelProperty:      "one",
+		FirstMidLevelProperty:  "two",
 		SecondMidLevelProperty: "three",
-		TopLevelProperty: "four",
+		TopLevelProperty:       "four",
 	}
 	structC := calc.DiamondInheritanceTopLevelStruct{
-		BaseLevelProperty: "one",
-		FirstMidLevelProperty: "two",
+		BaseLevelProperty:      "one",
+		FirstMidLevelProperty:  "two",
 		SecondMidLevelProperty: "different",
-		TopLevelProperty: "four",
+		TopLevelProperty:       "four",
 	}
 
 	assert.Equal(structA, structB)
@@ -829,7 +827,7 @@ type myDoNotOverridePrivates struct {
 	calc.DoNotOverridePrivates
 }
 
-func (s *myDoNotOverridePrivates) PrivateProperty() string  {
+func (s *myDoNotOverridePrivates) PrivateProperty() string {
 	return "privateProperty-Override"
 }
 
@@ -851,10 +849,10 @@ func (suite *ComplianceSuite) TestDoNotOverridePrivates_property_getter_private(
 func (suite *ComplianceSuite) TestStructs_withDiamondInheritance_correctlyDedupeProperties() {
 	assert := suite.Assert()
 	s := calc.DiamondInheritanceTopLevelStruct{
-		BaseLevelProperty: "base",
-		FirstMidLevelProperty: "mid1",
+		BaseLevelProperty:      "base",
+		FirstMidLevelProperty:  "mid1",
 		SecondMidLevelProperty: "mid2",
-		TopLevelProperty: "top",
+		TopLevelProperty:       "top",
 	}
 
 	assert.Equal("base", s.BaseLevelProperty)

--- a/packages/@jsii/go-runtime-test/project/go.mod
+++ b/packages/@jsii/go-runtime-test/project/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/aws/jsii-runtime-go v0.0.0
 	github.com/aws/jsii/jsii-calc/go/jsiicalc/v3 v3.20.120
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/jcb v0.0.0
 	github.com/stretchr/testify v1.7.0
 )
 
 replace (
 	github.com/aws/jsii-runtime-go => ../../go-runtime/jsii-runtime-go
 	github.com/aws/jsii/jsii-calc/go/jsiicalc/v3 => ../jsii-calc/go/jsiicalc
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase => ../jsii-calc/go/scopejsiicalcbase
+	github.com/aws/jsii/jsii-calc/go/jcb => ../jsii-calc/go/jcb
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 => ../jsii-calc/go/scopejsiicalcbaseofbase
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib => ../jsii-calc/go/scopejsiicalclib
 )

--- a/packages/@jsii/go-runtime-test/project/main_test.go
+++ b/packages/@jsii/go-runtime-test/project/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 	returnsParam "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/returnsparam"
 	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
 )
 
 func TestMain(m *testing.M) {
@@ -115,7 +115,7 @@ func TestUpcasingReflectable(t *testing.T) {
 	}
 
 	actual := entries[0]
-	expected := submodule.ReflectableEntry{Key: strings.ToUpper(key), Value: val}
+	expected := customsubmodulename.ReflectableEntry{Key: strings.ToUpper(key), Value: val}
 	if actual != expected {
 		t.Errorf("Expected %v; Received: %v", expected, actual)
 	}

--- a/packages/@jsii/kernel/test/kernel.test.ts
+++ b/packages/@jsii/kernel/test/kernel.test.ts
@@ -425,6 +425,7 @@ defineTest(
         },
         go: {
           moduleName: 'github.com/aws/jsii/jsii-calc/go',
+          versionSuffix: '-devpreview',
         },
         java: {
           package: 'software.amazon.jsii.tests.calculator.lib',

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -55,7 +55,8 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go",
+        "packageName": "jcb"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator.base",

--- a/packages/@scope/jsii-calc-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base/test/assembly.jsii
@@ -64,7 +64,8 @@
       "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
     },
     "go": {
-      "moduleName": "github.com/aws/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go",
+      "packageName": "jcb"
     },
     "java": {
       "maven": {
@@ -201,5 +202,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "rKhrKvGvuY8DnHhiQFIGMiFOU8AU+S9ZVk9c3/rUJNk="
+  "fingerprint": "rIJAOTzUs2OYke2UCJzexq/fqJOiqmR9PbTMlf37o/A="
 }

--- a/packages/@scope/jsii-calc-lib/lib/submodule/.jsiirc.json
+++ b/packages/@scope/jsii-calc-lib/lib/submodule/.jsiirc.json
@@ -8,6 +8,9 @@
     },
     "python": {
       "module": "scope.jsii_calc_lib.custom_submodule_name"
+    },
+    "go" :{
+      "packageName": "customsubmodulename"
     }
   }
 }

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -49,7 +49,8 @@
     "outdir": "dist",
     "targets": {
       "go": {
-        "moduleName": "github.com/aws/jsii/jsii-calc/go"
+        "moduleName": "github.com/aws/jsii/jsii-calc/go",
+        "versionSuffix": "-devpreview"
       },
       "java": {
         "package": "software.amazon.jsii.tests.calculator.lib",

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -19,7 +19,8 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go",
+          "packageName": "jcb"
         },
         "java": {
           "maven": {
@@ -98,6 +99,9 @@
         "dotnet": {
           "namespace": "Amazon.JSII.Tests.CustomSubmoduleName"
         },
+        "go": {
+          "packageName": "customsubmodulename"
+        },
         "java": {
           "package": "software.amazon.jsii.tests.calculator.custom_submodule_name"
         },
@@ -114,7 +118,8 @@
       "versionSuffix": "-devpreview"
     },
     "go": {
-      "moduleName": "github.com/aws/jsii/jsii-calc/go"
+      "moduleName": "github.com/aws/jsii/jsii-calc/go",
+      "versionSuffix": "-devpreview"
     },
     "java": {
       "maven": {
@@ -872,5 +877,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "YlmxPtOusVTgKe2YUzZDpB4UnmnU3zZ0UUdXwSDcgOo="
+  "fingerprint": "6We+OU9YxfTRfwXErreAyzcH2dVH29FgV8eiBRjowAY="
 }

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -38,7 +38,8 @@
     "lint": "eslint . --ext .js,.ts --ignore-path=.gitignore",
     "lint:fix": "yarn lint --fix",
     "test": "(ls test/test.*.js | xargs -n1 node) && diff-test test/assembly.jsii .jsii",
-    "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
+    "test:update": "npm run build && UPDATE_DIFF=1 npm run test",
+    "update": "./update-all.sh"
   },
   "dependencies": {
     "@fixtures/jsii-calc-bundled": "file:../@fixtures/jsii-calc-bundled",

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -48,7 +48,8 @@
           "packageId": "Amazon.JSII.Tests.CalculatorPackageId.BasePackageId"
         },
         "go": {
-          "moduleName": "github.com/aws/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go",
+          "packageName": "jcb"
         },
         "java": {
           "maven": {
@@ -102,6 +103,9 @@
             "dotnet": {
               "namespace": "Amazon.JSII.Tests.CustomSubmoduleName"
             },
+            "go": {
+              "packageName": "customsubmodulename"
+            },
             "java": {
               "package": "software.amazon.jsii.tests.calculator.custom_submodule_name"
             },
@@ -118,7 +122,8 @@
           "versionSuffix": "-devpreview"
         },
         "go": {
-          "moduleName": "github.com/aws/jsii/jsii-calc/go"
+          "moduleName": "github.com/aws/jsii/jsii-calc/go",
+          "versionSuffix": "-devpreview"
         },
         "java": {
           "maven": {
@@ -14870,5 +14875,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "rH6rK3iHNatb4ojll7sd8rvJ4k/89Kybg89FRd96Hno="
+  "fingerprint": "uNidGL2tgHT8QUQRcLCiHny0p3nFE+RgNLoUqTDbHcM="
 }

--- a/packages/jsii-calc/update-all.sh
+++ b/packages/jsii-calc/update-all.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+cd ${scriptdir}
+
+modules="\
+  ../@scope/jsii-calc-base-of-base \
+  ../@scope/jsii-calc-base \
+  ../@scope/jsii-calc-lib \
+  ./"
+
+for mod in $modules; do
+  node -p "require('./package.json').name"
+  (
+    cd $mod
+    yarn build
+    yarn test:update
+  )
+done
+

--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -11,7 +11,7 @@ import { shell } from '../util';
 import { Documentation } from './go/documentation';
 import { GOMOD_FILENAME, RootPackage } from './go/package';
 import { JSII_INIT_PACKAGE } from './go/runtime';
-import { goPackageName, tarballName } from './go/util';
+import { tarballName } from './go/util';
 
 export class Golang extends Target {
   private readonly goGenerator: GoGenerator;
@@ -35,7 +35,7 @@ export class Golang extends Target {
     // copy generated sources to the output directory
     await this.copyFiles(sourceDir, outDir);
 
-    const pkgDir = path.join(outDir, goPackageName(this.assembly.name));
+    const pkgDir = path.join(outDir, this.goGenerator.rootPackage.packageName);
 
     // write `local.go.mod` with "replace" directives for local modules
     const localGoMod = await this.writeLocalGoMod(pkgDir);
@@ -154,7 +154,7 @@ class GoGenerator implements IGenerator {
     tarball: string,
     { license, notice }: Legalese,
   ): Promise<any> {
-    const output = path.join(outDir, goPackageName(this.assembly.name));
+    const output = path.join(outDir, this.rootPackage.packageName);
     await this.code.save(output);
     await fs.copyFile(
       tarball,

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -14,7 +14,12 @@ import {
   JSII_INIT_ALIAS,
 } from './runtime';
 import { GoClass, GoType, Enum, GoInterface, Struct } from './types';
-import { findTypeInTree, goPackageName, flatMap, tarballName } from './util';
+import {
+  findTypeInTree,
+  goPackageNameForAssembly,
+  flatMap,
+  tarballName,
+} from './util';
 import { VersionFile } from './version-file';
 
 export const GOMOD_FILENAME = 'go.mod';
@@ -206,9 +211,14 @@ export class RootPackage extends Package {
   private readonly versionFile: VersionFile;
 
   public constructor(assembly: Assembly) {
-    const packageName = goPackageName(assembly.name);
+    const goConfig = assembly.targets?.go ?? {};
+    const packageName = goPackageNameForAssembly(assembly);
     const filePath = '';
-    const moduleName = assembly.targets?.go?.moduleName ?? '';
+    const moduleName = goConfig.moduleName ?? '';
+    let version = assembly.version;
+    if (goConfig.versionSuffix) {
+      version += goConfig.versionSuffix;
+    }
 
     super(
       assembly.types,
@@ -216,11 +226,11 @@ export class RootPackage extends Package {
       packageName,
       filePath,
       moduleName,
-      assembly.version,
+      version,
     );
 
     this.assembly = assembly;
-    this.version = assembly.version;
+    this.version = version;
     this.versionFile = new VersionFile(this.version);
 
     if (this.assembly.readme?.markdown) {
@@ -384,7 +394,7 @@ export class InternalPackage extends Package {
   public readonly parent: Package;
 
   public constructor(root: Package, parent: Package, assembly: JsiiSubmodule) {
-    const packageName = goPackageName(assembly.name);
+    const packageName = goPackageNameForAssembly(assembly);
     const filePath =
       parent === root ? packageName : `${parent.filePath}/${packageName}`;
 

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -215,10 +215,7 @@ export class RootPackage extends Package {
     const packageName = goPackageNameForAssembly(assembly);
     const filePath = '';
     const moduleName = goConfig.moduleName ?? '';
-    let version = assembly.version;
-    if (goConfig.versionSuffix) {
-      version += goConfig.versionSuffix;
-    }
+    const version = `${assembly.version}${goConfig.versionSuffix ?? ''}`;
 
     super(
       assembly.types,

--- a/packages/jsii-pacmak/lib/targets/go/util.ts
+++ b/packages/jsii-pacmak/lib/targets/go/util.ts
@@ -1,4 +1,4 @@
-import { Assembly } from 'jsii-reflect';
+import { Assembly, Submodule } from 'jsii-reflect';
 
 import { Package } from './package';
 import { GoMethod, GoTypeMember, GoType } from './types';
@@ -24,8 +24,15 @@ export function findTypeInTree(
 /*
  * Format NPM package names as idiomatic Go module name
  */
-export function goPackageName(name: string): string {
-  return name.replace(/[^a-z0-9.]/gi, '').toLowerCase();
+export function goPackageNameForAssembly(
+  assembly: Assembly | Submodule,
+): string {
+  const config = assembly.targets?.go ?? {};
+  if (config.packageName) {
+    return config.packageName;
+  }
+
+  return assembly.name.replace(/[^a-z0-9.]/gi, '').toLowerCase();
 }
 
 export function flatMap<T, R>(

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -855,6 +855,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 <root>
  ┗━ 📁 go
     ┗━ 📁 scopejsiicalclib
+       ┣━ 📁 customsubmodulename
+       ┃  ┣━ 📄 customsubmodulename.go
+       ┃  ┗━ 📄 customsubmodulename.init.go
        ┣━ 📄 go.mod
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii.go
@@ -863,9 +866,6 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
        ┣━ 📄 NOTICE
        ┣━ 📄 scopejsiicalclib.go
        ┣━ 📄 scopejsiicalclib.init.go
-       ┣━ 📁 submodule
-       ┃  ┣━ 📄 submodule.go
-       ┃  ┗━ 📄 submodule.init.go
        ┗━ 📄 version
 `;
 
@@ -1077,6 +1077,205 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/NOTICE 1`] = `
 jsii
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename.go 1`] = `
+package customsubmodulename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+)
+
+// Deprecated.
+type IReflectable interface {
+	// Deprecated.
+	Entries() []ReflectableEntry
+}
+
+// The jsii proxy for IReflectable
+type jsiiProxy_IReflectable struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IReflectable) Entries() []ReflectableEntry {
+	var returns []ReflectableEntry
+	_jsii_.Get(
+		j,
+		"entries",
+		&returns,
+	)
+	return returns
+}
+
+// This class is here to show we can use nested classes across module boundaries.
+// Deprecated.
+type NestingClass interface {
+}
+
+// The jsii proxy struct for NestingClass
+type jsiiProxy_NestingClass struct {
+	_ byte // padding
+}
+
+// This class is here to show we can use nested classes across module boundaries.
+// Deprecated.
+type NestingClass_NestedClass interface {
+	Property() string
+}
+
+// The jsii proxy struct for NestingClass_NestedClass
+type jsiiProxy_NestingClass_NestedClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_NestingClass_NestedClass) Property() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+// Deprecated.
+func NewNestingClass_NestedClass() NestingClass_NestedClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_NestingClass_NestedClass{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
+		nil /* no parameters */,
+		[]_jsii_.FQN{},
+		nil, // no overrides
+		&j,
+	)
+
+	return &j
+}
+
+// This is a struct, nested within a class.
+//
+// Normal.
+// Deprecated.
+type NestingClass_NestedStruct struct {
+	// Deprecated.
+	Name string \`json:"name"\`
+}
+
+// Deprecated.
+type ReflectableEntry struct {
+	// Deprecated.
+	Key string \`json:"key"\`
+	// Deprecated.
+	Value interface{} \`json:"value"\`
+}
+
+// Deprecated.
+type Reflector interface {
+	AsMap(reflectable IReflectable) map[string]interface{}
+}
+
+// The jsii proxy struct for Reflector
+type jsiiProxy_Reflector struct {
+	_ byte // padding
+}
+
+// Deprecated.
+func NewReflector() Reflector {
+	_init_.Initialize()
+
+	j := jsiiProxy_Reflector{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.Reflector",
+		nil /* no parameters */,
+		[]_jsii_.FQN{},
+		nil, // no overrides
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated.
+func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) map[string]interface{} {
+	var returns map[string]interface{}
+
+	_jsii_.Invoke(
+		r,
+		"asMap",
+		[]interface{}{reflectable},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename.init.go 1`] = `
+package customsubmodulename
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go"
+)
+
+func init() {
+	_jsii_.RegisterInterface(
+		"@scope/jsii-calc-lib.submodule.IReflectable",
+		reflect.TypeOf((*IReflectable)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "entries", GoGetter: "Entries"},
+		},
+		func() interface{} {
+			return &jsiiProxy_IReflectable{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-lib.submodule.NestingClass",
+		reflect.TypeOf((*NestingClass)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_NestingClass{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
+		reflect.TypeOf((*NestingClass_NestedClass)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "property", GoGetter: "Property"},
+		},
+		func() interface{} {
+			return &jsiiProxy_NestingClass_NestedClass{}
+		},
+	)
+	_jsii_.RegisterStruct(
+		"@scope/jsii-calc-lib.submodule.NestingClass.NestedStruct",
+		reflect.TypeOf((*NestingClass_NestedStruct)(nil)).Elem(),
+	)
+	_jsii_.RegisterStruct(
+		"@scope/jsii-calc-lib.submodule.ReflectableEntry",
+		reflect.TypeOf((*ReflectableEntry)(nil)).Elem(),
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-lib.submodule.Reflector",
+		reflect.TypeOf((*Reflector)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "asMap", GoMethod: "AsMap"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Reflector{}
+		},
+	)
+}
 
 `;
 
@@ -1563,205 +1762,6 @@ func init() {
 	_jsii_.RegisterStruct(
 		"@scope/jsii-calc-lib.StructWithOnlyOptionals",
 		reflect.TypeOf((*StructWithOnlyOptionals)(nil)).Elem(),
-	)
-}
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/submodule/submodule.go 1`] = `
-package submodule
-
-import (
-	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
-)
-
-// Deprecated.
-type IReflectable interface {
-	// Deprecated.
-	Entries() []ReflectableEntry
-}
-
-// The jsii proxy for IReflectable
-type jsiiProxy_IReflectable struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IReflectable) Entries() []ReflectableEntry {
-	var returns []ReflectableEntry
-	_jsii_.Get(
-		j,
-		"entries",
-		&returns,
-	)
-	return returns
-}
-
-// This class is here to show we can use nested classes across module boundaries.
-// Deprecated.
-type NestingClass interface {
-}
-
-// The jsii proxy struct for NestingClass
-type jsiiProxy_NestingClass struct {
-	_ byte // padding
-}
-
-// This class is here to show we can use nested classes across module boundaries.
-// Deprecated.
-type NestingClass_NestedClass interface {
-	Property() string
-}
-
-// The jsii proxy struct for NestingClass_NestedClass
-type jsiiProxy_NestingClass_NestedClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_NestingClass_NestedClass) Property() string {
-	var returns string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-// Deprecated.
-func NewNestingClass_NestedClass() NestingClass_NestedClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_NestingClass_NestedClass{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
-		nil /* no parameters */,
-		[]_jsii_.FQN{},
-		nil, // no overrides
-		&j,
-	)
-
-	return &j
-}
-
-// This is a struct, nested within a class.
-//
-// Normal.
-// Deprecated.
-type NestingClass_NestedStruct struct {
-	// Deprecated.
-	Name string \`json:"name"\`
-}
-
-// Deprecated.
-type ReflectableEntry struct {
-	// Deprecated.
-	Key string \`json:"key"\`
-	// Deprecated.
-	Value interface{} \`json:"value"\`
-}
-
-// Deprecated.
-type Reflector interface {
-	AsMap(reflectable IReflectable) map[string]interface{}
-}
-
-// The jsii proxy struct for Reflector
-type jsiiProxy_Reflector struct {
-	_ byte // padding
-}
-
-// Deprecated.
-func NewReflector() Reflector {
-	_init_.Initialize()
-
-	j := jsiiProxy_Reflector{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.Reflector",
-		nil /* no parameters */,
-		[]_jsii_.FQN{},
-		nil, // no overrides
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated.
-func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) map[string]interface{} {
-	var returns map[string]interface{}
-
-	_jsii_.Invoke(
-		r,
-		"asMap",
-		[]interface{}{reflectable},
-		&returns,
-	)
-
-	return returns
-}
-
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/submodule/submodule.init.go 1`] = `
-package submodule
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go"
-)
-
-func init() {
-	_jsii_.RegisterInterface(
-		"@scope/jsii-calc-lib.submodule.IReflectable",
-		reflect.TypeOf((*IReflectable)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "entries", GoGetter: "Entries"},
-		},
-		func() interface{} {
-			return &jsiiProxy_IReflectable{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-lib.submodule.NestingClass",
-		reflect.TypeOf((*NestingClass)(nil)).Elem(),
-		nil, // no members
-		func() interface{} {
-			return &jsiiProxy_NestingClass{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
-		reflect.TypeOf((*NestingClass_NestedClass)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "property", GoGetter: "Property"},
-		},
-		func() interface{} {
-			return &jsiiProxy_NestingClass_NestedClass{}
-		},
-	)
-	_jsii_.RegisterStruct(
-		"@scope/jsii-calc-lib.submodule.NestingClass.NestedStruct",
-		reflect.TypeOf((*NestingClass_NestedStruct)(nil)).Elem(),
-	)
-	_jsii_.RegisterStruct(
-		"@scope/jsii-calc-lib.submodule.ReflectableEntry",
-		reflect.TypeOf((*ReflectableEntry)(nil)).Elem(),
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-lib.submodule.Reflector",
-		reflect.TypeOf((*Reflector)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "asMap", GoMethod: "AsMap"},
-		},
-		func() interface{} {
-			return &jsiiProxy_Reflector{}
-		},
 	)
 }
 
@@ -2558,7 +2558,7 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
 )
 
 type AbstractClass interface {
@@ -9365,10 +9365,10 @@ type jsiiProxy_NestedClassInstance struct {
 	_ byte // padding
 }
 
-func NestedClassInstance_MakeInstance() submodule.NestingClass_NestedClass {
+func NestedClassInstance_MakeInstance() customsubmodulename.NestingClass_NestedClass {
 	_init_.Initialize()
 
-	var returns submodule.NestingClass_NestedClass
+	var returns customsubmodulename.NestingClass_NestedClass
 
 	_jsii_.StaticInvoke(
 		"jsii-calc.NestedClassInstance",
@@ -12099,17 +12099,17 @@ type UnionProperties struct {
 
 // Ensures submodule-imported types from dependencies can be used correctly.
 type UpcasingReflectable interface {
-	submodule.IReflectable
-	Entries() []submodule.ReflectableEntry
+	customsubmodulename.IReflectable
+	Entries() []customsubmodulename.ReflectableEntry
 }
 
 // The jsii proxy struct for UpcasingReflectable
 type jsiiProxy_UpcasingReflectable struct {
-	submodule.IReflectable // implements @scope/jsii-calc-lib.submodule.IReflectable
+	customsubmodulename.IReflectable // implements @scope/jsii-calc-lib.submodule.IReflectable
 }
 
-func (j *jsiiProxy_UpcasingReflectable) Entries() []submodule.ReflectableEntry {
-	var returns []submodule.ReflectableEntry
+func (j *jsiiProxy_UpcasingReflectable) Entries() []customsubmodulename.ReflectableEntry {
+	var returns []customsubmodulename.ReflectableEntry
 	_jsii_.Get(
 		j,
 		"entries",
@@ -12135,9 +12135,9 @@ func NewUpcasingReflectable(delegate map[string]interface{}) UpcasingReflectable
 	return &j
 }
 
-func UpcasingReflectable_Reflector() submodule.Reflector {
+func UpcasingReflectable_Reflector() customsubmodulename.Reflector {
 	_init_.Initialize()
-	var returns submodule.Reflector
+	var returns customsubmodulename.Reflector
 	_jsii_.StaticGet(
 		"jsii-calc.UpcasingReflectable",
 		"reflector",

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -3,19 +3,19 @@
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/ 1`] = `
 <root>
  ┗━ 📁 go
-    ┗━ 📁 scopejsiicalcbase
+    ┗━ 📁 jcb
        ┣━ 📄 go.mod
+       ┣━ 📄 jcb.go
+       ┣━ 📄 jcb.init.go
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii.go
        ┃  ┗━ 📄 scope-jsii-calc-base-0.0.0.tgz
        ┣━ 📄 LICENSE
        ┣━ 📄 NOTICE
-       ┣━ 📄 scopejsiicalcbase.go
-       ┣━ 📄 scopejsiicalcbase.init.go
        ┗━ 📄 version
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/LICENSE 1`] = `
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/LICENSE 1`] = `
 
                                  Apache License
                            Version 2.0, January 2004
@@ -220,14 +220,14 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcba
    limitations under the License.
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/NOTICE 1`] = `
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/NOTICE 1`] = `
 jsii
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/go.mod 1`] = `
-module github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/go.mod 1`] = `
+module github.com/aws/jsii/jsii-calc/go/jcb
 
 go 1.16
 
@@ -238,45 +238,13 @@ require (
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/jsii/jsii.go 1`] = `
-// Package jsii contains the functionaility needed for jsii packages to
-// initialize their dependencies and themselves. Users should never need to use this package
-// directly. If you find you need to - please report a bug at
-// https://github.com/aws/jsii/issues/new/choose
-package jsii
-
-import (
-	_                       "embed"
-
-	_jsii_                  "github.com/aws/jsii-runtime-go"
-
-	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
-)
-
-//go:embed scope-jsii-calc-base-0.0.0.tgz
-var tarball []byte
-
-// Initialize loads the necessary packages in the @jsii/kernel to support the enclosing module.
-// The implementation is idempotent (and hence safe to be called over and over).
-func Initialize() {
-	// Ensure all dependencies are initialized
-	scopejsiicalcbaseofbase.Initialize()
-
-	// Load this library into the kernel
-	_jsii_.Load("@scope/jsii-calc-base", "0.0.0", tarball)
-}
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/jsii/scope-jsii-calc-base-0.0.0.tgz 1`] = `go/scopejsiicalcbase/jsii/scope-jsii-calc-base-0.0.0.tgz is a tarball`;
-
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/scopejsiicalcbase.go 1`] = `
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb.go 1`] = `
 // An example direct dependency for jsii-calc.
-package scopejsiicalcbase
+package jcb
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jcb/jsii"
 
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 )
@@ -389,8 +357,8 @@ func StaticConsumer_Consume(args interface{}) {
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/scopejsiicalcbase.init.go 1`] = `
-package scopejsiicalcbase
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb.init.go 1`] = `
+package jcb
 
 import (
 	"reflect"
@@ -438,7 +406,39 @@ func init() {
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/scopejsiicalcbase/version 1`] = `
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jsii/jsii.go 1`] = `
+// Package jsii contains the functionaility needed for jsii packages to
+// initialize their dependencies and themselves. Users should never need to use this package
+// directly. If you find you need to - please report a bug at
+// https://github.com/aws/jsii/issues/new/choose
+package jsii
+
+import (
+	_                       "embed"
+
+	_jsii_                  "github.com/aws/jsii-runtime-go"
+
+	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
+)
+
+//go:embed scope-jsii-calc-base-0.0.0.tgz
+var tarball []byte
+
+// Initialize loads the necessary packages in the @jsii/kernel to support the enclosing module.
+// The implementation is idempotent (and hence safe to be called over and over).
+func Initialize() {
+	// Ensure all dependencies are initialized
+	scopejsiicalcbaseofbase.Initialize()
+
+	// Load this library into the kernel
+	_jsii_.Load("@scope/jsii-calc-base", "0.0.0", tarball)
+}
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jsii/scope-jsii-calc-base-0.0.0.tgz 1`] = `go/jcb/jsii/scope-jsii-calc-base-0.0.0.tgz is a tarball`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/version 1`] = `
 0.0.0
 
 `;
@@ -1087,7 +1087,7 @@ go 1.16
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
+	github.com/aws/jsii/jsii-calc/go/jcb v0.0.0
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1
 )
 
@@ -1105,7 +1105,7 @@ import (
 
 	_jsii_                  "github.com/aws/jsii-runtime-go"
 
-	scopejsiicalcbase       "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
+	jcb                     "github.com/aws/jsii/jsii-calc/go/jcb/jsii"
 	scopejsiicalcbaseofbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 )
 
@@ -1116,7 +1116,7 @@ var tarball []byte
 // The implementation is idempotent (and hence safe to be called over and over).
 func Initialize() {
 	// Ensure all dependencies are initialized
-	scopejsiicalcbase.Initialize()
+	jcb.Initialize()
 	scopejsiicalcbaseofbase.Initialize()
 
 	// Load this library into the kernel
@@ -1135,7 +1135,7 @@ import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
+	"github.com/aws/jsii/jsii-calc/go/jcb"
 )
 
 // Deprecated.
@@ -1222,14 +1222,14 @@ func (i *jsiiProxy_IFriendly) Hello() string {
 // far enough up the tree.
 // Deprecated.
 type IThreeLevelsInterface interface {
-	scopejsiicalcbase.IBaseInterface
+	jcb.IBaseInterface
 	// Deprecated.
 	Baz()
 }
 
 // The jsii proxy for IThreeLevelsInterface
 type jsiiProxy_IThreeLevelsInterface struct {
-	scopejsiicalcbase.IBaseInterface // extends @scope/jsii-calc-base.IBaseInterface
+	jcb.IBaseInterface // extends @scope/jsii-calc-base.IBaseInterface
 }
 
 func (i *jsiiProxy_IThreeLevelsInterface) Baz() {
@@ -1340,14 +1340,14 @@ func (n *jsiiProxy_Number) TypeName() interface{} {
 // Abstract class which represents a numeric value.
 // Deprecated.
 type NumericValue interface {
-	scopejsiicalcbase.Base
+	jcb.Base
 	Value() float64
 	ToString() string
 }
 
 // The jsii proxy struct for NumericValue
 type jsiiProxy_NumericValue struct {
-	scopejsiicalcbase.Base // extends @scope/jsii-calc-base.Base
+	jcb.Base // extends @scope/jsii-calc-base.Base
 }
 
 func (j *jsiiProxy_NumericValue) Value() float64 {
@@ -1768,7 +1768,7 @@ func init() {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/version 1`] = `
-0.0.0
+0.0.0-devpreview
 
 `;
 
@@ -2388,8 +2388,8 @@ go 1.16
 
 require (
 	github.com/aws/jsii-runtime-go v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase v0.0.0
-	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0
+	github.com/aws/jsii/jsii-calc/go/jcb v0.0.0
+	github.com/aws/jsii/jsii-calc/go/scopejsiicalclib v0.0.0-devpreview
 	github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2 v2.1.1 // indirect
 )
 
@@ -2520,12 +2520,12 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii/jsii.go 1`] =
 package jsii
 
 import (
-	_                 "embed"
+	_                "embed"
 
-	_jsii_            "github.com/aws/jsii-runtime-go"
+	_jsii_           "github.com/aws/jsii-runtime-go"
 
-	scopejsiicalcbase "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase/jsii"
-	scopejsiicalclib  "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+	jcb              "github.com/aws/jsii/jsii-calc/go/jcb/jsii"
+	scopejsiicalclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
 )
 
 //go:embed jsii-calc-3.20.120.tgz
@@ -2535,7 +2535,7 @@ var tarball []byte
 // The implementation is idempotent (and hence safe to be called over and over).
 func Initialize() {
 	// Ensure all dependencies are initialized
-	scopejsiicalcbase.Initialize()
+	jcb.Initialize()
 	scopejsiicalclib.Initialize()
 
 	// Load this library into the kernel
@@ -2554,8 +2554,8 @@ import (
 	_jsii_ "github.com/aws/jsii-runtime-go"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 
+	"github.com/aws/jsii/jsii-calc/go/jcb"
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbase"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/submodule"
@@ -7611,9 +7611,9 @@ func (i *ImplictBaseOfBase) ToVeryBaseProps() scopejsiicalcbaseofbase.VeryBasePr
 	}
 }
 
-// ToBaseProps is a convenience function to obtain a new scopejsiicalcbase.BaseProps from this ImplictBaseOfBase.
-func (i *ImplictBaseOfBase) ToBaseProps() scopejsiicalcbase.BaseProps {
-	return scopejsiicalcbase.BaseProps {
+// ToBaseProps is a convenience function to obtain a new jcb.BaseProps from this ImplictBaseOfBase.
+func (i *ImplictBaseOfBase) ToBaseProps() jcb.BaseProps {
+	return jcb.BaseProps {
 		Foo: i.Foo,
 		Bar: i.Bar,
 	}
@@ -12186,7 +12186,7 @@ func (u *jsiiProxy_UseBundledDependency) Value() interface{} {
 
 // Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
 type UseCalcBase interface {
-	Hello() scopejsiicalcbase.Base
+	Hello() jcb.Base
 }
 
 // The jsii proxy struct for UseCalcBase
@@ -12210,8 +12210,8 @@ func NewUseCalcBase() UseCalcBase {
 	return &j
 }
 
-func (u *jsiiProxy_UseCalcBase) Hello() scopejsiicalcbase.Base {
-	var returns scopejsiicalcbase.Base
+func (u *jsiiProxy_UseCalcBase) Hello() jcb.Base {
+	var returns jcb.Base
 
 	_jsii_.Invoke(
 		u,


### PR DESCRIPTION
Add two features to the `go` targets config in package.json:

- `packageName` can be used to customize the name of the go package (previously this was always derived from the javascript name).
- `versionSuffix` can be used to append a suffix to the version number (e.g. `-devpreview`).

Resolves #2632

This is needed in order to control the name of the AWS CDK go bindings so they are the same between v1 and v2. Currently the v1 name would have been `monocdk` and v2 `awscdklib` and we want both to actually be `awscdk` per the decision in [this RFC](https://github.com/aws/aws-cdk-rfcs/blob/master/text/0079-cdk-2.0.md#releasing-to-package-managers).


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
