### PR TITLE
fix(rosetta): enum resolution breaks for properties

### DIFF
--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -223,8 +223,7 @@ export function resolveEnumLiteral(typeChecker: ts.TypeChecker, type: ts.Type) {
     return type;
   }
 
-  const parentDeclaration = type.symbol.declarations?.[0]?.parent;
-  return fmap(parentDeclaration, typeChecker.getTypeAtLocation) ?? type;
+  return typeChecker.getBaseTypeOfLiteralType(type);
 }
 
 export function resolvedSymbolAtLocation(typeChecker: ts.TypeChecker, node: ts.Node) {


### PR DESCRIPTION
On some examples in the CDK repository, Rosetta breaks in the
`resolveEnumLiteral()` function. The error is `Cannot read property
'kind' of undefined` and occurs somewhere deep in the call stack of
TypeScript.

It occurs when an enum is being passed as a struct property.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
