### PR TITLE
fix(rosetta): `didCompile` evaluates to true when compilation not attempted

### DIFF
--- a/packages/jsii-rosetta/test/translate.test.ts
+++ b/packages/jsii-rosetta/test/translate.test.ts
@@ -112,3 +112,35 @@ test('Snippets from different locations have different keys', () => {
 
   expect(snippetKey(snippet1)).not.toEqual(snippetKey(snippet2));
 });
+
+test('didSuccessfullyCompile is true when compilation is attempted', () => {
+  const visibleSource = 'console.log("banana");';
+
+  const snippet: TypeScriptSnippet = {
+    visibleSource,
+    location: { api: { api: 'type', fqn: 'my.class' } },
+  };
+
+  // WHEN
+  const subject = new SnippetTranslator(snippet, {
+    includeCompilerDiagnostics: true,
+  });
+  subject.renderUsing(new PythonVisitor());
+
+  expect(subject.didSuccessfullyCompile).toBeTruthy();
+});
+
+test('didSuccessfullyCompile is undefined when compilation is not attempted', () => {
+  const visibleSource = 'console.log("banana");';
+
+  const snippet: TypeScriptSnippet = {
+    visibleSource,
+    location: { api: { api: 'type', fqn: 'my.class' } },
+  };
+
+  // WHEN
+  const subject = new SnippetTranslator(snippet);
+  subject.renderUsing(new PythonVisitor());
+
+  expect(subject.didSuccessfullyCompile).toBeUndefined();
+});


### PR DESCRIPTION
When `rosetta:extract` is run, the property `didCompile` evalutes to `true`
even when compilation was not attempted. This causes lots of confusion.
The correct way to handle this is to return `undefined` when compilation is
not attempted. Then, (I assume) `didCompile` will not show up in the tablet
file at all when compilation is not asked for (via `--compile` or `strict`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
