### PR TITLE
chore(superchain): set UID and GID of superchain user

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y curl gpg tar zsh
 SHELL ["/bin/zsh", "-c"]
 
 # Prepare maven binary distribution
-ARG M2_VERSION="3.8.2"
+ARG M2_VERSION="3.8.3"
 ENV M2_DISTRO="https://www.apache.org/dist/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -sL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                               \

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -206,8 +206,8 @@ RUN chmod 600 /root/.ssh/config
 COPY superchain/dockerd-entrypoint.sh /usr/local/bin/
 
 # Create the image's non-root user, and enable no-password sudo
-RUN adduser --shell /bin/bash --gecos "Docker User" --disabled-password --uid 1001 --gid 1001 --no-log-init superchain  \
-  && adduser superchain sudo                                                                                            \
+RUN groupadd --gid 1001 superchain                                                                                      \
+  && useradd --shell /bin/bash --comment "Docker User" --uid 1001 --gid 1001 --no-log-init --groups sudo superchain     \
   && echo "%sudo ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/nopasswd                                                  \
   && chmod 0440 /etc/sudoers.d/nopasswd
 COPY --chown=superchain:superchain superchain/m2-settings.xml /home/superchain/.m2/settings.xml

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -206,7 +206,7 @@ RUN chmod 600 /root/.ssh/config
 COPY superchain/dockerd-entrypoint.sh /usr/local/bin/
 
 # Create the image's non-root user, and enable no-password sudo
-RUN adduser --shell /bin/bash --gecos "Docker User" --disabled-password superchain                                      \
+RUN adduser --shell /bin/bash --gecos "Docker User" --disabled-password --uid 1001 --gid 1001 --no-log-init superchain  \
   && adduser superchain sudo                                                                                            \
   && echo "%sudo ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers.d/nopasswd                                                  \
   && chmod 0440 /etc/sudoers.d/nopasswd


### PR DESCRIPTION
In order to facilitate use with GitHub Actions, explicitly set the UID and GID
of the `superchain` user to `1001`, which is the UID/GID set on the GitHub
working directory on the file system.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
