### PR TITLE
feat(superchain): `$NVM_USE_VERSION` selects Node.js version

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -84,11 +84,13 @@ RUN amazon-linux-extras install docker                                          
 VOLUME /var/lib/docker
 
 # Install Node using NVM (Node Version Manager) so we can have multiple Node versions installed and easily switch
-# between them.
+# between them. $NVM_USE_VERSION becomes a global variable the container responds to to pick a Node version on startup,
+# if set.
 ENV NVM_DIR /usr/local/nvm
 
-RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash -                                   \
-  && echo 'source "$NVM_DIR/nvm.sh"' >> $HOME/.bash_profile
+RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash -              \
+  && echo 'source "$NVM_DIR/nvm.sh"' >> $HOME/.bash_profile                                                             \
+  && echo '[[ -z "$NVM_USE_VERSION" ]] || nvm use "$NVM_USE_VERSION"' >> $HOME/.bash_profile
 
 # Because we wrote things to .bash_profile, make the default shell a login shell so it gets sourced.
 # Also set BASH_ENV to make bash source this EVEN if it's not a login shell (later on when the container

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -14,9 +14,18 @@ SDK             | Version
 `.NET SDK`      | `>= 3.1.101`
 `mono`          | `>= 6.8.0.105`
 `Javascript`    | `node >= 10.19.0` with `npm >= 6.13.4`
+                | `node >= 14.24.0` with `npm >= 6.13.4`
+                | (both managed via NVM)
 `PowerShell`    | `pwsh >= 6.2.3`
 `Python 3`      | `python3 >= 3.7.4` with `pip3 >= 20.0.2`
 `Go`            | `go >= 1.16`
+
+### Notes on Node.js
+
+You *must* use `bash` (not `sh`) to run commands in this container.
+
+By default, Node.js will be at version 10. To switch to Node 14,
+pass `-e NVM_USE_VERSION=14` into the container at startup.
 
 ## Included Tools & Utilities
 


### PR DESCRIPTION
We added multiple Node versions into the Superchain image, and made it
possible to switch between them using NVM.

Doing so would require putting `nvm use 14` at the top of every script
that wanted to run against a newer Node version, and so would require
modification to scripts in our branches.

Another, more effective, way to configure the Node version is to be able
to do it without modifying the scripts themselves, but by specifying it
via the runtime environment. In this case, via environment variable that
can be set on the Docker environment.

The `$NVM_USE_VERSION` environment variable will lead to an implicit
execution of `nvm use $NVM_USE_VERSION` at container startup time, if
present.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
