### PR TITLE
chore: use @xmldom namespace on npm instead of source

### DIFF
--- a/packages/jsii-rosetta/lib/markdown/xml-comment-renderer.ts
+++ b/packages/jsii-rosetta/lib/markdown/xml-comment-renderer.ts
@@ -8,7 +8,7 @@ const ESCAPE = makeXmlEscaper();
 
 // The types for 'xmldom' are not complete.
 /* eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports */
-const { DOMParser, XMLSerializer } = require('xmldom');
+const { DOMParser, XMLSerializer } = require('@xmldom/xmldom');
 
 /**
  * A renderer that will render a CommonMark tree to .NET XML comments

--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -35,7 +35,7 @@
     "commonmark": "^0.30.0",
     "fs-extra": "^9.1.0",
     "typescript": "~3.9.10",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "@xmldom/xmldom": "^0.7.0",
     "yargs": "^16.2.0"
   },
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.1.tgz#b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
   integrity sha512-4vSVUiOPJLmr45S8rMGy7WDvpWxfFxfP/Qx/cxZFCfvoypTYpPPL1X8VIZMe0WTA+Jr7blUxwUSEZNkjoMTgSw==
 
+"@xmldom/xmldom@^0.7.0":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.2.tgz#d920079e66806b2626b5311955f6a7c4bed1cba8"
+  integrity sha512-t/Zqo0ewes3iq6zGqEqJNUWI27Acr3jkmSUNp6E3nl0Z2XbtqAG5XYqPNLdYonILmhcxANsIidh69tHzjXtuRg==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -7937,10 +7942,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-"xmldom@github:xmldom/xmldom#0.7.0":
-  version "0.7.0"
-  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Fixes #2969

The xmldom package has moved. See https://github.com/xmldom/xmldom/issues/271



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
