### PR TITLE
fix(rosetta): `infuse` creates untranslated examples

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -99,6 +99,7 @@ function main() {
         const result = await infuse(absAssemblies, args.TABLET, {
           outputFile: absOutput,
           log: args.log,
+          tabletOutputFile: args.TABLET,
         });
 
         let totalTypes = 0;

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -6,17 +6,22 @@ import { SnippetSelector, mean, meanLength, shortest, longest } from '../snippet
 import { LanguageTablet, TranslatedSnippet } from '../tablets/tablets';
 
 export interface InfuseResult {
-  coverageResults: Record<string, InfuseTypes>;
+  readonly coverageResults: Record<string, InfuseTypes>;
 }
 
 export interface InfuseTypes {
-  types: number;
-  typesWithInsertedExamples: number;
+  readonly types: number;
+  readonly typesWithInsertedExamples: number;
 }
 
 export interface InfuseOptions {
-  outputFile: string;
-  log: boolean;
+  readonly outputFile: string;
+  readonly log: boolean;
+
+  /**
+   * Where to write the updated tablet back
+   */
+  readonly tabletOutputFile?: string;
 }
 
 export const DEFAULT_INFUSION_RESULTS_NAME = 'infusion-results.html';
@@ -73,7 +78,7 @@ export async function infuse(
           };
           logOutput(stream, typeFqn, createHtmlEntry(selectedFromSelector));
         }
-        insertExample(meanResult.originalSource.source, type);
+        insertExample(meanResult, type, tab);
         typesWithInsertedExamples++;
       }
     }
@@ -87,6 +92,12 @@ export async function infuse(
   }
 
   stream?.close();
+
+  // If we copied examples onto different types, we'll also have inserted new snippets
+  // with different keys into the tablet. We must now write the updated tablet somewhere.
+  if (options?.tabletOutputFile) {
+    await tab.save(options.tabletOutputFile);
+  }
 
   return {
     coverageResults: coverageResults,
@@ -141,14 +152,21 @@ function filterForTypesWithoutExamples(types: { [fqn: string]: spec.Type }): Rec
 }
 
 /**
- * Insert an example into the docs of a type.
+ * Insert an example into the docs of a type, and insert it back into the tablet under a new key
  */
-function insertExample(example: string, type: spec.Type): void {
+function insertExample(example: TranslatedSnippet, type: spec.Type, tablet: LanguageTablet): void {
   if (type.docs) {
-    type.docs.example = example;
+    type.docs.example = example.originalSource.source;
   } else {
-    type.docs = { example: example };
+    type.docs = { example: example.originalSource.source };
   }
+
+  tablet.addSnippet(
+    example.withLocation({
+      api: { api: 'type', fqn: type.fqn },
+      field: { field: 'example' },
+    }),
+  );
 }
 
 /**

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -15,8 +15,9 @@ export interface InfuseTypes {
 }
 
 export interface InfuseOptions {
-  readonly outputFile: string;
-  readonly log: boolean;
+  readonly outputFile?: string;
+
+  readonly log?: boolean;
 
   /**
    * Where to write the updated tablet back
@@ -46,6 +47,10 @@ export async function infuse(
 ): Promise<InfuseResult> {
   let stream: fs.WriteStream | undefined = undefined;
   if (options?.log) {
+    if (!options.outputFile) {
+      throw new Error("If 'log' is set, 'outputFile' must be set as well.");
+    }
+
     // Create stream for html file and insert some styling
     stream = fs.createWriteStream(options.outputFile, {
       encoding: 'utf-8',

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { TargetLanguage } from '../languages';
-import { TypeScriptSnippet } from '../snippet';
+import { TypeScriptSnippet, SnippetLocation } from '../snippet';
 import { mapValues } from '../util';
 import { snippetKey } from './key';
 import { TabletSchema, TranslatedSnippetSchema, ORIGINAL_SNIPPET_KEY } from './schema';
@@ -177,6 +177,13 @@ export class TranslatedSnippet {
     return new TranslatedSnippet({
       ...this.snippet,
       fqnsFingerprint: fp,
+    });
+  }
+
+  public withLocation(location: SnippetLocation) {
+    return new TranslatedSnippet({
+      ...this.snippet,
+      location,
     });
   }
 

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -59,10 +59,7 @@ export class LanguageTablet {
       );
     }
 
-    Object.assign(
-      this.snippets,
-      mapValues(obj.snippets, (schema: TranslatedSnippetSchema) => TranslatedSnippet.fromSchema(schema)),
-    );
+    Object.assign(this.snippets, mapValues(obj.snippets, TranslatedSnippet.fromSchema));
   }
 
   public get count() {
@@ -185,6 +182,10 @@ export class TranslatedSnippet {
       ...this.snippet,
       location,
     });
+  }
+
+  public toJSON() {
+    return this._snippet;
   }
 
   private asTypescriptSnippet(): TypeScriptSnippet {


### PR DESCRIPTION
The new `infuse` feature replicates examples from READMEs to types.

However, because of caching, example locations have become part of their
identifying key. Because an example has moved to a different location,
it now has a different key, and because that key is not in the tablet
yet the example will count as untranslated (requiring live conversion
during `pacmak` time, and increasing the pack time).

When we copy an example to a different type, also create a copy at
the new type location in the tablet, so that it will count as
pretranslated.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
