### PR TITLE
fix(rosetta): use `--compile` flag by default

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -139,8 +139,8 @@ function main() {
           .option('compile', {
             alias: 'c',
             type: 'boolean',
-            describe: 'Try compiling',
-            default: false,
+            describe: 'Try compiling (on by default, use --no-compile to switch off)',
+            default: true,
           })
           .option('directory', {
             alias: 'd',


### PR DESCRIPTION
The way we are trending, there is no good reason anymore to NOT compile
your examples. We have good support for parallelism and caching now,
so the argument that it takes too much time to do the additional
analysis no longer really holds.

Also, why should people have to remember to pass this flag for default
that should arguably be the default?

Make it the default.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
