### PR TITLE
chore: upgrade cattrs dependency to 1.7.1 (py3.7+)

### DIFF
--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     install_requires=[
         "attrs~=20.1",
         "cattrs~=1.0.0 ; python_version < '3.7'",
-        "cattrs~=1.6.0 ; python_version >= '3.7'",
+        "cattrs~=1.7.1 ; python_version >= '3.7'",
         "importlib_resources ; python_version < '3.7'",
         "python-dateutil",
         "typing_extensions~=3.7",


### PR DESCRIPTION
Version `1.6.0` has been yanked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
