### PR TITLE
fix(rosetta): remember live-translated snippets without fixtures

### DIFF
--- a/packages/jsii-rosetta/lib/rosetta.ts
+++ b/packages/jsii-rosetta/lib/rosetta.ts
@@ -178,6 +178,7 @@ export class Rosetta {
 
     // Try to live-convert it on the spot (we won't have "where" information or fixtures)
     const snippet = this.translator.translate(source, this.options.targetLanguages);
+    this.liveTablet.addSnippet(snippet);
     return snippet.get(targetLang);
   }
 

--- a/packages/jsii-rosetta/test/rosetta.test.ts
+++ b/packages/jsii-rosetta/test/rosetta.test.ts
@@ -1,6 +1,13 @@
 import * as mockfs from 'mock-fs';
 
-import { Rosetta, LanguageTablet, TranslatedSnippet, TypeScriptSnippet, DEFAULT_TABLET_NAME } from '../lib';
+import {
+  Rosetta,
+  LanguageTablet,
+  TranslatedSnippet,
+  TypeScriptSnippet,
+  DEFAULT_TABLET_NAME,
+  Translation,
+} from '../lib';
 import { TargetLanguage } from '../lib/languages';
 import { fakeAssembly } from './jsii/fake-assembly';
 import { testSnippetLocation } from './testutil';
@@ -10,20 +17,29 @@ const SAMPLE_CODE: TypeScriptSnippet = {
   location: testSnippetLocation('sample'),
 };
 
-test('Rosetta object can do live translation', () => {
-  // GIVEN
-  const rosetta = new Rosetta({
-    liveConversion: true,
-    targetLanguages: [TargetLanguage.PYTHON],
+describe('Rosetta object can do live translation', () => {
+  let rosetta: Rosetta;
+  let translated: Translation | undefined;
+  beforeEach(() => {
+    // GIVEN
+    rosetta = new Rosetta({
+      liveConversion: true,
+      targetLanguages: [TargetLanguage.PYTHON],
+    });
+
+    // WHEN
+    translated = rosetta.translateSnippet(SAMPLE_CODE, TargetLanguage.PYTHON);
   });
 
-  // WHEN
-  const translated = rosetta.translateSnippet(SAMPLE_CODE, TargetLanguage.PYTHON);
+  test('output is correct', () => {
+    expect(translated).toMatchObject({
+      source: 'call_this_function()',
+      language: 'python',
+    });
+  });
 
-  // THEN
-  expect(translated).toMatchObject({
-    source: 'call_this_function()',
-    language: 'python',
+  test('translations are added to liveTablet', () => {
+    expect(rosetta.liveTablet.count).toEqual(1);
   });
 });
 


### PR DESCRIPTION
We used to only remember snippets we live-translated using the rosetta
API if we were able to find a fixture for them.

There's no good reason for this. Also remember them if we live-translate
without a fixture.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
