### PR TITLE
docs: Fix broken link to Contribution Guide

### DIFF
--- a/gh-pages/content/index.md
+++ b/gh-pages/content/index.md
@@ -100,7 +100,7 @@ header bar:
 ## How to contribute
 
 The [*jsii project*](https://github.com/aws/jsii) welcomes all kind of contributions. You can refer to the
-[Contribution Guide](https://github.com/aws/jsii/trees/main/CONTRIBUTING.md) on GitHub to get more information about how
+[Contribution Guide](https://github.com/aws/jsii/blob/main/CONTRIBUTING.md) on GitHub to get more information about how
 to contribute to the project in general.
 
 !!! tip


### PR DESCRIPTION
The previous link pointed to a 404 page. I updated it to point to the repository's `CONTRIBUTING.md`.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
