### PR TITLE
fix(jsii): require statement for the warning file is generated for non-exported files

### DIFF
--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -399,9 +399,7 @@ describe('Call injections', () => {
           }
         `,
       },
-      (pi) => {
-        pi.main = '';
-      },
+      undefined /* callback */,
       { addDeprecationWarnings: true },
     );
 

--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -388,6 +388,31 @@ describe('Call injections', () => {
     );
   });
 
+  test('does not generate a require statement for non-exported files', async () => {
+    const result = await compileJsiiForTest(
+      {
+        'index.ts': ``,
+        'some/folder/source.ts': `
+          export class Foo {
+            ${DEPRECATED}
+            public bar(){}
+          }
+        `,
+      },
+      (pi) => {
+        pi.main = '';
+      },
+      { addDeprecationWarnings: true },
+    );
+
+    const expectedPath = ['..', '..', '.warnings.jsii.js'].join('/');
+
+    const content = jsFile(result, 'some/folder/source');
+    expect(content).not.toContain(
+      `const jsiiDeprecationWarnings = require("${expectedPath}")`,
+    );
+  });
+
   test('deprecated methods', async () => {
     const result = await compileJsiiForTest(
       `


### PR DESCRIPTION
This change makes the transformer only run on module exports, which are the ones actually processed by the assembler.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
