### PR TITLE
fix(pacmak): development version cannot pack java

### DIFF
--- a/packages/jsii-pacmak/lib/targets/version-utils.ts
+++ b/packages/jsii-pacmak/lib/targets/version-utils.ts
@@ -158,7 +158,7 @@ function toBracketNotation(
     target = TargetName.JAVASCRIPT,
   }: { semver?: boolean; target?: TargetName } = {},
 ): string {
-  if (semverRange === '*') {
+  if (semverRange === '*' || semverRange === '^0.0.0') {
     semverRange = '>=0.0.0';
   }
   const range = new Range(semverRange);

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.ts.snap
@@ -89,7 +89,7 @@ exports[`diamond-struct-parameter.ts: <outDir>/dotnet/Example.Test.Demo/Example.
     <EmbeddedResource Include="testpkg-0.0.1.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -528,7 +528,7 @@ exports[`diamond-struct-parameter.ts: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -1503,7 +1503,7 @@ exports[`nested-types.ts: <outDir>/dotnet/Example.Test.Demo/Example.Test.Demo.cs
     <EmbeddedResource Include="testpkg-0.0.1.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -2027,7 +2027,7 @@ exports[`nested-types.ts: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.ts.snap
@@ -208,7 +208,7 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -717,7 +717,7 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -1214,7 +1214,7 @@ exports[`foo@2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -1700,7 +1700,7 @@ exports[`foo@4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -52,7 +52,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/dotnet/Amazon.JSII
     <EmbeddedResource Include="scope-jsii-calc-base-0.0.0.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
     <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[2.1.1,3.0.0)" />
   </ItemGroup>
   <PropertyGroup>
@@ -549,7 +549,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
     <EmbeddedResource Include="scope-jsii-calc-base-of-base-2.1.1.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -1033,8 +1033,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/dotnet/Amazon.JSII.
     <EmbeddedResource Include="scope-jsii-calc-lib-0.0.0.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,)" />
     <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BaseOfBasePackageId" Version="[2.1.1,3.0.0)" />
   </ItemGroup>
   <PropertyGroup>
@@ -3104,8 +3104,8 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     <EmbeddedResource Include="jsii-calc-3.20.120.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="(,0.0.1)" />
-    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="(,0.0.1)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
+    <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.BasePackageId" Version="[0.0.0,)" />
     <PackageReference Include="Amazon.JSII.Tests.CalculatorPackageId.LibPackageId" Version="[0.0.0-devpreview,0.0.1)" />
   </ItemGroup>
   <PropertyGroup>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -286,7 +286,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/java/pom.xml 1`] =
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -1004,7 +1004,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/pom.x
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -1696,7 +1696,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/java/pom.xml 1`] = 
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
       <artifactId>calculator-base</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
@@ -1706,7 +1706,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/java/pom.xml 1`] = 
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -4149,17 +4149,17 @@ exports[`Generated code for "jsii-calc": <outDir>/java/pom.xml 1`] = `
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
       <artifactId>calculator-base</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii.tests</groupId>
       <artifactId>calculator-lib</artifactId>
-      <version>(,0.0.1.DEVPREVIEW)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.jsii</groupId>
       <artifactId>jsii-runtime</artifactId>
-      <version>(,0.0.1)</version>
+      <version>[0.0.0,)</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>

--- a/packages/jsii-pacmak/test/targets/version-utils.test.ts
+++ b/packages/jsii-pacmak/test/targets/version-utils.test.ts
@@ -91,6 +91,10 @@ describe(toMavenVersionRange, () => {
   }
 });
 
+test('Maven dependency on jsii-runtime for a development version is workable', () => {
+  expect(toMavenVersionRange('^0.0.0')).toEqual('[0.0.0,)');
+});
+
 describe(toNuGetVersionRange, () => {
   for (const [semver, { nuget }] of Object.entries(examples)) {
     test(`${semver} translates to ${nuget}`, () =>


### PR DESCRIPTION
When the version of `jsii-pacmak` is `0.0.0`, it will write the following
requirement for `jsii-runtime`: `[,0.0.1)`. There is no version that satisfies
that dependency, so the build fails.

Make an exception: if the version we're trying to install is `^0.0.0`,
translate it to "any old version" instead.

Fixes #3107.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
