### PR TITLE
fix(rosetta): snippet throughput incorrect

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -78,7 +78,7 @@ export async function extractSnippets(
 
     const delta = (Date.now() - startTime) / 1000;
     logging.info(
-      `Translated ${translateCount} snippets in ${delta} seconds (${(delta / tablet.count).toPrecision(3)}s/snippet)`,
+      `Translated ${translateCount} snippets in ${delta} seconds (${(delta / translateCount).toPrecision(3)}s/snippet)`,
     );
     diagnostics.push(...result.diagnostics);
   } else {


### PR DESCRIPTION
We were dividing by the total number of snippets, instead of the actually translated ones.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
