### PR TITLE
chore: superchain image validation should use docker creds on pull requests

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -50,9 +50,9 @@ jobs:
             fi
           fi
 
-      # We only authenticate to Docker for 'push' events, as 'pull_request' from forks will not have the secret
+      # We only authenticate to Docker on the 'aws/jsii' repo, as forks will not have the secret
       - name: Login to Docker
-        if: steps.should-run.outputs.result == 'true' && github.event_name == 'push'
+        if: steps.should-run.outputs.result == 'true' && github.repository == 'aws/jsii'
         # The DOCKER_CREDENTIALS secret is expected to contain a username:token pair
         run: |-
           docker login                                                          \


### PR DESCRIPTION
Currently, the logic only runs the docker login command on 'push'
events.
This results in throttling from public ECR. See
https://github.com/aws/jsii/pull/3057/checks?check_run_id=3870908318

Change this instead to a check on the repository name to filter out
forks.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
