### PR TITLE
feat(pacmak): opt out of jsii assembly validation

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -110,6 +110,11 @@ import { VERSION_DESC } from '../lib/version';
       // This is expected to be a path, which should be normalized
       normalize: true,
     })
+    .option('validate-assemblies', {
+      type: 'boolean',
+      desc: 'Whether jsii assemblies should be validated. This can be expensive and is skipped by default.',
+      default: false,
+    })
     .version(VERSION_DESC)
     .strict().argv;
 
@@ -134,6 +139,7 @@ import { VERSION_DESC } from '../lib/version';
     rosettaTablet: argv['rosetta-tablet'],
     targets: argv.targets?.map((target) => target as TargetName),
     updateNpmIgnoreFiles: argv.npmignore,
+    validateAssemblies: argv['validate-assemblies'],
   });
 })().catch((err) => {
   process.stderr.write(`${err.stack}\n`);

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -32,6 +32,7 @@ export async function pacmak({
   targets = Object.values(TargetName),
   timers = new Timers(),
   updateNpmIgnoreFiles = false,
+  validateAssemblies = false,
 }: PacmakOptions): Promise<void> {
   const rosetta = new Rosetta({ liveConversion: rosettaLiveConversion });
   if (rosettaTablet) {
@@ -65,7 +66,7 @@ export async function pacmak({
     const system = new TypeSystem();
     return Promise.all(
       modulesToPackage.map(async (m) => {
-        await m.load(system);
+        await m.load(system, validateAssemblies);
         return rosetta.addAssembly(m.assembly.spec, m.moduleDirectory);
       }),
     );
@@ -247,6 +248,14 @@ export interface PacmakOptions {
    * @default false
    */
   readonly updateNpmIgnoreFiles?: boolean;
+
+  /**
+   * Whether assemblies should be validated or not. Validation can be expensive and can be skipped if the assemblies
+   * can be assumed to be valid.
+   *
+   * @default false
+   */
+  readonly validateAssemblies?: boolean;
 }
 
 //#endregion

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -87,9 +87,9 @@ export class JsiiModule {
     return this._tarball.object;
   }
 
-  public async load(system: TypeSystem) {
+  public async load(system: TypeSystem, validate = true) {
     return system
-      .loadModule(this.moduleDirectory)
+      .loadModule(this.moduleDirectory, { validate })
       .then((assembly) => (this._assembly = assembly));
   }
 

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -1,4 +1,3 @@
-import * as spec from '@jsii/spec';
 import { spawn, SpawnOptions } from 'child_process';
 import * as fs from 'fs-extra';
 import * as os from 'os';
@@ -224,23 +223,6 @@ export async function shell(
     });
   }
   return spawn1();
-}
-
-/**
- * Loads the assembly from a given module root directory.
- *
- * @param modulePath the path at which the node module is located.
- *
- * @return the parsed ``Assembly``.
- *
- * @throws if the module does not contain a JSII assembly file, or if it's invalid.
- */
-export async function loadAssembly(modulePath: string): Promise<spec.Assembly> {
-  const assmPath = path.join(modulePath, spec.SPEC_FILE_NAME);
-  if (!(await fs.pathExists(assmPath))) {
-    throw new Error(`Could not find ${assmPath}. Was the module built?`);
-  }
-  return spec.validateAssembly(await fs.readJson(assmPath));
 }
 
 /**


### PR DESCRIPTION
Assembly validation can be expensive (both in time and memory). This is
ususally not necessary, as assemblies cna generally be assumed to be
valid.

This adds a new optional option to `jsii-pacmak` to enable assembly
validation, and opts out of it when loading type systems by default.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
