### PR TITLE
feat(rosetta): propagate max heap size to worker threads

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as ts from 'typescript';
+import * as v8 from 'v8';
 
 import { loadAssemblies, allTypeScriptSnippets } from '../jsii/assemblies';
 import * as logging from '../logging';
@@ -210,6 +211,12 @@ async function workerBasedTranslateAll(
   ): Promise<import('./extract_worker').TranslateResponse> {
     return new Promise((resolve, reject) => {
       const wrk = new worker.Worker(path.join(__dirname, 'extract_worker.js'), {
+        resourceLimits: {
+          // Note: V8 heap statistics are expressed in bytes, so we divide by 1MiB (1,048,576 bytes)
+          maxOldGenerationSizeMb: Math.ceil(
+            v8.getHeapStatistics().heap_size_limit / 1_048_576,
+          ),
+        },
         workerData: request,
       });
       wrk.on('message', resolve);


### PR DESCRIPTION
Worker threads have their own memory limits, which have relatively low
defaults. In order to improve the effectiveness of rosetta, this ensures
all worker threads have the same maximum heap size as the parent process.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
