### PR TITLE
chore: upgrade xmldom from 0.6.0 to 0.7.0

### DIFF
--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -35,7 +35,7 @@
     "commonmark": "^0.29.3",
     "fs-extra": "^9.1.0",
     "typescript": "~3.9.9",
-    "xmldom": "^0.6.0",
+    "xmldom": "github:xmldom/xmldom#0.7.0",
     "yargs": "^16.2.0"
   },
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8840,10 +8840,9 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
+"xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This uses a custom resolution to the xmldom GitHub repoisoty, as they
are currently unable to publish the fixed version to npmjs.com. See
xmldom/xmldom#271 for more information. The custom resolution can be
removed once npmjs.com has 0.7.0 or above.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
