### PR TITLE
fix(jsii-pacmak): modules not packed in topological order

### DIFF
--- a/packages/jsii-pacmak/lib/npm-modules.ts
+++ b/packages/jsii-pacmak/lib/npm-modules.ts
@@ -58,7 +58,11 @@ export async function findJsiiModules(
       );
     }
 
-    const dependencyNames = Object.keys(pkg.dependencies ?? {});
+    const dependencyNames = [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.peerDependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ];
 
     // if --recurse is set, find dependency dirs and build them.
     if (recurse) {

--- a/packages/jsii-pacmak/test/npm-modules.test.ts
+++ b/packages/jsii-pacmak/test/npm-modules.test.ts
@@ -44,12 +44,50 @@ describe(findJsiiModules, () => {
         },
       },
     });
+    // devDependency
+    await mkdirp(join(workDir, 'packageC'));
+    await writeJson(join(workDir, 'packageC', 'package.json'), {
+      name: 'packageC',
+      jsii: {
+        outdir: 'dist',
+        targets: {
+          python: {},
+        },
+      },
+      devDependencies: {
+        packageB: '*',
+      },
+    });
+    // peerDependency
+    await mkdirp(join(workDir, 'packageD'));
+    await writeJson(join(workDir, 'packageD', 'package.json'), {
+      name: 'packageD',
+      jsii: {
+        outdir: 'dist',
+        targets: {
+          python: {},
+        },
+      },
+      devDependencies: {
+        packageA: '*',
+      },
+    });
 
     const mods = await findJsiiModules(
-      [join(workDir, 'packageA'), join(workDir, 'packageB')],
+      [
+        join(workDir, 'packageD'),
+        join(workDir, 'packageA'),
+        join(workDir, 'packageB'),
+        join(workDir, 'packageC'),
+      ],
       false,
     );
-    expect(mods.map((m) => m.name)).toEqual(['packageB', 'packageA']);
+    expect(mods.map((m) => m.name)).toEqual([
+      'packageB',
+      'packageA',
+      'packageC',
+      'packageD',
+    ]);
   });
 
   test('without deps loads packages in given order', async () => {


### PR DESCRIPTION
The current topological sorting of modules for packing only takes into account
packages dependencies, but not peer or dev dependencies. This can lead to
packing errors when a package only has a dev dependency on another package
within the same repo.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
