### PR TITLE
feat(reflect): add `allTypes` accessor

### DIFF
--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -169,6 +169,20 @@ export class Assembly extends ModuleLike {
     return Object.values(submodules);
   }
 
+  /**
+   * All types, even those in submodules and nested submodules.
+   */
+  public get types(): readonly Type[] {
+    return Object.values(this.typeMap);
+  }
+
+  /**
+   * Return all types in the current assembly/submodule and all submodules underneath
+   */
+  public get allTypes(): readonly Type[] {
+    return [...this.types, ...this.allSubmodules.flatMap((s) => s.types)];
+  }
+
   public findType(fqn: string) {
     const type = this.tryFindType(fqn);
     if (!type) {

--- a/packages/jsii-reflect/test/independent.test.ts
+++ b/packages/jsii-reflect/test/independent.test.ts
@@ -1,10 +1,9 @@
-import { PackageInfo, sourceToAssemblyHelper } from 'jsii';
-
 import * as reflect from '../lib';
+import { assemblyFromSource } from './util';
 
 test('get full github source location for a class or method', async () => {
   // WHEN
-  const assembly = await loadSource(
+  const assembly = await assemblyFromSource(
     `
     export class Foo {
       public bar() {
@@ -27,12 +26,3 @@ test('get full github source location for a class or method', async () => {
     'https://github.com/aws/jsii/blob/master/some/sub/dir/index.ts#L1',
   );
 });
-
-async function loadSource(
-  source: string,
-  cb: (obj: PackageInfo) => void,
-): Promise<reflect.Assembly> {
-  const ass = await sourceToAssemblyHelper(source, cb);
-  const ts = new reflect.TypeSystem();
-  return ts.addAssembly(new reflect.Assembly(ts, ass));
-}

--- a/packages/jsii-reflect/test/type-system.test.ts
+++ b/packages/jsii-reflect/test/type-system.test.ts
@@ -3,7 +3,7 @@ import { Stability } from '@jsii/spec';
 import * as path from 'path';
 
 import { TypeSystem } from '../lib';
-import { typeSystemFromSource } from './util';
+import { typeSystemFromSource, assemblyFromSource } from './util';
 
 let typesys: TypeSystem;
 
@@ -409,6 +409,15 @@ test('TypeSystem.methods', async () => {
   }
   `);
   expect(ts.methods).toHaveLength(2);
+});
+
+test('Assembly allTypes includes submodule types', async () => {
+  const asm = await assemblyFromSource({
+    'index.ts': 'export * as submod from "./submod";',
+    'submod.ts': `export class Foo {}`,
+  });
+
+  expect(asm.allTypes.map((t) => t.fqn)).toEqual(['testpkg.submod.Foo']);
 });
 
 function resolveModuleDir(name: string) {

--- a/packages/jsii-reflect/test/util.ts
+++ b/packages/jsii-reflect/test/util.ts
@@ -1,10 +1,20 @@
-import { sourceToAssemblyHelper } from 'jsii/lib/helpers';
+import { sourceToAssemblyHelper, MultipleSourceFiles, PackageInfo } from 'jsii';
 
 import { Assembly, TypeSystem } from '../lib';
 
-export async function typeSystemFromSource(source: string) {
-  const assembly = await sourceToAssemblyHelper(source);
+export async function typeSystemFromSource(
+  source: string | MultipleSourceFiles,
+  cb?: (obj: PackageInfo) => void,
+) {
+  const asm = await assemblyFromSource(source, cb);
+  return asm.system;
+}
+
+export async function assemblyFromSource(
+  source: string | MultipleSourceFiles,
+  cb?: (obj: PackageInfo) => void,
+): Promise<Assembly> {
+  const ass = await sourceToAssemblyHelper(source, cb);
   const ts = new TypeSystem();
-  ts.addAssembly(new Assembly(ts, assembly));
-  return ts;
+  return ts.addAssembly(new Assembly(ts, ass));
 }

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -17,6 +17,14 @@ import { loadProjectInfo, ProjectInfo } from './project-info';
 import { formatDiagnostic } from './utils';
 
 /**
+ * A set of source files for `sourceToAssemblyHelper`, at least containing 'index.ts'
+ */
+export type MultipleSourceFiles = {
+  'index.ts': string;
+  [name: string]: string;
+};
+
+/**
  * Compile a piece of source and return the JSII assembly for it
  *
  * Only usable for trivial cases and tests.
@@ -25,7 +33,7 @@ import { formatDiagnostic } from './utils';
  *               a map of fileName to content, which *must* include `index.ts`.
  */
 export async function sourceToAssemblyHelper(
-  source: string | { 'index.ts': string; [name: string]: string },
+  source: string | MultipleSourceFiles,
   cb?: (obj: PackageInfo) => void,
 ): Promise<spec.Assembly> {
   return (await compileJsiiForTest(source, cb)).assembly;


### PR DESCRIPTION
In the presence of submodules, `assembly.types` only returns types in
the assembly root. Add a new accessor, `allTypes`, which will return
all types in the assembly regardless of module.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
