### PR TITLE
chore: using queue action in the 'Synchronize that PR to upstream and merge it (no-squash)' rule

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -127,10 +127,9 @@ pull_request_rules:
       dismiss_reviews:
         approved: true
         changes_requested: false
-      merge:
-        strict: smart+fasttrack
+      queue:
+        name: default
         method: merge
-        strict_method: merge
         commit_message: title+body
       comment:
         message: Merging (no-squash)...


### PR DESCRIPTION
This action was left behind in the [previous PR](https://github.com/aws/jsii/pull/3079).


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
