### PR TITLE
fix(pacmak): add 'silly' loglevel for command output

### DIFF
--- a/packages/jsii-pacmak/lib/logging.ts
+++ b/packages/jsii-pacmak/lib/logging.ts
@@ -3,10 +3,12 @@ export enum Level {
   QUIET = 0,
   INFO = 1,
   VERBOSE = 2,
+  SILLY = 3,
 }
 
 export const LEVEL_INFO: number = Level.INFO;
 export const LEVEL_VERBOSE: number = Level.VERBOSE;
+export const LEVEL_SILLY: number = Level.SILLY;
 
 /** The minimal logging level for messages to be emitted. */
 export let level = Level.QUIET;

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -54,7 +54,6 @@ export class JsiiModule {
    */
   public async npmPack() {
     this._tarball = await Scratch.make(async (tmpdir) => {
-      logging.debug(`Running "npm pack ${this.moduleDirectory}" in ${tmpdir}`);
       // Quoting (JSON-stringifying) the module directory in order to avoid
       // problems if there are spaces or other special characters in the path.
       const args = ['pack', JSON.stringify(this.moduleDirectory)];

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -159,13 +159,13 @@ export async function shell(
       const stdout = new Array<Buffer>();
       const stderr = new Array<Buffer>();
       child.stdout.on('data', (chunk) => {
-        if (logging.level >= logging.LEVEL_VERBOSE) {
+        if (logging.level >= logging.LEVEL_SILLY) {
           process.stderr.write(chunk); // notice - we emit all build output to stderr
         }
         stdout.push(Buffer.from(chunk));
       });
       child.stderr.on('data', (chunk) => {
-        if (logging.level >= logging.LEVEL_VERBOSE) {
+        if (logging.level >= logging.LEVEL_SILLY) {
           process.stderr.write(chunk);
         }
         stderr.push(Buffer.from(chunk));


### PR DESCRIPTION
Pacmak outputs both the command-line commands as well as stdout/stderr
for those commands under the `verbose` loglevel.

That's too much at one log level: I definitely want to know about the
commands without getting spammed with all the command outputs.

Introduce a new loglevel, `silly`, and move the command output to
that level.

Also remove a log line from `npmPack` that is redundant with the
log line that prints the command that's going to be executed.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
