### PR TITLE
fix(pacmak/go): missing go.sum entry

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -42,8 +42,12 @@ export class Golang extends Target {
 
     try {
       // run `go build` with local.go.mod, go 1.16 requires that we download
-      // modules explicit so go.sum is updated.
-      await go('mod', ['download', '-modfile', localGoMod.path], {
+      // modules explicit so go.sum is updated. We'd normally want to use
+      // `go mod download`, but because of a bug in go 1.16, we have to use
+      // `go mod tidy` instead.
+      //
+      // See: https://github.com/golang/go/issues/44129
+      await go('mod', ['tidy', '-modfile', localGoMod.path], {
         cwd: pkgDir,
       });
     } catch (e) {
@@ -125,6 +129,7 @@ export class Golang extends Target {
     await fs.writeFile(path.join(pkgDir, localGoMod), content, {
       encoding: 'utf-8',
     });
+
     return { path: localGoMod, content };
   }
 }


### PR DESCRIPTION
Switch to using `go mod tidy` instead of `go mod download` to work
around https://github.com/golang/go/issues/44129. This caused tests to
fail due to using `go1.16.x`, which is susceptible to this bug (`go1.17`
will have the fix).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
