### PR TITLE
fix(pacmak): remove disclaimer on compiling examples

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
@@ -10,10 +10,7 @@ import {
 } from 'jsii-rosetta';
 import * as xmlbuilder from 'xmlbuilder';
 
-import {
-  INCOMPLETE_DISCLAIMER_COMPILING,
-  INCOMPLETE_DISCLAIMER_NONCOMPILING,
-} from '..';
+import { INCOMPLETE_DISCLAIMER_NONCOMPILING } from '..';
 import { renderSummary } from '../_utils';
 import { DotNetNameUtils } from './nameutils';
 
@@ -188,9 +185,6 @@ export class DotNetDocGenerator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (translated.didCompile && INCOMPLETE_DISCLAIMER_COMPILING) {
-      return `// ${INCOMPLETE_DISCLAIMER_COMPILING}\n${translated.source}`;
-    }
     if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
       return `// ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
     }

--- a/packages/jsii-pacmak/lib/targets/index.ts
+++ b/packages/jsii-pacmak/lib/targets/index.ts
@@ -35,7 +35,5 @@ export const ALL_BUILDERS: { [key in TargetName]: BuilderFactory } = {
     new IndependentPackageBuilder(TargetName.PYTHON, Python, ms, o),
 };
 
-export const INCOMPLETE_DISCLAIMER_COMPILING =
-  'Example automatically generated. See https://github.com/aws/jsii/issues/826';
 export const INCOMPLETE_DISCLAIMER_NONCOMPILING =
-  'Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826';
+  'Example automatically generated from non-compiling source. May contain errors.';

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -30,11 +30,7 @@ import { VERSION, VERSION_DESC } from '../version';
 import { stabilityPrefixFor, renderSummary } from './_utils';
 import { toMavenVersionRange, toReleaseVersion } from './version-utils';
 
-import {
-  INCOMPLETE_DISCLAIMER_COMPILING,
-  INCOMPLETE_DISCLAIMER_NONCOMPILING,
-  TargetName,
-} from '.';
+import { INCOMPLETE_DISCLAIMER_NONCOMPILING, TargetName } from '.';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
 const spdxLicenseList = require('spdx-license-list');
@@ -3013,9 +3009,6 @@ class JavaGenerator extends Generator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (translated.didCompile && INCOMPLETE_DISCLAIMER_COMPILING) {
-      return `// ${INCOMPLETE_DISCLAIMER_COMPILING}\n${translated.source}`;
-    }
     if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
       return `// ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
     }

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -29,11 +29,7 @@ import {
 import { die, toPythonIdentifier } from './python/util';
 import { toPythonVersionRange, toReleaseVersion } from './version-utils';
 
-import {
-  INCOMPLETE_DISCLAIMER_COMPILING,
-  INCOMPLETE_DISCLAIMER_NONCOMPILING,
-  TargetName,
-} from '.';
+import { INCOMPLETE_DISCLAIMER_NONCOMPILING, TargetName } from '.';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
 const spdxLicenseList = require('spdx-license-list');
@@ -2400,9 +2396,6 @@ class PythonGenerator extends Generator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (translated.didCompile && INCOMPLETE_DISCLAIMER_COMPILING) {
-      return `# ${INCOMPLETE_DISCLAIMER_COMPILING}\n${translated.source}`;
-    }
     if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
       return `# ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
     }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -4129,7 +4129,6 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// Here's how you use it:
     ///
     /// <code><![CDATA[
-    /// // Example automatically generated. See https://github.com/aws/jsii/issues/826
     /// Calculator calculator = new Calculator();
     /// calculator.Add(5);
     /// calculator.Mul(3);
@@ -4139,8 +4138,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// I will repeat this example again, but in an @example tag.
     /// </remarks>
     /// <example>
-    /// <code>// Example automatically generated. See https://github.com/aws/jsii/issues/826
-    /// Calculator calculator = new Calculator();
+    /// <code>Calculator calculator = new Calculator();
     /// calculator.Add(5);
     /// calculator.Mul(3);
     /// Console.WriteLine(calculator.Expression.Value);</code>
@@ -4699,8 +4697,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// <strong>CustomAttribute</strong>: hasAValue
     /// </remarks>
     /// <example>
-    /// <code>// Example automatically generated. See https://github.com/aws/jsii/issues/826
-    /// public void AnExample()
+    /// <code>public void AnExample()
     /// {
     /// }</code>
     /// </example>
@@ -6233,8 +6230,7 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// Multiple paragraphs are separated by an empty line.
     /// </remarks>
     /// <example>
-    /// <code>// Example automatically generated. See https://github.com/aws/jsii/issues/826
-    /// int x = 12 + 44;
+    /// <code>int x = 12 + 44;
     /// string s1 = "string";
     /// string s2 = @"string
     /// with new newlines"; // see https://github.com/aws/jsii/issues/2569
@@ -13780,21 +13776,18 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// First, create a calculator:
     ///
     /// <code><![CDATA[
-    /// // Example automatically generated. See https://github.com/aws/jsii/issues/826
     /// Calculator calculator = new Calculator();
     /// ]]></code>
     ///
     /// Then call some operations:
     ///
     /// <code><![CDATA[
-    /// // Example automatically generated. See https://github.com/aws/jsii/issues/826
     /// calculator.Add(10);
     /// ]]></code>
     ///
     /// <h2>Code Samples</h2>
     ///
     /// <code><![CDATA[
-    /// // Example automatically generated. See https://github.com/aws/jsii/issues/826
     /// /* This is totes a magic comment in here, just you wait! */
     /// string foo = "bar";
     /// ]]></code>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.ts.snap
@@ -5612,7 +5612,6 @@ package software.amazon.jsii.tests.calculator;
  * Here's how you use it:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * Calculator calculator = new Calculator();
  * calculator.add(5);
  * calculator.mul(3);
@@ -5624,7 +5623,6 @@ package software.amazon.jsii.tests.calculator;
  * Example:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * Calculator calculator = new Calculator();
  * calculator.add(5);
  * calculator.mul(3);
@@ -6625,7 +6623,6 @@ package software.amazon.jsii.tests.calculator;
  * Example:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * public void anExample() {
  * }
  * </pre></blockquote>
@@ -9298,7 +9295,6 @@ package software.amazon.jsii.tests.calculator;
  * Example:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * Number x = 12 + 44;
  * String s1 = "string";
  * String s2 = "string \\nwith new newlines"; // see https://github.com/aws/jsii/issues/2569
@@ -24119,21 +24115,18 @@ exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/am
  * First, create a calculator:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * Calculator calculator = new Calculator();
  * </pre></blockquote>
  * <p>
  * Then call some operations:
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * calculator.add(10);
  * </pre></blockquote>
  * <p>
  * <h2>Code Samples</h2>
  * <p>
  * <blockquote><pre>
- * // Example automatically generated. See https://github.com/aws/jsii/issues/826
  * /* This is totes a magic comment in here, just you wait! *&#47;
  * String foo = "bar";
  * </pre></blockquote>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -2383,21 +2383,18 @@ This library is used to demonstrate and test the features of JSII
 First, create a calculator:
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 calculator = calc.Calculator()
 \`\`\`
 
 Then call some operations:
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 calculator.add(10)
 \`\`\`
 
 ## Code Samples
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 # This is totes a magic comment in here, just you wait!
 foo = "bar"
 \`\`\`
@@ -2525,21 +2522,18 @@ This library is used to demonstrate and test the features of JSII
 First, create a calculator:
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 calculator = calc.Calculator()
 \`\`\`
 
 Then call some operations:
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 calculator.add(10)
 \`\`\`
 
 ## Code Samples
 
 \`\`\`python
-# Example automatically generated. See https://github.com/aws/jsii/issues/826
 # This is totes a magic comment in here, just you wait!
 foo = "bar"
 \`\`\`
@@ -3119,7 +3113,6 @@ class Calculator(
 
     Here's how you use it::
 
-       # Example automatically generated. See https://github.com/aws/jsii/issues/826
        calculator = calc.Calculator()
        calculator.add(5)
        calculator.mul(3)
@@ -3129,7 +3122,6 @@ class Calculator(
 
     Example::
 
-        # Example automatically generated. See https://github.com/aws/jsii/issues/826
         calculator = calc.Calculator()
         calculator.add(5)
         calculator.mul(3)
@@ -3419,7 +3411,6 @@ class ClassWithDocs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.ClassWithDocs"
 
     Example::
 
-        # Example automatically generated. See https://github.com/aws/jsii/issues/826
         def an_example():
             pass
     '''
@@ -4525,7 +4516,6 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
     Example::
 
-        # Example automatically generated. See https://github.com/aws/jsii/issues/826
         x = 12 + 44
         s1 = "string"
         s2 = """string


### PR DESCRIPTION
We're pretty confident in our rosetta translations by now. If we
successfully compiled the example, no need to prefix it with
a disclaimer anymore: the translation is most likely correct.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
