### PR TITLE
chore: upgrade Maven to 3.8.4

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y curl gpg tar zsh
 SHELL ["/bin/zsh", "-c"]
 
 # Prepare maven binary distribution
-ARG M2_VERSION="3.8.3"
+ARG M2_VERSION="3.8.4"
 ENV M2_DISTRO="https://www.apache.org/dist/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -sL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                               \


### PR DESCRIPTION
This is necessary to unbreak the Docker image builds; the old Maven
distribution has a GPG signature that no longer validates. It breaks
with the error:

```
2.502 gpg: Signature made Mon Sep 27 18:32:53 2021 UTC
2.502 gpg:                using RSA key 1A2A1C94BDE89688
2.503 gpg: BAD signature from "Michael Osipov (Java developer) <1983-01-06@gmx.net>" [unknown]
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
