### PR TITLE
fix(pacmak): don't automatically translate examples without asking

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -139,7 +139,9 @@ import { VERSION_DESC } from '../lib/version';
     argv['rosetta-translate-live'] !== undefined &&
     argv['rosetta-unknown-snippets'] !== undefined
   ) {
-    throw new Error('Prefer using --rosetta-unknown-snippets over --rosetta-translate-live');
+    throw new Error(
+      'Prefer using --rosetta-unknown-snippets over --rosetta-translate-live',
+    );
   }
 
   const rosettaUnknownSnippets =

--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -95,7 +95,7 @@ import { VERSION_DESC } from '../lib/version';
     .option('rosetta-translate-live', {
       type: 'boolean',
       desc: "Translate code samples on-the-fly if they can't be found in the samples tablet (deprecated)",
-      default: true,
+      default: undefined,
     })
     .option('rosetta-unknown-snippets', {
       type: 'string',
@@ -135,6 +135,19 @@ import { VERSION_DESC } from '../lib/version';
   // Default to 4 threads in case of concurrency, good enough for most situations
   debug('command line arguments:', argv);
 
+  if (
+    argv['rosetta-translate-live'] !== undefined &&
+    argv['rosetta-unknown-snippets'] !== undefined
+  ) {
+    throw new Error('Prefer using --rosetta-unknown-snippets over --rosetta-translate-live');
+  }
+
+  const rosettaUnknownSnippets =
+    (argv['rosetta-unknown-snippets'] as UnknownSnippetMode | undefined) ??
+    (argv['rosetta-translate-live']
+      ? UnknownSnippetMode.TRANSLATE
+      : UnknownSnippetMode.VERBATIM);
+
   return pacmak({
     argv,
     clean: argv.clean,
@@ -147,10 +160,7 @@ import { VERSION_DESC } from '../lib/version';
     outputDirectory: argv.outdir,
     parallel: argv.parallel,
     recurse: argv.recurse,
-    rosettaLiveConversion: argv['rosetta-translate-live'],
-    rosettaUnknownSnippets: argv['rosetta-unknown-snippets'] as
-      | UnknownSnippetMode
-      | undefined,
+    rosettaUnknownSnippets,
     rosettaTablet: argv['rosetta-tablet'],
     targets: argv.targets?.map((target) => target as TargetName),
     updateNpmIgnoreFiles: argv.npmignore,

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -29,7 +29,6 @@ export async function pacmak({
   outputDirectory,
   parallel = true,
   recurse = false,
-  rosettaLiveConversion,
   rosettaTablet,
   targets = Object.values(TargetName),
   timers = new Timers(),
@@ -37,13 +36,7 @@ export async function pacmak({
   updateNpmIgnoreFiles = false,
   validateAssemblies = false,
 }: PacmakOptions): Promise<void> {
-  const unknownSnippets =
-    rosettaUnknownSnippets ??
-    (rosettaLiveConversion
-      ? UnknownSnippetMode.TRANSLATE
-      : UnknownSnippetMode.VERBATIM);
-
-  const rosetta = new Rosetta({ unknownSnippets });
+  const rosetta = new Rosetta({ unknownSnippets: rosettaUnknownSnippets });
   if (rosettaTablet) {
     await rosetta.loadTabletFromFile(rosettaTablet);
   }
@@ -237,18 +230,9 @@ export interface PacmakOptions {
   readonly recurse?: boolean;
 
   /**
-   * Whether `jsii-rosetta` conversion should be performed in-band for examples found in documentation which are not
-   * already translated in the `rosettaTablet` file.
-   *
-   * @default false
-   * @deprecated Use `rosettaUnknownSnippets` instead.
-   */
-  readonly rosettaLiveConversion?: boolean;
-
-  /**
    * How rosetta should treat snippets that cannot be loaded from a translation tablet.
    *
-   * @default - falls back to the default of `rosettaLiveConversion`.
+   * @default UnknownSnippetMode.VERBATIM
    */
   readonly rosettaUnknownSnippets?: UnknownSnippetMode;
 


### PR DESCRIPTION
Given the current state of example tooling, the existing default
was a bad choice.

It forces everyone who is publishing jsii packages everywhere to
spend CPU cycles to do example parsing and translation which is
bound to fail anyway (as the fixtures and compilation directory
will probably not be set up for success, and translation
must proceed in a single-threaded fashion).

The new default is to use translations if they exist, and otherwise
don't do translations.

* Builds that care (i.e., mostly the CDK build), will be using `rosetta
  extract` already to be efficient and correct about compilation, and
  the tablet files will be picked up as usual.
* Builds that don't care will get more efficient.

BREAKING CHANGES: Pacmak no longer tries to translate examples
by default: this feature is now opt-in.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
