### PR TITLE
fix(python): module import fails with: KeyError: '__all__'

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1597,6 +1597,8 @@ class PythonModule implements PythonType {
         code.line(`${member},`);
       }
       code.unindent(']');
+    } else {
+      code.line('__all__ = []');
     }
 
     // Finally, we'll use publication to ensure that all of the non-public names

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1598,7 +1598,7 @@ class PythonModule implements PythonType {
       }
       code.unindent(']');
     } else {
-      code.line('__all__ = []');
+      code.line('__all__: List[typing.Any] = []');
     }
 
     // Finally, we'll use publication to ensure that all of the non-public names

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -10589,7 +10589,7 @@ import typing_extensions
 
 from .._jsii import *
 
-__all__ = []
+__all__: List[typing.Any] = []
 
 publication.publish()
 
@@ -10806,7 +10806,7 @@ import typing_extensions
 
 from .._jsii import *
 
-__all__ = []
+__all__: List[typing.Any] = []
 
 publication.publish()
 
@@ -11163,7 +11163,7 @@ import typing_extensions
 
 from .._jsii import *
 
-__all__ = []
+__all__: List[typing.Any] = []
 
 publication.publish()
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -10589,6 +10589,7 @@ import typing_extensions
 
 from .._jsii import *
 
+__all__ = []
 
 publication.publish()
 
@@ -10805,6 +10806,7 @@ import typing_extensions
 
 from .._jsii import *
 
+__all__ = []
 
 publication.publish()
 
@@ -11161,6 +11163,7 @@ import typing_extensions
 
 from .._jsii import *
 
+__all__ = []
 
 publication.publish()
 


### PR DESCRIPTION
Always emit an `__all__` declaration even if the module does not export
anything.

Fixes #2750



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
