### PR TITLE
fix(pacmak): Generate Relative Module Imports in Python

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -25,6 +25,7 @@ import {
   PythonImports,
   mergePythonImports,
   toPackageName,
+  toPythonFqn,
 } from './python/type-name';
 import { die, toPythonIdentifier } from './python/util';
 import { toPythonVersionRange, toReleaseVersion } from './version-utils';
@@ -1677,19 +1678,21 @@ class PythonModule implements PythonType {
         // "import jsii_calc.submodule.nested_submodule.deeply_nested"
         // this builds a relative import like
         // "from .submodule.nested_submodule import deeply_nested"
-        const assemblyName = toSnakeCase(
-          module.assembly.name.replace('-', '_'),
-        );
+        // This enables distributing python packages and using the
+        // generated modules in the same codebase.
+        const assemblyName = toPythonFqn(
+          module.assembly.name,
+          module.assembly,
+        ).pythonFqn;
 
-        const namespaces = module.pythonName.split('.');
-        const assemblyNameIndex = namespaces.indexOf(assemblyName) + 1;
-        const submodule = namespaces.slice(assemblyNameIndex);
+        const submodule = module.pythonName
+          .replace(`${assemblyName}.`, '')
+          .split('.');
 
         const submodulePath = submodule
           .slice(0, submodule.length - 1)
           .join('.');
         const submoduleName = submodule[submodule.length - 1];
-
         code.line(`from .${submodulePath} import ${submoduleName}`);
       }
     }

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1673,7 +1673,24 @@ class PythonModule implements PythonType {
       for (const module of this.modules.sort((l, r) =>
         l.pythonName.localeCompare(r.pythonName),
       )) {
-        code.line(`import ${module.pythonName}`);
+        // Rather than generating an absolute import like
+        // "import jsii_calc.submodule.nested_submodule.deeply_nested"
+        // this builds a relative import like
+        // "from .submodule.nested_submodule import deeply_nested"
+        const assemblyName = toSnakeCase(
+          module.assembly.name.replace('-', '_'),
+        );
+
+        const namespaces = module.pythonName.split('.');
+        const assemblyNameIndex = namespaces.indexOf(assemblyName) + 1;
+        const submodule = namespaces.slice(assemblyNameIndex);
+
+        const submodulePath = submodule
+          .slice(0, submodule.length - 1)
+          .join('.');
+        const submoduleName = submodule[submodule.length - 1];
+
+        code.line(`from .${submodulePath} import ${submoduleName}`);
       }
     }
   }

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -373,7 +373,7 @@ class UserType implements TypeName {
   }
 }
 
-function toPythonFqn(fqn: string, rootAssm: Assembly) {
+export function toPythonFqn(fqn: string, rootAssm: Assembly) {
   const { assemblyName, packageName, tail } = getPackageName(fqn, rootAssm);
   const fqnParts: string[] = [packageName];
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -1830,7 +1830,7 @@ __all__ = [
 publication.publish()
 
 # Loading modules to ensure their types are registered with the jsii runtime library
-import scope.jsii_calc_lib.custom_submodule_name
+from .scope.jsii_calc_lib import custom_submodule_name
 
 `;
 
@@ -10195,38 +10195,38 @@ __all__ = [
 publication.publish()
 
 # Loading modules to ensure their types are registered with the jsii runtime library
-import jsii_calc.cdk16625
-import jsii_calc.cdk16625.donotimport
-import jsii_calc.composition
-import jsii_calc.derived_class_has_no_properties
-import jsii_calc.interface_in_namespace_includes_classes
-import jsii_calc.interface_in_namespace_only_interface
-import jsii_calc.module2530
-import jsii_calc.module2617
-import jsii_calc.module2647
-import jsii_calc.module2689
-import jsii_calc.module2689.methods
-import jsii_calc.module2689.props
-import jsii_calc.module2689.retval
-import jsii_calc.module2689.structs
-import jsii_calc.module2692
-import jsii_calc.module2692.submodule1
-import jsii_calc.module2692.submodule2
-import jsii_calc.module2700
-import jsii_calc.module2702
-import jsii_calc.nodirect
-import jsii_calc.nodirect.sub1
-import jsii_calc.nodirect.sub2
-import jsii_calc.onlystatic
-import jsii_calc.python_self
-import jsii_calc.submodule
-import jsii_calc.submodule.back_references
-import jsii_calc.submodule.child
-import jsii_calc.submodule.isolated
-import jsii_calc.submodule.nested_submodule
-import jsii_calc.submodule.nested_submodule.deeply_nested
-import jsii_calc.submodule.param
-import jsii_calc.submodule.returnsparam
+from . import cdk16625
+from .cdk16625 import donotimport
+from . import composition
+from . import derived_class_has_no_properties
+from . import interface_in_namespace_includes_classes
+from . import interface_in_namespace_only_interface
+from . import module2530
+from . import module2617
+from . import module2647
+from . import module2689
+from .module2689 import methods
+from .module2689 import props
+from .module2689 import retval
+from .module2689 import structs
+from . import module2692
+from .module2692 import submodule1
+from .module2692 import submodule2
+from . import module2700
+from . import module2702
+from . import nodirect
+from .nodirect import sub1
+from .nodirect import sub2
+from . import onlystatic
+from . import python_self
+from . import submodule
+from .submodule import back_references
+from .submodule import child
+from .submodule import isolated
+from .submodule import nested_submodule
+from .submodule.nested_submodule import deeply_nested
+from .submodule import param
+from .submodule import returnsparam
 
 `;
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -1830,7 +1830,7 @@ __all__ = [
 publication.publish()
 
 # Loading modules to ensure their types are registered with the jsii runtime library
-from .scope.jsii_calc_lib import custom_submodule_name
+from . import custom_submodule_name
 
 `;
 


### PR DESCRIPTION
The goal of this PR is, to find a way for generated Python code to work with namespaced modules regardless of the way it is consumed. While the current implementation of submodule imports seem to work fine when distributed as packages, it's breaking apart when the generated code is imported relatively as part of a single code base. That's what we do in cdktf and the reason why we have locked jsii to `1.37.0` at the moment.

The general idea is, to generate relative imports rather than fqn imports in Python. This could be a potential way to address https://github.com/aws/jsii/issues/3078

```python
# Before    
import jsii_calc.submodule
import jsii_calc.submodule.nested_submodule
import jsii_calc.submodule.nested_submodule.deeply_nested

# After
from . import submodule
from .submodule import nested_submodule
from .submodule.nested_submodule import deeply_nested
```

Besides from a few snapshots being changed, it seems like the tests are still working with this change. However, I'm not sure  about the general implications. So, this entire PR is really meant to be a conversation starter. 

I have confirmed that an import like `import . from some_aws_namespace` would work for us in cdktf.

## References

- https://github.com/aws/jsii/issues/3078
- https://github.com/aws/jsii/pull/3049
- https://github.com/hashicorp/terraform-cdk/issues/1152
- https://github.com/hashicorp/terraform-cdk/pull/1288

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
