### PR TITLE
fix(java): implemented interface is not registered

### DIFF
--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -1,4 +1,4 @@
-package software.amazon.jsii;
+qpackage software.amazon.jsii;
 
 import software.amazon.jsii.api.Callback;
 import software.amazon.jsii.api.GetRequest;
@@ -679,6 +679,8 @@ public final class JsiiEngine implements JsiiCallbackHandler {
         if (declaredAnnotation != null) {
             // If it's an interface, then we can return a singleton set with that!
             if (classToInspect.isInterface()) {
+                // Ensure the interface's module has been loaded...
+                loadModule(declaredAnnotation.module());
                 return Collections.singleton(declaredAnnotation.fqn());
             }
             // If it was NOT an interface, then this type already "implies" all interfaces -- nothing to declare.

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -1,4 +1,4 @@
-qpackage software.amazon.jsii;
+package software.amazon.jsii;
 
 import software.amazon.jsii.api.Callback;
 import software.amazon.jsii.api.GetRequest;

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiEngine.java
@@ -674,18 +674,18 @@ public final class JsiiEngine implements JsiiCallbackHandler {
      * @return the list of jsii FQNs of interfaces implemented by {@code classToInspect}
      */
     private Collection<String> discoverInterfaces(final Class<?> classToInspect) {
-        final Set<String> interfaces = new HashSet<>();
         // If {@classToInspect} has the @Jsii annotation, it's a jsii well-known type
-        if (classToInspect.isAnnotationPresent(Jsii.class)) {
+        final Jsii declaredAnnotation = classToInspect.getDeclaredAnnotation(Jsii.class);
+        if (declaredAnnotation != null) {
             // If it's an interface, then we can return a singleton set with that!
             if (classToInspect.isInterface()) {
-                final Jsii jsii = classToInspect.getAnnotation(Jsii.class);
-                interfaces.add(jsii.fqn());
+                return Collections.singleton(declaredAnnotation.fqn());
             }
             // If it was NOT an interface, then this type already "implies" all interfaces -- nothing to declare.
-            return interfaces;
+            return Collections.emptySet();
         }
         // If this wasn't an @Jsii well-known type, browse up the interface declarations, and collect results
+        final Set<String> interfaces = new HashSet<>();
         for (final Class<?> iface : classToInspect.getInterfaces()) {
             interfaces.addAll(discoverInterfaces(iface));
         }


### PR DESCRIPTION
When extending a "jsii well-known type", additional jsii interfaces
implemented were not registered with the kernel, because of a flaw in
how interface discovery works. The `@Jsii` annotation is `@Inherited`,
meaning that a sub-class of an annotated type is annotated (this is
desirable)... However, this means the fact the annotation is present on
a type does not imply it _is_ a "jsii well-known type"... Instead, we
must check whether the annotation is _declared_ by the current type (if
not, then the annotation is inherited from a parent class).

Fixes #2951



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
