### PR TITLE
revert(rosetta): 'extract' does not translate samples in submodule READMEs

### DIFF
--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -68,18 +68,6 @@ export function allSnippetSources(
     });
   }
 
-  for (const [submoduleFqn, submodule] of Object.entries(
-    assembly.submodules ?? {},
-  )) {
-    if (submodule.readme) {
-      ret.push({
-        type: 'markdown',
-        markdown: submodule.readme.markdown,
-        where: removeSlashes(`${submoduleFqn}-README`),
-      });
-    }
-  }
-
   if (assembly.types) {
     Object.values(assembly.types).forEach((type) => {
       emitDocs(type.docs, `${assembly.name}.${type.name}`);

--- a/packages/jsii-rosetta/test/jsii/assemblies.test.ts
+++ b/packages/jsii-rosetta/test/jsii/assemblies.test.ts
@@ -29,33 +29,6 @@ test('Extract snippet from README', () => {
   expect(snippets[0].visibleSource).toEqual('someExample();');
 });
 
-test('Extract snippet from submodule READMEs', () => {
-  const snippets = Array.from(
-    allTypeScriptSnippets([
-      {
-        assembly: fakeAssembly({
-          submodules: {
-            'my.submodule': {
-              readme: {
-                markdown: [
-                  'Before the example.',
-                  '```ts',
-                  'someExample();',
-                  '```',
-                  'After the example.',
-                ].join('\n'),
-              },
-            },
-          },
-        }),
-        directory: path.join(__dirname, 'fixtures'),
-      },
-    ]),
-  );
-
-  expect(snippets[0].visibleSource).toEqual('someExample();');
-});
-
 test('Extract snippet from type docstring', () => {
   const snippets = Array.from(
     allTypeScriptSnippets([


### PR DESCRIPTION
Reverts aws/jsii#2712

The mentioned commit breaks our cdk integ test since it depends on https://github.com/aws/aws-cdk/pull/13670, which hasn't landed on the release branch yet. 

This will be reintroduced after we release CDK. 