### PR TITLE
chore: fix docker-in-docker

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -244,6 +244,7 @@ ENV LANG="C.UTF-8"                                                              
 ENV PATH="${PATH}:${CARGO_HOME}/bin:${GOROOT}/bin:${M2}"
 
 COPY --from=staging / /
+VOLUME /var/lib/docker
 
 ## Image Metadata
 ARG BUILD_TIMESTAMP
@@ -266,6 +267,7 @@ CMD ["/bin/bash"]
 FROM superchain as test
 ENV CI=true
 COPY --chown=superchain:superchain . /tmp/source
+VOLUME /var/lib/docker
 WORKDIR /tmp/source
 # Make sure we start fresh (symlinks from outside the build may cause issues, e.g: python venvs)
 RUN git clean -fqdx

--- a/superchain/dockerd-entrypoint.sh
+++ b/superchain/dockerd-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 /usr/bin/dockerd \
   --host=unix:///var/run/docker.sock \
   --host=tcp://127.0.0.1:2375 \
-  --storage-driver=overlay &>/var/log/docker.log &
+  --storage-driver=overlay2 &>/var/log/docker.log &
 
 
 tries=0


### PR DESCRIPTION
We were missing a VOLUME declaration in the final image, which prevented
dockerd from properly starting within Docker (complaining that overlay2
is not a valid parameter).

The VOLUME is required because overlay-on-overlay is not supported (and
using a VOLUME guarantees that there is no overlay underneath it).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
