### PR TITLE
feat: added a map from symbol identifiers to fully qualified names in the assembly

### DIFF
--- a/packages/@jsii/spec/lib/assembly.ts
+++ b/packages/@jsii/spec/lib/assembly.ts
@@ -143,6 +143,11 @@ export interface Assembly extends AssemblyConfiguration, Documentable {
    * @default none
    */
   bin?: { readonly [script: string]: string };
+
+  /**
+   * Map of symbol identifiers to their corresponding FQNs
+   */
+  symbolToFqn: { [symbolId: string]: string };
 }
 
 /**
@@ -198,7 +203,7 @@ export type Submodule = SourceLocatable & Targetable;
  * Versions of the JSII Assembly Specification.
  */
 export enum SchemaVersion {
-  LATEST = 'jsii/0.10.0',
+  LATEST = 'jsii/0.11.0',
 }
 
 /**

--- a/packages/@jsii/spec/test/name-tree.test.ts
+++ b/packages/@jsii/spec/test/name-tree.test.ts
@@ -25,6 +25,7 @@ test('correctly represents sample assembly', () => {
       'org.jsii.TypeA.NestedType': makeType('org.jsii.TypeA', 'NestedType'),
       'org.jsii.enums.TypeB': makeType('org.jsii.enums', 'TypeB'),
     },
+    symbolToFqn: {},
   };
 
   // WHEN

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -263,6 +263,7 @@ const TEST_DEP_ASSEMBLY: spec.Assembly = {
     'jsii-test-dep-dep': '3.2.1',
   },
   jsiiVersion: VERSION,
+  symbolToFqn: {},
 };
 
 const TEST_DEP_DEP_ASSEMBLY: spec.Assembly = {
@@ -281,6 +282,7 @@ const TEST_DEP_DEP_ASSEMBLY: spec.Assembly = {
   },
   jsiiVersion: VERSION,
   fingerprint: 'F1NG3RPR1N7',
+  symbolToFqn: {},
 };
 
 /**

--- a/packages/jsii/test/symbol-identifiers.test.ts
+++ b/packages/jsii/test/symbol-identifiers.test.ts
@@ -1,0 +1,32 @@
+import { compileJsiiForTest } from '../lib';
+
+test('Symbol map is generated', async () => {
+  const result = await compileJsiiForTest(
+    {
+      'index.ts': `
+        export * from './some/nested/file';
+        export class Foo {
+          public bar(){}
+        } 
+      `,
+      'some/nested/file.ts': `
+        export interface Bar {
+          readonly x: string;
+        }
+        export enum Baz {
+          ALPHA = 0,
+          BETA = 1,
+        }
+        `,
+    },
+    undefined /* callback */,
+    { stripDeprecated: true },
+  );
+
+  console.log(result.assembly);
+  expect(result.assembly.symbolToFqn).toEqual({
+    'index:Foo': 'testpkg.Foo',
+    'some/nested/file:Bar': 'testpkg.Bar',
+    'some/nested/file:Baz': 'testpkg.Baz',
+  });
+});


### PR DESCRIPTION
Symbol identifiers follow the pattern `<relative file path without extension>:<scope names>/<symbol name>`

This will be useful for the generation of deprecation warnings and to improve the Rosetta samples.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
