### PR TITLE
chore(java): re-implement error stream sink in Java runtime

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -46,12 +46,8 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
     </developers>
 
     <scm>
-        <connection>scm:${packageInfo.repository.type}:${
-  packageInfo.repository.url
-}</connection>
-        <developerConnection>scm:${packageInfo.repository.type}:${
-  packageInfo.repository.url
-}</developerConnection>
+        <connection>scm:${packageInfo.repository.type}:${packageInfo.repository.url}</connection>
+        <developerConnection>scm:${packageInfo.repository.type}:${packageInfo.repository.url}</developerConnection>
         <url>${packageInfo.repository.url}</url>
         <tag>v${packageInfo.version}</tag>
     </scm>

--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -46,8 +46,12 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
     </developers>
 
     <scm>
-        <connection>scm:${packageInfo.repository.type}:${packageInfo.repository.url}</connection>
-        <developerConnection>scm:${packageInfo.repository.type}:${packageInfo.repository.url}</developerConnection>
+        <connection>scm:${packageInfo.repository.type}:${
+  packageInfo.repository.url
+}</connection>
+        <developerConnection>scm:${packageInfo.repository.type}:${
+  packageInfo.repository.url
+}</developerConnection>
         <url>${packageInfo.repository.url}</url>
         <tag>v${packageInfo.version}</tag>
     </scm>
@@ -65,7 +69,6 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <jetbrains-annotations.version>[13.0.0,20.0-a0)</jetbrains-annotations.version>
         <junit.version>[5.7.0,5.8-a0)</junit.version>
         <mockito.version>[3.5.13,4.0-a0)</mockito.version>
-        <zt-exec.version>[1.12,2.0-a0)</zt-exec.version>
     </properties>
 
     <dependencies>
@@ -127,13 +130,6 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>\${javax-annotations.version}</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.zeroturnaround/zt-exec -->
-        <dependency>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>zt-exec</artifactId>
-            <version>\${zt-exec.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This allows us to reduce our dependency surface by skipping `zt-exec`,
as we only need a tiny, tiny fraction of the many features they provide.
Re-implemented the error stream sink we had previously (before swicthing
to `zt-exec`) by drawing inspiration from how `zt-exec` makes it work.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
