### PR TITLE
fix(jsii): constants can't mix letters and digits

### DIFF
--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -87,7 +87,7 @@ function _defaultValidations(): ValidationFunction[] {
       }
 
       for (const member of type.members) {
-        if (member.name && member.name !== Case.constant(member.name)) {
+        if (member.name && !isConstantCase(member.name)) {
           diagnostic(
             JsiiDiagnostic.JSII_8001_ALL_CAPS_ENUM_MEMBERS.createDetached(
               member.name,
@@ -130,7 +130,7 @@ function _defaultValidations(): ValidationFunction[] {
       }
       if (
         member.name &&
-        member.name !== Case.constant(member.name) &&
+        !isConstantCase(member.name) &&
         member.name !== Case.pascal(member.name) &&
         member.name !== Case.camel(member.name)
       ) {
@@ -712,4 +712,16 @@ function _dereference(
 
 function _isEmpty(array: undefined | any[]): array is undefined {
   return array == null || array.length === 0;
+}
+
+/**
+ * Return whether an identifier only consists of upperchase characters, digits and underscores
+ *
+ * We have our own check here (isConstantCase) which is more lenient than what
+ * `case.constant()` prescribes. We also want to allow combinations of letters
+ * and digits without underscores: `C5A`, which `case` would force to `C5_A`.
+ * The hint we print will still use `case.constant()` but that is fine.
+ */
+function isConstantCase(x: string) {
+  return !/[^A-Z0-9_]/.exec(x);
 }

--- a/packages/jsii/test/enums.test.ts
+++ b/packages/jsii/test/enums.test.ts
@@ -1,3 +1,5 @@
+import { EnumType } from '@jsii/spec';
+
 import { sourceToAssemblyHelper } from '../lib';
 
 // ----------------------------------------------------------------------
@@ -38,4 +40,20 @@ test('test parsing enum with two members and assigned values', async () => {
     name: 'Foo',
     symbolId: 'index:Foo',
   });
+});
+
+// ----------------------------------------------------------------------
+
+test('enums can have a mix of letters and number', async () => {
+  const assembly = await sourceToAssemblyHelper(`
+    export enum Foo {
+      Q5X,
+      IB3M,
+    }
+  `);
+
+  expect((assembly.types!['testpkg.Foo'] as EnumType).members).toEqual([
+    { name: 'Q5X' },
+    { name: 'IB3M' },
+  ]);
 });


### PR DESCRIPTION
An enum identifier like `C5A` is not possible: the `case` library we use
to assert casing will insist you change it to `C5_A`.

Bypass this rule for constant-like values: do a more lenient validation
of our own.

Fixes #3208.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
