### PR TITLE
feat(rosetta): JSII_ROSETTA_MAX_WORKER_COUNT limits max workers

### DIFF
--- a/packages/jsii-rosetta/README.md
+++ b/packages/jsii-rosetta/README.md
@@ -195,6 +195,6 @@ Worker threads are enabled by default on NodeJS 12.x, and can be enabled on Node
 $ node --experimental-worker /path/to/jsii-rosetta extract ...
 ```
 
-If worker thread support is enabled, `jsii-rosetta` will use a number of workers equal to half the number of CPU cores,
+If worker thread support is available, `jsii-rosetta` will use a number of workers equal to half the number of CPU cores,
 up to a maximum of 16 workers. This default maximum can be overridden by setting the `JSII_ROSETTA_MAX_WORKER_COUNT`
 environment variable.

--- a/packages/jsii-rosetta/README.md
+++ b/packages/jsii-rosetta/README.md
@@ -194,3 +194,7 @@ Worker threads are enabled by default on NodeJS 12.x, and can be enabled on Node
 ```
 $ node --experimental-worker /path/to/jsii-rosetta extract ...
 ```
+
+If worker thread support is enabled, `jsii-rosetta` will use a number of workers equal to half the number of CPU cores,
+up to a maximum of 16 workers. This default maximum can be overridden by setting the `JSII_ROSETTA_MAX_WORKER_COUNT`
+environment variable.

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -165,7 +165,11 @@ async function workerBasedTranslateAll(
 ): Promise<TranslateAllResult> {
   // Use about half the advertised cores because hyperthreading doesn't seem to help that
   // much (on my machine, using more than half the cores actually makes it slower).
-  const N = Math.max(1, Math.ceil(os.cpus().length / 2));
+  // Cap to a reasonable top-level limit to prevent thrash on machines with many, many cores.
+  const maxWorkers = parseInt(
+    process.env.JSII_ROSETTA_MAX_WORKER_COUNT ?? '16',
+  );
+  const N = Math.min(maxWorkers, Math.max(1, Math.ceil(os.cpus().length / 2)));
   const snippetArr = Array.from(snippets);
   const groups = divideEvenly(N, snippetArr);
   logging.info(


### PR DESCRIPTION
The current behavior of rosetta (extract) is to use a number of node worker
threads equal to half the number of CPU cores. On large CI/CD build hardware,
this may mean creating a huge number of worker threads which causes more
contention than benefit.

Introduce `JSII_ROSETTA_MAX_WORKER_COUNT` to limit the maximum number of workers
(defaults to `16`).

See https://github.com/aws/aws-cdk/pull/14389 for more motivation from the AWS CDK.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
