### PR TITLE
fix(go): missing methods for multiple inheritance of the same interface

### DIFF
--- a/packages/jsii-calc/lib/index.ts
+++ b/packages/jsii-calc/lib/index.ts
@@ -15,3 +15,4 @@ export * as module2647 from './module2647';
 export * as module2689 from './module2689';
 export * as module2692 from './module2692';
 export * as module2530 from './module2530';
+export * as module2700 from './module2700';

--- a/packages/jsii-calc/lib/module2700/index.ts
+++ b/packages/jsii-calc/lib/module2700/index.ts
@@ -1,0 +1,17 @@
+export interface IFoo {
+  bar(): string;
+  readonly baz: number;
+}
+
+export class Base implements IFoo {
+  public readonly baz = 120;
+  public bar() {
+    return 'bar';
+  }
+}
+
+export class Derived extends Base implements IFoo {
+  public zoo() {
+    return 'zoo';
+  }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -271,6 +271,12 @@
         "line": 2
       }
     },
+    "jsii-calc.module2700": {
+      "locationInModule": {
+        "filename": "lib/index.ts",
+        "line": 18
+      }
+    },
     "jsii-calc.nodirect": {
       "locationInModule": {
         "filename": "lib/index.ts",
@@ -14766,6 +14772,152 @@
         }
       ]
     },
+    "jsii-calc.module2700.Base": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.module2700.Base",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "interfaces": [
+        "jsii-calc.module2700.IFoo"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/module2700/index.ts",
+        "line": 6
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/module2700/index.ts",
+            "line": 8
+          },
+          "name": "bar",
+          "overrides": "jsii-calc.module2700.IFoo",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "Base",
+      "namespace": "module2700",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/module2700/index.ts",
+            "line": 7
+          },
+          "name": "baz",
+          "overrides": "jsii-calc.module2700.IFoo",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
+    "jsii-calc.module2700.Derived": {
+      "assembly": "jsii-calc",
+      "base": "jsii-calc.module2700.Base",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.module2700.Derived",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "interfaces": [
+        "jsii-calc.module2700.IFoo"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/module2700/index.ts",
+        "line": 13
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/module2700/index.ts",
+            "line": 14
+          },
+          "name": "zoo",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "Derived",
+      "namespace": "module2700"
+    },
+    "jsii-calc.module2700.IFoo": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.module2700.IFoo",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "lib/module2700/index.ts",
+        "line": 1
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/module2700/index.ts",
+            "line": 2
+          },
+          "name": "bar",
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "IFoo",
+      "namespace": "module2700",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "lib/module2700/index.ts",
+            "line": 3
+          },
+          "name": "baz",
+          "type": {
+            "primitive": "number"
+          }
+        }
+      ]
+    },
     "jsii-calc.nodirect.sub1.TypeFromSub1": {
       "assembly": "jsii-calc",
       "docs": {
@@ -15522,5 +15674,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "ELEXfVI6U0WtgZz/uZCYxVmrnbgWKv+bjZ55LY5pjAE="
+  "fingerprint": "tN40QG7OJMwvZrncnCWdHHQjS9MvubkL128BGefSM1A="
 }

--- a/packages/jsii-pacmak/lib/targets/go/types/class.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/class.ts
@@ -27,9 +27,6 @@ export class GoClass extends GoType {
   public readonly properties: GoProperty[];
   public readonly staticProperties: GoProperty[];
 
-  private readonly reimplementedMethods?: readonly ClassMethod[];
-  private readonly reimplementedProperties?: readonly GoProperty[];
-
   private _extends?: GoClass | null;
   private _implements?: readonly GoInterface[];
 
@@ -40,7 +37,7 @@ export class GoClass extends GoType {
 
     const methods = new Array<ClassMethod>();
     const staticMethods = new Array<StaticMethod>();
-    for (const method of type.ownMethods) {
+    for (const method of type.allMethods) {
       if (method.static) {
         staticMethods.push(new StaticMethod(this, method));
       } else {
@@ -53,7 +50,7 @@ export class GoClass extends GoType {
 
     const properties = new Array<GoProperty>();
     const staticProperties = new Array<GoProperty>();
-    for (const prop of type.ownProperties) {
+    for (const prop of type.allProperties) {
       if (prop.static) {
         staticProperties.push(new GoProperty(this, prop));
       } else {
@@ -63,31 +60,6 @@ export class GoClass extends GoType {
     // Ensure consistent order, mostly cosmetic.
     this.properties = properties.sort(comparators.byName);
     this.staticProperties = staticProperties.sort(comparators.byName);
-
-    // If there is more than one base, and any ancestor (including transitive)
-    // comes from a different assembly, we will re-implement all members on the
-    // proxy struct, as otherwise we run the risk of un-promotable methods
-    // caused by inheriting the same interface via multiple paths (since we have
-    // to represent those as embedded types).
-    const hasMultipleBases = type.interfaces.length > (type.base ? 0 : 1);
-    if (
-      hasMultipleBases &&
-      type
-        .getAncestors()
-        .some((ancestor) => ancestor.assembly.fqn !== type.assembly.fqn)
-    ) {
-      this.reimplementedMethods = type.allMethods
-        .filter((method) => !method.static && method.definingType !== type)
-        .map((method) => new ClassMethod(this, method))
-        .sort(comparators.byName);
-
-      this.reimplementedProperties = type.allProperties
-        .filter(
-          (property) => !property.static && property.definingType !== type,
-        )
-        .map((property) => new GoProperty(this, property))
-        .sort(comparators.byName);
-    }
 
     if (type.initializer) {
       this.initializer = new GoClassConstructor(this, type.initializer);
@@ -143,10 +115,6 @@ export class GoClass extends GoType {
     for (const method of this.methods) {
       method.emit(context);
     }
-
-    for (const method of this.reimplementedMethods ?? []) {
-      method.emit(context);
-    }
   }
 
   public emitRegistration(code: CodeMaker): void {
@@ -183,8 +151,6 @@ export class GoClass extends GoType {
       ...this.properties,
       ...this.staticMethods,
       ...this.staticProperties,
-      ...(this.reimplementedMethods ?? []),
-      ...(this.reimplementedProperties ?? []),
     ];
   }
 
@@ -238,9 +204,6 @@ export class GoClass extends GoType {
       return;
     }
     for (const property of this.properties) {
-      property.emitGetterProxy(context);
-    }
-    for (const property of this.reimplementedProperties ?? []) {
       property.emitGetterProxy(context);
     }
     context.code.line();
@@ -304,9 +267,6 @@ export class GoClass extends GoType {
   // emits the implementation of the setters for the struct
   private emitSetters(context: EmitContext): void {
     for (const property of this.properties) {
-      property.emitSetterProxy(context);
-    }
-    for (const property of this.reimplementedProperties ?? []) {
       property.emitSetterProxy(context);
     }
   }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -2916,6 +2916,10 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┃     ┣━ 📄 Foo.cs
        ┃           ┃     ┣━ 📄 IBar.cs
        ┃           ┃     ┗━ 📄 IFoo.cs
+       ┃           ┣━ 📁 Module2700
+       ┃           ┃  ┣━ 📄 Base.cs
+       ┃           ┃  ┣━ 📄 Derived.cs
+       ┃           ┃  ┗━ 📄 IFoo.cs
        ┃           ┣━ 📄 Multiply.cs
        ┃           ┣━ 📄 NamespaceDoc.cs
        ┃           ┣━ 📄 Negate.cs
@@ -12644,6 +12648,130 @@ namespace Amazon.JSII.Tests.CalculatorNamespace.Module2692.Submodule2
             public string Bar1
             {
                 get => GetInstanceProperty<string>()!;
+            }
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Module2700/Base.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.Module2700
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Module2700.Base), fullyQualifiedName: "jsii-calc.module2700.Base")]
+    public class Base : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.Module2700.IFoo
+    {
+        public Base(): base(new DeputyProps(System.Array.Empty<object?>()))
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Base(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Base(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod(name: "bar", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}", isOverride: true)]
+        public virtual string Bar()
+        {
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
+        }
+
+        [JsiiProperty(name: "baz", typeJson: "{\\"primitive\\":\\"number\\"}")]
+        public virtual double Baz
+        {
+            get => GetInstanceProperty<double>()!;
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Module2700/Derived.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.Module2700
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Module2700.Derived), fullyQualifiedName: "jsii-calc.module2700.Derived")]
+    public class Derived : Amazon.JSII.Tests.CalculatorNamespace.Module2700.Base, Amazon.JSII.Tests.CalculatorNamespace.Module2700.IFoo
+    {
+        public Derived(): base(new DeputyProps(System.Array.Empty<object?>()))
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Derived(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Derived(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod(name: "zoo", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+        public virtual string Zoo()
+        {
+            return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/Module2700/IFoo.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.Module2700
+{
+    [JsiiInterface(nativeType: typeof(IFoo), fullyQualifiedName: "jsii-calc.module2700.IFoo")]
+    public interface IFoo
+    {
+        [JsiiProperty(name: "baz", typeJson: "{\\"primitive\\":\\"number\\"}")]
+        double Baz
+        {
+            get;
+        }
+        [JsiiMethod(name: "bar", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+        string Bar();
+
+        [JsiiTypeProxy(nativeType: typeof(IFoo), fullyQualifiedName: "jsii-calc.module2700.IFoo")]
+        internal sealed class _Proxy : DeputyBase, Amazon.JSII.Tests.CalculatorNamespace.Module2700.IFoo
+        {
+            private _Proxy(ByRefValue reference): base(reference)
+            {
+            }
+
+            [JsiiProperty(name: "baz", typeJson: "{\\"primitive\\":\\"number\\"}")]
+            public double Baz
+            {
+                get => GetInstanceProperty<double>()!;
+            }
+
+            [JsiiMethod(name: "bar", returnsJson: "{\\"type\\":{\\"primitive\\":\\"string\\"}}")]
+            public string Bar()
+            {
+                return InvokeInstanceMethod<string>(new System.Type[]{}, new object[]{})!;
             }
         }
     }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -1496,6 +1496,8 @@ type Number interface {
 	IDoublable
 	DoubleValue() float64
 	Value() float64
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Number
@@ -1579,6 +1581,7 @@ type NumericValue interface {
 	jcb.Base
 	Value() float64
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for NumericValue
@@ -1629,17 +1632,45 @@ func (n *jsiiProxy_NumericValue) ToString() string {
 	return returns
 }
 
+// Returns: the name of the class (to verify native type names are created for derived classes).
+// Deprecated.
+func (n *jsiiProxy_NumericValue) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
 // Represents an operation on values.
 // Deprecated.
 type Operation interface {
 	NumericValue
+	Value() float64
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Operation
 type jsiiProxy_Operation struct {
 	jsiiProxy_NumericValue // extends @scope/jsii-calc-lib.NumericValue
 }
+
+func (j *jsiiProxy_Operation) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
 
 // Deprecated.
 func NewOperation() Operation {
@@ -1666,6 +1697,21 @@ func (o *jsiiProxy_Operation) ToString() string {
 	_jsii_.Invoke(
 		o,
 		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+// Deprecated.
+func (o *jsiiProxy_Operation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		o,
+		"typeName",
 		nil /* no parameters */,
 		&returns,
 	)
@@ -1870,6 +1916,9 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃  ┗━ 📁 submodule2
        ┃     ┣━ 📄 submodule2.go
        ┃     ┗━ 📄 submodule2.init.go
+       ┣━ 📁 module2700
+       ┃  ┣━ 📄 module2700.go
+       ┃  ┗━ 📄 module2700.init.go
        ┣━ 📁 nodirect
        ┃  ┣━ 📄 nodirect.go
        ┃  ┣━ 📁 sub1
@@ -2176,6 +2225,7 @@ type CompositeOperation interface {
 	SetStringStyle(val CompositeOperation_CompositionStringStyle)
 	Value() float64
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for CompositeOperation
@@ -2281,6 +2331,20 @@ func (c *jsiiProxy_CompositeOperation) ToString() string {
 	_jsii_.Invoke(
 		c,
 		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (c *jsiiProxy_CompositeOperation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"typeName",
 		nil /* no parameters */,
 		&returns,
 	)
@@ -2394,12 +2458,25 @@ func (j *jsiiProxy_Base) SetProp(val string) {
 
 type Derived interface {
 	Base
+	Prop() string
+	SetProp(val string)
 }
 
 // The jsii proxy struct for Derived
 type jsiiProxy_Derived struct {
 	jsiiProxy_Base // extends jsii-calc.DerivedClassHasNoProperties.Base
 }
+
+func (j *jsiiProxy_Derived) Prop() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"prop",
+		&returns,
+	)
+	return returns
+}
+
 
 func NewDerived() Derived {
 	_init_.Initialize()
@@ -2415,6 +2492,14 @@ func NewDerived() Derived {
 	)
 
 	return &j
+}
+
+func (j *jsiiProxy_Derived) SetProp(val string) {
+	_jsii_.Set(
+		j,
+		"prop",
+		val,
+	)
 }
 
 
@@ -2639,6 +2724,7 @@ import (
 type AbstractClass interface {
 	AbstractClassBase
 	IInterfaceImplementedByAbstractClass
+	AbstractProperty() string
 	PropFromInterface() string
 	AbstractMethod(name string) string
 	NonAbstractMethod() float64
@@ -2648,6 +2734,16 @@ type AbstractClass interface {
 type jsiiProxy_AbstractClass struct {
 	jsiiProxy_AbstractClassBase // extends jsii-calc.AbstractClassBase
 	jsiiProxy_IInterfaceImplementedByAbstractClass // implements jsii-calc.IInterfaceImplementedByAbstractClass
+}
+
+func (j *jsiiProxy_AbstractClass) AbstractProperty() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"abstractProperty",
+		&returns,
+	)
+	return returns
 }
 
 func (j *jsiiProxy_AbstractClass) PropFromInterface() string {
@@ -2880,13 +2976,37 @@ func (a *jsiiProxy_AbstractSuite) WorkItAll(seed string) string {
 // The "+" binary operation.
 type Add interface {
 	BinaryOperation
+	Lhs() scopejsiicalclib.NumericValue
+	Rhs() scopejsiicalclib.NumericValue
 	Value() float64
+	Hello() string
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Add
 type jsiiProxy_Add struct {
 	jsiiProxy_BinaryOperation // extends jsii-calc.BinaryOperation
+}
+
+func (j *jsiiProxy_Add) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"lhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Add) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"rhs",
+		&returns,
+	)
+	return returns
 }
 
 func (j *jsiiProxy_Add) Value() float64 {
@@ -2917,6 +3037,20 @@ func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue
 	return &j
 }
 
+// (deprecated) Say hello!
+func (a *jsiiProxy_Add) Hello() string {
+	var returns string
+
+	_jsii_.Invoke(
+		a,
+		"hello",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
 // (deprecated) String representation of the value.
 func (a *jsiiProxy_Add) ToString() string {
 	var returns string
@@ -2924,6 +3058,20 @@ func (a *jsiiProxy_Add) ToString() string {
 	_jsii_.Invoke(
 		a,
 		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (a *jsiiProxy_Add) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		a,
+		"typeName",
 		nil /* no parameters */,
 		&returns,
 	)
@@ -3784,7 +3932,10 @@ type BinaryOperation interface {
 	scopejsiicalclib.IFriendly
 	Lhs() scopejsiicalclib.NumericValue
 	Rhs() scopejsiicalclib.NumericValue
+	Value() float64
 	Hello() string
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for BinaryOperation
@@ -3959,18 +4110,27 @@ type Calculator interface {
 	composition.CompositeOperation
 	Curr() scopejsiicalclib.NumericValue
 	SetCurr(val scopejsiicalclib.NumericValue)
+	DecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	DecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
 	Expression() scopejsiicalclib.NumericValue
 	MaxValue() float64
 	SetMaxValue(val float64)
 	OperationsLog() []scopejsiicalclib.NumericValue
 	OperationsMap() map[string][]scopejsiicalclib.NumericValue
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
 	UnionProperty() interface{}
 	SetUnionProperty(val interface{})
+	Value() float64
 	Add(value float64)
 	Mul(value float64)
 	Neg()
 	Pow(value float64)
 	ReadUnionValue() float64
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Calculator
@@ -3983,6 +4143,26 @@ func (j *jsiiProxy_Calculator) Curr() scopejsiicalclib.NumericValue {
 	_jsii_.Get(
 		j,
 		"curr",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) DecorationPostfixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) DecorationPrefixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
 		&returns,
 	)
 	return returns
@@ -4028,11 +4208,31 @@ func (j *jsiiProxy_Calculator) OperationsMap() map[string][]scopejsiicalclib.Num
 	return returns
 }
 
+func (j *jsiiProxy_Calculator) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
 func (j *jsiiProxy_Calculator) UnionProperty() interface{} {
 	var returns interface{}
 	_jsii_.Get(
 		j,
 		"unionProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
 		&returns,
 	)
 	return returns
@@ -4064,10 +4264,34 @@ func (j *jsiiProxy_Calculator) SetCurr(val scopejsiicalclib.NumericValue) {
 	)
 }
 
+func (j *jsiiProxy_Calculator) SetDecorationPostfixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetDecorationPrefixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
 func (j *jsiiProxy_Calculator) SetMaxValue(val float64) {
 	_jsii_.Set(
 		j,
 		"maxValue",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
 		val,
 	)
 }
@@ -4123,6 +4347,34 @@ func (c *jsiiProxy_Calculator) ReadUnionValue() float64 {
 	_jsii_.Invoke(
 		c,
 		"readUnionValue",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// (deprecated) String representation of the value.
+func (c *jsiiProxy_Calculator) ToString() string {
+	var returns string
+
+	_jsii_.Invoke(
+		c,
+		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (c *jsiiProxy_Calculator) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"typeName",
 		nil /* no parameters */,
 		&returns,
 	)
@@ -5860,7 +6112,11 @@ func (j *jsiiProxy_DynamicPropertyBearer) SetValueStore(val string) {
 
 type DynamicPropertyBearerChild interface {
 	DynamicPropertyBearer
+	DynamicProperty() string
+	SetDynamicProperty(val string)
 	OriginalValue() string
+	ValueStore() string
+	SetValueStore(val string)
 	OverrideValue(newValue string) string
 }
 
@@ -5869,11 +6125,31 @@ type jsiiProxy_DynamicPropertyBearerChild struct {
 	jsiiProxy_DynamicPropertyBearer // extends jsii-calc.DynamicPropertyBearer
 }
 
+func (j *jsiiProxy_DynamicPropertyBearerChild) DynamicProperty() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"dynamicProperty",
+		&returns,
+	)
+	return returns
+}
+
 func (j *jsiiProxy_DynamicPropertyBearerChild) OriginalValue() string {
 	var returns string
 	_jsii_.Get(
 		j,
 		"originalValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) ValueStore() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"valueStore",
 		&returns,
 	)
 	return returns
@@ -5894,6 +6170,22 @@ func NewDynamicPropertyBearerChild(originalValue string) DynamicPropertyBearerCh
 	)
 
 	return &j
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) SetDynamicProperty(val string) {
+	_jsii_.Set(
+		j,
+		"dynamicProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) SetValueStore(val string) {
+	_jsii_.Set(
+		j,
+		"valueStore",
+		val,
+	)
 }
 
 // Sets \`this.dynamicProperty\` to the new value, and returns the old value.
@@ -7536,6 +7828,7 @@ func (i *jsiiProxy_ImplementsInterfaceWithInternal) Visible() {
 
 type ImplementsInterfaceWithInternalSubclass interface {
 	ImplementsInterfaceWithInternal
+	Visible()
 }
 
 // The jsii proxy struct for ImplementsInterfaceWithInternalSubclass
@@ -7557,6 +7850,14 @@ func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInterna
 	)
 
 	return &j
+}
+
+func (i *jsiiProxy_ImplementsInterfaceWithInternalSubclass) Visible() {
+	_jsii_.InvokeVoid(
+		i,
+		"visible",
+		nil /* no parameters */,
+	)
 }
 
 type ImplementsPrivateInterface interface {
@@ -7614,6 +7915,7 @@ type InbetweenClass interface {
 	PublicClass
 	IPublicInterface2
 	Ciao() string
+	Hello()
 }
 
 // The jsii proxy struct for InbetweenClass
@@ -7649,6 +7951,14 @@ func (i *jsiiProxy_InbetweenClass) Ciao() string {
 	)
 
 	return returns
+}
+
+func (i *jsiiProxy_InbetweenClass) Hello() {
+	_jsii_.InvokeVoid(
+		i,
+		"hello",
+		nil /* no parameters */,
+	)
 }
 
 // Verifies that collections of interfaces or structs are correctly handled.
@@ -7844,14 +8154,26 @@ func NewIssue2638B() Issue2638B {
 
 type JSII417Derived interface {
 	JSII417PublicBaseOfBase
+	HasRoot() bool
 	Property() string
 	Bar()
 	Baz()
+	Foo()
 }
 
 // The jsii proxy struct for JSII417Derived
 type jsiiProxy_JSII417Derived struct {
 	jsiiProxy_JSII417PublicBaseOfBase // extends jsii-calc.JSII417PublicBaseOfBase
+}
+
+func (j *jsiiProxy_JSII417Derived) HasRoot() bool {
+	var returns bool
+	_jsii_.Get(
+		j,
+		"hasRoot",
+		&returns,
+	)
+	return returns
 }
 
 func (j *jsiiProxy_JSII417Derived) Property() string {
@@ -7881,6 +8203,21 @@ func NewJSII417Derived(property string) JSII417Derived {
 	return &j
 }
 
+func JSII417Derived_MakeInstance() JSII417PublicBaseOfBase {
+	_init_.Initialize()
+
+	var returns JSII417PublicBaseOfBase
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JSII417Derived",
+		"makeInstance",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
 func (j *jsiiProxy_JSII417Derived) Bar() {
 	_jsii_.InvokeVoid(
 		j,
@@ -7893,6 +8230,14 @@ func (j *jsiiProxy_JSII417Derived) Baz() {
 	_jsii_.InvokeVoid(
 		j,
 		"baz",
+		nil /* no parameters */,
+	)
+}
+
+func (j *jsiiProxy_JSII417Derived) Foo() {
+	_jsii_.InvokeVoid(
+		j,
+		"foo",
 		nil /* no parameters */,
 	)
 }
@@ -9078,11 +9423,15 @@ type Multiply interface {
 	BinaryOperation
 	IFriendlier
 	IRandomNumberGenerator
+	Lhs() scopejsiicalclib.NumericValue
+	Rhs() scopejsiicalclib.NumericValue
 	Value() float64
 	Farewell() string
 	Goodbye() string
+	Hello() string
 	Next() float64
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Multiply
@@ -9090,16 +9439,6 @@ type jsiiProxy_Multiply struct {
 	jsiiProxy_BinaryOperation // extends jsii-calc.BinaryOperation
 	jsiiProxy_IFriendlier // implements jsii-calc.IFriendlier
 	jsiiProxy_IRandomNumberGenerator // implements jsii-calc.IRandomNumberGenerator
-}
-
-func (j *jsiiProxy_Multiply) Value() float64 {
-	var returns float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
 }
 
 func (j *jsiiProxy_Multiply) Lhs() scopejsiicalclib.NumericValue {
@@ -9117,6 +9456,16 @@ func (j *jsiiProxy_Multiply) Rhs() scopejsiicalclib.NumericValue {
 	_jsii_.Get(
 		j,
 		"rhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Multiply) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
 		&returns,
 	)
 	return returns
@@ -9168,6 +9517,20 @@ func (m *jsiiProxy_Multiply) Goodbye() string {
 	return returns
 }
 
+// (deprecated) Say hello!
+func (m *jsiiProxy_Multiply) Hello() string {
+	var returns string
+
+	_jsii_.Invoke(
+		m,
+		"hello",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
 // Returns another random number.
 func (m *jsiiProxy_Multiply) Next() float64 {
 	var returns float64
@@ -9196,20 +9559,6 @@ func (m *jsiiProxy_Multiply) ToString() string {
 	return returns
 }
 
-// (deprecated) Say hello!
-func (m *jsiiProxy_Multiply) Hello() string {
-	var returns string
-
-	_jsii_.Invoke(
-		m,
-		"hello",
-		nil /* no parameters */,
-		&returns,
-	)
-
-	return returns
-}
-
 // Returns: the name of the class (to verify native type names are created for derived classes).
 func (m *jsiiProxy_Multiply) TypeName() interface{} {
 	var returns interface{}
@@ -9228,11 +9577,13 @@ func (m *jsiiProxy_Multiply) TypeName() interface{} {
 type Negate interface {
 	UnaryOperation
 	IFriendlier
+	Operand() scopejsiicalclib.NumericValue
 	Value() float64
 	Farewell() string
 	Goodbye() string
 	Hello() string
 	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Negate
@@ -9241,21 +9592,21 @@ type jsiiProxy_Negate struct {
 	jsiiProxy_IFriendlier // implements jsii-calc.IFriendlier
 }
 
-func (j *jsiiProxy_Negate) Value() float64 {
-	var returns float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
 func (j *jsiiProxy_Negate) Operand() scopejsiicalclib.NumericValue {
 	var returns scopejsiicalclib.NumericValue
 	_jsii_.Get(
 		j,
 		"operand",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Negate) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
 		&returns,
 	)
 	return returns
@@ -10103,8 +10454,17 @@ func (p *jsiiProxy_Polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) s
 type Power interface {
 	composition.CompositeOperation
 	Base() scopejsiicalclib.NumericValue
+	DecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	DecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
 	Expression() scopejsiicalclib.NumericValue
 	Pow() scopejsiicalclib.NumericValue
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
+	Value() float64
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Power
@@ -10117,6 +10477,26 @@ func (j *jsiiProxy_Power) Base() scopejsiicalclib.NumericValue {
 	_jsii_.Get(
 		j,
 		"base",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) DecorationPostfixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) DecorationPrefixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
 		&returns,
 	)
 	return returns
@@ -10142,6 +10522,26 @@ func (j *jsiiProxy_Power) Pow() scopejsiicalclib.NumericValue {
 	return returns
 }
 
+func (j *jsiiProxy_Power) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
 
 // Creates a Power operation.
 func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) Power {
@@ -10158,6 +10558,58 @@ func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericVa
 	)
 
 	return &j
+}
+
+func (j *jsiiProxy_Power) SetDecorationPostfixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Power) SetDecorationPrefixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Power) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
+		val,
+	)
+}
+
+// (deprecated) String representation of the value.
+func (p *jsiiProxy_Power) ToString() string {
+	var returns string
+
+	_jsii_.Invoke(
+		p,
+		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (p *jsiiProxy_Power) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		p,
+		"typeName",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
 }
 
 // Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.
@@ -11467,14 +11919,43 @@ type StructWithJavaReservedWords struct {
 // An operation that sums multiple values.
 type Sum interface {
 	composition.CompositeOperation
+	DecorationPostfixes() []string
+	SetDecorationPostfixes(val []string)
+	DecorationPrefixes() []string
+	SetDecorationPrefixes(val []string)
 	Expression() scopejsiicalclib.NumericValue
 	Parts() []scopejsiicalclib.NumericValue
 	SetParts(val []scopejsiicalclib.NumericValue)
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
+	Value() float64
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for Sum
 type jsiiProxy_Sum struct {
 	composition.CompositeOperation // extends jsii-calc.composition.CompositeOperation
+}
+
+func (j *jsiiProxy_Sum) DecorationPostfixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) DecorationPrefixes() []string {
+	var returns []string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
+		&returns,
+	)
+	return returns
 }
 
 func (j *jsiiProxy_Sum) Expression() scopejsiicalclib.NumericValue {
@@ -11497,6 +11978,26 @@ func (j *jsiiProxy_Sum) Parts() []scopejsiicalclib.NumericValue {
 	return returns
 }
 
+func (j *jsiiProxy_Sum) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
 
 func NewSum() Sum {
 	_init_.Initialize()
@@ -11514,6 +12015,22 @@ func NewSum() Sum {
 	return &j
 }
 
+func (j *jsiiProxy_Sum) SetDecorationPostfixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Sum) SetDecorationPrefixes(val []string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
 func (j *jsiiProxy_Sum) SetParts(val []scopejsiicalclib.NumericValue) {
 	_jsii_.Set(
 		j,
@@ -11522,9 +12039,47 @@ func (j *jsiiProxy_Sum) SetParts(val []scopejsiicalclib.NumericValue) {
 	)
 }
 
+func (j *jsiiProxy_Sum) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
+		val,
+	)
+}
+
+// (deprecated) String representation of the value.
+func (s *jsiiProxy_Sum) ToString() string {
+	var returns string
+
+	_jsii_.Invoke(
+		s,
+		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (s *jsiiProxy_Sum) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		s,
+		"typeName",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
 type SupportsNiceJavaBuilder interface {
 	SupportsNiceJavaBuilderWithRequiredProps
+	Bar() float64
 	Id() float64
+	PropId() string
 	Rest() []string
 }
 
@@ -11533,11 +12088,31 @@ type jsiiProxy_SupportsNiceJavaBuilder struct {
 	jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps // extends jsii-calc.SupportsNiceJavaBuilderWithRequiredProps
 }
 
+func (j *jsiiProxy_SupportsNiceJavaBuilder) Bar() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"bar",
+		&returns,
+	)
+	return returns
+}
+
 func (j *jsiiProxy_SupportsNiceJavaBuilder) Id() float64 {
 	var returns float64
 	_jsii_.Get(
 		j,
 		"id",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilder) PropId() string {
+	var returns string
+	_jsii_.Get(
+		j,
+		"propId",
 		&returns,
 	)
 	return returns
@@ -12143,6 +12718,9 @@ func UmaskCheck_Mode() float64 {
 type UnaryOperation interface {
 	scopejsiicalclib.Operation
 	Operand() scopejsiicalclib.NumericValue
+	Value() float64
+	ToString() string
+	TypeName() interface{}
 }
 
 // The jsii proxy struct for UnaryOperation
@@ -12155,6 +12733,16 @@ func (j *jsiiProxy_UnaryOperation) Operand() scopejsiicalclib.NumericValue {
 	_jsii_.Get(
 		j,
 		"operand",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_UnaryOperation) Value() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"value",
 		&returns,
 	)
 	return returns
@@ -12175,6 +12763,35 @@ func NewUnaryOperation(operand scopejsiicalclib.NumericValue) UnaryOperation {
 	)
 
 	return &j
+}
+
+// String representation of the value.
+// Deprecated.
+func (u *jsiiProxy_UnaryOperation) ToString() string {
+	var returns string
+
+	_jsii_.Invoke(
+		u,
+		"toString",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+// Returns: the name of the class (to verify native type names are created for derived classes).
+func (u *jsiiProxy_UnaryOperation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		u,
+		"typeName",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
 }
 
 type UnionProperties struct {
@@ -14941,6 +15558,7 @@ import (
 type ExtendAndImplement interface {
 	scopejsiicalclib.BaseFor2647
 	scopejsiicalclib.IFriendly
+	Foo(obj jcb.IBaseInterface)
 	Hello() string
 	LocalMethod() string
 }
@@ -14968,6 +15586,15 @@ func NewExtendAndImplement(very scopejsiicalcbaseofbase.Very) ExtendAndImplement
 	return &j
 }
 
+// Deprecated.
+func (e *jsiiProxy_ExtendAndImplement) Foo(obj jcb.IBaseInterface) {
+	_jsii_.InvokeVoid(
+		e,
+		"foo",
+		[]interface{}{obj},
+	)
+}
+
 // (deprecated) Say hello!
 func (e *jsiiProxy_ExtendAndImplement) Hello() string {
 	var returns string
@@ -14993,15 +15620,6 @@ func (e *jsiiProxy_ExtendAndImplement) LocalMethod() string {
 	)
 
 	return returns
-}
-
-// Deprecated.
-func (e *jsiiProxy_ExtendAndImplement) Foo(obj jcb.IBaseInterface) {
-	_jsii_.InvokeVoid(
-		e,
-		"foo",
-		[]interface{}{obj},
-	)
 }
 
 
@@ -15405,6 +16023,221 @@ func init() {
 	_jsii_.RegisterStruct(
 		"jsii-calc.module2692.submodule2.Foo",
 		reflect.TypeOf((*Foo)(nil)).Elem(),
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700.go 1`] = `
+package module2700
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Base interface {
+	IFoo
+	Baz() float64
+	Bar() string
+}
+
+// The jsii proxy struct for Base
+type jsiiProxy_Base struct {
+	jsiiProxy_IFoo // implements jsii-calc.module2700.IFoo
+}
+
+func (j *jsiiProxy_Base) Baz() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"baz",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewBase() Base {
+	_init_.Initialize()
+
+	j := jsiiProxy_Base{}
+
+	_jsii_.Create(
+		"jsii-calc.module2700.Base",
+		nil /* no parameters */,
+		[]_jsii_.FQN{"jsii-calc.module2700.IFoo"},
+		nil, // no overrides
+		&j,
+	)
+
+	return &j
+}
+
+func (b *jsiiProxy_Base) Bar() string {
+	var returns string
+
+	_jsii_.Invoke(
+		b,
+		"bar",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+type Derived interface {
+	Base
+	IFoo
+	Baz() float64
+	Bar() string
+	Zoo() string
+}
+
+// The jsii proxy struct for Derived
+type jsiiProxy_Derived struct {
+	jsiiProxy_Base // extends jsii-calc.module2700.Base
+	jsiiProxy_IFoo // implements jsii-calc.module2700.IFoo
+}
+
+func (j *jsiiProxy_Derived) Baz() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"baz",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewDerived() Derived {
+	_init_.Initialize()
+
+	j := jsiiProxy_Derived{}
+
+	_jsii_.Create(
+		"jsii-calc.module2700.Derived",
+		nil /* no parameters */,
+		[]_jsii_.FQN{"jsii-calc.module2700.IFoo"},
+		nil, // no overrides
+		&j,
+	)
+
+	return &j
+}
+
+func (d *jsiiProxy_Derived) Bar() string {
+	var returns string
+
+	_jsii_.Invoke(
+		d,
+		"bar",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_Derived) Zoo() string {
+	var returns string
+
+	_jsii_.Invoke(
+		d,
+		"zoo",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+type IFoo interface {
+	Bar() string
+	Baz() float64
+}
+
+// The jsii proxy for IFoo
+type jsiiProxy_IFoo struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IFoo) Bar() string {
+	var returns string
+
+	_jsii_.Invoke(
+		i,
+		"bar",
+		nil /* no parameters */,
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_IFoo) Baz() float64 {
+	var returns float64
+	_jsii_.Get(
+		j,
+		"baz",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700.init.go 1`] = `
+package module2700
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.module2700.Base",
+		reflect.TypeOf((*Base)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Base{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
+			return &j
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.module2700.Derived",
+		reflect.TypeOf((*Derived)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+			_jsii_.MemberMethod{JsiiMethod: "zoo", GoMethod: "Zoo"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Derived{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_Base)
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
+			return &j
+		},
+	)
+	_jsii_.RegisterInterface(
+		"jsii-calc.module2700.IFoo",
+		reflect.TypeOf((*IFoo)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+		},
+		func() interface{} {
+			return &jsiiProxy_IFoo{}
+		},
 	)
 }
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -3729,6 +3729,10 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┃  ┗━ 📁 submodule2
           ┃                 ┃     ┣━ 📄 Bar.java
           ┃                 ┃     ┗━ 📄 Foo.java
+          ┃                 ┣━ 📁 module2700
+          ┃                 ┃  ┣━ 📄 Base.java
+          ┃                 ┃  ┣━ 📄 Derived.java
+          ┃                 ┃  ┗━ 📄 IFoo.java
           ┃                 ┣━ 📄 Multiply.java
           ┃                 ┣━ 📄 Negate.java
           ┃                 ┣━ 📄 NestedClassInstance.java
@@ -22596,6 +22600,160 @@ public interface Foo extends software.amazon.jsii.JsiiSerializable, software.ama
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/module2700/Base.java 1`] = `
+package software.amazon.jsii.tests.calculator.module2700;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.module2700.Base")
+public class Base extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.module2700.IFoo {
+
+    protected Base(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Base(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public Base() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    @Override
+    public @org.jetbrains.annotations.NotNull java.lang.String bar() {
+        return software.amazon.jsii.Kernel.call(this, "bar", software.amazon.jsii.NativeType.forClass(java.lang.String.class));
+    }
+
+    /**
+     */
+    @Override
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public @org.jetbrains.annotations.NotNull java.lang.Number getBaz() {
+        return software.amazon.jsii.Kernel.get(this, "baz", software.amazon.jsii.NativeType.forClass(java.lang.Number.class));
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/module2700/Derived.java 1`] = `
+package software.amazon.jsii.tests.calculator.module2700;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.module2700.Derived")
+public class Derived extends software.amazon.jsii.tests.calculator.module2700.Base implements software.amazon.jsii.tests.calculator.module2700.IFoo {
+
+    protected Derived(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Derived(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public Derived() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public @org.jetbrains.annotations.NotNull java.lang.String zoo() {
+        return software.amazon.jsii.Kernel.call(this, "zoo", software.amazon.jsii.NativeType.forClass(java.lang.String.class));
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/module2700/IFoo.java 1`] = `
+package software.amazon.jsii.tests.calculator.module2700;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.module2700.IFoo")
+@software.amazon.jsii.Jsii.Proxy(IFoo.Jsii$Proxy.class)
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+public interface IFoo extends software.amazon.jsii.JsiiSerializable {
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    @org.jetbrains.annotations.NotNull java.lang.Number getBaz();
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    @org.jetbrains.annotations.NotNull java.lang.String bar();
+
+    /**
+     * A proxy class which represents a concrete javascript instance of this type.
+     */
+    @software.amazon.jsii.Internal
+    final class Jsii$Proxy extends software.amazon.jsii.JsiiObject implements software.amazon.jsii.tests.calculator.module2700.IFoo.Jsii$Default {
+        protected Jsii$Proxy(final software.amazon.jsii.JsiiObjectRef objRef) {
+            super(objRef);
+        }
+
+        /**
+         */
+        @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        public final @org.jetbrains.annotations.NotNull java.lang.Number getBaz() {
+            return software.amazon.jsii.Kernel.get(this, "baz", software.amazon.jsii.NativeType.forClass(java.lang.Number.class));
+        }
+
+        /**
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
+        public final @org.jetbrains.annotations.NotNull java.lang.String bar() {
+            return software.amazon.jsii.Kernel.call(this, "bar", software.amazon.jsii.NativeType.forClass(java.lang.String.class));
+        }
+    }
+
+    /**
+     * Internal default implementation for {@link IFoo}.
+     */
+    @software.amazon.jsii.Internal
+    interface Jsii$Default extends IFoo {
+
+        /**
+         */
+        @Override
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        default @org.jetbrains.annotations.NotNull java.lang.Number getBaz() {
+            return software.amazon.jsii.Kernel.get(this, "baz", software.amazon.jsii.NativeType.forClass(java.lang.Number.class));
+        }
+
+        /**
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
+        default @org.jetbrains.annotations.NotNull java.lang.String bar() {
+            return software.amazon.jsii.Kernel.call(this, "bar", software.amazon.jsii.NativeType.forClass(java.lang.String.class));
+        }
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/nodirect/sub1/TypeFromSub1.java 1`] = `
 package software.amazon.jsii.tests.calculator.nodirect.sub1;
 
@@ -24455,6 +24613,9 @@ jsii-calc.module2689.structs.MyStruct=software.amazon.jsii.tests.calculator.modu
 jsii-calc.module2692.submodule1.Bar=software.amazon.jsii.tests.calculator.module2692.submodule1.Bar
 jsii-calc.module2692.submodule2.Bar=software.amazon.jsii.tests.calculator.module2692.submodule2.Bar
 jsii-calc.module2692.submodule2.Foo=software.amazon.jsii.tests.calculator.module2692.submodule2.Foo
+jsii-calc.module2700.Base=software.amazon.jsii.tests.calculator.module2700.Base
+jsii-calc.module2700.Derived=software.amazon.jsii.tests.calculator.module2700.Derived
+jsii-calc.module2700.IFoo=software.amazon.jsii.tests.calculator.module2700.IFoo
 jsii-calc.nodirect.sub1.TypeFromSub1=software.amazon.jsii.tests.calculator.nodirect.sub1.TypeFromSub1
 jsii-calc.nodirect.sub2.TypeFromSub2=software.amazon.jsii.tests.calculator.nodirect.sub2.TypeFromSub2
 jsii-calc.onlystatic.OnlyStaticMethods=software.amazon.jsii.tests.calculator.onlystatic.OnlyStaticMethods

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -2121,6 +2121,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃  ┃  ┗━ 📄 __init__.py
           ┃  ┗━ 📁 submodule2
           ┃     ┗━ 📄 __init__.py
+          ┣━ 📁 module2700
+          ┃  ┗━ 📄 __init__.py
           ┣━ 📁 nodirect
           ┃  ┣━ 📄 __init__.py
           ┃  ┣━ 📁 sub1
@@ -2444,6 +2446,7 @@ kwargs = json.loads(
         "jsii_calc.module2692",
         "jsii_calc.module2692.submodule1",
         "jsii_calc.module2692.submodule2",
+        "jsii_calc.module2700",
         "jsii_calc.nodirect",
         "jsii_calc.nodirect.sub1",
         "jsii_calc.nodirect.sub2",
@@ -10920,6 +10923,84 @@ class Foo(Bar, _Bar_ec7eccad):
 __all__ = [
     "Bar",
     "Foo",
+]
+
+publication.publish()
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2700/__init__.py 1`] = `
+import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+from .._jsii import *
+
+
+@jsii.interface(jsii_type="jsii-calc.module2700.IFoo")
+class IFoo(typing_extensions.Protocol):
+    @builtins.staticmethod
+    def __jsii_proxy_class__() -> typing.Type["_IFooProxy"]:
+        return _IFooProxy
+
+    @builtins.property # type: ignore[misc]
+    @jsii.member(jsii_name="baz")
+    def baz(self) -> jsii.Number:
+        ...
+
+    @jsii.member(jsii_name="bar")
+    def bar(self) -> builtins.str:
+        ...
+
+
+class _IFooProxy:
+    __jsii_type__: typing.ClassVar[str] = "jsii-calc.module2700.IFoo"
+
+    @builtins.property # type: ignore[misc]
+    @jsii.member(jsii_name="baz")
+    def baz(self) -> jsii.Number:
+        return typing.cast(jsii.Number, jsii.get(self, "baz"))
+
+    @jsii.member(jsii_name="bar")
+    def bar(self) -> builtins.str:
+        return typing.cast(builtins.str, jsii.invoke(self, "bar", []))
+
+
+@jsii.implements(IFoo)
+class Base(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2700.Base"):
+    def __init__(self) -> None:
+        jsii.create(Base, self, [])
+
+    @jsii.member(jsii_name="bar")
+    def bar(self) -> builtins.str:
+        return typing.cast(builtins.str, jsii.invoke(self, "bar", []))
+
+    @builtins.property # type: ignore[misc]
+    @jsii.member(jsii_name="baz")
+    def baz(self) -> jsii.Number:
+        return typing.cast(jsii.Number, jsii.get(self, "baz"))
+
+
+@jsii.implements(IFoo)
+class Derived(Base, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2700.Derived"):
+    def __init__(self) -> None:
+        jsii.create(Derived, self, [])
+
+    @jsii.member(jsii_name="zoo")
+    def zoo(self) -> builtins.str:
+        return typing.cast(builtins.str, jsii.invoke(self, "zoo", []))
+
+
+__all__ = [
+    "Base",
+    "Derived",
+    "IFoo",
 ]
 
 publication.publish()

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.ts.snap
@@ -213,6 +213,33 @@ exports[`jsii-tree --all 1`] = `
  │ │ │ │           ├── immutable
  │ │ │ │           └── type: string
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class Base (stable)
+ │ │ │   │ ├── interfaces: IFoo
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer (stable)
+ │ │ │   │   ├─┬ bar() method (stable)
+ │ │ │   │   │ └── returns: string
+ │ │ │   │   └─┬ baz property (stable)
+ │ │ │   │     ├── immutable
+ │ │ │   │     └── type: number
+ │ │ │   ├─┬ class Derived (stable)
+ │ │ │   │ ├── base: Base
+ │ │ │   │ ├── interfaces: IFoo
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer (stable)
+ │ │ │   │   └─┬ zoo() method (stable)
+ │ │ │   │     └── returns: string
+ │ │ │   └─┬ interface IFoo (stable)
+ │ │ │     └─┬ members
+ │ │ │       ├─┬ bar() method (stable)
+ │ │ │       │ ├── abstract
+ │ │ │       │ └── returns: string
+ │ │ │       └─┬ baz property (stable)
+ │ │ │         ├── abstract
+ │ │ │         ├── immutable
+ │ │ │         └── type: number
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1
@@ -3106,6 +3133,14 @@ exports[`jsii-tree --inheritance 1`] = `
  │ │ │ │         ├── Bar
  │ │ │ │         └── Bar
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class Base
+ │ │ │   │ └── interfaces: IFoo
+ │ │ │   ├─┬ class Derived
+ │ │ │   │ ├── base: Base
+ │ │ │   │ └── interfaces: IFoo
+ │ │ │   └── interface IFoo
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1
@@ -3590,6 +3625,21 @@ exports[`jsii-tree --members 1`] = `
  │ │ │ │       └─┬ members
  │ │ │ │         └── foo2 property
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class Base
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer
+ │ │ │   │   ├── bar() method
+ │ │ │   │   └── baz property
+ │ │ │   ├─┬ class Derived
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer
+ │ │ │   │   └── zoo() method
+ │ │ │   └─┬ interface IFoo
+ │ │ │     └─┬ members
+ │ │ │       ├── bar() method
+ │ │ │       └── baz property
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1
@@ -4881,6 +4931,7 @@ exports[`jsii-tree --signatures 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1
@@ -4960,6 +5011,11 @@ exports[`jsii-tree --types 1`] = `
  │ │ │ │     ├── interface Bar
  │ │ │ │     └── interface Foo
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├── class Base
+ │ │ │   ├── class Derived
+ │ │ │   └── interface IFoo
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1
@@ -5274,6 +5330,7 @@ exports[`jsii-tree 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.ts.snap
@@ -21,6 +21,7 @@ exports[`defaults 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1
@@ -65,6 +66,7 @@ exports[`inheritance 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1
@@ -109,6 +111,7 @@ exports[`members 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1
@@ -345,6 +348,33 @@ exports[`showAll 1`] = `
  │ │ │ │           ├── immutable
  │ │ │ │           └── type: string
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class Base
+ │ │ │   │ ├── interfaces: IFoo
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer
+ │ │ │   │   ├─┬ bar() method
+ │ │ │   │   │ └── returns: string
+ │ │ │   │   └─┬ baz property
+ │ │ │   │     ├── immutable
+ │ │ │   │     └── type: number
+ │ │ │   ├─┬ class Derived
+ │ │ │   │ ├── base: Base
+ │ │ │   │ ├── interfaces: IFoo
+ │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>() initializer
+ │ │ │   │   └─┬ zoo() method
+ │ │ │   │     └── returns: string
+ │ │ │   └─┬ interface IFoo
+ │ │ │     └─┬ members
+ │ │ │       ├─┬ bar() method
+ │ │ │       │ ├── abstract
+ │ │ │       │ └── returns: string
+ │ │ │       └─┬ baz property
+ │ │ │         ├── abstract
+ │ │ │         ├── immutable
+ │ │ │         └── type: number
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1
@@ -3196,6 +3226,7 @@ exports[`signatures 1`] = `
  │   │ └─┬ submodules
  │   │   ├── submodule1
  │   │   └── submodule2
+ │   ├── module2700
  │   ├─┬ nodirect
  │   │ └─┬ submodules
  │   │   ├── sub1
@@ -3275,6 +3306,11 @@ exports[`types 1`] = `
  │ │ │ │     ├── interface Bar
  │ │ │ │     └── interface Foo
  │ │ │ └── types
+ │ │ ├─┬ module2700
+ │ │ │ └─┬ types
+ │ │ │   ├── class Base
+ │ │ │   ├── class Derived
+ │ │ │   └── interface IFoo
  │ │ ├─┬ nodirect
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ sub1

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.ts.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.ts.snap
@@ -160,6 +160,8 @@ Array [
   "jsii-calc.module2689.methods.MyClass",
   "jsii-calc.module2689.props.MyClass",
   "jsii-calc.module2689.retval.MyClass",
+  "jsii-calc.module2700.Base",
+  "jsii-calc.module2700.Derived",
   "jsii-calc.nodirect.sub1.TypeFromSub1",
   "jsii-calc.nodirect.sub2.TypeFromSub2",
   "jsii-calc.onlystatic.OnlyStaticMethods",


### PR DESCRIPTION
If a class implements an interface from multiple paths (e.g. directly and via a base), then Go compilation fails with an ambiguity issue.

Simplify by always re-implementing all methods and properties in derived classes.

Fixes #2700



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
