### PR TITLE
fix(rosetta): hangs on 'markdown' command when a file is provided

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -30,7 +30,7 @@ function main() {
       'Translate a single snippet',
       (command) =>
         command
-          .positional('file', {
+          .positional('FILE', {
             type: 'string',
             describe: 'The file to translate (leave out for stdin)',
           })
@@ -41,7 +41,7 @@ function main() {
           }),
       wrapHandler(async (args) => {
         const result = translateTypeScript(
-          await makeFileSource(args.file ?? '-', 'stdin.ts'),
+          await makeFileSource(args.FILE ?? '-', 'stdin.ts'),
           makeVisitor(args),
         );
         renderResult(result);
@@ -52,7 +52,7 @@ function main() {
       'Translate a MarkDown file',
       (command) =>
         command
-          .positional('file', {
+          .positional('FILE', {
             type: 'string',
             describe: 'The file to translate (leave out for stdin)',
           })
@@ -63,7 +63,7 @@ function main() {
           }),
       wrapHandler(async (args) => {
         const result = translateMarkdown(
-          await makeFileSource(args.file ?? '-', 'stdin.md'),
+          await makeFileSource(args.FILE ?? '-', 'stdin.md'),
           makeVisitor(args),
         );
         renderResult(result);


### PR DESCRIPTION
This is caused due to a mismatch between the command declaration where
the argument is named 'FILE' and the positional declaration where the
parameter is named 'file'.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
