### PR TITLE
fix: crash when assembly originator key file is missing

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -6,6 +6,7 @@ import { Rosetta } from 'jsii-rosetta';
 import * as path from 'path';
 
 import { Generator, Legalese } from '../../generator';
+import { warn } from '../../logging';
 import { DotNetDocGenerator } from './dotnetdocgenerator';
 import { DotNetRuntimeGenerator } from './dotnetruntimegenerator';
 import { DotNetTypeResolver } from './dotnettyperesolver';
@@ -106,8 +107,13 @@ export class DotNetGenerator extends Generator {
       // There is an AOKF so we copy it to the out-dir so it's available for signing.
       const relativePath = assm.targets!.dotnet!.assemblyOriginatorKeyFile;
       const outPath = path.join(outdir, packageId, relativePath);
-      await fs.mkdirp(path.dirname(outPath));
-      await fs.copyFile(path.resolve(this.packageRoot, relativePath), outPath);
+      const keyFile = path.resolve(this.packageRoot, relativePath);
+      if (await fs.pathExists(keyFile)) {
+        await fs.mkdirp(path.dirname(outPath));
+        await fs.copyFile(keyFile, outPath);
+      } else {
+        warn(`Missing Assembly Originator Key File for ${assm.name}, not found in "${keyFile}". The assembly will NOT be strong-name signed!`)
+      }
     }
 
     // Create an anchor file for the current model


### PR DESCRIPTION
Instead of failing when the assembly originator key file is not found,
warn about it being missing and how the assembly will not be strong-name
signed as a result.

This is to be more compatible with the previously "broken" behavior,
where this file could be omitted or not actually used.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
