### PR TITLE
(chore): add escalation info to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -52,8 +52,7 @@ confidential information out.
 <!-- 
 NOTE: If your bug is meets one of the following criteria, and is not recieving proper attention, please notify the team directly by commenting @TEAM-MEMBER, or messaging @TEAM-MEMBER on our [Slack](https://cdk.dev/):
 
-* Breaking change in `Stable` construct library
 * Potential security violation
 * Bug impacts large number of users
-* Bug impacts performance of entire CDK
+* Bug impacts performance of all JSII
 -->

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -48,3 +48,12 @@ confidential information out.
 
 [1]: https://gist.github.com
 -->
+
+<!-- 
+NOTE: If your bug is meets one of the following criteria, and is not recieving proper attention, please notify the team directly by commenting @TEAM-MEMBER, or messaging @TEAM-MEMBER on our [Slack](https://cdk.dev/):
+
+* Breaking change in `Stable` construct library
+* Potential security violation
+* Bug impacts large number of users
+* Bug impacts performance of entire CDK
+-->


### PR DESCRIPTION
Adds information to bug issue template on escalating high-severity bugs that are not receiving the proper attention.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
