### PR TITLE
feat(@jsii/spec): `replaceAssembly` and `_fingerprint` functions

### DIFF
--- a/packages/@jsii/spec/lib/index.ts
+++ b/packages/@jsii/spec/lib/index.ts
@@ -2,3 +2,4 @@ export * from './assembly';
 export * from './configuration';
 export * from './name-tree';
 export * from './validate-assembly';
+export * from './replace-assembly';

--- a/packages/@jsii/spec/lib/replace-assembly.ts
+++ b/packages/@jsii/spec/lib/replace-assembly.ts
@@ -1,0 +1,48 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { Assembly } from './assembly';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+const sortJson = require('sort-json');
+
+/**
+ * Options for replacing the assembly
+ */
+interface ReplaceAssemblyOptions {
+  /**
+   * The assembly file extension that you want to overwrite.
+   */
+  readonly fileExtension: string;
+
+  /**
+   * The directory where the assembly is located.
+   */
+  readonly directory: string;
+}
+
+/**
+ * Replaces the file where the original assembly file *should* be found with a new assembly file.
+ * Recalculates the fingerprint of the assembly to avoid tampering detection.
+ */
+export async function replaceAssembly(
+  assembly: Assembly,
+  options: ReplaceAssemblyOptions,
+): Promise<void> {
+  const fileName = path.join(options.directory, options.fileExtension);
+  await fs.writeJson(fileName, _fingerprint(assembly), {
+    encoding: 'utf8',
+    spaces: 2,
+  });
+}
+
+function _fingerprint(assembly: Assembly): Assembly {
+  delete (assembly as any).fingerprint;
+  assembly = sortJson(assembly);
+  const fingerprint = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(assembly))
+    .digest('base64');
+  return { ...assembly, fingerprint };
+}

--- a/packages/@jsii/spec/lib/replace-assembly.ts
+++ b/packages/@jsii/spec/lib/replace-assembly.ts
@@ -37,6 +37,9 @@ export async function replaceAssembly(
   });
 }
 
+/**
+ * Create a new fingerprint for the assembly.
+ */
 export function _fingerprint(assembly: Assembly): Assembly {
   delete (assembly as any).fingerprint;
   assembly = sortJson(assembly);

--- a/packages/@jsii/spec/lib/replace-assembly.ts
+++ b/packages/@jsii/spec/lib/replace-assembly.ts
@@ -37,7 +37,7 @@ export async function replaceAssembly(
   });
 }
 
-function _fingerprint(assembly: Assembly): Assembly {
+export function _fingerprint(assembly: Assembly): Assembly {
   delete (assembly as any).fingerprint;
   assembly = sortJson(assembly);
   const fingerprint = crypto

--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -31,11 +31,14 @@
     "package": "package-js"
   },
   "dependencies": {
-    "jsonschema": "^1.4.0"
+    "jsonschema": "^1.4.0",
+    "sort-json": "^2.0.0",
+    "fs-extra": "^9.1.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node": "^12.20.28",
+    "@types/fs-extra": "^9.0.13",
     "eslint": "^7.32.0",
     "jest": "^27.2.4",
     "jsii-build-tools": "^0.0.0",

--- a/packages/@jsii/spec/test/name-tree.test.ts
+++ b/packages/@jsii/spec/test/name-tree.test.ts
@@ -1,5 +1,6 @@
 import * as spec from '../lib/assembly';
 import { NameTree } from '../lib/name-tree';
+import { makeType } from './testutil';
 
 const assemblyName = '@foo/bar';
 
@@ -21,9 +22,13 @@ test('correctly represents sample assembly', () => {
     fingerprint: '<no-fingerprint>',
     targets: {},
     types: {
-      'org.jsii.TypeA': makeType('org.jsii', 'TypeA'),
-      'org.jsii.TypeA.NestedType': makeType('org.jsii.TypeA', 'NestedType'),
-      'org.jsii.enums.TypeB': makeType('org.jsii.enums', 'TypeB'),
+      'org.jsii.TypeA': makeType('org.jsii', 'TypeA', assemblyName),
+      'org.jsii.TypeA.NestedType': makeType(
+        'org.jsii.TypeA',
+        'NestedType',
+        assemblyName,
+      ),
+      'org.jsii.enums.TypeB': makeType('org.jsii.enums', 'TypeB', assemblyName),
     },
   };
 
@@ -60,8 +65,3 @@ test('correctly represents sample assembly', () => {
     nameTree.children.org.children.jsii.children.enums.children.TypeB.fqn,
   ).toBe('org.jsii.enums.TypeB');
 });
-
-function makeType(ns: string, name: string): spec.Type {
-  const fqn = `${ns}.${name}`;
-  return { fqn, name, assembly: assemblyName, kind: spec.TypeKind.Class };
-}

--- a/packages/@jsii/spec/test/replace-assembly.test.ts
+++ b/packages/@jsii/spec/test/replace-assembly.test.ts
@@ -1,0 +1,76 @@
+import * as spec from '../lib/assembly';
+import { replaceAssembly } from '../lib/replace-assembly';
+import { makeType, TestJsiiModule } from './testutil';
+
+const assemblyName = 'hello';
+const fingerprint = 'fingerprint';
+describe('replaceAssembly', () => {
+  let assembly: spec.Assembly;
+  let module: TestJsiiModule;
+
+  beforeEach(async () => {
+    // GIVEN
+    assembly = {
+      schema: spec.SchemaVersion.LATEST,
+      name: assemblyName,
+      description: 'bla',
+      homepage: 'https://github.com/bla/bla',
+      author: { name: 'Author', roles: ['author'] },
+      repository: {
+        type: 'scm',
+        url: 'https://github.com/bla/bla',
+      },
+      version: '0.0.1',
+      jsiiVersion: 'TEST',
+      license: 'NONE',
+      fingerprint: fingerprint,
+      targets: {},
+      types: {
+        'org.jsii.TypeA': makeType('org.jsii', 'TypeA', assemblyName),
+      },
+    };
+    // Create a temp directory for the assembly
+    module = await TestJsiiModule.fromAssembly(assembly, {
+      name: assemblyName,
+    });
+  });
+
+  test('assembly is changed', async () => {
+    // WHEN
+    expect(assembly.types).toBeDefined();
+    assembly.types!['org.jsii.TypeA'].docs = { example: 'new TypeA();' };
+    // new assembly will have doc object for TypeA
+    await replaceAssembly(assembly, {
+      directory: module.moduleDirectory,
+      fileExtension: '.jsii',
+    });
+
+    // THEN
+    await module.syncAssembly();
+
+    expect(assembly.types).toBeDefined();
+    expect(assembly.types!['org.jsii.TypeA'].docs).toEqual({
+      example: 'new TypeA();',
+    });
+  });
+
+  test('fingerprint is updated', async () => {
+    // WHEN
+    // assert that the fingerprint is what we expect
+    expect(assembly.fingerprint).toEqual(fingerprint);
+    await replaceAssembly(assembly, {
+      directory: module.moduleDirectory,
+      fileExtension: '.jsii',
+    });
+
+    // THEN
+    await module.syncAssembly();
+
+    // there is a new fingerprint
+    expect(assembly.fingerprint).not.toEqual(fingerprint);
+  });
+
+  afterAll(async () => {
+    await module.cleanup();
+  });
+});

--- a/packages/@jsii/spec/test/replace-assembly.test.ts
+++ b/packages/@jsii/spec/test/replace-assembly.test.ts
@@ -1,12 +1,12 @@
 import * as spec from '../lib/assembly';
 import { replaceAssembly } from '../lib/replace-assembly';
-import { makeType, TestJsiiModule } from './testutil';
+import { makeType, TestAssembly } from './testutil';
 
 const assemblyName = 'hello';
 const fingerprint = 'fingerprint';
 describe('replaceAssembly', () => {
   let assembly: spec.Assembly;
-  let module: TestJsiiModule;
+  let module: TestAssembly;
 
   beforeEach(async () => {
     // GIVEN
@@ -30,7 +30,7 @@ describe('replaceAssembly', () => {
       },
     };
     // Create a temp directory for the assembly
-    module = await TestJsiiModule.fromAssembly(assembly, {
+    module = await TestAssembly.fromAssembly(assembly, {
       name: assemblyName,
     });
   });
@@ -41,7 +41,7 @@ describe('replaceAssembly', () => {
     assembly.types!['org.jsii.TypeA'].docs = { example: 'new TypeA();' };
     // new assembly will have doc object for TypeA
     await replaceAssembly(assembly, {
-      directory: module.moduleDirectory,
+      directory: module.directory,
       fileExtension: '.jsii',
     });
 
@@ -59,7 +59,7 @@ describe('replaceAssembly', () => {
     // assert that the fingerprint is what we expect
     expect(assembly.fingerprint).toEqual(fingerprint);
     await replaceAssembly(assembly, {
-      directory: module.moduleDirectory,
+      directory: module.directory,
       fileExtension: '.jsii',
     });
 

--- a/packages/@jsii/spec/test/testutil.ts
+++ b/packages/@jsii/spec/test/testutil.ts
@@ -12,13 +12,6 @@ export class TestJsiiModule {
     assembly: spec.Assembly,
     packageInfo: { name: string },
   ) {
-    // The following is silly, however: the helper has compiled the given source to
-    // an assembly, and output files, and then removed their traces from disk.
-    // But for the purposes of Rosetta, we need those files back on disk. So write
-    // them back out again >_<
-    //
-    // In fact we will drop them in 'node_modules/<name>' so they can be imported
-    // as if they were installed.
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec'));
     const modDir = path.join(tmpDir, 'node_modules', packageInfo.name);
     await fs.ensureDir(modDir);

--- a/packages/@jsii/spec/test/testutil.ts
+++ b/packages/@jsii/spec/test/testutil.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as spec from '../lib/assembly';
+
+/**
+ * Compile a jsii module from assembly, and produce an environment in which it is available as a module
+ */
+export class TestJsiiModule {
+  public static async fromAssembly(
+    assembly: spec.Assembly,
+    packageInfo: { name: string },
+  ) {
+    // The following is silly, however: the helper has compiled the given source to
+    // an assembly, and output files, and then removed their traces from disk.
+    // But for the purposes of Rosetta, we need those files back on disk. So write
+    // them back out again >_<
+    //
+    // In fact we will drop them in 'node_modules/<name>' so they can be imported
+    // as if they were installed.
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec'));
+    const modDir = path.join(tmpDir, 'node_modules', packageInfo.name);
+    await fs.ensureDir(modDir);
+
+    await fs.writeJSON(path.join(modDir, '.jsii'), assembly);
+    await fs.writeJSON(path.join(modDir, 'package.json'), {
+      name: packageInfo.name,
+    });
+    return new TestJsiiModule(assembly, modDir, tmpDir);
+  }
+
+  private constructor(
+    private _assembly: spec.Assembly,
+    public readonly moduleDirectory: string,
+    public readonly workspaceDirectory: string,
+  ) {}
+
+  public get assembly() {
+    return this._assembly;
+  }
+
+  public async syncAssembly() {
+    this._assembly = await fs.readJSON(
+      path.join(this.moduleDirectory, '.jsii'),
+    );
+  }
+
+  public async cleanup() {
+    await fs.remove(this.moduleDirectory);
+  }
+}
+
+export function makeType(
+  ns: string,
+  name: string,
+  assemblyName: string,
+): spec.Type {
+  const fqn = `${ns}.${name}`;
+  return { fqn, name, assembly: assemblyName, kind: spec.TypeKind.Class };
+}


### PR DESCRIPTION
This PR moves two functions to `@jsii/spec` that are used in a few other locations in jsii.
`replaceAssembly()` updates an assembly file with a modified file (and updates the fingerprint).
It is utilized in `jsii-rosetta` and will be utilized in the `generate-examples` project.
`_fingerprint()` is also used in the `jsii` folder.
The motivation is to avoid copy/pasting similar functions around.  

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
