### PR TITLE
fix(rosetta): `extract` ignores `--compile` option

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -47,6 +47,7 @@ export async function extractSnippets(
   }
 
   const translatorOptions: RosettaTranslatorOptions = {
+    includeCompilerDiagnostics: options.includeCompilerDiagnostics,
     assemblies: assemblies.map((a) => a.assembly),
   };
 

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -96,6 +96,20 @@ describe('with cache file', () => {
       (TARGET_LANGUAGES.java as any).version = oldJavaVersion;
     }
   });
+
+  test('compiler diagnostics property is passed on', async () => {
+    const translationFunction = jest.fn().mockResolvedValue({ diagnostics: [], translatedSnippets: [] });
+
+    await extract.extractSnippets([assembly.moduleDirectory], {
+      outputFile: path.join(assembly.moduleDirectory, 'dummy.tabl.json'),
+      validateAssemblies: false,
+      includeCompilerDiagnostics: true,
+      translatorFactory: (o) => {
+        expect(o.includeCompilerDiagnostics).toEqual(true);
+        return new MockTranslator(o, translationFunction);
+      },
+    });
+  });
 });
 
 test('do not ignore example strings', async () => {


### PR DESCRIPTION
In a recent refactor we failed to pass on the setting of the `--compile`
flag, leading to non-exhaustive compilation checks and also resulting
in a disclaimer being added to all translated snippets.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
