### PR TITLE
fix(rosetta): fails on "Debug Failure"

### DIFF
--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -142,7 +142,6 @@ function prefixDisclaimer(translation: Translation): string {
     ? 'This example was automatically transliterated.'
     : 'This example was automatically transliterated with incomplete type information. It may not work as-is.';
 
-
   return [
     `${comment} ${disclaimer}`,
     `${comment} See https://github.com/aws/jsii/issues/826 for more information.`,

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -140,7 +140,7 @@ function prefixDisclaimer(translation: Translation): string {
   const comment = commentToken();
   const disclaimer = translation.didCompile
     ? 'This example was automatically transliterated.'
-    : 'This example automatically transliterated with incomplete type information. It may not work as-is.';
+    : 'This example was automatically transliterated with incomplete type information. It may not work as-is.';
 
 
   return [

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -137,10 +137,18 @@ type Mutable<T> = { -readonly [K in keyof T]: Mutable<T[K]> };
 type AssemblyLoader = () => Promise<Mutable<Assembly>>;
 
 function prefixDisclaimer(translation: Translation): string {
-  const message = translation.didCompile
-    ? 'Example automatically generated. See https://github.com/aws/jsii/issues/826'
-    : 'Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826';
-  return `${commentToken()} ${message}\n${translation.source}`;
+  const comment = commentToken();
+  const disclaimer = translation.didCompile
+    ? 'This example was automatically transliterated.'
+    : 'This example automatically transliterated with incomplete type information. It may not work as-is.';
+
+
+  return [
+    `${comment} ${disclaimer}`,
+    `${comment} See https://github.com/aws/jsii/issues/826 for more information.`,
+    '',
+    translation.source,
+  ].join('\n');
 
   function commentToken() {
     // This is future-proofed a bit, but don't read too much in this...

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -62,7 +62,7 @@ function loadLiterateSource(
       if (fs.existsSync(jsFile)) {
         return fs.readFileSync(jsFile, { encoding: 'utf-8' });
       }
-      return `Missing literate source file ${literateFileName}`;
+      return `throw new Error("Could not render example: missing literate source file ${literateFileName}");`;
     }
     // This couldn't really happen in practice, but do the check anyway
     throw new Error(

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -55,10 +55,7 @@ export function fixturize(
   };
 }
 
-function loadLiterateSource(
-  directory: string,
-  literateFileName: string,
-) {
+function loadLiterateSource(directory: string, literateFileName: string) {
   const fullPath = path.join(directory, literateFileName);
   const exists = fs.existsSync(fullPath);
   if (!exists) {

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -150,9 +150,15 @@ export class SnippetTranslator {
       const program = this.compilation.program;
       const diagnostics = [
         ...neverThrowing(program.getGlobalDiagnostics)(),
-        ...neverThrowing(program.getSyntacticDiagnostics)(this.compilation.rootFile),
-        ...neverThrowing(program.getDeclarationDiagnostics)(this.compilation.rootFile),
-        ...neverThrowing(program.getSemanticDiagnostics)(this.compilation.rootFile),
+        ...neverThrowing(program.getSyntacticDiagnostics)(
+          this.compilation.rootFile,
+        ),
+        ...neverThrowing(program.getDeclarationDiagnostics)(
+          this.compilation.rootFile,
+        ),
+        ...neverThrowing(program.getSemanticDiagnostics)(
+          this.compilation.rootFile,
+        ),
       ];
       if (snippet.strict) {
         // In a strict assembly, so we'll need to brand all diagnostics here...
@@ -167,7 +173,9 @@ export class SnippetTranslator {
      * is here to avoid compiler crashes due to broken code examples that cause
      * the TypeScript compiler to hit a "Debug Failure".
      */
-    function neverThrowing<A extends unknown[], R>(call: (...args: A) => readonly R[]): (...args: A) => readonly R[] {
+    function neverThrowing<A extends unknown[], R>(
+      call: (...args: A) => readonly R[],
+    ): (...args: A) => readonly R[] {
       return (...args: A) => {
         try {
           return call(...args);

--- a/packages/jsii-rosetta/test/commands/transliterate.test.ts
+++ b/packages/jsii-rosetta/test/commands/transliterate.test.ts
@@ -1057,7 +1057,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`csharp
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"literate\\");
@@ -1068,7 +1068,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`csharp
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"omitted-literate\\");
@@ -1077,7 +1077,7 @@ new SampleClass('omitted-literate');
       # Missing fixture
 
       \`\`\`csharp
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"README.md\\");
@@ -1097,7 +1097,7 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// This example automatically transliterated with incomplete type information. It may not work as-is.
+              "example": "// This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new DoesNotCompile(this, \\"That\\", new Struct { Foo = 1337 });",
@@ -1164,7 +1164,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`java
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"literate\\");
@@ -1175,7 +1175,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`java
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"omitted-literate\\");
@@ -1184,7 +1184,7 @@ new SampleClass('omitted-literate');
       # Missing fixture
 
       \`\`\`java
-      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       new SampleClass(\\"README.md\\");
@@ -1204,7 +1204,7 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// This example automatically transliterated with incomplete type information. It may not work as-is.
+              "example": "// This example was automatically transliterated with incomplete type information. It may not work as-is.
       // See https://github.com/aws/jsii/issues/826 for more information.
 
       DoesNotCompile.Builder.create(this, \\"That\\").foo(1337).build();",
@@ -1271,7 +1271,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`python
-      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # This example was automatically transliterated with incomplete type information. It may not work as-is.
       # See https://github.com/aws/jsii/issues/826 for more information.
 
       SampleClass(\\"literate\\")
@@ -1282,7 +1282,7 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`python
-      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # This example was automatically transliterated with incomplete type information. It may not work as-is.
       # See https://github.com/aws/jsii/issues/826 for more information.
 
       SampleClass(\\"omitted-literate\\")
@@ -1291,7 +1291,7 @@ new SampleClass('omitted-literate');
       # Missing fixture
 
       \`\`\`python
-      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # This example was automatically transliterated with incomplete type information. It may not work as-is.
       # See https://github.com/aws/jsii/issues/826 for more information.
 
       SampleClass(\\"README.md\\")
@@ -1311,7 +1311,7 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "# This example automatically transliterated with incomplete type information. It may not work as-is.
+              "example": "# This example was automatically transliterated with incomplete type information. It may not work as-is.
       # See https://github.com/aws/jsii/issues/826 for more information.
 
       DoesNotCompile(self, \\"That\\", foo=1337)",

--- a/packages/jsii-rosetta/test/commands/transliterate.test.ts
+++ b/packages/jsii-rosetta/test/commands/transliterate.test.ts
@@ -949,8 +949,8 @@ new SampleClass('literate');
 import { SampleClass } from './index';
 
 /// !show
-/// ## This is a heading within the literate file!
-new SampleClass('literate');
+/// ## This is a heading within the omitted literate file!
+new SampleClass('omitted-literate');
       `,
     });
     fs.writeJsonSync(
@@ -1009,17 +1009,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`csharp
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      new SampleClass(\\"literate\\");
       \`\`\`
 
       # Missing literate source and fallback
 
-      ## This is a heading within the literate file!
+      ## This is a heading within the omitted literate file!
 
       \`\`\`csharp
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      new SampleClass(\\"omitted-literate\\");
       \`\`\`
 
       # Missing fixture
@@ -1108,17 +1108,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`java
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      new SampleClass(\\"literate\\");
       \`\`\`
 
       # Missing literate source and fallback
 
-      ## This is a heading within the literate file!
+      ## This is a heading within the omitted literate file!
 
       \`\`\`java
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      new SampleClass(\\"omitted-literate\\");
       \`\`\`
 
       # Missing fixture
@@ -1207,17 +1207,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`python
-      # Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      SampleClass(\\"literate\\")
       \`\`\`
 
       # Missing literate source and fallback
 
-      ## This is a heading within the literate file!
+      ## This is a heading within the omitted literate file!
 
       \`\`\`python
-      # Example automatically generated. See https://github.com/aws/jsii/issues/826
-      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      SampleClass(\\"omitted-literate\\")
       \`\`\`
 
       # Missing fixture

--- a/packages/jsii-rosetta/test/commands/transliterate.test.ts
+++ b/packages/jsii-rosetta/test/commands/transliterate.test.ts
@@ -914,7 +914,11 @@ test('single assembly, loose mode', () =>
       'README.md': `
 # Missing literate source
 
-[example is not found](missing-example.lit.ts)
+[ts source is not found](missing-example.lit.ts)
+
+# Missing literate source and fallback
+
+[example is not found](omit-example.lit.ts)
 
 # Missing fixture
 
@@ -940,6 +944,14 @@ import { SampleClass } from './index';
 /// ## This is a heading within the literate file!
 new SampleClass('literate');
       `,
+      // The `lit.ts`  source file and `lit.js` output will not be there in packaged form...
+      'omit-example.lit.ts': `
+import { SampleClass } from './index';
+
+/// !show
+/// ## This is a heading within the literate file!
+new SampleClass('literate');
+      `,
     });
     fs.writeJsonSync(
       path.join(tmpDir, SPEC_FILE_NAME),
@@ -949,6 +961,9 @@ new SampleClass('literate');
       },
     );
     for (const [file, content] of Object.entries(compilationResult.files)) {
+      if (file.startsWith('omit-')) {
+        continue;
+      }
       fs.writeFileSync(path.resolve(tmpDir, file), content, 'utf-8');
     }
 
@@ -994,8 +1009,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`csharp
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-      new index_1.SampleClass(\\"literate\\");
+      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      \`\`\`
+
+      # Missing literate source and fallback
+
+      ## This is a heading within the literate file!
+
+      \`\`\`csharp
+      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
       \`\`\`
 
       # Missing fixture
@@ -1084,8 +1108,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`java
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-      new SampleClass(\\"literate\\");
+      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      \`\`\`
+
+      # Missing literate source and fallback
+
+      ## This is a heading within the literate file!
+
+      \`\`\`java
+      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
       \`\`\`
 
       # Missing fixture
@@ -1174,8 +1207,17 @@ new SampleClass('literate');
       ## This is a heading within the literate file!
 
       \`\`\`python
-      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-      index_1.SampleClass(\\"literate\\")
+      # Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
+      \`\`\`
+
+      # Missing literate source and fallback
+
+      ## This is a heading within the literate file!
+
+      \`\`\`python
+      # Example automatically generated. See https://github.com/aws/jsii/issues/826
+      throw new Error(\\"Could not render example: missing literate source file omit-example.lit.ts\\");
       \`\`\`
 
       # Missing fixture

--- a/packages/jsii-rosetta/test/commands/transliterate.test.ts
+++ b/packages/jsii-rosetta/test/commands/transliterate.test.ts
@@ -145,7 +145,9 @@ export class ClassName implements IInterface {
           "markdown": "# README
 
       \`\`\`csharp
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      // This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       IInterface object = new ClassName(\\"this\\", 1337, new ClassNameProps { Foo = \\"bar\\" });
       object.Property = EnumType.OPTION_A;
       object.MethodCall();
@@ -169,7 +171,9 @@ export class ClassName implements IInterface {
             "fqn": "testpkg.ClassName",
             "initializer": Object {
               "docs": Object {
-                "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps { Property = EnumType.OPTION_B });",
                 "summary": "Create a new instance of ClassName.",
               },
@@ -209,7 +213,9 @@ export class ClassName implements IInterface {
             "methods": Array [
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName.StaticMethod();",
                   "remarks": "It can be invoked easily.",
                   "summary": "A static method.",
@@ -302,7 +308,9 @@ export class ClassName implements IInterface {
           "testpkg.EnumType": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+              "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps { Property = EnumType.OPTION_B });",
             },
             "fqn": "testpkg.EnumType",
@@ -314,14 +322,18 @@ export class ClassName implements IInterface {
             "members": Array [
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps { Property = EnumType.OPTION_A });",
                 },
                 "name": "OPTION_A",
               },
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps { Property = EnumType.OPTION_B });",
                 },
                 "name": "OPTION_B",
@@ -341,7 +353,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.MethodCall();",
                   "summary": "An instance method call.",
                 },
@@ -357,7 +371,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.Property = EnumType.OPTION_B;",
                   "summary": "A property value.",
                 },
@@ -409,7 +425,9 @@ export class ClassName implements IInterface {
           "markdown": "# README
 
       \`\`\`java
-      // Example automatically generated. See https://github.com/aws/jsii/issues/826
+      // This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       IInterface object = new ClassName(\\"this\\", 1337, new ClassNameProps().foo(\\"bar\\"));
       object.getProperty() = EnumType.getOPTION_A();
       object.methodCall();
@@ -433,7 +451,9 @@ export class ClassName implements IInterface {
             "fqn": "testpkg.ClassName",
             "initializer": Object {
               "docs": Object {
-                "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps().property(EnumType.getOPTION_B()));",
                 "summary": "Create a new instance of ClassName.",
               },
@@ -473,7 +493,9 @@ export class ClassName implements IInterface {
             "methods": Array [
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName.staticMethod();",
                   "remarks": "It can be invoked easily.",
                   "summary": "A static method.",
@@ -566,7 +588,9 @@ export class ClassName implements IInterface {
           "testpkg.EnumType": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+              "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps().property(EnumType.getOPTION_B()));",
             },
             "fqn": "testpkg.EnumType",
@@ -578,14 +602,18 @@ export class ClassName implements IInterface {
             "members": Array [
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps().property(EnumType.getOPTION_A()));",
                 },
                 "name": "OPTION_A",
               },
               Object {
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new ClassName(\\"this\\", 1337, new ClassNameProps().property(EnumType.getOPTION_B()));",
                 },
                 "name": "OPTION_B",
@@ -605,7 +633,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.methodCall();",
                   "summary": "An instance method call.",
                 },
@@ -621,7 +651,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "// Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "// This example was automatically transliterated.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.getProperty() = EnumType.getOPTION_B();",
                   "summary": "A property value.",
                 },
@@ -673,7 +705,9 @@ export class ClassName implements IInterface {
           "markdown": "# README
 
       \`\`\`python
-      # Example automatically generated. See https://github.com/aws/jsii/issues/826
+      # This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       object = ClassName(\\"this\\", 1337, foo=\\"bar\\")
       object.property = EnumType.OPTION_A
       object.method_call()
@@ -697,7 +731,9 @@ export class ClassName implements IInterface {
             "fqn": "testpkg.ClassName",
             "initializer": Object {
               "docs": Object {
-                "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName(\\"this\\", 1337, property=EnumType.OPTION_B)",
                 "summary": "Create a new instance of ClassName.",
               },
@@ -737,7 +773,9 @@ export class ClassName implements IInterface {
             "methods": Array [
               Object {
                 "docs": Object {
-                  "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName.static_method()",
                   "remarks": "It can be invoked easily.",
                   "summary": "A static method.",
@@ -830,7 +868,9 @@ export class ClassName implements IInterface {
           "testpkg.EnumType": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+              "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName(\\"this\\", 1337, property=EnumType.OPTION_B)",
             },
             "fqn": "testpkg.EnumType",
@@ -842,14 +882,18 @@ export class ClassName implements IInterface {
             "members": Array [
               Object {
                 "docs": Object {
-                  "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName(\\"this\\", 1337, property=EnumType.OPTION_A)",
                 },
                 "name": "OPTION_A",
               },
               Object {
                 "docs": Object {
-                  "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       ClassName(\\"this\\", 1337, property=EnumType.OPTION_B)",
                 },
                 "name": "OPTION_B",
@@ -869,7 +913,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.method_call()",
                   "summary": "An instance method call.",
                 },
@@ -885,7 +931,9 @@ export class ClassName implements IInterface {
               Object {
                 "abstract": true,
                 "docs": Object {
-                  "example": "# Example automatically generated. See https://github.com/aws/jsii/issues/826
+                  "example": "# This example was automatically transliterated.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       iface.property = EnumType.OPTION_B",
                   "summary": "A property value.",
                 },
@@ -1009,7 +1057,9 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`csharp
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"literate\\");
       \`\`\`
 
@@ -1018,14 +1068,18 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`csharp
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"omitted-literate\\");
       \`\`\`
 
       # Missing fixture
 
       \`\`\`csharp
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"README.md\\");
       \`\`\`",
         },
@@ -1043,7 +1097,9 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+              "example": "// This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new DoesNotCompile(this, \\"That\\", new Struct { Foo = 1337 });",
             },
             "fqn": "testpkg.SampleClass",
@@ -1108,7 +1164,9 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`java
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"literate\\");
       \`\`\`
 
@@ -1117,14 +1175,18 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`java
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"omitted-literate\\");
       \`\`\`
 
       # Missing fixture
 
       \`\`\`java
-      // Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      // This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       new SampleClass(\\"README.md\\");
       \`\`\`",
         },
@@ -1142,7 +1204,9 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "// Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+              "example": "// This example automatically transliterated with incomplete type information. It may not work as-is.
+      // See https://github.com/aws/jsii/issues/826 for more information.
+
       DoesNotCompile.Builder.create(this, \\"That\\").foo(1337).build();",
             },
             "fqn": "testpkg.SampleClass",
@@ -1207,7 +1271,9 @@ new SampleClass('omitted-literate');
       ## This is a heading within the literate file!
 
       \`\`\`python
-      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       SampleClass(\\"literate\\")
       \`\`\`
 
@@ -1216,14 +1282,18 @@ new SampleClass('omitted-literate');
       ## This is a heading within the omitted literate file!
 
       \`\`\`python
-      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       SampleClass(\\"omitted-literate\\")
       \`\`\`
 
       # Missing fixture
 
       \`\`\`python
-      # Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+      # This example automatically transliterated with incomplete type information. It may not work as-is.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       SampleClass(\\"README.md\\")
       \`\`\`",
         },
@@ -1241,7 +1311,9 @@ new SampleClass('omitted-literate');
           "testpkg.SampleClass": Object {
             "assembly": "testpkg",
             "docs": Object {
-              "example": "# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+              "example": "# This example automatically transliterated with incomplete type information. It may not work as-is.
+      # See https://github.com/aws/jsii/issues/826 for more information.
+
       DoesNotCompile(self, \\"That\\", foo=1337)",
             },
             "fqn": "testpkg.SampleClass",

--- a/packages/jsii-rosetta/test/translate.test.ts
+++ b/packages/jsii-rosetta/test/translate.test.ts
@@ -1,0 +1,40 @@
+import { SnippetTranslator, TypeScriptSnippet } from '../lib';
+import { VisualizeAstVisitor } from '../lib/languages/visualize';
+
+test('does not fail on "Debug Failure"', () => {
+  // GIVEN
+  const snippet: TypeScriptSnippet = {
+    completeSource:
+      'Missing literate source file test/integ.restapi-import.lit.ts',
+    where: '@aws-cdk.aws-apigateway-README-snippet4',
+    visibleSource:
+      "import { App, CfnOutput, NestedStack, NestedStackProps, Stack } from '@aws-cdk/core';\nimport { Construct } from 'constructs';\nimport { Deployment, Method, MockIntegration, PassthroughBehavior, RestApi, Stage } from '../lib';\n\n/**\n * This file showcases how to split up a RestApi's Resources and Methods across nested stacks.\n *\n * The root stack 'RootStack' first defines a RestApi.\n * Two nested stacks BooksStack and PetsStack, create corresponding Resources '/books' and '/pets'.\n * They are then…;\n\n  readonly methods?: Method[];\n}\n\nclass DeployStack extends NestedStack {\n  constructor(scope: Construct, props: DeployStackProps) {\n    super(scope, 'integ-restapi-import-DeployStack', props);\n\n    const deployment = new Deployment(this, 'Deployment', {\n      api: RestApi.fromRestApiId(this, 'RestApi', props.restApiId),\n    });\n    (props.methods ?? []).forEach((method) => deployment.node.addDependency(method));\n    new Stage(this, 'Stage', { deployment });\n  }\n}\n\nnew RootStack(new App());",
+    parameters: { lit: 'test/integ.restapi-import.lit.ts' },
+    strict: false,
+  };
+
+  // WHEN
+  const subject = new SnippetTranslator(snippet, {
+    includeCompilerDiagnostics: true,
+  });
+
+  // THEN
+  expect(subject.renderUsing(new VisualizeAstVisitor())).toMatchInlineSnapshot(`
+    "(ExpressionStatement Missing
+      (Identifier Missing))(ExpressionStatement literate
+      (Identifier literate))(ExpressionStatement source
+      (Identifier source))(ExpressionStatement file
+      (Identifier file))(ExpressionStatement test/integ.restapi-import.lit.ts
+      (BinaryExpression test/integ.restapi-import.lit.ts
+        (BinaryExpression test/integ.restapi
+          (Identifier test)
+          (SlashToken /)
+          (PropertyAccessExpression integ.restapi
+            (Identifier integ)
+            (Identifier restapi)))
+        (MinusToken -)
+        (PropertyAccessExpression import.lit.ts
+          import.lit
+          (Identifier ts))))"
+  `);
+});


### PR DESCRIPTION
In cases where a literate source file was missing, the substitution
value was not valid TypeScript, which could cause the comipler to fail
on an opaque error (`Debug Failure`).

This falls back to the visible code for the snippet instead of inserting a
placeholder, and also makes sure to rescue the `Debug Failure` where
it is emitted from, that is in the call to
`program.getDeclarationDiagnostics`.

Both of this changes result in greater chances of transliteration
success.

Related to cdklabs/jsii-docgen#369



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
