### PR TITLE
chore(golang): require instead of assert

### DIFF
--- a/packages/@jsii/go-runtime-test/project/compliance.go
+++ b/packages/@jsii/go-runtime-test/project/compliance.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -30,8 +30,8 @@ func (suite *ComplianceSuite) TearDownSuite() {
 	}
 }
 
-func (suite *ComplianceSuite) Assert() *assert.Assertions {
-	return assert.New(suite.T())
+func (suite *ComplianceSuite) Require() *require.Assertions {
+	return require.New(suite.T())
 }
 
 func (suite *ComplianceSuite) reportForTest() map[string]string {

--- a/packages/@jsii/go-runtime-test/project/compliance_test.go
+++ b/packages/@jsii/go-runtime-test/project/compliance_test.go
@@ -25,50 +25,50 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/child"
 	calclib "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
 	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 func (suite *ComplianceSuite) TestStatics() {
-	assert := suite.Assert()
+	require := suite.Require()
 
-	assert.Equal("hello ,Yoyo!", *calc.Statics_StaticMethod(jsii.String("Yoyo")))
-	assert.Equal("default", *calc.Statics_Instance().Value())
+	require.Equal("hello ,Yoyo!", *calc.Statics_StaticMethod(jsii.String("Yoyo")))
+	require.Equal("default", *calc.Statics_Instance().Value())
 
 	newStatics := calc.NewStatics(jsii.String("new value"))
 	calc.Statics_SetInstance(newStatics)
-	assert.Same(newStatics, calc.Statics_Instance())
-	assert.Equal("new value", *calc.Statics_Instance().Value())
+	require.Same(newStatics, calc.Statics_Instance())
+	require.Equal("new value", *calc.Statics_Instance().Value())
 
 	// the float64 conversion is a bit annoying - can we do something about it?
-	assert.Equal(float64(100), *calc.Statics_NonConstStatic())
+	require.Equal(float64(100), *calc.Statics_NonConstStatic())
 
 }
 
 func (suite *ComplianceSuite) TestPrimitiveTypes() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	types := calc.NewAllTypes()
 
 	// boolean
 	types.SetBooleanProperty(jsii.Bool(true))
-	assert.Equal(true, *types.BooleanProperty())
+	require.Equal(true, *types.BooleanProperty())
 
 	// string
 	types.SetStringProperty(jsii.String("foo"))
-	assert.Equal("foo", *types.StringProperty())
+	require.Equal("foo", *types.StringProperty())
 
 	// number
 	types.SetNumberProperty(jsii.Number(1234))
-	assert.Equal(float64(1234), *types.NumberProperty())
+	require.Equal(float64(1234), *types.NumberProperty())
 
 	// json
 	mapProp := map[string]interface{}{"Foo": map[string]interface{}{"Bar": 123}}
 	types.SetJsonProperty(&mapProp)
-	assert.Equal(float64(123), (*types.JsonProperty())["Foo"].(map[string]interface{})["Bar"])
+	require.Equal(float64(123), (*types.JsonProperty())["Foo"].(map[string]interface{})["Bar"])
 
 	types.SetDateProperty(jsii.Time(time.Unix(0, 123000000)))
-	assert.WithinDuration(time.Unix(0, 123000000), *types.DateProperty(), 0)
+	require.WithinDuration(time.Unix(0, 123000000), *types.DateProperty(), 0)
 }
 
 func (suite *ComplianceSuite) TestUseNestedStruct() {
@@ -78,35 +78,35 @@ func (suite *ComplianceSuite) TestUseNestedStruct() {
 }
 
 func (suite *ComplianceSuite) TestStaticMapInClassCanBeReadCorrectly() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	result := *calc.ClassWithCollections_StaticMap()
-	assert.Equal("value1", *result["key1"])
-	assert.Equal("value2", *result["key2"])
-	assert.Equal(2, len(result))
+	require.Equal("value1", *result["key1"])
+	require.Equal("value2", *result["key2"])
+	require.Equal(2, len(result))
 }
 
 func (suite *ComplianceSuite) TestTestNativeObjectsWithInterfaces() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	// create a pure and native object, not part of the jsii hierarchy, only implements a jsii interface
 	pureNative := newPureNativeFriendlyRandom()
 	generatorBoundToPureNative := calc.NewNumberGenerator(pureNative)
-	assert.Equal(pureNative, generatorBoundToPureNative.Generator())
-	assert.Equal(float64(100000), *generatorBoundToPureNative.NextTimes100())
-	assert.Equal(float64(200000), *generatorBoundToPureNative.NextTimes100())
+	require.Equal(pureNative, generatorBoundToPureNative.Generator())
+	require.Equal(float64(100000), *generatorBoundToPureNative.NextTimes100())
+	require.Equal(float64(200000), *generatorBoundToPureNative.NextTimes100())
 
 	subclassNative := NewSubclassNativeFriendlyRandom()
 	generatorBoundToPSubclassedObject := calc.NewNumberGenerator(subclassNative)
-	assert.Equal(subclassNative, generatorBoundToPSubclassedObject.Generator())
+	require.Equal(subclassNative, generatorBoundToPSubclassedObject.Generator())
 
 	generatorBoundToPSubclassedObject.IsSameGenerator(subclassNative)
-	assert.Equal(float64(10000), *generatorBoundToPSubclassedObject.NextTimes100())
-	assert.Equal(float64(20000), *generatorBoundToPSubclassedObject.NextTimes100())
+	require.Equal(float64(10000), *generatorBoundToPSubclassedObject.NextTimes100())
+	require.Equal(float64(20000), *generatorBoundToPSubclassedObject.NextTimes100())
 }
 
 func (suite *ComplianceSuite) TestMaps() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	// TODO: props should be optional
 	calc2 := calc.NewCalculator(&calc.CalculatorProps{})
@@ -115,67 +115,67 @@ func (suite *ComplianceSuite) TestMaps() {
 	calc2.Mul(jsii.Number(2))
 
 	result := *calc2.OperationsMap()
-	assert.Equal(2, len(*result["add"]))
-	assert.Equal(1, len(*result["mul"]))
+	require.Equal(2, len(*result["add"]))
+	require.Equal(1, len(*result["mul"]))
 	resultAdd := *result["add"]
-	assert.Equal(float64(30), *resultAdd[1].Value())
+	require.Equal(float64(30), *resultAdd[1].Value())
 }
 
 func (suite *ComplianceSuite) TestDates() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	types := calc.NewAllTypes()
 	types.SetDateProperty(jsii.Time(time.Unix(128, 0)))
-	assert.WithinDuration(time.Unix(128, 0), *types.DateProperty(), 0)
+	require.WithinDuration(time.Unix(128, 0), *types.DateProperty(), 0)
 
 	// weak type
 	types.SetAnyProperty(time.Unix(999, 0))
-	assert.WithinDuration(time.Unix(999, 0), types.AnyProperty().(time.Time), 0)
+	require.WithinDuration(time.Unix(999, 0), types.AnyProperty().(time.Time), 0)
 }
 
 func (suite *ComplianceSuite) TestCallMethods() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	calc := calc.NewCalculator(&calc.CalculatorProps{})
 	calc.Add(jsii.Number(10))
-	assert.Equal(float64(10), *calc.Value())
+	require.Equal(float64(10), *calc.Value())
 
 	calc.Mul(jsii.Number(2))
-	assert.Equal(float64(20), *calc.Value())
+	require.Equal(float64(20), *calc.Value())
 
 	calc.Pow(jsii.Number(5))
-	assert.Equal(float64(20*20*20*20*20), *calc.Value())
+	require.Equal(float64(20*20*20*20*20), *calc.Value())
 
 	calc.Neg()
-	assert.Equal(float64(-3200000), *calc.Value())
+	require.Equal(float64(-3200000), *calc.Value())
 }
 
 func (suite *ComplianceSuite) TestNodeStandardLibrary() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := calc.NewNodeStandardLibrary()
-	assert.Equal("Hello, resource! SYNC!", *obj.FsReadFileSync())
-	assert.NotEmpty(obj.OsPlatform())
-	assert.Equal("6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50", *obj.CryptoSha256())
+	require.Equal("Hello, resource! SYNC!", *obj.FsReadFileSync())
+	require.NotEmpty(obj.OsPlatform())
+	require.Equal("6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50", *obj.CryptoSha256())
 
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert.Equal("Hello, resource!", obj.FsReadFile())
+	require.Equal("Hello, resource!", obj.FsReadFile())
 }
 
 func (suite *ComplianceSuite) TestDynamicTypes() {
-	assert := suite.Assert()
+	require := suite.Require()
 	types := calc.NewAllTypes()
 
 	types.SetAnyProperty(false)
-	assert.Equal(false, types.AnyProperty())
+	require.Equal(false, types.AnyProperty())
 
 	// string
 	types.SetAnyProperty("String")
-	assert.Equal("String", types.AnyProperty())
+	require.Equal("String", types.AnyProperty())
 
 	// number
 	types.SetAnyProperty(12.5)
-	assert.Equal(12.5, types.AnyProperty())
+	require.Equal(12.5, types.AnyProperty())
 
 	// json (notice that when deserialized, it is deserialized as a map).
 	types.SetAnyProperty(map[string]interface{}{
@@ -192,48 +192,48 @@ func (suite *ComplianceSuite) TestDynamicTypes() {
 	v4 := v3[1]
 	v5 := v4.(map[string]interface{})
 	v6 := v5["World"].(float64)
-	assert.Equal(float64(123), v6)
+	require.Equal(float64(123), v6)
 
 	// array
 	types.SetAnyProperty([]string{"Hello", "World"})
 	a := types.AnyProperty().([]interface{})
-	assert.Equal("Hello", a[0].(string))
-	assert.Equal("World", a[1].(string))
+	require.Equal("Hello", a[0].(string))
+	require.Equal("World", a[1].(string))
 
 	// array of any
 	types.SetAnyProperty([]interface{}{"Hybrid", calclib.NewNumber(jsii.Number(12)), 123, false})
-	assert.Equal(float64(123), (types.AnyProperty()).([]interface{})[2])
+	require.Equal(float64(123), (types.AnyProperty()).([]interface{})[2])
 
 	// map
 	types.SetAnyProperty(map[string]string{"MapKey": "MapValue"})
-	assert.Equal("MapValue", ((types.AnyProperty()).(map[string]interface{}))["MapKey"])
+	require.Equal("MapValue", ((types.AnyProperty()).(map[string]interface{}))["MapKey"])
 
 	// map of any
 	types.SetAnyProperty(map[string]interface{}{"Goo": 19289812})
-	assert.Equal(float64(19289812), ((types.AnyProperty()).(map[string]interface{}))["Goo"])
+	require.Equal(float64(19289812), ((types.AnyProperty()).(map[string]interface{}))["Goo"])
 
 	// classes
 	mult := calc.NewMultiply(calclib.NewNumber(jsii.Number(10)), calclib.NewNumber(jsii.Number(20)))
 	types.SetAnyProperty(mult)
-	assert.Equal(mult, types.AnyProperty())
-	assert.Equal(float64(200), *((types.AnyProperty()).(calc.Multiply)).Value())
+	require.Equal(mult, types.AnyProperty())
+	require.Equal(float64(200), *((types.AnyProperty()).(calc.Multiply)).Value())
 
 	// date
 	types.SetAnyProperty(time.Unix(1234, 0))
-	assert.WithinDuration(time.Unix(1234, 0), types.AnyProperty().(time.Time), 0)
+	require.WithinDuration(time.Unix(1234, 0), types.AnyProperty().(time.Time), 0)
 }
 
 func (suite *ComplianceSuite) TestArrayReturnedByMethodCanBeRead() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	arr := *calc.ClassWithCollections_CreateAList()
 
-	assert.Contains(arr, jsii.String("one"))
-	assert.Contains(arr, jsii.String("two"))
+	require.Contains(arr, jsii.String("one"))
+	require.Contains(arr, jsii.String("two"))
 }
 
 func (suite *ComplianceSuite) TestUnionProperties() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	calc3 := calc.NewCalculator(&calc.CalculatorProps{
 		InitialValue: jsii.Number(0),
@@ -242,24 +242,24 @@ func (suite *ComplianceSuite) TestUnionProperties() {
 	calc3.SetUnionProperty(calc.NewMultiply(calclib.NewNumber(jsii.Number(9)), calclib.NewNumber(jsii.Number(3))))
 
 	_, ok := calc3.UnionProperty().(calc.Multiply)
-	assert.True(ok)
+	require.True(ok)
 
-	assert.Equal(float64(9*3), *calc3.ReadUnionValue())
+	require.Equal(float64(9*3), *calc3.ReadUnionValue())
 	calc3.SetUnionProperty(calc.NewPower(calclib.NewNumber(jsii.Number(10)), calclib.NewNumber(jsii.Number(3))))
 
 	_, ok = calc3.UnionProperty().(calc.Power)
-	assert.True(ok)
+	require.True(ok)
 }
 
 func (suite *ComplianceSuite) TestUseEnumFromScopedModule() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := calc.NewReferenceEnumFromScopedPackage()
-	assert.Equal(calclib.EnumFromScopedModule_VALUE2, obj.Foo())
+	require.Equal(calclib.EnumFromScopedModule_VALUE2, obj.Foo())
 	obj.SetFoo(calclib.EnumFromScopedModule_VALUE1)
-	assert.Equal(calclib.EnumFromScopedModule_VALUE1, obj.LoadFoo())
+	require.Equal(calclib.EnumFromScopedModule_VALUE1, obj.LoadFoo())
 	obj.SaveFoo(calclib.EnumFromScopedModule_VALUE2)
-	assert.Equal(calclib.EnumFromScopedModule_VALUE2, obj.Foo())
+	require.Equal(calclib.EnumFromScopedModule_VALUE2, obj.Foo())
 }
 
 func (suite *ComplianceSuite) TestCreateObjectAndCtorOverloads() {
@@ -267,25 +267,25 @@ func (suite *ComplianceSuite) TestCreateObjectAndCtorOverloads() {
 }
 
 func (suite *ComplianceSuite) TestGetAndSetEnumValues() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	calc := calc.NewCalculator(&calc.CalculatorProps{})
 	calc.Add(jsii.Number(9))
 	calc.Pow(jsii.Number(3))
-	assert.Equal(composition.CompositeOperation_CompositionStringStyle_NORMAL, calc.StringStyle())
+	require.Equal(composition.CompositeOperation_CompositionStringStyle_NORMAL, calc.StringStyle())
 
 	calc.SetStringStyle(composition.CompositeOperation_CompositionStringStyle_DECORATED)
-	assert.Equal(composition.CompositeOperation_CompositionStringStyle_DECORATED, calc.StringStyle())
-	assert.Equal("<<[[{{(((1 * (0 + 9)) * (0 + 9)) * (0 + 9))}}]]>>", *calc.ToString())
+	require.Equal(composition.CompositeOperation_CompositionStringStyle_DECORATED, calc.StringStyle())
+	require.Equal("<<[[{{(((1 * (0 + 9)) * (0 + 9)) * (0 + 9))}}]]>>", *calc.ToString())
 }
 
 func (suite *ComplianceSuite) TestListInClassCanBeReadCorrectly() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	classWithCollections := calc.NewClassWithCollections(&map[string]*string{}, &[]*string{jsii.String("one"), jsii.String("two")})
 	val := *classWithCollections.Array()
-	assert.Equal("one", *val[0])
-	assert.Equal("two", *val[1])
+	require.Equal("one", *val[0])
+	require.Equal("two", *val[1])
 }
 
 type derivedFromAllTypes struct {
@@ -304,46 +304,46 @@ func (suite *ComplianceSuite) AfterTest(suiteName, testName string) {
 }
 
 func (suite *ComplianceSuite) TestTestFluentApiWithDerivedClasses() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := newDerivedFromAllTypes()
 	obj.SetStringProperty(jsii.String("Hello"))
 	obj.SetNumberProperty(jsii.Number(12))
-	assert.Equal("Hello", *obj.StringProperty())
-	assert.Equal(float64(12), *obj.NumberProperty())
+	require.Equal("Hello", *obj.StringProperty())
+	require.Equal(float64(12), *obj.NumberProperty())
 }
 
 func (suite *ComplianceSuite) TestCanLoadEnumValues() {
-	assert := suite.Assert()
-	assert.NotEmpty(calc.EnumDispenser_RandomStringLikeEnum())
-	assert.NotEmpty(calc.EnumDispenser_RandomIntegerLikeEnum())
+	require := suite.Require()
+	require.NotEmpty(calc.EnumDispenser_RandomStringLikeEnum())
+	require.NotEmpty(calc.EnumDispenser_RandomIntegerLikeEnum())
 }
 
 func (suite *ComplianceSuite) TestCollectionOfInterfaces_ListOfStructs() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	list := *calc.InterfaceCollections_ListOfStructs()
-	assert.Equal("Hello, I'm String!", *list[0].RequiredString)
+	require.Equal("Hello, I'm String!", *list[0].RequiredString)
 }
 
 func (suite *ComplianceSuite) TestDoNotOverridePrivates_property_getter_public() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := doNotOverridePrivates.New()
-	assert.Equal("privateProperty", *obj.PrivatePropertyValue())
+	require.Equal("privateProperty", *obj.PrivatePropertyValue())
 
 	// verify the setter override is not invoked.
 	obj.ChangePrivatePropertyValue(jsii.String("MyNewValue"))
-	assert.Equal("MyNewValue", *obj.PrivatePropertyValue())
+	require.Equal("MyNewValue", *obj.PrivatePropertyValue())
 }
 
 func (suite *ComplianceSuite) TestEqualsIsResistantToPropertyShadowingResultVariable() {
-	assert := suite.Assert()
+	require := suite.Require()
 	first := calc.StructWithJavaReservedWords{Default: jsii.String("one")}
 	second := calc.StructWithJavaReservedWords{Default: jsii.String("one")}
 	third := calc.StructWithJavaReservedWords{Default: jsii.String("two")}
-	assert.Equal(first, second)
-	assert.NotEqual(first, third)
+	require.Equal(first, second)
+	require.NotEqual(first, third)
 }
 
 type overridableProtectedMemberDerived struct {
@@ -365,9 +365,9 @@ func (x *overridableProtectedMemberDerived) OverrideReadWrite() *string {
 }
 
 func (suite *ComplianceSuite) TestCanOverrideProtectedGetter() {
-	assert := suite.Assert()
+	require := suite.Require()
 	overridden := newOverridableProtectedMemberDerived()
-	assert.Equal("Cthulhu Fhtagn!", *overridden.ValueFromProtected())
+	require.Equal("Cthulhu Fhtagn!", *overridden.ValueFromProtected())
 }
 
 type implementsAdditionalInterface struct {
@@ -386,46 +386,46 @@ func (x implementsAdditionalInterface) ReturnStruct() *calc.StructB {
 }
 
 func (suite *ComplianceSuite) TestInterfacesCanBeUsedTransparently_WhenAddedToJsiiType() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	expected := calc.StructB{RequiredString: jsii.String("It's Britney b**ch!")}
 	delegate := newImplementsAdditionalInterface(expected)
 	consumer := calc.NewConsumePureInterface(delegate)
-	assert.Equal(expected, *consumer.WorkItBaby())
+	require.Equal(expected, *consumer.WorkItBaby())
 }
 
 func (suite *ComplianceSuite) TestStructs_nonOptionalequals() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	structA := calc.StableStruct{ReadonlyProperty: jsii.String("one")}
 	structB := calc.StableStruct{ReadonlyProperty: jsii.String("one")}
 	structC := calc.StableStruct{ReadonlyProperty: jsii.String("two")}
-	assert.Equal(structB, structA)
-	assert.NotEqual(structC, structA)
+	require.Equal(structB, structA)
+	require.NotEqual(structC, structA)
 }
 
 func (suite *ComplianceSuite) TestTestInterfaceParameter() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := calc.NewJSObjectLiteralForInterface()
 	friendly := obj.GiveMeFriendly()
-	assert.Equal("I am literally friendly!", *friendly.Hello())
+	require.Equal("I am literally friendly!", *friendly.Hello())
 
 	greetingAugmenter := calc.NewGreetingAugmenter()
 	betterGreeting := greetingAugmenter.BetterGreeting(friendly)
-	assert.Equal("I am literally friendly! Let me buy you a drink!", *betterGreeting)
+	require.Equal("I am literally friendly! Let me buy you a drink!", *betterGreeting)
 }
 
 func (suite *ComplianceSuite) TestLiftedKwargWithSameNameAsPositionalArg() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	// This is a replication of a test that mostly affects languages with keyword arguments (e.g: Python, Ruby, ...)
 	bell := calc.NewBell()
 	amb := calc.NewAmbiguousParameters(bell, &calc.StructParameterType{Scope: jsii.String("Driiiing!")})
-	assert.Equal(bell, amb.Scope())
+	require.Equal(bell, amb.Scope())
 
 	expected := calc.StructParameterType{Scope: jsii.String("Driiiing!")}
-	assert.Equal(expected, *amb.Props())
+	require.Equal(expected, *amb.Props())
 }
 
 type mulTen struct {
@@ -439,31 +439,31 @@ func newMulTen(value *float64) mulTen {
 }
 
 func (suite *ComplianceSuite) TestCreationOfNativeObjectsFromJavaScriptObjects() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	types := calc.NewAllTypes()
 
 	jsObj := calclib.NewNumber(jsii.Number(44))
 	types.SetAnyProperty(jsObj)
 	_, ok := (types.AnyProperty()).(calclib.Number)
-	assert.True(ok)
+	require.True(ok)
 
 	suite.FailTest("??", "??")
 
 	nativeObj := addTen.New(jsii.Number(10))
 	types.SetAnyProperty(nativeObj)
 	result1 := types.AnyProperty()
-	assert.Equal(nativeObj, result1)
+	require.Equal(nativeObj, result1)
 
 	nativeObj2 := newMulTen(jsii.Number(20))
 	types.SetAnyProperty(nativeObj2)
 	unmarshalledNativeObj, ok := (types.AnyProperty()).(mulTen)
-	assert.True(ok)
-	assert.Equal(nativeObj2, unmarshalledNativeObj)
+	require.True(ok)
+	require.Equal(nativeObj2, unmarshalledNativeObj)
 }
 
 func (suite *ComplianceSuite) TestStructs_ReturnedLiteralEqualsNativeBuilt() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	gms := calc.NewGiveMeStructs()
 	returnedLiteral := gms.StructLiteral()
@@ -472,30 +472,30 @@ func (suite *ComplianceSuite) TestStructs_ReturnedLiteralEqualsNativeBuilt() {
 		Optional3: jsii.Bool(false),
 	}
 
-	assert.Equal(*nativeBuilt.Optional1, *returnedLiteral.Optional1)
-	assert.Equal(nativeBuilt.Optional2, returnedLiteral.Optional2)
-	assert.Equal(*nativeBuilt.Optional3, *returnedLiteral.Optional3)
-	assert.EqualValues(nativeBuilt, *returnedLiteral)
-	assert.EqualValues(*returnedLiteral, nativeBuilt)
+	require.Equal(*nativeBuilt.Optional1, *returnedLiteral.Optional1)
+	require.Equal(nativeBuilt.Optional2, returnedLiteral.Optional2)
+	require.Equal(*nativeBuilt.Optional3, *returnedLiteral.Optional3)
+	require.EqualValues(nativeBuilt, *returnedLiteral)
+	require.EqualValues(*returnedLiteral, nativeBuilt)
 }
 
 func (suite *ComplianceSuite) TestClassesCanSelfReferenceDuringClassInitialization() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	outerClass := child.NewOuterClass()
-	assert.NotNil(outerClass.InnerClass())
+	require.NotNil(outerClass.InnerClass())
 }
 
 func (suite *ComplianceSuite) TestCanObtainStructReferenceWithOverloadedSetter() {
-	assert := suite.Assert()
-	assert.NotNil(calc.ConfusingToJackson_MakeStructInstance())
+	require := suite.Require()
+	require.NotNil(calc.ConfusingToJackson_MakeStructInstance())
 }
 
 func (suite *ComplianceSuite) TestCallbacksCorrectlyDeserializeArguments() {
-	assert := suite.Assert()
+	require := suite.Require()
 	renderer := NewTestCallbacksCorrectlyDeserializeArgumentsDataRenderer()
 
-	assert.Equal("{\n  \"anumber\": 50,\n  \"astring\": \"50\",\n  \"custom\": \"value\"\n}",
+	require.Equal("{\n  \"anumber\": 50,\n  \"astring\": \"50\",\n  \"custom\": \"value\"\n}",
 		*renderer.Render(&calclib.MyFirstStruct{Anumber: jsii.Number(50), Astring: jsii.String("50")}))
 }
 
@@ -516,21 +516,21 @@ func (r *testCallbacksCorrectlyDeserializeArgumentsDataRenderer) RenderMap(m *ma
 }
 
 func (suite *ComplianceSuite) TestCanUseInterfaceSetters() {
-	assert := suite.Assert()
+	require := suite.Require()
 	obj := calc.ObjectWithPropertyProvider_Provide()
 
 	obj.SetProperty(jsii.String("New Value"))
-	assert.True(*obj.WasSet())
+	require.True(*obj.WasSet())
 }
 
 func (suite *ComplianceSuite) TestPropertyOverrides_Interfaces() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	interfaceWithProps := TestPropertyOverridesInterfacesIInterfaceWithProperties{}
 	interact := calc.NewUsesInterfaceWithProperties(&interfaceWithProps)
-	assert.Equal("READ_ONLY_STRING", *interact.JustRead())
+	require.Equal("READ_ONLY_STRING", *interact.JustRead())
 
-	assert.Equal("Hello!?", *interact.WriteAndRead(jsii.String("Hello")))
+	require.Equal("Hello!?", *interact.WriteAndRead(jsii.String("Hello")))
 }
 
 type TestPropertyOverridesInterfacesIInterfaceWithProperties struct {
@@ -554,17 +554,17 @@ func (i *TestPropertyOverridesInterfacesIInterfaceWithProperties) SetReadWriteSt
 }
 
 func (suite *ComplianceSuite) TestTestJsiiAgent() {
-	assert := suite.Assert()
-	assert.Equal(fmt.Sprintf("%s/%s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH), *calc.JsiiAgent_Value())
+	require := suite.Require()
+	require.Equal(fmt.Sprintf("%s/%s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH), *calc.JsiiAgent_Value())
 }
 
 func (suite *ComplianceSuite) TestDoNotOverridePrivates_Method_Private() {
-	assert := suite.Assert()
+	require := suite.Require()
 	obj := &TestDoNotOverridePrivatesMethodPrivateDoNotOverridePrivates{
 		DoNotOverridePrivates: calc.NewDoNotOverridePrivates(),
 	}
 
-	assert.Equal("privateMethod", *obj.PrivateMethodValue())
+	require.Equal("privateMethod", *obj.PrivateMethodValue())
 }
 
 type TestDoNotOverridePrivatesMethodPrivateDoNotOverridePrivates struct {
@@ -576,7 +576,7 @@ func (d *TestDoNotOverridePrivatesMethodPrivateDoNotOverridePrivates) privateMet
 }
 
 func (suite *ComplianceSuite) TestPureInterfacesCanBeUsedTransparently() {
-	assert := suite.Assert()
+	require := suite.Require()
 	expected := &calc.StructB{
 		RequiredString: jsii.String("It's Britney b**ch!"),
 	}
@@ -585,7 +585,7 @@ func (suite *ComplianceSuite) TestPureInterfacesCanBeUsedTransparently() {
 		expected: expected,
 	}
 	consumer := calc.NewConsumePureInterface(delegate)
-	assert.EqualValues(expected, consumer.WorkItBaby())
+	require.EqualValues(expected, consumer.WorkItBaby())
 }
 
 type TestPureInterfacesCanBeUsedTransparentlyIStructReturningDelegate struct {
@@ -624,64 +624,64 @@ func (x myOverridableProtectedMember) OverrideMe() *string {
 }
 
 func (suite *ComplianceSuite) TestCanOverrideProtectedMethod() {
-	assert := suite.Assert()
+	require := suite.Require()
 	challenge := "Cthulhu Fhtagn!"
 
 	overridden := newMyOverridableProtectedMember()
 
-	assert.Equal(challenge, *overridden.ValueFromProtected())
+	require.Equal(challenge, *overridden.ValueFromProtected())
 }
 
 func (suite *ComplianceSuite) TestEraseUnsetDataValues() {
-	assert := suite.Assert()
+	require := suite.Require()
 	opts := calc.EraseUndefinedHashValuesOptions{Option1: jsii.String("option1")}
-	assert.True(*calc.EraseUndefinedHashValues_DoesKeyExist(&opts, jsii.String("option1")))
+	require.True(*calc.EraseUndefinedHashValues_DoesKeyExist(&opts, jsii.String("option1")))
 
-	assert.Equal(map[string]interface{}{"prop2": "value2"}, *calc.EraseUndefinedHashValues_Prop1IsNull())
-	assert.Equal(map[string]interface{}{"prop1": "value1"}, *calc.EraseUndefinedHashValues_Prop2IsUndefined())
+	require.Equal(map[string]interface{}{"prop2": "value2"}, *calc.EraseUndefinedHashValues_Prop1IsNull())
+	require.Equal(map[string]interface{}{"prop1": "value1"}, *calc.EraseUndefinedHashValues_Prop2IsUndefined())
 
-	assert.False(*calc.EraseUndefinedHashValues_DoesKeyExist(&opts, jsii.String("option2")))
+	require.False(*calc.EraseUndefinedHashValues_DoesKeyExist(&opts, jsii.String("option2")))
 }
 
 func (suite *ComplianceSuite) TestStructs_containsNullChecks() {
-	assert := suite.Assert()
+	require := suite.Require()
 	s := calclib.MyFirstStruct{} // <-- this struct has required fields
 	obj := calc.NewGiveMeStructs()
 
 	suite.FailTest("No validation of required fields in structs", "https://github.com/aws/jsii/issues/2672")
 
 	// we expect a failure here when we pass the struct to js
-	assert.PanicsWithError("", func() { obj.ReadFirstNumber(&s) })
+	require.PanicsWithError("", func() { obj.ReadFirstNumber(&s) })
 }
 
 func (suite *ComplianceSuite) TestUnionPropertiesWithBuilder() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj1 := calc.UnionProperties{Bar: 12, Foo: "Hello"}
-	assert.Equal(12, obj1.Bar)
-	assert.Equal("Hello", obj1.Foo)
+	require.Equal(12, obj1.Bar)
+	require.Equal("Hello", obj1.Foo)
 
 	obj2 := calc.UnionProperties{Bar: "BarIsString"}
-	assert.Equal("BarIsString", obj2.Bar)
-	assert.Empty(obj2.Foo)
+	require.Equal("BarIsString", obj2.Bar)
+	require.Empty(obj2.Foo)
 
 	allTypes := calc.NewAllTypes()
 	obj3 := calc.UnionProperties{Bar: allTypes, Foo: 999}
-	assert.Same(allTypes, obj3.Bar)
-	assert.Equal(999, obj3.Foo)
+	require.Same(allTypes, obj3.Bar)
+	require.Equal(999, obj3.Foo)
 }
 
 func (suite *ComplianceSuite) TestTestNullIsAValidOptionalMap() {
-	assert := suite.Assert()
-	assert.Nil(calc.DisappointingCollectionSource_MaybeMap())
+	require := suite.Require()
+	require.Nil(calc.DisappointingCollectionSource_MaybeMap())
 }
 
 func (suite *ComplianceSuite) TestMapReturnedByMethodCanBeRead() {
-	assert := suite.Assert()
+	require := suite.Require()
 	result := *calc.ClassWithCollections_CreateAMap()
-	assert.Equal("value1", *result["key1"])
-	assert.Equal("value2", *result["key2"])
-	assert.Equal(2, len(result))
+	require.Equal("value1", *result["key1"])
+	require.Equal("value2", *result["key2"])
+	require.Equal(2, len(result))
 }
 
 type myAbstractSuite struct {
@@ -710,17 +710,17 @@ func (s *myAbstractSuite) SetProperty(value *string) {
 }
 
 func (suite *ComplianceSuite) TestAbstractMembersAreCorrectlyHandled() {
-	assert := suite.Assert()
+	require := suite.Require()
 	abstractSuite := NewMyAbstractSuite(nil)
-	assert.Equal("Wrapped<String<Oomf!>>", *abstractSuite.WorkItAll(jsii.String("Oomf!")))
+	require.Equal("Wrapped<String<Oomf!>>", *abstractSuite.WorkItAll(jsii.String("Oomf!")))
 }
 
 func (suite *ComplianceSuite) TestCanOverrideProtectedSetter() {
-	assert := suite.Assert()
+	require := suite.Require()
 	challenge := "Bazzzzzzzzzzzaar..."
 	overridden := newTestCanOverrideProtectedSetterOverridableProtectedMember()
 	overridden.SwitchModes()
-	assert.Equal(challenge, *overridden.ValueFromProtected())
+	require.Equal(challenge, *overridden.ValueFromProtected())
 }
 
 type TestCanOverrideProtectedSetterOverridableProtectedMember struct {
@@ -739,18 +739,18 @@ func newTestCanOverrideProtectedSetterOverridableProtectedMember() *TestCanOverr
 
 
 func (suite *ComplianceSuite) TestObjRefsAreLabelledUsingWithTheMostCorrectType() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	ifaceRef := calc.Constructors_MakeInterface()
 	v := ifaceRef
-	assert.NotNil(v)
+	require.NotNil(v)
 
 	// TODO: I am not sure this is possible in Go (probably N/A)
 	suite.FailTest("N/A?", "")
 
 	classRef, ok := calc.Constructors_MakeClass().(calc.InbetweenClass)
-	assert.True(ok)
-	assert.NotNil(classRef)
+	require.True(ok)
+	require.NotNil(classRef)
 }
 
 func (suite *ComplianceSuite) TestStructs_StepBuilders() {
@@ -762,17 +762,17 @@ func (suite *ComplianceSuite) TestStaticListInClassCannotBeModified() {
 }
 
 func (suite *ComplianceSuite) TestStructsAreUndecoratedOntheWayToKernel() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	s := calc.StructB{RequiredString: jsii.String("Bazinga!"), OptionalBoolean: jsii.Bool(false)}
 	j := calc.JsonFormatter_Stringify(s)
 
 	var a map[string]interface{}
 	if err := json.Unmarshal([]byte(*j), &a); err != nil {
-		assert.FailNowf(err.Error(), "unmarshal failed")
+		require.FailNowf(err.Error(), "unmarshal failed")
 	}
 
-	assert.Equal(
+	require.Equal(
 		map[string]interface{}{
 			"requiredString":  "Bazinga!",
 			"optionalBoolean": false,
@@ -782,18 +782,18 @@ func (suite *ComplianceSuite) TestStructsAreUndecoratedOntheWayToKernel() {
 }
 
 func (suite *ComplianceSuite) TestReturnAbstract() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := calc.NewAbstractClassReturner()
 	obj2 := obj.GiveMeAbstract()
 
-	assert.Equal("Hello, John!!", *obj2.AbstractMethod(jsii.String("John")))
-	assert.Equal("propFromInterfaceValue", *obj2.PropFromInterface())
-	assert.Equal(float64(42), *obj2.NonAbstractMethod())
+	require.Equal("Hello, John!!", *obj2.AbstractMethod(jsii.String("John")))
+	require.Equal("propFromInterfaceValue", *obj2.PropFromInterface())
+	require.Equal(float64(42), *obj2.NonAbstractMethod())
 
 	iface := obj.GiveMeInterface()
-	assert.Equal("propFromInterfaceValue", *iface.PropFromInterface())
-	assert.Equal("hello-abstract-property", *obj.ReturnAbstractFromProperty().AbstractProperty())
+	require.Equal("propFromInterfaceValue", *iface.PropFromInterface())
+	require.Equal("hello-abstract-property", *obj.ReturnAbstractFromProperty().AbstractProperty())
 }
 
 func (suite *ComplianceSuite) TestCollectionOfInterfaces_MapOfInterfaces() {
@@ -804,7 +804,7 @@ func (suite *ComplianceSuite) TestCollectionOfInterfaces_MapOfInterfaces() {
 }
 
 func (suite *ComplianceSuite) TestStructs_multiplePropertiesEquals() {
-	assert := suite.Assert()
+	require := suite.Require()
 	structA := calc.DiamondInheritanceTopLevelStruct{
 		BaseLevelProperty:      jsii.String("one"),
 		FirstMidLevelProperty:  jsii.String("two"),
@@ -824,16 +824,16 @@ func (suite *ComplianceSuite) TestStructs_multiplePropertiesEquals() {
 		TopLevelProperty:       jsii.String("four"),
 	}
 
-	assert.Equal(structA, structB)
-	assert.NotEqual(structA, structC)
+	require.Equal(structA, structB)
+	require.NotEqual(structA, structC)
 }
 
 func (suite *ComplianceSuite) TestAsyncOverrides_callAsyncMethod() {
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert := suite.Assert()
+	require := suite.Require()
 	obj := calc.NewAsyncVirtualMethods()
-	assert.Equal(float64(128), *obj.CallMe())
-	assert.Equal(float64(528), *obj.OverrideMe(jsii.Number(44)))
+	require.Equal(float64(128), *obj.CallMe())
+	require.Equal(float64(528), *obj.OverrideMe(jsii.Number(44)))
 }
 
 type myDoNotOverridePrivates struct {
@@ -849,18 +849,18 @@ func (s *myDoNotOverridePrivates) SetPrivateProperty(value string) {
 }
 
 func (suite *ComplianceSuite) TestDoNotOverridePrivates_property_getter_private() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := myDoNotOverridePrivates{calc.NewDoNotOverridePrivates()}
-	assert.Equal("privateProperty", *obj.PrivatePropertyValue())
+	require.Equal("privateProperty", *obj.PrivatePropertyValue())
 
 	// verify the setter override is not invoked.
 	obj.ChangePrivatePropertyValue(jsii.String("MyNewValue"))
-	assert.Equal("MyNewValue", *obj.PrivatePropertyValue())
+	require.Equal("MyNewValue", *obj.PrivatePropertyValue())
 }
 
 func (suite *ComplianceSuite) TestStructs_withDiamondInheritance_correctlyDedupeProperties() {
-	assert := suite.Assert()
+	require := suite.Require()
 	s := calc.DiamondInheritanceTopLevelStruct{
 		BaseLevelProperty:      jsii.String("base"),
 		FirstMidLevelProperty:  jsii.String("mid1"),
@@ -868,10 +868,10 @@ func (suite *ComplianceSuite) TestStructs_withDiamondInheritance_correctlyDedupe
 		TopLevelProperty:       jsii.String("top"),
 	}
 
-	assert.Equal("base", *s.BaseLevelProperty)
-	assert.Equal("mid1", *s.FirstMidLevelProperty)
-	assert.Equal("mid2", *s.SecondMidLevelProperty)
-	assert.Equal("top", *s.TopLevelProperty)
+	require.Equal("base", *s.BaseLevelProperty)
+	require.Equal("mid1", *s.FirstMidLevelProperty)
+	require.Equal("mid2", *s.SecondMidLevelProperty)
+	require.Equal("top", *s.TopLevelProperty)
 }
 
 type myDoNotOverridePrivates2 struct {
@@ -883,13 +883,13 @@ func (s *myDoNotOverridePrivates2) PrivateProperty() string {
 }
 
 func (suite *ComplianceSuite) TestDoNotOverridePrivates_property_by_name_private() {
-	assert := suite.Assert()
+	require := suite.Require()
 	obj := myDoNotOverridePrivates2{calc.NewDoNotOverridePrivates()}
-	assert.Equal("privateProperty", *obj.PrivatePropertyValue())
+	require.Equal("privateProperty", *obj.PrivatePropertyValue())
 }
 
 func (suite *ComplianceSuite) TestMapInClassCanBeReadCorrectly() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	modifiableMap := map[string]*string{
 		"key": jsii.String("value"),
@@ -897,8 +897,8 @@ func (suite *ComplianceSuite) TestMapInClassCanBeReadCorrectly() {
 
 	classWithCollections := calc.NewClassWithCollections(&modifiableMap, &[]*string{})
 	result := *classWithCollections.Map()
-	assert.Equal("value", *result["key"])
-	assert.Equal(1, len(result))
+	require.Equal("value", *result["key"])
+	require.Equal(1, len(result))
 }
 
 type myAsyncVirtualMethods struct {
@@ -911,11 +911,11 @@ func (s *myAsyncVirtualMethods) OverrideMe(mult float64) {
 
 func (suite *ComplianceSuite) TestAsyncOverrides_overrideThrows() {
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := myAsyncVirtualMethods{calc.NewAsyncVirtualMethods()}
 	obj.CallMe()
-	assert.Panics(func() { obj.CallMe() })
+	require.Panics(func() { obj.CallMe() })
 }
 
 func (suite *ComplianceSuite) TestHashCodeIsResistantToPropertyShadowingResultVariable() {
@@ -934,7 +934,7 @@ func (suite *ComplianceSuite) TestReturnSubclassThatImplementsInterface976() {
 	t := suite.T()
 
 	obj := calc.SomeTypeJsii976_ReturnReturn()
-	assert.Equal(t, 333.0, *obj.Foo())
+	require.Equal(t, 333.0, *obj.Foo())
 }
 
 func (suite *ComplianceSuite) TestStructs_OptionalEquals() {
@@ -947,8 +947,8 @@ func (suite *ComplianceSuite) TestPropertyOverrides_Get_Calls_Super() {
 	so := &testPropertyOverridesGetCallsSuper{}
 	calc.NewSyncVirtualMethods_Override(so)
 
-	assert.Equal(t, "super:initial value", *so.RetrieveValueOfTheProperty())
-	assert.Equal(t, "super:initial value", *so.TheProperty())
+	require.Equal(t, "super:initial value", *so.RetrieveValueOfTheProperty())
+	require.Equal(t, "super:initial value", *so.TheProperty())
 }
 
 type testPropertyOverridesGetCallsSuper struct {
@@ -967,7 +967,7 @@ func (suite *ComplianceSuite) TestUnmarshallIntoAbstractType() {
 	c.Add(jsii.Number(120))
 	v := c.Curr()
 
-	assert.Equal(t, 120.0, *v.Value())
+	require.Equal(t, 120.0, *v.Value())
 }
 
 func (suite *ComplianceSuite) TestFail_SyncOverrides_CallsDoubleAsync_PropertyGetter() {
@@ -978,7 +978,7 @@ func (suite *ComplianceSuite) TestFail_SyncOverrides_CallsDoubleAsync_PropertyGe
 
 	defer func() {
 		err := recover()
-		assert.NotNil(t, err, "expected a failure to occur")
+		require.NotNil(t, err, "expected a failure to occur")
 	}()
 
 	obj.CallerIsProperty()
@@ -992,7 +992,7 @@ func (suite *ComplianceSuite) TestFail_SyncOverrides_CallsDoubleAsync_PropertySe
 
 	defer func() {
 		err := recover()
-		assert.NotNil(t, err, "expected a failure to occur")
+		require.NotNil(t, err, "expected a failure to occur")
 	}()
 
 	obj.SetCallerIsProperty(jsii.Number(12))
@@ -1002,9 +1002,9 @@ func (suite *ComplianceSuite) TestPropertyOverrides_Get_Set() {
 	t := suite.T()
 
 	so := syncOverrides.New()
-	assert.Equal(t, "I am an override!", *so.RetrieveValueOfTheProperty())
+	require.Equal(t, "I am an override!", *so.RetrieveValueOfTheProperty())
 	so.ModifyValueOfTheProperty(jsii.String("New Value"))
-	assert.Equal(t, "New Value", *so.AnotherTheProperty)
+	require.Equal(t, "New Value", *so.AnotherTheProperty)
 }
 
 func (suite *ComplianceSuite) TestVariadicMethodCanBeInvoked() {
@@ -1012,7 +1012,7 @@ func (suite *ComplianceSuite) TestVariadicMethodCanBeInvoked() {
 
 	vm := calc.NewVariadicMethod(jsii.Number(1))
 	result := vm.AsArray(jsii.Number(3), jsii.Number(4), jsii.Number(5), jsii.Number(6))
-	assert.Equal(t, []*float64{jsii.Number(1), jsii.Number(3), jsii.Number(4), jsii.Number(5), jsii.Number(6)}, *result)
+	require.Equal(t, []*float64{jsii.Number(1), jsii.Number(3), jsii.Number(4), jsii.Number(5), jsii.Number(6)}, *result)
 }
 
 func (suite *ComplianceSuite) TestCollectionTypes() {
@@ -1022,11 +1022,11 @@ func (suite *ComplianceSuite) TestCollectionTypes() {
 
 	// array
 	at.SetArrayProperty(&[]*string{jsii.String("Hello"), jsii.String("World")})
-	assert.Equal(t, "World", *(*at.ArrayProperty())[1])
+	require.Equal(t, "World", *(*at.ArrayProperty())[1])
 
 	// map
 	at.SetMapProperty(&map[string]calclib.Number{"Foo": calclib.NewNumber(jsii.Number(123))})
-	assert.Equal(t, 123.0, *(*at.MapProperty())["Foo"].Value())
+	require.Equal(t, 123.0, *(*at.MapProperty())["Foo"].Value())
 }
 
 func (suite *ComplianceSuite) TestAsyncOverrides_OverrideAsyncMethodByParentClass() {
@@ -1034,14 +1034,14 @@ func (suite *ComplianceSuite) TestAsyncOverrides_OverrideAsyncMethodByParentClas
 
 	obj := overrideAsyncMethods.NewOverrideAsyncMethodsByBaseClass()
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert.Equal(t, 4452.0, obj.CallMe())
+	require.Equal(t, 4452.0, obj.CallMe())
 }
 
 func (suite *ComplianceSuite) TestTestStructsCanBeDowncastedToParentType() {
 	t := suite.T()
 
-	assert.NotZero(t, calc.Demonstrate982_TakeThis())
-	assert.NotZero(t, calc.Demonstrate982_TakeThisToo())
+	require.NotZero(t, calc.Demonstrate982_TakeThis())
+	require.NotZero(t, calc.Demonstrate982_TakeThisToo())
 }
 
 func (suite *ComplianceSuite) TestPropertyOverrides_Get_Throws() {
@@ -1052,11 +1052,11 @@ func (suite *ComplianceSuite) TestPropertyOverrides_Get_Throws() {
 
 	defer func() {
 		err := recover()
-		assert.NotNil(t, err, "expected an error!")
+		require.NotNil(t, err, "expected an error!")
 		if e, ok := err.(error); ok {
 			err = e.Error()
 		}
-		assert.Equal(t, "Oh no, this is bad", err)
+		require.Equal(t, "Oh no, this is bad", err)
 	}()
 
 	so.RetrieveValueOfTheProperty()
@@ -1074,13 +1074,13 @@ func (suite *ComplianceSuite) TestGetSetPrimitiveProperties() {
 	t := suite.T()
 
 	number := calclib.NewNumber(jsii.Number(20))
-	assert.Equal(t, 20.0, *number.Value())
-	assert.Equal(t, 40.0, *number.DoubleValue())
-	assert.Equal(t, -30.0, *calc.NewNegate(calc.NewAdd(calclib.NewNumber(jsii.Number(20)), calclib.NewNumber(jsii.Number(10)))).Value())
-	assert.Equal(t, 20.0, *calc.NewMultiply(calc.NewAdd(calclib.NewNumber(jsii.Number(5)), calclib.NewNumber(jsii.Number(5))), calclib.NewNumber(jsii.Number(2))).Value())
-	assert.Equal(t, 3.0*3*3*3, *calc.NewPower(calclib.NewNumber(jsii.Number(3)), calclib.NewNumber(jsii.Number(4))).Value())
-	assert.Equal(t, 999.0, *calc.NewPower(calclib.NewNumber(jsii.Number(999)), calclib.NewNumber(jsii.Number(1))).Value())
-	assert.Equal(t, 1.0, *calc.NewPower(calclib.NewNumber(jsii.Number(999)), calclib.NewNumber(jsii.Number(0))).Value())
+	require.Equal(t, 20.0, *number.Value())
+	require.Equal(t, 40.0, *number.DoubleValue())
+	require.Equal(t, -30.0, *calc.NewNegate(calc.NewAdd(calclib.NewNumber(jsii.Number(20)), calclib.NewNumber(jsii.Number(10)))).Value())
+	require.Equal(t, 20.0, *calc.NewMultiply(calc.NewAdd(calclib.NewNumber(jsii.Number(5)), calclib.NewNumber(jsii.Number(5))), calclib.NewNumber(jsii.Number(2))).Value())
+	require.Equal(t, 3.0*3*3*3, *calc.NewPower(calclib.NewNumber(jsii.Number(3)), calclib.NewNumber(jsii.Number(4))).Value())
+	require.Equal(t, 999.0, *calc.NewPower(calclib.NewNumber(jsii.Number(999)), calclib.NewNumber(jsii.Number(1))).Value())
+	require.Equal(t, 1.0, *calc.NewPower(calclib.NewNumber(jsii.Number(999)), calclib.NewNumber(jsii.Number(0))).Value())
 }
 
 func (suite *ComplianceSuite) TestGetAndSetNonPrimitiveProperties() {
@@ -1090,7 +1090,7 @@ func (suite *ComplianceSuite) TestGetAndSetNonPrimitiveProperties() {
 	c.Add(jsii.Number(3200000))
 	c.Neg()
 	c.SetCurr(calc.NewMultiply(calclib.NewNumber(jsii.Number(2)), c.Curr()))
-	assert.Equal(t, -6400000.0, *c.Value())
+	require.Equal(t, -6400000.0, *c.Value())
 }
 
 func (suite *ComplianceSuite) TestReservedKeywordsAreSlugifiedInStructProperties() {
@@ -1103,7 +1103,7 @@ func (suite *ComplianceSuite) TestDoNotOverridePrivates_Method_Public() {
 
 	obj := doNotOverridePrivates.New()
 
-	assert.Equal(t, "privateMethod", *obj.PrivateMethodValue())
+	require.Equal(t, "privateMethod", *obj.PrivateMethodValue())
 }
 
 func (suite *ComplianceSuite) TestDoNotOverridePrivates_Property_By_Name_Public() {
@@ -1111,13 +1111,13 @@ func (suite *ComplianceSuite) TestDoNotOverridePrivates_Property_By_Name_Public(
 
 	obj := doNotOverridePrivates.New()
 
-	assert.Equal(t, "privateProperty", *obj.PrivatePropertyValue())
+	require.Equal(t, "privateProperty", *obj.PrivatePropertyValue())
 }
 
 func (suite *ComplianceSuite) TestTestNullIsAValidOptionalList() {
 	t := suite.T()
 
-	assert.Nil(t, calc.DisappointingCollectionSource_MaybeList())
+	require.Nil(t, calc.DisappointingCollectionSource_MaybeList())
 }
 
 func (suite *ComplianceSuite) TestMapInClassCannotBeModified() {
@@ -1129,7 +1129,7 @@ func (suite *ComplianceSuite) TestAsyncOverrides_TwoOverrides() {
 
 	obj := twoOverrides.New()
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert.Equal(t, 684.0, obj.CallMe())
+	require.Equal(t, 684.0, obj.CallMe())
 }
 
 func (suite *ComplianceSuite) TestPropertyOverrides_Set_Calls_Super() {
@@ -1139,7 +1139,7 @@ func (suite *ComplianceSuite) TestPropertyOverrides_Set_Calls_Super() {
 	calc.NewSyncVirtualMethods_Override(so)
 
 	so.ModifyValueOfTheProperty(jsii.String("New Value"))
-	assert.Equal(t, "New Value:by override", *so.TheProperty())
+	require.Equal(t, "New Value:by override", *so.TheProperty())
 }
 
 type testPropertyOverridesSetCallsSuper struct {
@@ -1158,14 +1158,14 @@ func (suite *ComplianceSuite) TestIso8601DoesNotDeserializeToDate() {
 	w := wallClock.NewWallClock(nowAsISO)
 	entropy := wallClock.NewEntropy(w)
 
-	assert.Equal(t, nowAsISO, *entropy.Increase())
+	require.Equal(t, nowAsISO, *entropy.Increase())
 }
 
 func (suite *ComplianceSuite) TestCollectionOfInterfaces_ListOfInterfaces() {
 	t := suite.T()
 
 	for _, obj := range *calc.InterfaceCollections_ListOfInterfaces() {
-		assert.Implements(t, (*calc.IBell)(nil), obj)
+		require.Implements(t, (*calc.IBell)(nil), obj)
 	}
 }
 
@@ -1173,7 +1173,7 @@ func (suite *ComplianceSuite) TestUndefinedAndNull() {
 	t := suite.T()
 
 	c := calc.NewCalculator(&calc.CalculatorProps{})
-	assert.Nil(t, c.MaxValue())
+	require.Nil(t, c.MaxValue())
 	c.SetMaxValue(nil)
 }
 
@@ -1198,24 +1198,24 @@ func (suite *ComplianceSuite) TestStructs_SerializeToJsii() {
 	}
 
 	gms := calc.NewGiveMeStructs()
-	assert.Equal(t, 999.0, *gms.ReadFirstNumber(&firstStruct))
-	assert.Equal(t, 1234.0, *gms.ReadFirstNumber(&calclib.MyFirstStruct{
+	require.Equal(t, 999.0, *gms.ReadFirstNumber(&firstStruct))
+	require.Equal(t, 1234.0, *gms.ReadFirstNumber(&calclib.MyFirstStruct{
 		Anumber:       derivedStruct.Anumber,
 		Astring:       derivedStruct.Astring,
 		FirstOptional: derivedStruct.FirstOptional,
 	}))
-	assert.Equal(t, doubleTrouble, gms.ReadDerivedNonPrimitive(&derivedStruct))
+	require.Equal(t, doubleTrouble, gms.ReadDerivedNonPrimitive(&derivedStruct))
 
 	literal := *gms.StructLiteral()
-	assert.Equal(t, "optional1FromStructLiteral", *literal.Optional1)
-	assert.Equal(t, false, *literal.Optional3)
-	assert.Nil(t, literal.Optional2)
+	require.Equal(t, "optional1FromStructLiteral", *literal.Optional1)
+	require.Equal(t, false, *literal.Optional3)
+	require.Nil(t, literal.Optional2)
 }
 
 func (suite *ComplianceSuite) TestCanObtainReferenceWithOverloadedSetter() {
 	t := suite.T()
 
-	assert.NotNil(t, calc.ConfusingToJackson_MakeInstance())
+	require.NotNil(t, calc.ConfusingToJackson_MakeInstance())
 }
 
 func (suite *ComplianceSuite) TestTestJsObjectLiteralToNative() {
@@ -1224,17 +1224,17 @@ func (suite *ComplianceSuite) TestTestJsObjectLiteralToNative() {
 	obj := calc.NewJSObjectLiteralToNative()
 	obj2 := obj.ReturnLiteral()
 
-	assert.Equal(t, "Hello", *obj2.PropA())
-	assert.Equal(t, 102.0, *obj2.PropB())
+	require.Equal(t, "Hello", *obj2.PropA())
+	require.Equal(t, 102.0, *obj2.PropB())
 }
 
 func (suite *ComplianceSuite) TestClassWithPrivateConstructorAndAutomaticProperties() {
 	t := suite.T()
 
 	obj := calc.ClassWithPrivateConstructorAndAutomaticProperties_Create(jsii.String("Hello"), jsii.String("Bye"))
-	assert.Equal(t, "Bye", *obj.ReadWriteString())
+	require.Equal(t, "Bye", *obj.ReadWriteString())
 	obj.SetReadWriteString(jsii.String("Hello"))
-	assert.Equal(t, "Hello", *obj.ReadOnlyString())
+	require.Equal(t, "Hello", *obj.ReadOnlyString())
 }
 
 func (suite *ComplianceSuite) TestArrayReturnedByMethodCannotBeModified() {
@@ -1261,15 +1261,15 @@ func (suite *ComplianceSuite) TestCorrectlyDeserializesStructUnions() {
 		OptionalStructA: a1,
 	}
 
-	assert.True(t, *calc.StructUnionConsumer_IsStructA(a0))
-	assert.True(t, *calc.StructUnionConsumer_IsStructA(a1))
-	assert.False(t, *calc.StructUnionConsumer_IsStructA(b0))
-	assert.False(t, *calc.StructUnionConsumer_IsStructA(b1))
+	require.True(t, *calc.StructUnionConsumer_IsStructA(a0))
+	require.True(t, *calc.StructUnionConsumer_IsStructA(a1))
+	require.False(t, *calc.StructUnionConsumer_IsStructA(b0))
+	require.False(t, *calc.StructUnionConsumer_IsStructA(b1))
 
-	assert.False(t, *calc.StructUnionConsumer_IsStructB(a0))
-	assert.False(t, *calc.StructUnionConsumer_IsStructB(a1))
-	assert.True(t, *calc.StructUnionConsumer_IsStructB(b0))
-	assert.True(t, *calc.StructUnionConsumer_IsStructB(b1))
+	require.False(t, *calc.StructUnionConsumer_IsStructB(a0))
+	require.False(t, *calc.StructUnionConsumer_IsStructB(a1))
+	require.True(t, *calc.StructUnionConsumer_IsStructB(b0))
+	require.True(t, *calc.StructUnionConsumer_IsStructB(b1))
 }
 
 func (suite *ComplianceSuite) TestSubclassing() {
@@ -1279,7 +1279,7 @@ func (suite *ComplianceSuite) TestSubclassing() {
 	c := calc.NewCalculator(&calc.CalculatorProps{})
 	c.SetCurr(addTen.New(jsii.Number(33)))
 	c.Neg()
-	assert.Equal(t, -43.0, *c.Value())
+	require.Equal(t, -43.0, *c.Value())
 }
 
 func (suite *ComplianceSuite) TestTestInterfaces() {
@@ -1295,26 +1295,26 @@ func (suite *ComplianceSuite) TestTestInterfaces() {
 	add := calc.NewAdd(calclib.NewNumber(jsii.Number(10)), calclib.NewNumber(jsii.Number(20)))
 	friendly = add
 	// friendlier = add // <-- shouldn't compile since Add implements IFriendly
-	assert.Equal(t, "Hello, I am a binary operation. What's your name?", *friendly.Hello())
+	require.Equal(t, "Hello, I am a binary operation. What's your name?", *friendly.Hello())
 
 	multiply := calc.NewMultiply(calclib.NewNumber(jsii.Number(10)), calclib.NewNumber(jsii.Number(30)))
 	friendly = multiply
 	friendlier = multiply
 	randomNumberGenerator = multiply
 	// friendlyRandomGenerator = multiply // <-- shouldn't compile
-	assert.Equal(t, "Hello, I am a binary operation. What's your name?", *friendly.Hello())
-	assert.Equal(t, "Goodbye from Multiply!", *friendlier.Goodbye())
-	assert.Equal(t, 89.0, *randomNumberGenerator.Next())
+	require.Equal(t, "Hello, I am a binary operation. What's your name?", *friendly.Hello())
+	require.Equal(t, "Goodbye from Multiply!", *friendlier.Goodbye())
+	require.Equal(t, 89.0, *randomNumberGenerator.Next())
 
 	friendlyRandomGenerator = calc.NewDoubleTrouble()
-	assert.Equal(t, "world", *friendlyRandomGenerator.Hello())
-	assert.Equal(t, 12.0, *friendlyRandomGenerator.Next())
+	require.Equal(t, "world", *friendlyRandomGenerator.Hello())
+	require.Equal(t, 12.0, *friendlyRandomGenerator.Next())
 
 	poly := calc.NewPolymorphism()
-	assert.Equal(t, "oh, Hello, I am a binary operation. What's your name?", *poly.SayHello(friendly))
-	assert.Equal(t, "oh, world", *poly.SayHello(friendlyRandomGenerator))
-	assert.Equal(t, "oh, I am a native!", *poly.SayHello(friendlyRandom.NewPure()))
-	assert.Equal(t, "oh, SubclassNativeFriendlyRandom", *poly.SayHello(friendlyRandom.NewSubclass()))
+	require.Equal(t, "oh, Hello, I am a binary operation. What's your name?", *poly.SayHello(friendly))
+	require.Equal(t, "oh, world", *poly.SayHello(friendlyRandomGenerator))
+	require.Equal(t, "oh, I am a native!", *poly.SayHello(friendlyRandom.NewPure()))
+	require.Equal(t, "oh, SubclassNativeFriendlyRandom", *poly.SayHello(friendlyRandom.NewSubclass()))
 }
 
 func (suite *ComplianceSuite) TestReservedKeywordsAreSlugifiedInClassProperties() {
@@ -1322,17 +1322,17 @@ func (suite *ComplianceSuite) TestReservedKeywordsAreSlugifiedInClassProperties(
 }
 
 func (suite *ComplianceSuite) TestObjectIdDoesNotGetReallocatedWhenTheConstructorPassesThisOut() {
-	reflector := NewPartiallyInitializedThisConsumerImpl(suite.Assert())
+	reflector := NewPartiallyInitializedThisConsumerImpl(suite.Require())
 	calc.NewConstructorPassesThisOut(reflector)
 }
 
 type partiallyInitializedThisConsumerImpl struct {
 	calc.PartiallyInitializedThisConsumer `overrides:"ConsumePartiallyInitializedThis"`
-	assert                                *assert.Assertions
+	require                                *require.Assertions
 }
 
-func NewPartiallyInitializedThisConsumerImpl(assert *assert.Assertions) *partiallyInitializedThisConsumerImpl {
-	p := partiallyInitializedThisConsumerImpl{assert: assert}
+func NewPartiallyInitializedThisConsumerImpl(assert *require.Assertions) *partiallyInitializedThisConsumerImpl {
+	p := partiallyInitializedThisConsumerImpl{require: assert}
 	calc.NewPartiallyInitializedThisConsumer_Override(&p)
 	return &p
 }
@@ -1340,21 +1340,21 @@ func NewPartiallyInitializedThisConsumerImpl(assert *assert.Assertions) *partial
 func (p *partiallyInitializedThisConsumerImpl) ConsumePartiallyInitializedThis(obj calc.ConstructorPassesThisOut, dt *time.Time, ev calc.AllTypesEnum) *string {
 	epoch := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-	p.assert.NotNil(obj)
-	p.assert.Equal(epoch, *dt)
-	p.assert.Equal(calc.AllTypesEnum_THIS_IS_GREAT, ev)
+	p.require.NotNil(obj)
+	p.require.Equal(epoch, *dt)
+	p.require.Equal(calc.AllTypesEnum_THIS_IS_GREAT, ev)
 
 	return jsii.String("OK")
 }
 
 func (suite *ComplianceSuite) TestInterfaceBuilder() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	interact := calc.NewUsesInterfaceWithProperties(&TestInterfaceBuilderIInterfaceWithProperties{value: jsii.String("READ_WRITE")})
-	assert.Equal("READ_ONLY", *interact.JustRead())
+	require.Equal("READ_ONLY", *interact.JustRead())
 
-	assert.Equal("Hello", *interact.WriteAndRead(jsii.String("Hello")))
+	require.Equal("Hello", *interact.WriteAndRead(jsii.String("Hello")))
 }
 
 type TestInterfaceBuilderIInterfaceWithProperties struct {
@@ -1375,22 +1375,22 @@ func (i *TestInterfaceBuilderIInterfaceWithProperties) SetReadWriteString(val *s
 
 func (suite *ComplianceSuite) TestUnionTypes() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	types := calc.NewAllTypes()
 
 	// single valued property
 	types.SetUnionProperty(1234)
-	assert.Equal(float64(1234), types.UnionProperty())
+	require.Equal(float64(1234), types.UnionProperty())
 
 	types.SetUnionProperty("Hello")
-	assert.Equal("Hello", types.UnionProperty())
+	require.Equal("Hello", types.UnionProperty())
 
 	types.SetUnionProperty(calc.NewMultiply(calclib.NewNumber(jsii.Number(2)), calclib.NewNumber(jsii.Number(12))))
 	multiply, ok := types.UnionProperty().(calc.Multiply)
 
-	assert.True(ok)
-	assert.Equal(float64(24), *multiply.Value())
+	require.True(ok)
+	require.Equal(float64(24), *multiply.Value())
 
 	// map
 	m := map[string]interface{}{"Foo": calclib.NewNumber(jsii.Number(99))}
@@ -1398,8 +1398,8 @@ func (suite *ComplianceSuite) TestUnionTypes() {
 
 	unionMapProp := *types.UnionMapProperty()
 	number, ok := unionMapProp["Foo"].(calclib.Number)
-	assert.True(ok)
-	assert.Equal(float64(99), *number.Value())
+	require.True(ok)
+	require.Equal(float64(99), *number.Value())
 
 	// array
 	suite.FailTest("Unable to set an array of interfaces", "https://github.com/aws/jsii/issues/2686")
@@ -1408,20 +1408,20 @@ func (suite *ComplianceSuite) TestUnionTypes() {
 
 	unionArrayProp := *types.UnionArrayProperty()
 	number, ok = unionArrayProp[1].(calclib.Number)
-	assert.True(ok)
-	assert.Equal(33, *number.Value())
+	require.True(ok)
+	require.Equal(33, *number.Value())
 }
 
 func (suite *ComplianceSuite) TestArrays() {
-	assert := suite.Assert()
+	require := suite.Require()
 	sum := calc.NewSum()
 
 	suite.FailTest("Unable to set an array of interfaces", "https://github.com/aws/jsii/issues/2686")
 	sum.SetParts(&[]calclib.NumericValue{calclib.NewNumber(jsii.Number(5)), calclib.NewNumber(jsii.Number(10)), calc.NewMultiply(calclib.NewNumber(jsii.Number(2)), calclib.NewNumber(jsii.Number(3)))})
-	assert.Equal(10+5+(2*3), sum.Value())
-	assert.Equal(5, *(*sum.Parts())[0].Value())
-	assert.Equal(6, *(*sum.Parts())[2].Value())
-	assert.Equal("(((0 + 5) + 10) + (2 * 3))", *sum.ToString())
+	require.Equal(10+5+(2*3), sum.Value())
+	require.Equal(5, *(*sum.Parts())[0].Value())
+	require.Equal(6, *(*sum.Parts())[2].Value())
+	require.Equal("(((0 + 5) + 10) + (2 * 3))", *sum.ToString())
 }
 
 func (suite *ComplianceSuite) TestStaticMapInClassCannotBeModified() {
@@ -1430,19 +1430,19 @@ func (suite *ComplianceSuite) TestStaticMapInClassCannotBeModified() {
 
 func (suite *ComplianceSuite) TestConsts() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
-	assert.Equal("hello", *calc.Statics_Foo())
+	require.Equal("hello", *calc.Statics_Foo())
 	obj := calc.Statics_ConstObj()
-	assert.Equal("world", *obj.Hello())
+	require.Equal("world", *obj.Hello())
 
-	assert.Equal(float64(1234), *calc.Statics_BAR())
-	assert.Equal("world", *(*calc.Statics_ZooBar())["hello"])
+	require.Equal(float64(1234), *calc.Statics_BAR())
+	require.Equal("world", *(*calc.Statics_ZooBar())["hello"])
 }
 
 func (suite *ComplianceSuite) TestReceiveInstanceOfPrivateClass() {
-	assert := suite.Assert()
-	assert.True(*calc.NewReturnsPrivateImplementationOfInterface().PrivateImplementation().Success())
+	require := suite.Require()
+	require.True(*calc.NewReturnsPrivateImplementationOfInterface().PrivateImplementation().Success())
 }
 
 func (suite *ComplianceSuite) TestMapReturnedByMethodCannotBeModified() {
@@ -1450,11 +1450,11 @@ func (suite *ComplianceSuite) TestMapReturnedByMethodCannotBeModified() {
 }
 
 func (suite *ComplianceSuite) TestStaticListInClassCanBeReadCorrectly() {
-	assert := suite.Assert()
+	require := suite.Require()
 
 	arr := *calc.ClassWithCollections_StaticArray()
-	assert.Contains(arr, jsii.String("one"))
-	assert.Contains(arr, jsii.String("two"))
+	require.Contains(arr, jsii.String("one"))
+	require.Contains(arr, jsii.String("two"))
 }
 
 func (suite *ComplianceSuite) TestFluentApi() {
@@ -1463,20 +1463,20 @@ func (suite *ComplianceSuite) TestFluentApi() {
 
 func (suite *ComplianceSuite) TestCanLeverageIndirectInterfacePolymorphism() {
 	provider := calc.NewAnonymousImplementationProvider()
-	assert := suite.Assert()
-	assert.Equal(float64(1337), *provider.ProvideAsClass().Value())
+	require := suite.Require()
+	require.Equal(float64(1337), *provider.ProvideAsClass().Value())
 
 	suite.FailTest("Unable to reuse instances between parent/child interfaces", "https://github.com/aws/jsii/issues/2688")
-	assert.Equal(float64(1337), *provider.ProvideAsInterface().Value())
-	assert.Equal("to implement", *provider.ProvideAsInterface().Verb())
+	require.Equal(float64(1337), *provider.ProvideAsInterface().Value())
+	require.Equal("to implement", *provider.ProvideAsInterface().Verb())
 }
 
 func (suite *ComplianceSuite) TestPropertyOverrides_Set_Throws() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 	so := NewTestPropertyOverrides_Set_ThrowsSyncVirtualMethods()
 
-	assert.Panics(func() { so.ModifyValueOfTheProperty(jsii.String("Hii")) })
+	require.Panics(func() { so.ModifyValueOfTheProperty(jsii.String("Hii")) })
 }
 
 type testPropertyOverrides_Set_ThrowsSyncVirtualMethods struct {
@@ -1499,14 +1499,14 @@ func (suite *ComplianceSuite) TestStructs_NonOptionalhashCode() {
 
 func (suite *ComplianceSuite) TestTestLiteralInterface() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 	obj := calc.NewJSObjectLiteralForInterface()
 	friendly := obj.GiveMeFriendly()
-	assert.Equal("I am literally friendly!", *friendly.Hello())
+	require.Equal("I am literally friendly!", *friendly.Hello())
 
 	gen := obj.GiveMeFriendlyGenerator()
-	assert.Equal("giveMeFriendlyGenerator", *gen.Hello())
-	assert.Equal(float64(42), *gen.Next())
+	require.Equal("giveMeFriendlyGenerator", *gen.Hello())
+	require.Equal(float64(42), *gen.Next())
 }
 
 func (suite *ComplianceSuite) TestReservedKeywordsAreSlugifiedInMethodNames() {
@@ -1514,13 +1514,13 @@ func (suite *ComplianceSuite) TestReservedKeywordsAreSlugifiedInMethodNames() {
 }
 
 func (suite *ComplianceSuite) TestPureInterfacesCanBeUsedTransparently_WhenTransitivelyImplementing() {
-	assert := suite.Assert()
+	require := suite.Require()
 	expected := calc.StructB{
 		RequiredString: jsii.String("It's Britney b**ch!"),
 	}
 	delegate := NewIndirectlyImplementsStructReturningDelegate(&expected)
 	consumer := calc.NewConsumePureInterface(delegate)
-	assert.EqualValues(expected, *consumer.WorkItBaby())
+	require.EqualValues(expected, *consumer.WorkItBaby())
 }
 
 func NewIndirectlyImplementsStructReturningDelegate(expected *calc.StructB) calc.IStructReturningDelegate {
@@ -1541,46 +1541,46 @@ func (i ImplementsStructReturningDelegate) ReturnStruct() *calc.StructB {
 
 func (suite *ComplianceSuite) TestExceptions() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	calc3 := calc.NewCalculator(&calc.CalculatorProps{InitialValue: jsii.Number(20), MaximumValue: jsii.Number(30)})
 	calc3.Add(jsii.Number(3))
-	assert.Equal(float64(23), *calc3.Value())
+	require.Equal(float64(23), *calc3.Value())
 
 	// TODO: should assert the actual error here - not working for some reasons
-	assert.Panics(func() {
+	require.Panics(func() {
 		calc3.Add(jsii.Number(10))
 	})
 
 	calc3.SetMaxValue(jsii.Number(40))
 	calc3.Add(jsii.Number(10))
-	assert.Equal(float64(33), *calc3.Value())
+	require.Equal(float64(33), *calc3.Value())
 
 }
 
 func (suite *ComplianceSuite) TestSyncOverrides_CallsSuper() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := syncOverrides.New()
 	obj.ReturnSuper = false
 	obj.Multiplier = 1
 
-	assert.Equal(float64(10*5), *obj.CallerIsProperty())
+	require.Equal(float64(10*5), *obj.CallerIsProperty())
 
 	obj.ReturnSuper = true // js code returns n * 2
-	assert.Equal(float64(10*2), *obj.CallerIsProperty())
+	require.Equal(float64(10*2), *obj.CallerIsProperty())
 }
 
 func (suite *ComplianceSuite) TestAsyncOverrides_OverrideCallsSuper() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := OverrideCallsSuper{AsyncVirtualMethods: calc.NewAsyncVirtualMethods()}
 
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert.Equal(1441, *obj.OverrideMe(jsii.Number(12)))
-	assert.Equal(1209, *obj.CallMe())
+	require.Equal(1441, *obj.OverrideMe(jsii.Number(12)))
+	require.Equal(1209, *obj.CallMe())
 }
 
 type OverrideCallsSuper struct {
@@ -1594,35 +1594,35 @@ func (o *OverrideCallsSuper) OverrideMe(mult *float64) *float64 {
 
 func (suite *ComplianceSuite) TestSyncOverrides() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := syncOverrides.New()
 	obj.ReturnSuper = false
 	obj.Multiplier = 1
 
-	assert.Equal(float64(10*5), *obj.CallerIsMethod())
+	require.Equal(float64(10*5), *obj.CallerIsMethod())
 
 	// affect the result
 	obj.Multiplier = 5
-	assert.Equal(float64(10*5*5), *obj.CallerIsMethod())
+	require.Equal(float64(10*5*5), *obj.CallerIsMethod())
 
 	// verify callbacks are invoked from a property
-	assert.Equal(float64(10*5*5), *obj.CallerIsProperty())
+	require.Equal(float64(10*5*5), *obj.CallerIsProperty())
 
 }
 
 func (suite *ComplianceSuite) TestAsyncOverrides_OverrideAsyncMethod() {
 
-	assert := suite.Assert()
+	require := suite.Require()
 
 	obj := overrideAsyncMethods.New()
 
 	suite.FailTest("Async methods are not implemented", "https://github.com/aws/jsii/issues/2670")
-	assert.Equal(float64(4452), obj.CallMe())
+	require.Equal(float64(4452), obj.CallMe())
 }
 
 func (suite *ComplianceSuite) TestFail_SyncOverrides_CallsDoubleAsync_Method() {
-	suite.Assert().Panics(func() {
+	suite.Require().Panics(func() {
 		obj := syncOverrides.New()
 		obj.CallAsync = true
 		obj.CallerIsMethod()
@@ -1630,9 +1630,9 @@ func (suite *ComplianceSuite) TestFail_SyncOverrides_CallsDoubleAsync_Method() {
 }
 
 func (suite *ComplianceSuite) TestCollectionOfInterfaces_MapOfStructs() {
-	assert := suite.Assert()
+	require := suite.Require()
 	m := *calc.InterfaceCollections_MapOfStructs()
-	assert.Equal("Hello, I'm String!", *(*m["A"]).RequiredString)
+	require.Equal("Hello, I'm String!", *(*m["A"]).RequiredString)
 }
 
 // required to make `go test` recognize the suite.


### PR DESCRIPTION
Use the `require` package instead of `assert` in order to fail fast.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
