### PR TITLE
fix(pacmak): dotnet code docs loses indentation

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
@@ -205,8 +205,10 @@ export class DotNetDocGenerator {
       xml.att(name, value);
     }
     const xmlstring = xml.end({ allowEmpty: true, pretty: false });
-
-    for (const line of xmlstring.split('\n').map((x) => x.trim())) {
+    const trimLeft = tag !== 'code';
+    for (const line of xmlstring
+      .split('\n')
+      .map((x) => (trimLeft ? x.trim() : x.trimRight()))) {
       this.code.line(`/// ${line}`);
     }
   }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.ts.snap
@@ -6235,8 +6235,8 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
     /// string s2 = @"string
     /// with new newlines"; // see https://github.com/aws/jsii/issues/2569
     /// string s3 = @"string
-    /// with
-    /// new lines";</code>
+    ///             with
+    ///             new lines";</code>
     /// </example>
     [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.DocumentedClass), fullyQualifiedName: "jsii-calc.DocumentedClass")]
     public class DocumentedClass : DeputyBase


### PR DESCRIPTION
Currently code examples in dotnet lose their indentation styles because we call `trim()` on each line in the code example. We want that behavior for other types of xml docs but not for code. This PR makes code a special case that calls `trimRight()` on each line, preserving the indentation on the left.

The only change in the snapshots is translating this example: 
```ts
docs const x = 12 + 44;
const s1 = "string";
const s2 = "string \nwith new newlines"; // see https://github.com/aws/jsii/issues/2569
const s3 = `string
            with
            new lines`;
```

to this:
```
<code>int x = 12 + 44;
string s1 = "string";
string s2 = @"string
with new newlines"; // see https://github.com/aws/jsii/issues/2569
string s3 = @"string
            with
            new lines";</code>
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
