### PR TITLE
chore: permissions for github actions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,6 +10,8 @@ jobs:
        (github.event.pull_request.user.login == 'aws-cdk-automation' 
         || github.event.pull_request.user.login == 'dependabot[bot]' 
         || github.event.pull_request.user.login == 'dependabot-preview[bot]')
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/auto-approve-action@v2.1.0

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   cleanup:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,17 +1,19 @@
 name: Closed Issue Message
 on:
-    issues:
-       types: [closed]
+  issues:
+    types: [closed]
 jobs:
-    auto_comment:
-        runs-on: ubuntu-latest
-        steps:
-        - uses: aws-actions/closed-issue-message@v1
-          with:
-            # These inputs are both required
-            repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for our team to see. 
-                     If you need more assistance, please either tag a team member or open a new issue that references this one. 
-                     If you wish to keep having a conversation with other community members under this issue feel free to do so.
+  auto_comment:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aws-actions/closed-issue-message@v1
+      with:
+        # These inputs are both required
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        message: |
+           ### ⚠️COMMENT VISIBILITY WARNING⚠️
+           Comments on closed issues are hard for our team to see. 
+           If you need more assistance, please either tag a team member or open a new issue that references this one.
+           If you wish to keep having a conversation with other community members under this issue feel free to do so.

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   superchain:
     name: jsii/superchain
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     name: build
+    permissions:
+      content: read
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -51,6 +53,8 @@ jobs:
     name: Publish
     needs: build
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      content: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: build
     permissions:
-      content: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -54,7 +54,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
-      content: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     name: Build
     permissions:
-      content: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # Set up all of our standard runtimes
@@ -114,7 +114,7 @@ jobs:
   create-release-package:
     name: Create Release Package
     permissions:
-      content: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # Set up all of our standard runtimes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   build:
     name: Build
+    permissions:
+      content: read
     runs-on: ubuntu-latest
     steps:
       # Set up all of our standard runtimes
@@ -111,6 +113,8 @@ jobs:
 
   create-release-package:
     name: Create Release Package
+    permissions:
+      content: read
     runs-on: ubuntu-latest
     steps:
       # Set up all of our standard runtimes

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -1,15 +1,16 @@
 name: Yarn Upgrade
 
 on:
-  # Temporarily disable this workflow
-  #schedule:
+  schedule:
     # Every wednesday at 13:37 UTC
-    #- cron: 37 13 * * 3
+    - cron: 37 13 * * 3
   workflow_dispatch: {}
 
 jobs:
   upgrade:
     name: Yarn Upgrade
+    permissions:
+      content: read
     runs-on: ubuntu-latest
     steps:
 
@@ -104,6 +105,38 @@ jobs:
 
       - name: Run "yarn upgrade"
         run: yarn upgrade
+
+      # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
+      # Creating a pull request requires write permissions and it's best to keep write privileges isolated.
+      - name: Create Patch
+        run: |-
+          git add .
+          git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
+      - name: Upload Patch
+        uses: actions/upload-artifact@v2
+        with:
+          name: upgrade.patch
+          path: ${{ runner.temp }}/upgrade.patch
+
+  pr:
+    name: Create Pull Request
+    needs: upgrade
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out
+        uses: actions/checkout@v2
+
+      - name: Download patch
+        uses: actions/download-artifact@v2
+        with:
+          name: upgrade.patch
+          path: ${{ runner.temp }}
+
+      - name: Apply patch
+        run: '[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp }}/upgrade.patch || echo "Empty patch. Skipping."'
 
       - name: Make Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
By default, all Github actions have read permissions via the standard
`GITHUB_TOKEN`. For jobs that require write permission, explicitly
add the necessary permissions.

In the case of the 'Yarn Upgrade' Github action, separated the
'upgrade' step and the 'pull request' step into separate
jobs to build a better security boundary between the two.

Inspired from: https://github.com/projen/projen/blob/a4f875d07b57f8f8247b9352e34c3c83759afe82/.github/workflows/upgrade-dependencies.yml

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
