### PR TITLE
chore: fix pr-labeler permissions

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
     - run: gh pr edit ${{ github.event.pull_request.number }} --add-label "pr/auto-approve" -R ${{ github.repository }}
       env:


### PR DESCRIPTION
Apparently, in order to add labels to a PR, the token must have write permissions to issues as well, otherwise it will silently fail.

See https://github.com/cli/cli/issues/4631

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
