### PR TITLE
fix(jsii): unexpected deprecated warnings when a deprecated interface is extended

### DIFF
--- a/packages/jsii/lib/transforms/deprecation-warnings.ts
+++ b/packages/jsii/lib/transforms/deprecation-warnings.ts
@@ -42,10 +42,7 @@ export class DeprecationWarningsInjector {
         ),
       );
 
-      if (
-        spec.isDeprecated(type) &&
-        (spec.isEnumType(type) || (spec.isInterfaceType(type) && type.datatype))
-      ) {
+      if (spec.isDeprecated(type) && spec.isEnumType(type)) {
         // The type is deprecated
         statements.push(
           createWarningFunctionCall(type.fqn, type.docs?.deprecated),
@@ -78,12 +75,14 @@ export class DeprecationWarningsInjector {
         }
       } else if (spec.isInterfaceType(type) && type.datatype) {
         for (const prop of Object.values(type.properties ?? {})) {
-          if (spec.isDeprecated(prop)) {
-            // The property is deprecated
+          if (spec.isDeprecated(prop) || spec.isDeprecated(type)) {
+            // If the property individually is deprecated, or the entire type is deprecated
+            const deprecatedDocs =
+              prop.docs?.deprecated ?? type.docs?.deprecated;
             statements.push(
               createWarningFunctionCall(
                 `${type.fqn}#${prop.name}`,
-                prop.docs?.deprecated,
+                deprecatedDocs,
                 ts.createIdentifier(`"${prop.name}" in ${PARAMETER_NAME}`),
               ),
             );

--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -166,25 +166,6 @@ function testpkg_Baz(p) {
     );
   });
 
-  test('generates a call to print if the type is deprecated', async () => {
-    const result = await compileJsiiForTest(
-      `
-        ${DEPRECATED}
-        export interface Foo {}
-        `,
-      undefined /* callback */,
-      { addDeprecationWarnings: true },
-    );
-
-    expect(jsFile(result, '.warnings.jsii')).toMatch(`function testpkg_Foo(p) {
-    if (p == null)
-        return;
-    visitedObjects.add(p);
-    print("testpkg.Foo", "Use something else");
-    visitedObjects.delete(p);
-}`);
-  });
-
   test('generates functions for enums', async () => {
     const result = await compileJsiiForTest(
       `
@@ -266,12 +247,13 @@ function testpkg_Baz(p) {
 `);
   });
 
-  test('generates calls for deprecated interface', async () => {
+  test('generates calls for each property of a deprecated type', async () => {
     const result = await compileJsiiForTest(
       `
       /** @deprecated use Bar instead */
       export interface Foo {
         readonly bar: string;
+        readonly baz: number;
       }
       `,
       undefined /* callback */,
@@ -284,6 +266,8 @@ function testpkg_Baz(p) {
     visitedObjects.add(p);
     if ("bar" in p)
         print("testpkg.Foo#bar", "use Bar instead");
+    if ("baz" in p)
+        print("testpkg.Foo#baz", "use Bar instead");
     visitedObjects.delete(p);
 }
 `);

--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -266,6 +266,29 @@ function testpkg_Baz(p) {
 `);
   });
 
+  test('generates calls for deprecated interface', async () => {
+    const result = await compileJsiiForTest(
+      `
+      /** @deprecated use Bar instead */
+      export interface Foo {
+        readonly bar: string;
+      }
+      `,
+      undefined /* callback */,
+      { addDeprecationWarnings: true },
+    );
+
+    expect(jsFile(result, '.warnings.jsii')).toMatch(`function testpkg_Foo(p) {
+    if (p == null)
+        return;
+    visitedObjects.add(p);
+    if ("bar" in p)
+        print("testpkg.Foo#bar", "use Bar instead");
+    visitedObjects.delete(p);
+}
+`);
+  });
+
   test('generates calls for types in other assemblies', async () => {
     const calcBaseRoot = resolveModuleDir('@scope/jsii-calc-base');
     const calcLibRoot = resolveModuleDir('@scope/jsii-calc-lib');


### PR DESCRIPTION
It is common in the AWS CDK for non-deprecated interfaces to extend
deprecated interfaces.
Currently, when this occurs and the non-deprecated subclass is
referenced, a warning is generated notifying the deprecation of its
superclass.

Modify the implementation such that the warning is produced only when
a property of the deprecated interface is referenced.

In the case when a deprecated interface with no required properties is
used without any of its properties set, a warning will not be generated.
This should occur rarely and the trade off is acceptable.

fixes #3111



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
