### PR TITLE
feat(go): variadic type helpers to build slices

### DIFF
--- a/packages/@jsii/go-runtime/jsii-runtime-go/go.mod
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/go.mod
@@ -2,4 +2,7 @@ module github.com/aws/jsii-runtime-go
 
 go 1.16
 
-require github.com/Masterminds/semver/v3 v3.1.1
+require (
+	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/stretchr/testify v1.7.0
+)

--- a/packages/@jsii/go-runtime/jsii-runtime-go/go.sum
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/go.sum
@@ -1,2 +1,14 @@
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime.go
@@ -373,13 +373,49 @@ func Close() {
 }
 
 // Bool obtains a pointer to the provided bool.
-func Bool(v bool) *bool           { return &v }
+func Bool(v bool) *bool { return &v }
+
+// Bools obtains a pointer to a slice of pointers to all the provided booleans.
+func Bools(v ...bool) *[]*bool {
+	slice := make([]*bool, len(v))
+	for i := 0; i < len(v); i++ {
+		slice[i] = Bool(v[i])
+	}
+	return &slice
+}
 
 // Number obtains a pointer to the provided float64.
-func Number(v float64) *float64   { return &v }
+func Number(v float64) *float64 { return &v }
+
+// Numbers obtains a pointer to a slice of pointers to all the provided numbers.
+func Numbers(v ...float64) *[]*float64 {
+	slice := make([]*float64, len(v))
+	for i := 0; i < len(v); i++ {
+		slice[i] = Number(v[i])
+	}
+	return &slice
+}
 
 // String obtains a pointer to the provided string.
-func String(v string) *string     { return &v }
+func String(v string) *string { return &v }
+
+// Strings obtains a pointer to a slice of pointers to all the provided strings.
+func Strings(v ...string) *[]*string {
+	slice := make([]*string, len(v))
+	for i := 0; i < len(v); i++ {
+		slice[i] = String(v[i])
+	}
+	return &slice
+}
 
 // Time obtains a pointer to the provided time.Time.
 func Time(v time.Time) *time.Time { return &v }
+
+// Times obtains a pointer to a slice of pointers to all the provided time.Time.
+func Times(v ...time.Time) *[]*time.Time {
+	slice := make([]*time.Time, len(v))
+	for i := 0; i < len(v); i++ {
+		slice[i] = Time(v[i])
+	}
+	return &slice
+}

--- a/packages/@jsii/go-runtime/jsii-runtime-go/runtime_test.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/runtime_test.go
@@ -1,0 +1,43 @@
+package jsii
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestBool(t *testing.T) {
+	assert.Equal(t, true, *Bool(true))
+	assert.Equal(t, false, *Bool(false))
+}
+
+func TestBools(t *testing.T) {
+	assert.Equal(t, []*bool{Bool(true), Bool(false), Bool(false), Bool(true)}, *Bools(true, false, false, true))
+}
+
+func TestNumber(t *testing.T) {
+	assert.Equal(t, 123.45, *Number(123.45))
+	assert.Equal(t, 1337.0, *Number(1337))
+}
+
+func TestNumbers(t *testing.T) {
+	assert.Equal(t, []*float64{Number(42), Number(1337)}, *Numbers(42, 1337))
+}
+
+func TestString(t *testing.T) {
+	assert.Equal(t, "Hello", *String("Hello"))
+}
+
+func TestStrings(t *testing.T) {
+	assert.Equal(t, []*string{String("Hello"), String("World")}, *Strings("Hello", "World"))
+}
+
+func TestTime(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, now, *Time(now))
+}
+
+func TestTimes(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, []*time.Time{Time(now)}, *Times(now))
+}


### PR DESCRIPTION
It is somewhat inconvenient to build slices of optional values, and
new variadic helpers can help soothe that pain in many circumstances...

Adding variadic slice helpers:
- `Bools`
- `Numbers`
- `Strings`
- `Times`

Effectively, this allows replacing:

```go
&[]*string{
  jsii.String("Foo"),
  jsii.String("Bar"),
  jsii.String("Baz"),
}
```

With the more compact:

```go
jsii.Strings("Foo", "Bar", "Baz")
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
