### PR TITLE
fix(go): arguments named "_" result in invalid code

### DIFF
--- a/packages/jsii-calc/lib/index.ts
+++ b/packages/jsii-calc/lib/index.ts
@@ -14,3 +14,4 @@ export * as nodirect from './no-direct-types';
 export * as module2647 from './module2647';
 export * as module2689 from './module2689';
 export * as module2692 from './module2692';
+export * as module2530 from './module2530';

--- a/packages/jsii-calc/lib/module2530/index.ts
+++ b/packages/jsii-calc/lib/module2530/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Verifies a method with parameters "_" can be generated.
+ * @see https://github.com/aws/jsii/issues/2530
+ */
+export class MyClass {
+  public static bar(_: boolean) {
+    return;
+  }
+
+  public constructor(_: number) {
+    return;
+  }
+
+  public foo(_: string) {
+    return;
+  }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -211,6 +211,12 @@
         "line": 142
       }
     },
+    "jsii-calc.module2530": {
+      "locationInModule": {
+        "filename": "lib/index.ts",
+        "line": 17
+      }
+    },
     "jsii-calc.module2647": {
       "locationInModule": {
         "filename": "lib/index.ts",
@@ -14173,6 +14179,78 @@
       "name": "CompositionStringStyle",
       "namespace": "composition.CompositeOperation"
     },
+    "jsii-calc.module2530.MyClass": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "see": "https://github.com/aws/jsii/issues/2530",
+        "stability": "stable",
+        "summary": "Verifies a method with parameters \"_\" can be generated."
+      },
+      "fqn": "jsii-calc.module2530.MyClass",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "lib/module2530/index.ts",
+          "line": 10
+        },
+        "parameters": [
+          {
+            "name": "_",
+            "type": {
+              "primitive": "number"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/module2530/index.ts",
+        "line": 5
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/module2530/index.ts",
+            "line": 6
+          },
+          "name": "bar",
+          "parameters": [
+            {
+              "name": "_",
+              "type": {
+                "primitive": "boolean"
+              }
+            }
+          ],
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/module2530/index.ts",
+            "line": 14
+          },
+          "name": "foo",
+          "parameters": [
+            {
+              "name": "_",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "MyClass",
+      "namespace": "module2530"
+    },
     "jsii-calc.module2647.ExtendAndImplement": {
       "assembly": "jsii-calc",
       "base": "@scope/jsii-calc-lib.BaseFor2647",
@@ -15344,5 +15422,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "zzayVZr0GAzkOZJ5SHHy3UvRxdZ1DZAPChbY/MkerHU="
+  "fingerprint": "hBZRskNm0XPeSO9U+PMqKKVZ2faqmKnE9eVN2tY1Wik="
 }

--- a/packages/jsii-pacmak/lib/targets/go/util.ts
+++ b/packages/jsii-pacmak/lib/targets/go/util.ts
@@ -94,6 +94,7 @@ const RESERVED_WORDS: { [word: string]: string } = {
   import: 'import_',
   return: 'return_',
   var: 'var_',
+  _: '_arg',
 };
 
 /*

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -2893,6 +2893,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 LevelOneProps.cs
        ┃           ┣━ 📄 LoadBalancedFargateServiceProps.cs
        ┃           ┣━ 📄 MethodNamedProperty.cs
+       ┃           ┣━ 📁 Module2530
+       ┃           ┃  ┗━ 📄 MyClass.cs
        ┃           ┣━ 📁 Module2647
        ┃           ┃  ┗━ 📄 ExtendAndImplement.cs
        ┃           ┣━ 📁 Module2689
@@ -12134,6 +12136,54 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         public virtual double Elite
         {
             get => GetInstanceProperty<double>()!;
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Module2530/MyClass.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.Module2530
+{
+    /// <summary>Verifies a method with parameters "_" can be generated.</summary>
+    /// <remarks>
+    /// <strong>See</strong>: https://github.com/aws/jsii/issues/2530
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Module2530.MyClass), fullyQualifiedName: "jsii-calc.module2530.MyClass", parametersJson: "[{\\"name\\":\\"_\\",\\"type\\":{\\"primitive\\":\\"number\\"}}]")]
+    public class MyClass : DeputyBase
+    {
+        public MyClass(double _): base(new DeputyProps(new object?[]{_}))
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected MyClass(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected MyClass(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod(name: "bar", parametersJson: "[{\\"name\\":\\"_\\",\\"type\\":{\\"primitive\\":\\"boolean\\"}}]")]
+        public static void Bar(bool _)
+        {
+            InvokeStaticVoidMethod(typeof(Amazon.JSII.Tests.CalculatorNamespace.Module2530.MyClass), new System.Type[]{typeof(bool)}, new object[]{_});
+        }
+
+        [JsiiMethod(name: "foo", parametersJson: "[{\\"name\\":\\"_\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
+        public virtual void Foo(string _)
+        {
+            InvokeInstanceVoidMethod(new System.Type[]{typeof(string)}, new object[]{_});
         }
     }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -294,13 +294,6 @@ type BaseProps struct {
 	Bar string \`json:"bar"\`
 }
 
-// ToVeryBaseProps is a convenience function to obtain a new scopejsiicalcbaseofbase.VeryBaseProps from this BaseProps.
-func (b *BaseProps) ToVeryBaseProps() scopejsiicalcbaseofbase.VeryBaseProps {
-	return scopejsiicalcbaseofbase.VeryBaseProps {
-		Foo: b.Foo,
-	}
-}
-
 type IBaseInterface interface {
 	scopejsiicalcbaseofbase.IVeryBaseInterface
 	Bar()
@@ -1849,6 +1842,9 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┣━ 📄 jsiicalc.go
        ┣━ 📄 jsiicalc.init.go
        ┣━ 📄 LICENSE
+       ┣━ 📁 module2530
+       ┃  ┣━ 📄 module2530.go
+       ┃  ┗━ 📄 module2530.init.go
        ┣━ 📁 module2647
        ┃  ┣━ 📄 module2647.go
        ┃  ┗━ 📄 module2647.init.go
@@ -4149,13 +4145,6 @@ type ChildStruct982 struct {
 	Bar float64 \`json:"bar"\`
 }
 
-// ToParentStruct982 is a convenience function to obtain a new ParentStruct982 from this ChildStruct982.
-func (c *ChildStruct982) ToParentStruct982() ParentStruct982 {
-	return ParentStruct982 {
-		Foo: c.Foo,
-	}
-}
-
 type ClassThatImplementsTheInternalInterface interface {
 	INonInternalInterface
 	A() string
@@ -5487,15 +5476,6 @@ type DerivedStruct struct {
 	OptionalArray []string \`json:"optionalArray"\`
 }
 
-// ToMyFirstStruct is a convenience function to obtain a new scopejsiicalclib.MyFirstStruct from this DerivedStruct.
-func (d *DerivedStruct) ToMyFirstStruct() scopejsiicalclib.MyFirstStruct {
-	return scopejsiicalclib.MyFirstStruct {
-		Anumber: d.Anumber,
-		Astring: d.Astring,
-		FirstOptional: d.FirstOptional,
-	}
-}
-
 type DiamondBottom struct {
 	// Deprecated.
 	HoistedTop string \`json:"hoistedTop"\`
@@ -5504,22 +5484,6 @@ type DiamondBottom struct {
 	// Deprecated.
 	Right bool \`json:"right"\`
 	Bottom string \`json:"bottom"\`
-}
-
-// ToDiamondLeft is a convenience function to obtain a new scopejsiicalclib.DiamondLeft from this DiamondBottom.
-func (d *DiamondBottom) ToDiamondLeft() scopejsiicalclib.DiamondLeft {
-	return scopejsiicalclib.DiamondLeft {
-		HoistedTop: d.HoistedTop,
-		Left: d.Left,
-	}
-}
-
-// ToDiamondRight is a convenience function to obtain a new scopejsiicalclib.DiamondRight from this DiamondBottom.
-func (d *DiamondBottom) ToDiamondRight() scopejsiicalclib.DiamondRight {
-	return scopejsiicalclib.DiamondRight {
-		HoistedTop: d.HoistedTop,
-		Right: d.Right,
-	}
 }
 
 type DiamondInheritanceBaseLevelStruct struct {
@@ -5531,23 +5495,9 @@ type DiamondInheritanceFirstMidLevelStruct struct {
 	FirstMidLevelProperty string \`json:"firstMidLevelProperty"\`
 }
 
-// ToDiamondInheritanceBaseLevelStruct is a convenience function to obtain a new DiamondInheritanceBaseLevelStruct from this DiamondInheritanceFirstMidLevelStruct.
-func (d *DiamondInheritanceFirstMidLevelStruct) ToDiamondInheritanceBaseLevelStruct() DiamondInheritanceBaseLevelStruct {
-	return DiamondInheritanceBaseLevelStruct {
-		BaseLevelProperty: d.BaseLevelProperty,
-	}
-}
-
 type DiamondInheritanceSecondMidLevelStruct struct {
 	BaseLevelProperty string \`json:"baseLevelProperty"\`
 	SecondMidLevelProperty string \`json:"secondMidLevelProperty"\`
-}
-
-// ToDiamondInheritanceBaseLevelStruct is a convenience function to obtain a new DiamondInheritanceBaseLevelStruct from this DiamondInheritanceSecondMidLevelStruct.
-func (d *DiamondInheritanceSecondMidLevelStruct) ToDiamondInheritanceBaseLevelStruct() DiamondInheritanceBaseLevelStruct {
-	return DiamondInheritanceBaseLevelStruct {
-		BaseLevelProperty: d.BaseLevelProperty,
-	}
 }
 
 type DiamondInheritanceTopLevelStruct struct {
@@ -5555,29 +5505,6 @@ type DiamondInheritanceTopLevelStruct struct {
 	FirstMidLevelProperty string \`json:"firstMidLevelProperty"\`
 	SecondMidLevelProperty string \`json:"secondMidLevelProperty"\`
 	TopLevelProperty string \`json:"topLevelProperty"\`
-}
-
-// ToDiamondInheritanceBaseLevelStruct is a convenience function to obtain a new DiamondInheritanceBaseLevelStruct from this DiamondInheritanceTopLevelStruct.
-func (d *DiamondInheritanceTopLevelStruct) ToDiamondInheritanceBaseLevelStruct() DiamondInheritanceBaseLevelStruct {
-	return DiamondInheritanceBaseLevelStruct {
-		BaseLevelProperty: d.BaseLevelProperty,
-	}
-}
-
-// ToDiamondInheritanceFirstMidLevelStruct is a convenience function to obtain a new DiamondInheritanceFirstMidLevelStruct from this DiamondInheritanceTopLevelStruct.
-func (d *DiamondInheritanceTopLevelStruct) ToDiamondInheritanceFirstMidLevelStruct() DiamondInheritanceFirstMidLevelStruct {
-	return DiamondInheritanceFirstMidLevelStruct {
-		BaseLevelProperty: d.BaseLevelProperty,
-		FirstMidLevelProperty: d.FirstMidLevelProperty,
-	}
-}
-
-// ToDiamondInheritanceSecondMidLevelStruct is a convenience function to obtain a new DiamondInheritanceSecondMidLevelStruct from this DiamondInheritanceTopLevelStruct.
-func (d *DiamondInheritanceTopLevelStruct) ToDiamondInheritanceSecondMidLevelStruct() DiamondInheritanceSecondMidLevelStruct {
-	return DiamondInheritanceSecondMidLevelStruct {
-		BaseLevelProperty: d.BaseLevelProperty,
-		SecondMidLevelProperty: d.SecondMidLevelProperty,
-	}
 }
 
 // Verifies that null/undefined can be returned for optional collections.
@@ -7681,21 +7608,6 @@ type ImplictBaseOfBase struct {
 	Foo scopejsiicalcbaseofbase.Very \`json:"foo"\`
 	Bar string \`json:"bar"\`
 	Goo string \`json:"goo"\`
-}
-
-// ToVeryBaseProps is a convenience function to obtain a new scopejsiicalcbaseofbase.VeryBaseProps from this ImplictBaseOfBase.
-func (i *ImplictBaseOfBase) ToVeryBaseProps() scopejsiicalcbaseofbase.VeryBaseProps {
-	return scopejsiicalcbaseofbase.VeryBaseProps {
-		Foo: i.Foo,
-	}
-}
-
-// ToBaseProps is a convenience function to obtain a new jcb.BaseProps from this ImplictBaseOfBase.
-func (i *ImplictBaseOfBase) ToBaseProps() jcb.BaseProps {
-	return jcb.BaseProps {
-		Foo: i.Foo,
-		Bar: i.Bar,
-	}
 }
 
 type InbetweenClass interface {
@@ -14822,6 +14734,87 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/module2530.go 1`] = `
+package module2530
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Verifies a method with parameters "_" can be generated.
+// See: https://github.com/aws/jsii/issues/2530
+//
+type MyClass interface {
+	Foo(_arg string)
+}
+
+// The jsii proxy struct for MyClass
+type jsiiProxy_MyClass struct {
+	_ byte // padding
+}
+
+func NewMyClass(_arg float64) MyClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_MyClass{}
+
+	_jsii_.Create(
+		"jsii-calc.module2530.MyClass",
+		[]interface{}{_arg},
+		[]_jsii_.FQN{},
+		nil, // no overrides
+		&j,
+	)
+
+	return &j
+}
+
+func MyClass_Bar(_arg bool) {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"jsii-calc.module2530.MyClass",
+		"bar",
+		[]interface{}{_arg},
+	)
+}
+
+func (m *jsiiProxy_MyClass) Foo(_arg string) {
+	_jsii_.InvokeVoid(
+		m,
+		"foo",
+		[]interface{}{_arg},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/module2530.init.go 1`] = `
+package module2530
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.module2530.MyClass",
+		reflect.TypeOf((*MyClass)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+		},
+		func() interface{} {
+			return &jsiiProxy_MyClass{}
+		},
+	)
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/module2647.go 1`] = `
 package module2647
 
@@ -15282,20 +15275,6 @@ type Foo struct {
 	Bar2 string \`json:"bar2"\`
 	Bar1 string \`json:"bar1"\`
 	Foo2 string \`json:"foo2"\`
-}
-
-// ToBar is a convenience function to obtain a new Bar from this Foo.
-func (f *Foo) ToBar() Bar {
-	return Bar {
-		Bar2: f.Bar2,
-	}
-}
-
-// ToBar is a convenience function to obtain a new submodule1.Bar from this Foo.
-func (f *Foo) ToBar() submodule1.Bar {
-	return submodule1.Bar {
-		Bar1: f.Bar1,
-	}
 }
 
 
@@ -15797,13 +15776,6 @@ func InnerClass_StaticProp() SomeStruct {
 type KwargsProps struct {
 	Prop SomeEnum \`json:"prop"\`
 	Extra string \`json:"extra"\`
-}
-
-// ToSomeStruct is a convenience function to obtain a new SomeStruct from this KwargsProps.
-func (k *KwargsProps) ToSomeStruct() SomeStruct {
-	return SomeStruct {
-		Prop: k.Prop,
-	}
 }
 
 // Checks that classes can self-reference during initialization.

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -3710,6 +3710,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 LevelOneProps.java
           ┃                 ┣━ 📄 LoadBalancedFargateServiceProps.java
           ┃                 ┣━ 📄 MethodNamedProperty.java
+          ┃                 ┣━ 📁 module2530
+          ┃                 ┃  ┗━ 📄 MyClass.java
           ┃                 ┣━ 📁 module2647
           ┃                 ┃  ┗━ 📄 ExtendAndImplement.java
           ┃                 ┣━ 📁 module2689
@@ -21729,6 +21731,55 @@ public interface Hello extends software.amazon.jsii.JsiiSerializable {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/module2530/MyClass.java 1`] = `
+package software.amazon.jsii.tests.calculator.module2530;
+
+/**
+ * Verifies a method with parameters "_" can be generated.
+ * <p>
+ * @see https://github.com/aws/jsii/issues/2530
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.module2530.MyClass")
+public class MyClass extends software.amazon.jsii.JsiiObject {
+
+    protected MyClass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected MyClass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * @param _ This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public MyClass(final @org.jetbrains.annotations.NotNull java.lang.Number _) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(_, "_ is required") });
+    }
+
+    /**
+     * @param _ This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public static void bar(final @org.jetbrains.annotations.NotNull java.lang.Boolean _) {
+        software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.module2530.MyClass.class, "bar", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(_, "_ is required") });
+    }
+
+    /**
+     * @param _ This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public void foo(final @org.jetbrains.annotations.NotNull java.lang.String _) {
+        software.amazon.jsii.Kernel.call(this, "foo", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(_, "_ is required") });
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/module2647/ExtendAndImplement.java 1`] = `
 package software.amazon.jsii.tests.calculator.module2647;
 
@@ -24320,6 +24371,7 @@ jsii-calc.VoidCallback=software.amazon.jsii.tests.calculator.VoidCallback
 jsii-calc.WithPrivatePropertyInConstructor=software.amazon.jsii.tests.calculator.WithPrivatePropertyInConstructor
 jsii-calc.composition.CompositeOperation=software.amazon.jsii.tests.calculator.composition.CompositeOperation
 jsii-calc.composition.CompositeOperation.CompositionStringStyle=software.amazon.jsii.tests.calculator.composition.CompositeOperation$CompositionStringStyle
+jsii-calc.module2530.MyClass=software.amazon.jsii.tests.calculator.module2530.MyClass
 jsii-calc.module2647.ExtendAndImplement=software.amazon.jsii.tests.calculator.module2647.ExtendAndImplement
 jsii-calc.module2689.methods.MyClass=software.amazon.jsii.tests.calculator.module2689.methods.MyClass
 jsii-calc.module2689.props.MyClass=software.amazon.jsii.tests.calculator.module2689.props.MyClass

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -2101,6 +2101,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃  ┗━ 📄 __init__.py
           ┣━ 📁 interface_in_namespace_only_interface
           ┃  ┗━ 📄 __init__.py
+          ┣━ 📁 module2530
+          ┃  ┗━ 📄 __init__.py
           ┣━ 📁 module2647
           ┃  ┗━ 📄 __init__.py
           ┣━ 📁 module2689
@@ -2432,6 +2434,7 @@ kwargs = json.loads(
         "jsii_calc.derived_class_has_no_properties",
         "jsii_calc.interface_in_namespace_includes_classes",
         "jsii_calc.interface_in_namespace_only_interface",
+        "jsii_calc.module2530",
         "jsii_calc.module2647",
         "jsii_calc.module2689",
         "jsii_calc.module2689.methods",
@@ -10382,6 +10385,56 @@ class Hello:
 
 __all__ = [
     "Hello",
+]
+
+publication.publish()
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2530/__init__.py 1`] = `
+import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from .._jsii import *
+
+
+class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2530.MyClass"):
+    '''Verifies a method with parameters "_" can be generated.
+
+    :see: https://github.com/aws/jsii/issues/2530
+    '''
+
+    def __init__(self, _: jsii.Number) -> None:
+        '''
+        :param _: -
+        '''
+        jsii.create(MyClass, self, [_])
+
+    @jsii.member(jsii_name="bar") # type: ignore[misc]
+    @builtins.classmethod
+    def bar(cls, _: builtins.bool) -> None:
+        '''
+        :param _: -
+        '''
+        return typing.cast(None, jsii.sinvoke(cls, "bar", [_]))
+
+    @jsii.member(jsii_name="foo")
+    def foo(self, _: builtins.str) -> None:
+        '''
+        :param _: -
+        '''
+        return typing.cast(None, jsii.invoke(self, "foo", [_]))
+
+
+__all__ = [
+    "MyClass",
 ]
 
 publication.publish()

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.ts.snap
@@ -102,6 +102,25 @@ exports[`jsii-tree --all 1`] = `
  │ │ │   └─┬ enum CompositionStringStyle (stable)
  │ │ │     ├── NORMAL (stable)
  │ │ │     └── DECORATED (stable)
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └─┬ class MyClass (stable)
+ │ │ │     └─┬ members
+ │ │ │       ├─┬ <initializer>(_) initializer (stable)
+ │ │ │       │ └─┬ parameters
+ │ │ │       │   └─┬ _
+ │ │ │       │     └── type: number
+ │ │ │       ├─┬ static bar(_) method (stable)
+ │ │ │       │ ├── static
+ │ │ │       │ ├─┬ parameters
+ │ │ │       │ │ └─┬ _
+ │ │ │       │ │   └── type: boolean
+ │ │ │       │ └── returns: void
+ │ │ │       └─┬ foo(_) method (stable)
+ │ │ │         ├─┬ parameters
+ │ │ │         │ └─┬ _
+ │ │ │         │   └── type: string
+ │ │ │         └── returns: void
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └─┬ class ExtendAndImplement (stable)
@@ -3036,6 +3055,9 @@ exports[`jsii-tree --inheritance 1`] = `
  │ │ │   ├─┬ class CompositeOperation
  │ │ │   │ └── base: Operation
  │ │ │   └── enum CompositionStringStyle
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └── class MyClass
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └─┬ class ExtendAndImplement
@@ -3492,6 +3514,13 @@ exports[`jsii-tree --members 1`] = `
  │ │ │   └─┬ enum CompositionStringStyle
  │ │ │     ├── NORMAL
  │ │ │     └── DECORATED
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └─┬ class MyClass
+ │ │ │     └─┬ members
+ │ │ │       ├── <initializer>(_) initializer
+ │ │ │       ├── static bar(_) method
+ │ │ │       └── foo(_) method
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └─┬ class ExtendAndImplement
@@ -4816,6 +4845,7 @@ exports[`jsii-tree --signatures 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules
@@ -4875,6 +4905,9 @@ exports[`jsii-tree --types 1`] = `
  │ │ │ └─┬ types
  │ │ │   ├── class CompositeOperation
  │ │ │   └── enum CompositionStringStyle
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └── class MyClass
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └── class ExtendAndImplement
@@ -5204,6 +5237,7 @@ exports[`jsii-tree 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.ts.snap
@@ -9,6 +9,7 @@ exports[`defaults 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules
@@ -52,6 +53,7 @@ exports[`inheritance 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules
@@ -95,6 +97,7 @@ exports[`members 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules
@@ -231,6 +234,25 @@ exports[`showAll 1`] = `
  │ │ │   └─┬ enum CompositionStringStyle
  │ │ │     ├── NORMAL
  │ │ │     └── DECORATED
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └─┬ class MyClass
+ │ │ │     └─┬ members
+ │ │ │       ├─┬ <initializer>(_) initializer
+ │ │ │       │ └─┬ parameters
+ │ │ │       │   └─┬ _
+ │ │ │       │     └── type: number
+ │ │ │       ├─┬ static bar(_) method
+ │ │ │       │ ├── static
+ │ │ │       │ ├─┬ parameters
+ │ │ │       │ │ └─┬ _
+ │ │ │       │ │   └── type: boolean
+ │ │ │       │ └── returns: void
+ │ │ │       └─┬ foo(_) method
+ │ │ │         ├─┬ parameters
+ │ │ │         │ └─┬ _
+ │ │ │         │   └── type: string
+ │ │ │         └── returns: void
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └─┬ class ExtendAndImplement
@@ -3147,6 +3169,7 @@ exports[`signatures 1`] = `
  │   ├── InterfaceInNamespaceOnlyInterface
  │   ├── PythonSelf
  │   ├── composition
+ │   ├── module2530
  │   ├── module2647
  │   ├─┬ module2689
  │   │ └─┬ submodules
@@ -3206,6 +3229,9 @@ exports[`types 1`] = `
  │ │ │ └─┬ types
  │ │ │   ├── class CompositeOperation
  │ │ │   └── enum CompositionStringStyle
+ │ │ ├─┬ module2530
+ │ │ │ └─┬ types
+ │ │ │   └── class MyClass
  │ │ ├─┬ module2647
  │ │ │ └─┬ types
  │ │ │   └── class ExtendAndImplement

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.ts.snap
@@ -154,6 +154,7 @@ Array [
   "jsii-calc.VoidCallback",
   "jsii-calc.WithPrivatePropertyInConstructor",
   "jsii-calc.composition.CompositeOperation",
+  "jsii-calc.module2530.MyClass",
   "jsii-calc.module2647.ExtendAndImplement",
   "jsii-calc.module2689.methods.MyClass",
   "jsii-calc.module2689.props.MyClass",


### PR DESCRIPTION
It is common in TypeScript to use `_` as an argument name if the argument is not used. This is an invalid name in Go, so replace it with `_arg`.

Fixes #2530



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
