### PR TITLE
feat: @struct type system hint

### DIFF
--- a/gh-pages/content/user-guides/lib-author/.pages.yml
+++ b/gh-pages/content/user-guides/lib-author/.pages.yml
@@ -5,4 +5,5 @@ nav:
   - quick-start
   - typescript-restrictions.md
   - configuration
+  - hints.md
   - toolchain

--- a/gh-pages/content/user-guides/lib-author/hints.md
+++ b/gh-pages/content/user-guides/lib-author/hints.md
@@ -1,0 +1,27 @@
+# Type system hints
+
+The `jsii` compiler interprets some documentation tags as hints that influence
+the type system represented in the `.jsii` assembly files.
+
+## Forcing an interface to be considered a *struct*
+
+Using the `@struct` tag, an interface will be interpreted as a
+[*struct*][struct] even if its name starts with a capital `I`, followed by
+another capital letter (which normally would make them be treated as
+[*behavioral interfaces*][interface]):
+
+[struct]: ../../specification/2-type-system.md#structs
+[interface]: ../../specification/2-type-system.md#behavioral-interfaces
+
+```ts
+/**
+ * @struct
+ */
+export interface IPRange {
+  readonly cidr: string:
+}
+```
+
+!!! important
+    The `@struct` hint can only be used on interface declarations. Attempting to
+    use them on any other declaration will result in a compilation error.

--- a/gh-pages/content/user-guides/lib-author/typescript-restrictions.md
+++ b/gh-pages/content/user-guides/lib-author/typescript-restrictions.md
@@ -58,6 +58,12 @@ The `jsii` type model distinguishes two kinds of *interfaces*:
 A name convention is used to distinguish between these two: *behavioral interfaces* must have a name that starts with a
 `I` prefix, while *structs* must not have such a prefix.
 
+!!! info
+    The [`/** @struct */` type system hint][hint] can be used to force an *interface* with a name starting with the `I`
+    prefix to be handled as a *struct* instead of a *behavioral interface*.
+
+    [hint]: hints.md#forcing-an-interface-to-be-considered-a-struct
+
 ```ts hl_lines="5-8"
 /**
  * Since there is no `I` prefix, Foo is considered to be a struct.

--- a/packages/@jsii/spec/lib/assembly.ts
+++ b/packages/@jsii/spec/lib/assembly.ts
@@ -358,32 +358,11 @@ export interface Docs {
   default?: string;
 
   /**
-   * Hints provided to the compiler via TSDoc annotations.
-   */
-  hints?: TypeSystemHints;
-
-  /**
    * Custom tags that are not any of the default ones
    *
    * @default none
    */
   custom?: { [tag: string]: string };
-}
-
-/**
- * Type system hints applied to the documented entity.
- */
-export interface TypeSystemHints {
-  /**
-   * The `@struct` hint can be applied to interfaces, to ensure they are
-   * handled as structs, even if their name stats with a capital letter 'I',
-   * which would normally make them be considered as behavioral interfaces.
-   *
-   * This is only valid on `interface` declarations.
-   *
-   * @default false
-   */
-  struct?: boolean;
 }
 
 /**

--- a/packages/@jsii/spec/lib/assembly.ts
+++ b/packages/@jsii/spec/lib/assembly.ts
@@ -358,11 +358,32 @@ export interface Docs {
   default?: string;
 
   /**
+   * Hints provided to the compiler via TSDoc annotations.
+   */
+  hints?: TypeSystemHints;
+
+  /**
    * Custom tags that are not any of the default ones
    *
    * @default none
    */
   custom?: { [tag: string]: string };
+}
+
+/**
+ * Type system hints applied to the documented entity.
+ */
+export interface TypeSystemHints {
+  /**
+   * The `@struct` hint can be applied to interfaces, to ensure they are
+   * handled as structs, even if their name stats with a capital letter 'I',
+   * which would normally make them be considered as behavioral interfaces.
+   *
+   * This is only valid on `interface` declarations.
+   *
+   * @default false
+   */
+  struct?: boolean;
 }
 
 /**

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -46,7 +46,7 @@ export class Assembler implements Emitter {
 
   private _diagnostics = new Array<JsiiDiagnostic>();
   private _deferred = new Array<DeferredRecord>();
-  private _types: { [fqn: string]: spec.Type; } = {};
+  private _types: { [fqn: string]: spec.Type } = {};
 
   /** Map of Symbol to namespace export Symbol */
   private readonly _submoduleMap = new Map<ts.Symbol, ts.Symbol>();
@@ -420,12 +420,12 @@ export class Assembler implements Emitter {
     const tsFullName = this._typeChecker.getFullyQualifiedName(type.symbol);
     const tsName = singleValuedEnum
       ? // If it's a single-valued enum, we need to remove the last qualifier to get back to the enum.
-      tsFullName.replace(/\.[^.]+$/, '')
+        tsFullName.replace(/\.[^.]+$/, '')
       : tsFullName;
 
     let typeDeclaration = singleValuedEnum
       ? // If it's a single-valued enum, we need to move to the parent to have the enum declaration
-      type.symbol.valueDeclaration.parent
+        type.symbol.valueDeclaration.parent
       : type.symbol.valueDeclaration;
     if (!typeDeclaration && type.symbol.declarations.length > 0) {
       typeDeclaration = type.symbol.declarations[0];
@@ -627,8 +627,8 @@ export class Assembler implements Emitter {
       resolution.resolvedModule.resolvedFileName
         .split(path.sep)
         .filter((entry) => entry === 'node_modules').length !==
-      packageRoot.split(path.sep).filter((entry) => entry === 'node_modules')
-        .length
+        packageRoot.split(path.sep).filter((entry) => entry === 'node_modules')
+          .length
     ) {
       // External re-exports are "pure-javascript" sugar; they need not be
       // represented in the jsii Assembly since the types in there will be
@@ -675,7 +675,7 @@ export class Assembler implements Emitter {
       this: Assembler,
       sym: ts.Symbol,
       inlineNamespace = false,
-    ): Promise<{ fqn: string; fqnResolutionPrefix: string; }> {
+    ): Promise<{ fqn: string; fqnResolutionPrefix: string }> {
       if (this._submoduleMap.has(sym)) {
         const parent = this._submodules.get(this._submoduleMap.get(sym)!)!;
         const fqn = `${parent.fqn}.${sym.name}`;
@@ -1151,8 +1151,9 @@ export class Assembler implements Emitter {
 
     this._warnAboutReservedWords(type.symbol);
 
-    const fqn = `${[this.projectInfo.name, ...ctx.namespace].join('.')}.${type.symbol.name
-      }`;
+    const fqn = `${[this.projectInfo.name, ...ctx.namespace].join('.')}.${
+      type.symbol.name
+    }`;
 
     const jsiiType: spec.ClassType = bindings.setClassRelatedNode(
       {
@@ -1331,8 +1332,8 @@ export class Assembler implements Emitter {
         const member: ts.Symbol = ts.isConstructorDeclaration(memberDecl)
           ? (memberDecl as any).symbol
           : this._typeChecker.getSymbolAtLocation(
-            ts.getNameOfDeclaration(memberDecl)!,
-          )!;
+              ts.getNameOfDeclaration(memberDecl)!,
+            )!;
 
         if (
           !(declaringType.symbol.getDeclarations() ?? []).find(
@@ -1426,7 +1427,7 @@ export class Assembler implements Emitter {
             jsiiType.initializer.protected =
               (ts.getCombinedModifierFlags(ctorDeclaration) &
                 ts.ModifierFlags.Protected) !==
-              0 || undefined;
+                0 || undefined;
           }
         }
         this._verifyConsecutiveOptionals(
@@ -1682,8 +1683,9 @@ export class Assembler implements Emitter {
     const jsiiType: spec.EnumType = bindings.setEnumRelatedNode(
       {
         assembly: this.projectInfo.name,
-        fqn: `${[this.projectInfo.name, ...ctx.namespace].join('.')}.${symbol.name
-          }`,
+        fqn: `${[this.projectInfo.name, ...ctx.namespace].join('.')}.${
+          symbol.name
+        }`,
         kind: spec.TypeKind.Enum,
         members: members.map((m) => {
           const { docs } = this._visitDocumentation(m.symbol, typeContext);
@@ -1729,9 +1731,12 @@ export class Assembler implements Emitter {
           _findHint(decl, 'struct')!,
           'struct',
           'interfaces with only readonly properties',
-        ).addRelatedInformation(
-          ts.getNameOfDeclaration(decl) ?? decl, 'The annotated declaration is here'
-        ).preformat(this.projectInfo.projectRoot),
+        )
+          .addRelatedInformation(
+            ts.getNameOfDeclaration(decl) ?? decl,
+            'The annotated declaration is here',
+          )
+          .preformat(this.projectInfo.projectRoot),
       );
       // Clean up the bad hint...
       delete (result.hints as any).struct;
@@ -1885,21 +1890,24 @@ export class Assembler implements Emitter {
           this._diagnostics.push(
             jsiiType.methods!.reduce(
               (diag, mthod) => {
-                let node = bindings.getMethodRelatedNode(mthod);
+                const node = bindings.getMethodRelatedNode(mthod);
                 return node
                   ? diag.addRelatedInformation(
-                    ts.getNameOfDeclaration(node) ?? node,
-                    `A method is declared here`,
-                  )
+                      ts.getNameOfDeclaration(node) ?? node,
+                      `A method is declared here`,
+                    )
                   : diag;
               },
               JsiiDiagnostic.JSII_7001_ILLEGAL_HINT.create(
                 _findHint(declaration, 'struct')!,
                 'struct',
                 'interfaces with only readonly properties',
-              ).addRelatedInformation(
-                ts.getNameOfDeclaration(declaration) ?? declaration, 'The annotated declartion is here'
-              ).preformat(this.projectInfo.projectRoot),
+              )
+                .addRelatedInformation(
+                  ts.getNameOfDeclaration(declaration) ?? declaration,
+                  'The annotated declartion is here',
+                )
+                .preformat(this.projectInfo.projectRoot),
             ),
           );
         }
@@ -3239,8 +3247,14 @@ function _nameOrDeclarationNode(symbol: ts.Symbol): ts.Node {
   return ts.getNameOfDeclaration(declaration) ?? declaration;
 }
 
-function _findHint(decl: ts.Declaration, hint: string): ts.JSDocTag | undefined {
-  const [node] = ts.getAllJSDocTags(decl, (tag): tag is ts.JSDocTag => tag.tagName.text === hint);
+function _findHint(
+  decl: ts.Declaration,
+  hint: string,
+): ts.JSDocTag | undefined {
+  const [node] = ts.getAllJSDocTags(
+    decl,
+    (tag): tag is ts.JSDocTag => tag.tagName.text === hint,
+  );
   return node;
 }
 

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -49,6 +49,7 @@ enum DocTag {
   SUBCLASSABLE = 'subclassable',
   EXAMPLE = 'example',
   STABILITY = 'stability',
+  STRUCT = 'struct',
 }
 
 /**
@@ -171,6 +172,11 @@ function parseDocParts(
       }
     }
     return undefined;
+  }
+
+  if (eatTag(DocTag.STRUCT) != null) {
+    docs.hints = docs.hints ?? {};
+    docs.hints.struct = true;
   }
 
   docs.default = eatTag(DocTag.DEFAULT, DocTag.DEFAULT_VALUE);

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -152,6 +152,7 @@ function parseDocParts(
 ): DocsParsingResult {
   const diagnostics = new Array<string>();
   const docs: spec.Docs = {};
+  const hints: TypeSystemHints = {};
 
   [docs.summary, docs.remarks] = splitSummary(comments);
 
@@ -175,8 +176,7 @@ function parseDocParts(
   }
 
   if (eatTag(DocTag.STRUCT) != null) {
-    docs.hints = docs.hints ?? {};
-    docs.hints.struct = true;
+    hints.struct = true;
   }
 
   docs.default = eatTag(DocTag.DEFAULT, DocTag.DEFAULT_VALUE);
@@ -239,12 +239,21 @@ function parseDocParts(
     }
   }
 
-  return { docs, diagnostics };
+  return { docs, diagnostics, hints };
 }
 
 export interface DocsParsingResult {
   docs: spec.Docs;
+  hints: TypeSystemHints;
   diagnostics?: string[];
+}
+
+export interface TypeSystemHints {
+  /**
+   * Only present on interfaces. This indicates that interface must be handled as a struct/data type
+   * even through it's name starts with a capital letter `I`.
+   */
+  struct?: boolean;
 }
 
 /**

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -1,6 +1,7 @@
 import * as spec from '@jsii/spec';
 import { camel, constant as allCaps, pascal } from 'case';
 import * as ts from 'typescript';
+import { TypeSystemHints } from './docs';
 
 import { JSII_DIAGNOSTICS_CODE, _formatDiagnostic } from './utils';
 
@@ -627,7 +628,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
 
   public static readonly JSII_7001_ILLEGAL_HINT = Code.error({
     code: 7001,
-    formatter: (hint: keyof spec.TypeSystemHints, ...valid: readonly string[]) =>
+    formatter: (hint: keyof TypeSystemHints, ...valid: readonly string[]) =>
       `Illegal use of "@${hint}" hint. It is only valid on ${valid.join(', ')}.`,
     name: 'documentation/illegal-hint',
   });

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -1,8 +1,8 @@
 import * as spec from '@jsii/spec';
 import { camel, constant as allCaps, pascal } from 'case';
 import * as ts from 'typescript';
-import { TypeSystemHints } from './docs';
 
+import { TypeSystemHints } from './docs';
 import { JSII_DIAGNOSTICS_CODE, _formatDiagnostic } from './utils';
 
 /**
@@ -629,7 +629,9 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public static readonly JSII_7001_ILLEGAL_HINT = Code.error({
     code: 7001,
     formatter: (hint: keyof TypeSystemHints, ...valid: readonly string[]) =>
-      `Illegal use of "@${hint}" hint. It is only valid on ${valid.join(', ')}.`,
+      `Illegal use of "@${hint}" hint. It is only valid on ${valid.join(
+        ', ',
+      )}.`,
     name: 'documentation/illegal-hint',
   });
 
@@ -797,6 +799,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public readonly relatedInformation =
     new Array<ts.DiagnosticRelatedInformation>();
 
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
   #formatted?: string;
 
   /**

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -2,7 +2,7 @@ import * as spec from '@jsii/spec';
 import { camel, constant as allCaps, pascal } from 'case';
 import * as ts from 'typescript';
 
-import { JSII_DIAGNOSTICS_CODE } from './utils';
+import { JSII_DIAGNOSTICS_CODE, _formatDiagnostic } from './utils';
 
 /**
  * Descriptors for all valid jsii diagnostic codes.
@@ -625,6 +625,13 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'documentation/non-existent-parameter',
   });
 
+  public static readonly JSII_7001_ILLEGAL_HINT = Code.error({
+    code: 7001,
+    formatter: (hint: keyof spec.TypeSystemHints, ...valid: readonly string[]) =>
+      `Illegal use of "@${hint}" hint. It is only valid on ${valid.join(', ')}.`,
+    name: 'documentation/illegal-hint',
+  });
+
   public static readonly JSII_7999_DOCUMENTATION_ERROR = Code.error({
     code: 7999,
     formatter: (messageText) => messageText,
@@ -789,6 +796,8 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public readonly relatedInformation =
     new Array<ts.DiagnosticRelatedInformation>();
 
+  #formatted?: string;
+
   /**
    * Creates a new `JsiiDiagnostic` with the provided properties.
    *
@@ -817,6 +826,32 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     this.relatedInformation.push(
       JsiiDiagnostic.JSII_9999_RELATED_INFO.create(node, message),
     );
+    // Clearing out #formatted, as this would no longer be the correct string.
+    this.#formatted = undefined;
+    return this;
+  }
+
+  /**
+   * Formats this diagnostic with color and context if possible, and returns it.
+   * The formatted diagnostic is cached, so that it can be re-used. This is
+   * useful for diagnostic messages involving trivia -- as the trivia may have
+   * been obliterated from the `SourceFile` by the `TsCommentReplacer`, which
+   * makes the error messages really confusing.
+   */
+  public format(projectRoot: string): string {
+    if (this.#formatted == null) {
+      this.#formatted = _formatDiagnostic(this, projectRoot);
+    }
+    return this.#formatted;
+  }
+
+  /**
+   * Ensures the formatted diagnostic is prepared for later re-use.
+   *
+   * @returns `this`
+   */
+  public preformat(projectRoot: string): this {
+    this.format(projectRoot);
     return this;
   }
 }

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -61,6 +61,27 @@ export function formatDiagnostic(
   diagnostic: ts.Diagnostic,
   projectRoot: string,
 ) {
+  if (JsiiDiagnostic.isJsiiDiagnostic(diagnostic)) {
+    // Ensure we leverage pre-rendered diagnostics where available.
+    return diagnostic.format(projectRoot);
+  }
+  return _formatDiagnostic(diagnostic, projectRoot);
+}
+
+/**
+ * Formats a diagnostic message with color and context, if possible. Users
+ * should use `formatDiagnostic` instead, as this implementation is inteded for
+ * internal usafe only.
+ *
+ * @param diagnostic  the diagnostic message ot be formatted.
+ * @param projectRoot the root of the TypeScript project.
+ *
+ * @returns a formatted string.
+ */
+ export function _formatDiagnostic(
+  diagnostic: ts.Diagnostic,
+  projectRoot: string,
+) {
   const formatDiagnosticsHost: ts.FormatDiagnosticsHost = {
     getCurrentDirectory: () => projectRoot,
     getCanonicalFileName: (fileName) => fileName,

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -78,7 +78,7 @@ export function formatDiagnostic(
  *
  * @returns a formatted string.
  */
- export function _formatDiagnostic(
+export function _formatDiagnostic(
   diagnostic: ts.Diagnostic,
   projectRoot: string,
 ) {

--- a/packages/jsii/test/__snapshots__/negatives.test.ts.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.ts.snap
@@ -699,6 +699,49 @@ neg.struct-extends-interface.ts:6:18 - error JSII8007: Interface contains behavi
 
 `;
 
+exports[`struct-hint-on-class 1`] = `
+neg.struct-hint-on-class.ts:4:4 - error JSII7001: Illegal use of "@struct" hint. It is only valid on interfaces with only readonly properties.
+
+4  * @struct
+     ~~~~~~~
+
+  neg.struct-hint-on-class.ts:6:14
+    6 export class ClassName { }
+                   ~~~~~~~~~
+    The annotated declaration is here
+
+`;
+
+exports[`struct-hint-on-enum 1`] = `
+neg.struct-hint-on-enum.ts:4:4 - error JSII7001: Illegal use of "@struct" hint. It is only valid on interfaces with only readonly properties.
+
+4  * @struct
+     ~~~~~~~
+
+  neg.struct-hint-on-enum.ts:6:13
+    6 export enum EnumName { A, B }
+                  ~~~~~~~~
+    The annotated declaration is here
+
+`;
+
+exports[`struct-hint-with-methods 1`] = `
+neg.struct-hint-with-methods.ts:1:72 - error JSII7001: Illegal use of "@struct" hint. It is only valid on interfaces with only readonly properties.
+
+1 
+  
+
+  neg.struct-hint-with-methods.ts:2:18
+    2 export interface INotAStruct {
+                       ~~~~~~~~~~~
+    The annotated declartion is here
+  neg.struct-hint-with-methods.ts:3:3
+    3   method(): void;
+        ~~~~~~
+    A method is declared here
+
+`;
+
 exports[`submodules-cannot-have-colliding-names 1`] = `
 neg.submodules-cannot-have-colliding-names.ts:3:14 - error JSII5011: Submodule "ns1" conflicts with "Ns1, as different languages could represent it as: "ns1", "Ns1""
 

--- a/packages/jsii/test/hints.test.ts
+++ b/packages/jsii/test/hints.test.ts
@@ -1,4 +1,5 @@
 import { InterfaceType, TypeKind } from '@jsii/spec';
+
 import { sourceToAssemblyHelper } from '../lib';
 
 describe('@struct', () => {
@@ -11,7 +12,9 @@ describe('@struct', () => {
     `);
 
     expect(assembly.types!['testpkg.IPSet'].kind).toBe(TypeKind.Interface);
-    expect((assembly.types!['testpkg.IPSet'] as InterfaceType).datatype).toBe(true);
+    expect((assembly.types!['testpkg.IPSet'] as InterfaceType).datatype).toBe(
+      true,
+    );
   });
 
   test('can be used on any struct', async () => {
@@ -23,6 +26,8 @@ describe('@struct', () => {
     `);
 
     expect(assembly.types!['testpkg.Struct'].kind).toBe(TypeKind.Interface);
-    expect((assembly.types!['testpkg.Struct'] as InterfaceType).datatype).toBe(true);
+    expect((assembly.types!['testpkg.Struct'] as InterfaceType).datatype).toBe(
+      true,
+    );
   });
 });

--- a/packages/jsii/test/hints.test.ts
+++ b/packages/jsii/test/hints.test.ts
@@ -1,0 +1,28 @@
+import { InterfaceType, TypeKind } from '@jsii/spec';
+import { sourceToAssemblyHelper } from '../lib';
+
+describe('@struct', () => {
+  test('causes behavioral-named interfaces to be structs', async () => {
+    const assembly = await sourceToAssemblyHelper(`
+      /** @struct */
+      export interface IPSet {
+        readonly cidr: string;
+      }
+    `);
+
+    expect(assembly.types!['testpkg.IPSet'].kind).toBe(TypeKind.Interface);
+    expect((assembly.types!['testpkg.IPSet'] as InterfaceType).datatype).toBe(true);
+  });
+
+  test('can be used on any struct', async () => {
+    const assembly = await sourceToAssemblyHelper(`
+      /** @struct */
+      export interface Struct {
+        readonly cidr: string;
+      }
+    `);
+
+    expect(assembly.types!['testpkg.Struct'].kind).toBe(TypeKind.Interface);
+    expect((assembly.types!['testpkg.Struct'] as InterfaceType).datatype).toBe(true);
+  });
+});

--- a/packages/jsii/test/negatives/neg.struct-hint-on-class.ts
+++ b/packages/jsii/test/negatives/neg.struct-hint-on-class.ts
@@ -1,0 +1,6 @@
+/**
+ * Attempting to tag a class as a struct.
+ *
+ * @struct
+ */
+export class ClassName { }

--- a/packages/jsii/test/negatives/neg.struct-hint-on-enum.ts
+++ b/packages/jsii/test/negatives/neg.struct-hint-on-enum.ts
@@ -1,0 +1,6 @@
+/**
+ * Attempting to tag an enum as a struct.
+ *
+ * @struct
+ */
+export enum EnumName { A, B }

--- a/packages/jsii/test/negatives/neg.struct-hint-with-methods.ts
+++ b/packages/jsii/test/negatives/neg.struct-hint-with-methods.ts
@@ -1,0 +1,8 @@
+/**
+ * Attempt to force a behavioral interface to be a struct...
+ *
+ * @struct
+ */
+export interface INotAStruct {
+  method(): void;
+}


### PR DESCRIPTION
Using the hint allows any interface to always be treated as a struct (as
long as all it's properties are readonly and it has no methods) even if
it has an `I`-prefixed name.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
