### PR TITLE
fix(rosetta): gets confused by type unions

### DIFF
--- a/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.cs
+++ b/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.cs
@@ -1,0 +1,6 @@
+Takes(new MyProps {
+    Struct = new SomeStruct {
+        Enabled = false,
+        Option = "option"
+    }
+});

--- a/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.java
+++ b/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.java
@@ -1,0 +1,6 @@
+takes(MyProps.builder()
+        .struct(SomeStruct.builder()
+                .enabled(false)
+                .option("option")
+                .build())
+        .build());

--- a/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.py
+++ b/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.py
@@ -1,0 +1,6 @@
+takes(
+    struct=SomeStruct(
+        enabled=False,
+        option="option"
+    )
+)

--- a/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.ts
+++ b/packages/jsii-rosetta/test/translations/structs/infer_struct_from_union.ts
@@ -1,0 +1,29 @@
+/// !hide
+/// fake-from-jsii
+interface IResolvable {
+  resolve(): any;
+}
+
+/// fake-from-jsii
+interface SomeStruct {
+  readonly enabled: boolean | IResolvable;
+  readonly option?: string | IResolvable;
+}
+
+/// fake-from-jsii
+interface MyProps {
+  readonly struct?: IResolvable | SomeStruct;
+}
+
+function takes(props: MyProps) {
+}
+/// !show
+
+takes({
+  struct: {
+    enabled: false,
+    option: 'option',
+  },
+});
+
+


### PR DESCRIPTION
Rosetta gets confused by type unions when it's trying to derive
the type of a struct.

This bites CDK as we're generating examples for L1s, and they all have
unions with `IResolvable` in all their properties.

If we can match a struct, let's do so.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
