### PR TITLE
fix(superchain): use entrypoint to set up nvm

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -87,25 +87,20 @@ VOLUME /var/lib/docker
 # between them. $NVM_USE_VERSION becomes a global variable the container responds to to pick a Node version on startup,
 # if set.
 ENV NVM_DIR /usr/local/nvm
+COPY run.sh /usr/local/bin/
 
-RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash -              \
-  && echo 'source "$NVM_DIR/nvm.sh"' >> $HOME/.bash_profile                                                             \
-  && echo '[[ -z "$NVM_USE_VERSION" ]] || nvm use "$NVM_USE_VERSION"' >> $HOME/.bash_profile
-
-# Because we wrote things to .bash_profile, make the default shell a login shell so it gets sourced.
-# Also set BASH_ENV to make bash source this EVEN if it's not a login shell (later on when the container
-# gets executed)
-SHELL [ "/bin/bash", "--login", "-c" ]
-ENV BASH_ENV /root/.bash_profile
-
-# Source NVM into this shell and install Node 10 and 14. First installed version (10) becomes default.
-RUN nvm install 10                                                                                                     \
+RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash -             \
+  && chmod a+x /usr/local/bin/run.sh                                                                                   \
+  # Source NVM into this shell
+  && source $NVM_DIR/nvm.sh                                                                                            \
+  # Install Node 10 and yarn on node 10. First installed version becomes default.
+  && nvm install 10                                                                                                    \
+  && nvm exec 10 npm install -g yarn                                                                                   \
+  # Install Node 14 and yarn on node 14.
   && nvm install 14                                                                                                    \
+  && nvm exec 14 npm install -g yarn                                                                                   \
+  # Make npm play nicer with Docker containers running as "root".
   && npm set unsafe-perm true
-
-# Can't install Yarn using yum anymore now that we're using nvm, so install it using NPM
-RUN nvm exec 10 npm install -g yarn                                                                                    \
-  && nvm exec 14 npm install -g yarn
 
 # Install some configuration
 COPY ssh_config /root/.ssh/config
@@ -126,4 +121,5 @@ LABEL org.opencontainers.image.created=${BUILD_TIMESTAMP}                       
       org.opencontainers.image.revision=$COMMIT_ID                                                                      \
       org.opencontainers.image.authors="Amazon Web Services (https://aws.amazon.com)"
 
-CMD ["/bin/bash", "--login"]
+ENTRYPOINT ["/usr/local/bin/run.sh"]
+CMD ["/bin/bash"]

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -8,24 +8,26 @@ required in order to package [jsii] projects in all supported languages.
 
 ## Included Language SDKs
 
-SDK             | Version
-----------------|-------------------------------------------
-`OpenJDK 8`     | Amazon Corretto `>= 8.242.08.1`
-`.NET SDK`      | `>= 3.1.101`
-`mono`          | `>= 6.8.0.105`
-`Javascript`    | `node >= 10.19.0` with `npm >= 6.13.4`
-                | `node >= 14.24.0` with `npm >= 6.13.4`
-                | (both managed via NVM)
-`PowerShell`    | `pwsh >= 6.2.3`
-`Python 3`      | `python3 >= 3.7.4` with `pip3 >= 20.0.2`
-`Go`            | `go >= 1.16`
+SDK           | Version
+--------------|-------------------------------------------
+`OpenJDK 8`   | Amazon Corretto `>= 8.242.08.1`
+`.NET SDK`    | `>= 3.1.101`
+`mono`        | `>= 6.8.0.105`
+`Node`        | `node >= 10.19.0` with `npm >= 6.13.4`
+`Node` (Alt)  | `node >= 14.24.0` with `npm >= 6.13.4` (see [notes] below)
+`PowerShell`  | `pwsh >= 6.2.3`
+`Python 3`    | `python3 >= 3.7.4` with `pip3 >= 20.0.2`
+`Go`          | `go >= 1.16`
+
+[notes]: #notes-on-node.js
 
 ### Notes on Node.js
 
-You *must* use `bash` (not `sh`) to run commands in this container.
+By default, Node.js will be at version 10. To switch to Node 14, pass
+`-e NVM_USE_VERSION=14` into the container at startup, or use
+[`nvm` commands][nvm] to switch between versions or to install other versions.
 
-By default, Node.js will be at version 10. To switch to Node 14,
-pass `-e NVM_USE_VERSION=14` into the container at startup.
+[nvm]: https://github.com/nvm-sh/nvm
 
 ## Included Tools & Utilities
 

--- a/superchain/run.sh
+++ b/superchain/run.sh
@@ -3,4 +3,4 @@
 source "$NVM_DIR/nvm.sh"
 [[ -z "$NVM_USE_VERSION" ]] || nvm use "$NVM_USE_VERSION"
 
-exec $@
+exec "$@"

--- a/superchain/run.sh
+++ b/superchain/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+source "$NVM_DIR/nvm.sh"
+[[ -z "$NVM_USE_VERSION" ]] || nvm use "$NVM_USE_VERSION"
+
+exec $@


### PR DESCRIPTION
This ensures node is always in the PATH at the start of a container (unless
the user replaced the entrypoint). This attempts to minimize overhead of the
overall setup by using exec in the run.sh script.

Fixes #2734

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
