### PR TITLE
feat(rosetta): generate rosetta tablets next to each assembly

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -1,10 +1,13 @@
-import { loadAssemblies, allTypeScriptSnippets } from '../jsii/assemblies';
+import * as path from 'path';
+
+import { loadAssemblies, allTypeScriptSnippets, loadAllDefaultTablets } from '../jsii/assemblies';
 import * as logging from '../logging';
 import { RosettaTranslator, RosettaTranslatorOptions } from '../rosetta-translator';
-import { TypeScriptSnippet } from '../snippet';
+import { TypeScriptSnippet, SnippetParameters } from '../snippet';
 import { snippetKey } from '../tablets/key';
-import { LanguageTablet } from '../tablets/tablets';
+import { LanguageTablet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
 import { RosettaDiagnostic } from '../translate';
+import { groupBy, isDefined } from '../util';
 import { infuse } from './infuse';
 
 export interface ExtractResult {
@@ -13,15 +16,26 @@ export interface ExtractResult {
 }
 
 export interface ExtractOptions {
-  readonly outputFile: string;
-  readonly includeCompilerDiagnostics: boolean;
-  readonly validateAssemblies: boolean;
+  readonly includeCompilerDiagnostics?: boolean;
+  readonly validateAssemblies?: boolean;
   readonly only?: string[];
 
   /**
    * A tablet file to be loaded and used as a source for caching
    */
-  readonly cacheTabletFile?: string;
+  readonly cacheFromFile?: string;
+
+  /**
+   * A tablet file to append translated snippets to
+   */
+  readonly cacheToFile?: string;
+
+  /**
+   * Trim cache to only contain translations found in the current assemblies
+   *
+   * @default false
+   */
+  readonly trimCache?: boolean;
 
   /**
    * Make a translator (just for testing)
@@ -35,8 +49,9 @@ export async function extractAndInfuse(
   loose = false,
 ): Promise<ExtractResult> {
   const result = await extractSnippets(assemblyLocations, options, loose);
-  await infuse(assemblyLocations, options.outputFile, {
-    tabletOutputFile: options.outputFile,
+  await infuse(assemblyLocations, {
+    cacheFromFile: options.cacheFromFile,
+    cacheToFile: options.cacheToFile,
   });
   return result;
 }
@@ -46,21 +61,28 @@ export async function extractAndInfuse(
  */
 export async function extractSnippets(
   assemblyLocations: string[],
-  options: ExtractOptions,
+  options: ExtractOptions = {},
   loose = false,
 ): Promise<ExtractResult> {
   const only = options.only ?? [];
 
   logging.info(`Loading ${assemblyLocations.length} assemblies`);
-  const assemblies = await loadAssemblies(assemblyLocations, options.validateAssemblies);
+  const assemblies = await loadAssemblies(assemblyLocations, options.validateAssemblies ?? false);
 
   let snippets = Array.from(allTypeScriptSnippets(assemblies, loose));
   if (only.length > 0) {
     snippets = filterSnippets(snippets, only);
   }
 
+  // Map every assembly to a list of snippets, so that we know what implicit
+  // tablet to write the translations to later on.
+  const snippetsPerAssembly = groupBy(
+    snippets.map((s) => ({ key: snippetKey(s), location: projectDirectory(s) })),
+    (x) => x.location,
+  );
+
   const translatorOptions: RosettaTranslatorOptions = {
-    includeCompilerDiagnostics: options.includeCompilerDiagnostics,
+    includeCompilerDiagnostics: options.includeCompilerDiagnostics ?? false,
     assemblies: assemblies.map((a) => a.assembly),
   };
 
@@ -68,10 +90,14 @@ export async function extractSnippets(
     ? options.translatorFactory(translatorOptions)
     : new RosettaTranslator(translatorOptions);
 
-  if (options.cacheTabletFile) {
-    await translator.addToCache(options.cacheTabletFile);
+  // Prime the snippet cache with:
+  // - Cache source file
+  // - Default tablets found next to each assembly
+  if (options.cacheFromFile) {
+    await translator.addToCache(options.cacheFromFile);
   }
-  await translator.addToCache(options.outputFile);
+  translator.addTabletsToCache(...Object.values(await loadAllDefaultTablets(assemblies)));
+
   if (translator.hasCache()) {
     const { translations, remaining } = translator.readFromCache(snippets);
     logging.info(`Reused ${translations.length} translations from cache`);
@@ -96,8 +122,27 @@ export async function extractSnippets(
     logging.info('Nothing left to translate');
   }
 
-  logging.info(`Saving language tablet to ${options.outputFile}`);
-  await translator.tablet.save(options.outputFile);
+  // Save to individual tablet files, and optionally append to the output file
+  await Promise.all(
+    Object.entries(snippetsPerAssembly).map(async ([location, snips]) => {
+      const asmTabletFile = path.join(location, DEFAULT_TABLET_NAME);
+      logging.debug(`Writing ${snips.length} translations to ${asmTabletFile}`);
+      const translations = snips.map(({ key }) => translator.tablet.tryGetSnippet(key)).filter(isDefined);
+
+      const asmTablet = new LanguageTablet();
+      asmTablet.addSnippet(...translations);
+      await asmTablet.save(asmTabletFile);
+    }),
+  );
+
+  if (options.cacheToFile) {
+    logging.info(`Adding translations to ${options.cacheToFile}`);
+    const output = options.trimCache
+      ? new LanguageTablet()
+      : await LanguageTablet.fromOptionalFile(options.cacheToFile);
+    output.addTablet(translator.tablet);
+    await output.save(options.cacheToFile);
+  }
 
   return { diagnostics, tablet: translator.tablet };
 }
@@ -107,4 +152,12 @@ export async function extractSnippets(
  */
 function filterSnippets(ts: TypeScriptSnippet[], includeIds: string[]) {
   return ts.filter((t) => includeIds.includes(snippetKey(t)));
+}
+
+function projectDirectory(ts: TypeScriptSnippet) {
+  const dir = ts.parameters?.[SnippetParameters.$PROJECT_DIRECTORY];
+  if (!dir) {
+    throw new Error(`Snippet does not have associated project directory: ${JSON.stringify(ts.location)}`);
+  }
+  return dir;
 }

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -130,7 +130,7 @@ export async function extractSnippets(
       const translations = snips.map(({ key }) => translator.tablet.tryGetSnippet(key)).filter(isDefined);
 
       const asmTablet = new LanguageTablet();
-      asmTablet.addSnippet(...translations);
+      asmTablet.addSnippets(...translations);
       await asmTablet.save(asmTabletFile);
     }),
   );

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -1,9 +1,19 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 
-import { loadAssemblies, replaceAssembly } from '../jsii/assemblies';
+import {
+  loadAssemblies,
+  replaceAssembly,
+  loadAllDefaultTablets,
+  LoadedAssembly,
+  allTypeScriptSnippets,
+} from '../jsii/assemblies';
+import { renderMetadataline, TypeScriptSnippet } from '../snippet';
 import { SnippetSelector, mean, meanLength, shortest, longest } from '../snippet-selectors';
-import { LanguageTablet, TranslatedSnippet } from '../tablets/tablets';
+import { snippetKey } from '../tablets/key';
+import { LanguageTablet, TranslatedSnippet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
+import { isDefined, mkDict, fmap, indexBy } from '../util';
 
 export interface InfuseResult {
   readonly coverageResults: Record<string, InfuseTypes>;
@@ -15,14 +25,17 @@ export interface InfuseTypes {
 }
 
 export interface InfuseOptions {
-  readonly outputFile?: string;
-
-  readonly log?: boolean;
+  readonly logFile?: string;
 
   /**
-   * Where to write the updated tablet back
+   * Where to read additional translations
    */
-  readonly tabletOutputFile?: string;
+  readonly cacheFromFile?: string;
+
+  /**
+   * In addition to the implicit tablets, also write all added examples to this additional output tablet
+   */
+  readonly cacheToFile?: string;
 }
 
 export const DEFAULT_INFUSION_RESULTS_NAME = 'infusion-results.html';
@@ -40,73 +53,102 @@ class DefaultRecord<A> {
   }
 }
 
-export async function infuse(
-  assemblyLocations: string[],
-  tabletFile: string,
-  options?: InfuseOptions,
-): Promise<InfuseResult> {
+/**
+ * Infuse will analyze the snippets in a set of tablets, and update the assembly to add
+ * examples to types that don't have any yet, based on snippets that use the given type.
+ */
+export async function infuse(assemblyLocations: string[], options?: InfuseOptions): Promise<InfuseResult> {
   let stream: fs.WriteStream | undefined = undefined;
-  if (options?.log) {
-    if (!options.outputFile) {
-      throw new Error("If 'log' is set, 'outputFile' must be set as well.");
-    }
-
+  if (options?.logFile) {
     // Create stream for html file and insert some styling
-    stream = fs.createWriteStream(options.outputFile, {
-      encoding: 'utf-8',
-    });
+    stream = fs.createWriteStream(options.logFile, { encoding: 'utf-8' });
     startFile(stream);
   }
 
   // Load tablet file and assemblies
-  const tab = new LanguageTablet();
-  await tab.load(tabletFile);
-  const assemblies = await loadAssemblies(assemblyLocations, true);
+  const assemblies = await loadAssemblies(assemblyLocations, false);
+  const defaultTablets = await loadAllDefaultTablets(assemblies);
 
-  const snippetsFromFqn = mapFqns(tab);
-  const coverageResults: Record<string, InfuseTypes> = {};
-  for (const { assembly, directory } of assemblies) {
-    stream?.write(`<h1>@aws-cdk/${directory.split('/').pop()}</h1>\n`);
-
-    let typesWithInsertedExamples = 0;
-    const filteredTypes = filterForTypesWithoutExamples(assembly.types ?? {});
-    for (const [typeFqn, type] of Object.entries(filteredTypes)) {
-      if (snippetsFromFqn[typeFqn] !== undefined) {
-        const meanResult = mean(snippetsFromFqn[typeFqn]);
-        if (options?.log) {
-          const selected = Object.entries(ADDITIONAL_SELECTORS).map(
-            ([name, fn]) => [name, fn(snippetsFromFqn[typeFqn])] as const,
-          );
-          const selectedFromSelector = {
-            ...makeDict(selected),
-            mean: meanResult,
-          };
-          logOutput(stream, typeFqn, createHtmlEntry(selectedFromSelector));
-        }
-        insertExample(meanResult, type, tab);
-        typesWithInsertedExamples++;
-      }
-    }
-
-    // eslint-disable-next-line no-await-in-loop
-    await replaceAssembly(assembly, directory);
-    coverageResults[directory] = {
-      types: Object.keys(filteredTypes).length,
-      typesWithInsertedExamples,
-    };
+  const availableTranslations = new LanguageTablet();
+  if (options?.cacheFromFile) {
+    availableTranslations.addTablet(await LanguageTablet.fromOptionalFile(options.cacheFromFile));
   }
+  availableTranslations.addTablet(...Object.values(defaultTablets));
+
+  const { translationsByFqn, originalsByKey } = availableSnippetsPerFqn(assemblies, availableTranslations);
+
+  const additionalOutputTablet = options?.cacheToFile
+    ? await LanguageTablet.fromOptionalFile(options?.cacheToFile)
+    : new LanguageTablet();
+
+  const coverageResults = mkDict(
+    await Promise.all(
+      assemblies.map(async ({ assembly, directory }) => {
+        stream?.write(`<h1>${assembly.name}</h1>\n`);
+
+        const implicitTablet = defaultTablets[directory];
+        if (!implicitTablet) {
+          throw new Error(`No tablet found for ${directory}`);
+        }
+
+        let insertedExamples = 0;
+        const filteredTypes = filterForTypesWithoutExamples(assembly.types ?? {});
+        for (const [typeFqn, type] of Object.entries(filteredTypes)) {
+          const available = translationsByFqn[typeFqn];
+          if (!available) {
+            continue;
+          }
+
+          const example = pickBestExample(typeFqn, available, stream);
+          const original = originalsByKey[example.key];
+          insertExample(example, original, type, [implicitTablet, additionalOutputTablet]);
+          insertedExamples++;
+        }
+
+        if (insertedExamples > 0) {
+          // Save the updated assembly and implicit tablets
+          // eslint-disable-next-line no-await-in-loop
+          await Promise.all([
+            replaceAssembly(assembly, directory),
+            implicitTablet.save(path.join(directory, DEFAULT_TABLET_NAME)),
+          ]);
+        }
+
+        return [
+          directory,
+          {
+            types: Object.keys(filteredTypes).length,
+            typesWithInsertedExamples: insertedExamples,
+          } as InfuseTypes,
+        ] as const;
+      }),
+    ),
+  );
 
   stream?.close();
 
   // If we copied examples onto different types, we'll also have inserted new snippets
   // with different keys into the tablet. We must now write the updated tablet somewhere.
-  if (options?.tabletOutputFile) {
-    await tab.save(options.tabletOutputFile);
+  if (options?.cacheToFile) {
+    await additionalOutputTablet.save(options.cacheToFile);
   }
 
   return {
     coverageResults: coverageResults,
   };
+}
+
+function pickBestExample(typeFqn: string, choices: TranslatedSnippet[], logStream?: fs.WriteStream) {
+  const meanResult = mean(choices);
+  if (logStream) {
+    const selected = Object.entries(ADDITIONAL_SELECTORS).map(([name, fn]) => [name, fn(choices)] as const);
+    const selectedFromSelector = {
+      ...makeDict(selected),
+      mean: meanResult,
+    };
+    logOutput(logStream, typeFqn, createHtmlEntry(selectedFromSelector));
+  }
+  return meanResult;
 }
 
 function startFile(stream: fs.WriteStream) {
@@ -159,34 +201,62 @@ function filterForTypesWithoutExamples(types: { [fqn: string]: spec.Type }): Rec
 /**
  * Insert an example into the docs of a type, and insert it back into the tablet under a new key
  */
-function insertExample(example: TranslatedSnippet, type: spec.Type, tablet: LanguageTablet): void {
+function insertExample(
+  example: TranslatedSnippet,
+  original: TypeScriptSnippet | undefined,
+  type: spec.Type,
+  tablets: LanguageTablet[],
+): void {
+  const exampleMetadata = fmap(original?.parameters, renderMetadataline);
+
   if (type.docs) {
     type.docs.example = example.originalSource.source;
+    if (exampleMetadata) {
+      type.docs.custom = { ...type.docs.custom, exampleMetadata };
+    }
   } else {
-    type.docs = { example: example.originalSource.source };
+    type.docs = {
+      example: example.originalSource.source,
+      custom: fmap(exampleMetadata, (exampleMetadata) => ({ exampleMetadata })),
+    };
   }
 
-  tablet.addSnippet(
-    example.withLocation({
-      api: { api: 'type', fqn: type.fqn },
-      field: { field: 'example' },
-    }),
-  );
+  for (const tablet of tablets) {
+    tablet.addSnippet(
+      example.withLocation({
+        api: { api: 'type', fqn: type.fqn },
+        field: { field: 'example' },
+      }),
+    );
+  }
 }
 
 /**
+ * Return a map of FQN -> snippet keys that exercise that FQN.
+ *
+ * For a snippet to qualify, it must both:
+ *
+ * a) be current (i.e.: exist in the input assemblies)
+ * b) have been analyzed (i.e.: exist in one of the translated tablets)
+ *
  * Returns a map of fqns to a list of keys that represent snippets that include the fqn.
  */
-function mapFqns(tab: LanguageTablet): Record<string, TranslatedSnippet[]> {
-  const fqnsReferencedMap = new DefaultRecord<TranslatedSnippet>();
+function availableSnippetsPerFqn(asms: readonly LoadedAssembly[], translationsTablet: LanguageTablet) {
+  const ret = new DefaultRecord<TranslatedSnippet>();
 
-  for (const key of tab.snippetKeys) {
-    const snippet = tab.tryGetSnippet(key)!;
-    for (const fqn of snippet.snippet.fqnsReferenced ?? []) {
-      fqnsReferencedMap.add(fqn, snippet);
+  const originalsByKey = indexBy(allTypeScriptSnippets(asms), snippetKey);
+
+  const translations = Object.keys(originalsByKey)
+    .map((key) => translationsTablet.tryGetSnippet(key))
+    .filter(isDefined);
+
+  for (const trans of translations) {
+    for (const fqn of trans.snippet.fqnsReferenced ?? []) {
+      ret.add(fqn, trans);
     }
   }
-  return fqnsReferencedMap.index;
+
+  return { originalsByKey, translationsByFqn: ret.index };
 }
 
 function makeDict<A>(xs: Array<readonly [string, A]>): Record<string, A> {

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -73,7 +73,7 @@ export async function infuse(assemblyLocations: string[], options?: InfuseOption
   if (options?.cacheFromFile) {
     availableTranslations.addTablet(await LanguageTablet.fromOptionalFile(options.cacheFromFile));
   }
-  availableTranslations.addTablet(...Object.values(defaultTablets));
+  availableTranslations.addTablets(...Object.values(defaultTablets));
 
   const { translationsByFqn, originalsByKey } = availableSnippetsPerFqn(assemblies, availableTranslations);
 

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -3,11 +3,13 @@ import { readJson, writeJson } from 'fs-extra';
 import { resolve } from 'path';
 
 import { fixturize } from '../fixtures';
+import { EXAMPLE_METADATA_JSDOCTAG } from '../jsii/assemblies';
 import { TargetLanguage } from '../languages';
 import { debug } from '../logging';
 import { RosettaTabletReader, UnknownSnippetMode } from '../rosetta-reader';
 import { SnippetParameters, typeScriptSnippetFromVisibleSource, ApiLocation, parseMetadataLine } from '../snippet';
 import { Translation } from '../tablets/tablets';
+import { fmap } from '../util';
 
 export interface TransliterateAssemblyOptions {
   /**
@@ -215,7 +217,7 @@ function transliterateType(
 
     if (docs?.example) {
       const location = { api, field: { field: 'example' } } as const;
-      const metadata = docs.custom?.exampleMetadata ? parseMetadataLine(docs.custom?.exampleMetadata) : {};
+      const metadata = fmap(docs.custom?.[EXAMPLE_METADATA_JSDOCTAG], parseMetadataLine) ?? {};
       const snippet = fixturize(
         typeScriptSnippetFromVisibleSource(docs.example, location, true /* strict */, {
           [SnippetParameters.$PROJECT_DIRECTORY]: workingDirectory,

--- a/packages/jsii-rosetta/lib/commands/trim-cache.ts
+++ b/packages/jsii-rosetta/lib/commands/trim-cache.ts
@@ -1,0 +1,32 @@
+import { loadAssemblies, allTypeScriptSnippets } from '../jsii/assemblies';
+import * as logging from '../logging';
+import { snippetKey } from '../tablets/key';
+import { LanguageTablet } from '../tablets/tablets';
+import { isDefined } from '../util';
+
+export interface TrimCacheOptions {
+  /**
+   * Locations of assemblies to search for snippets
+   */
+  readonly assemblyLocations: string[];
+
+  /**
+   * Cache to trim
+   */
+  readonly cacheFile: string;
+}
+
+export async function trimCache(options: TrimCacheOptions): Promise<void> {
+  logging.info(`Loading ${options.assemblyLocations.length} assemblies`);
+  const assemblies = await loadAssemblies(options.assemblyLocations, false);
+
+  const snippets = Array.from(allTypeScriptSnippets(assemblies));
+
+  const original = await LanguageTablet.fromFile(options.cacheFile);
+  const updated = new LanguageTablet();
+  updated.addSnippet(...snippets.map((snip) => original.tryGetSnippet(snippetKey(snip))).filter(isDefined));
+  await updated.save(options.cacheFile);
+
+  // eslint-disable-next-line prettier/prettier
+  logging.info(`${options.cacheFile}: ${updated.count} snippets remaining (${original.count} - ${updated.count} trimmed)`);
+}

--- a/packages/jsii-rosetta/lib/commands/trim-cache.ts
+++ b/packages/jsii-rosetta/lib/commands/trim-cache.ts
@@ -24,7 +24,7 @@ export async function trimCache(options: TrimCacheOptions): Promise<void> {
 
   const original = await LanguageTablet.fromFile(options.cacheFile);
   const updated = new LanguageTablet();
-  updated.addSnippet(...snippets.map((snip) => original.tryGetSnippet(snippetKey(snip))).filter(isDefined));
+  updated.addSnippets(...snippets.map((snip) => original.tryGetSnippet(snippetKey(snip))).filter(isDefined));
   await updated.save(options.cacheFile);
 
   // eslint-disable-next-line prettier/prettier

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -14,37 +14,31 @@ import {
   parseMetadataLine,
 } from '../snippet';
 import { enforcesStrictMode } from '../strict';
+import { LanguageTablet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
 import { fmap, mkDict, sortBy } from '../util';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const sortJson = require('sort-json');
 
+/**
+ * The JSDoc tag users can use to associate non-visible metadata with an example
+ *
+ * In a Markdown section, metadata goes after the code block fence, where it will
+ * be attached to the example but invisible.
+ *
+ *    ```ts metadata=goes here
+ *
+ * But in doc comments, '@example' already delineates the example, and any metadata
+ * in there added by the '///' tags becomes part of the visible code (there is no
+ * place to put hidden information).
+ *
+ * We introduce the '@exampleMetadata' tag to put that additional information.
+ */
+export const EXAMPLE_METADATA_JSDOCTAG = 'exampleMetadata';
+
 export interface LoadedAssembly {
-  assembly: spec.Assembly;
-  directory: string;
-}
-
-export function loadAssembliesSync(
-  assemblyLocations: readonly string[],
-  validateAssemblies: boolean,
-): readonly LoadedAssembly[] {
-  return assemblyLocations.map(loadAssemblySync);
-
-  function loadAssemblySync(location: string): LoadedAssembly {
-    const stat = fs.statSync(location);
-    if (stat.isDirectory()) {
-      return loadAssemblySync(path.join(location, '.jsii'));
-    }
-    return {
-      assembly: loadAssemblyFromFileSync(location, validateAssemblies),
-      directory: path.dirname(location),
-    };
-  }
-}
-
-function loadAssemblyFromFileSync(filename: string, validate: boolean): spec.Assembly {
-  const contents = fs.readJSONSync(filename, { encoding: 'utf-8' });
-  return validate ? spec.validateAssembly(contents) : (contents as spec.Assembly);
+  readonly assembly: spec.Assembly;
+  readonly directory: string;
 }
 
 /**
@@ -61,6 +55,7 @@ export async function loadAssemblies(
     if (stat.isDirectory()) {
       return loadAssembly(path.join(location, '.jsii'));
     }
+
     return {
       assembly: await loadAssemblyFromFile(location, validateAssemblies),
       directory: path.dirname(location),
@@ -73,9 +68,25 @@ async function loadAssemblyFromFile(filename: string, validate: boolean): Promis
   return validate ? spec.validateAssembly(contents) : (contents as spec.Assembly);
 }
 
+/**
+ * Load the default tablets for every assembly, if available
+ *
+ * Returns a map of { directory -> tablet }.
+ */
+export async function loadAllDefaultTablets(asms: readonly LoadedAssembly[]): Promise<Record<string, LanguageTablet>> {
+  return mkDict(
+    await Promise.all(
+      asms.map(
+        async (a) =>
+          [a.directory, await LanguageTablet.fromOptionalFile(path.join(a.directory, DEFAULT_TABLET_NAME))] as const,
+      ),
+    ),
+  );
+}
+
 export type AssemblySnippetSource =
   | { type: 'markdown'; markdown: string; location: ApiLocation }
-  | { type: 'example'; source: string; metadata: { [key: string]: string } | undefined; location: ApiLocation };
+  | { type: 'example'; source: string; metadata?: { [key: string]: string }; location: ApiLocation };
 
 /**
  * Return all markdown and example snippets from the given assembly
@@ -133,7 +144,7 @@ export function allSnippetSources(assembly: spec.Assembly): AssemblySnippetSourc
       ret.push({
         type: 'example',
         source: docs.example,
-        metadata: fmap(docs.custom?.exampleMetadata, parseMetadataLine),
+        metadata: fmap(docs.custom?.[EXAMPLE_METADATA_JSDOCTAG], parseMetadataLine),
         location,
       });
     }

--- a/packages/jsii-rosetta/lib/rosetta-translator.ts
+++ b/packages/jsii-rosetta/lib/rosetta-translator.ts
@@ -68,6 +68,12 @@ export class RosettaTranslator {
     this.cache.addTablet(tab);
   }
 
+  public addTabletsToCache(...tablets: LanguageTablet[]) {
+    for (const tab of tablets) {
+      this.cache.addTablet(tab);
+    }
+  }
+
   public hasCache() {
     return this.cache.count > 0;
   }

--- a/packages/jsii-rosetta/lib/snippet.ts
+++ b/packages/jsii-rosetta/lib/snippet.ts
@@ -235,6 +235,15 @@ export function parseMetadataLine(metadata: string): Record<string, string> {
   }
 }
 
+export function renderMetadataline(metadata: Record<string, string> = {}): string | undefined {
+  const line = Object.entries(metadata)
+    .filter(([key, _]) => !key.startsWith('$'))
+    .map(([key, value]) => (value !== '' ? `${key}=${value}` : key))
+    .join(' ');
+
+  return line ? line : undefined;
+}
+
 /**
  * Recognized snippet parameters
  */

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -47,11 +47,23 @@ export class LanguageTablet {
 
   private readonly snippets: Record<string, TranslatedSnippet> = {};
 
-  public addSnippet(...snippets: TranslatedSnippet[]) {
+  /**
+   * Add one or more snippets to this tablet
+   */
+  public addSnippets(...snippets: TranslatedSnippet[]) {
     for (const snippet of snippets) {
       const existingSnippet = this.snippets[snippet.key];
       this.snippets[snippet.key] = existingSnippet ? existingSnippet.mergeTranslations(snippet) : snippet;
     }
+  }
+
+  /**
+   * Add one snippet to this tablet
+   *
+   * @deprecated use addSnippets instead
+   */
+  public addSnippet(snippet: TranslatedSnippet) {
+    this.addSnippets(snippet);
   }
 
   public get snippetKeys() {
@@ -59,14 +71,23 @@ export class LanguageTablet {
   }
 
   /**
-   * Add all snippets from the given tablet into this one
+   * Add all snippets from the given tablets into this one
    */
-  public addTablet(...tablets: LanguageTablet[]) {
+  public addTablets(...tablets: LanguageTablet[]) {
     for (const tablet of tablets) {
       for (const snippet of Object.values(tablet.snippets)) {
         this.addSnippet(snippet);
       }
     }
+  }
+
+  /**
+   * Add all snippets from the given tablet into this one
+   *
+   * @deprecated Use `addTablets()` instead.
+   */
+  public addTablet(tablet: LanguageTablet) {
+    this.addTablets(tablet);
   }
 
   public tryGetSnippet(key: string): TranslatedSnippet | undefined {

--- a/packages/jsii-rosetta/lib/typescript/types.ts
+++ b/packages/jsii-rosetta/lib/typescript/types.ts
@@ -1,6 +1,7 @@
 import * as ts from 'typescript';
 
 import { hasAllFlags, hasAnyFlag, resolveEnumLiteral, resolvedSymbolAtLocation } from '../jsii/jsii-utils';
+import { isDefined } from '../util';
 
 /**
  * Return the first non-undefined type from a union
@@ -151,10 +152,6 @@ export function arrayElementType(type: ts.Type): ts.Type | undefined {
 export function typeOfExpression(typeChecker: ts.TypeChecker, node: ts.Expression) {
   const t = typeChecker.getContextualType(node) ?? typeChecker.getTypeAtLocation(node);
   return resolveEnumLiteral(typeChecker, t);
-}
-
-function isDefined<A>(x: A): x is NonNullable<A> {
-  return x !== undefined;
 }
 
 /**

--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -197,3 +197,11 @@ export function groupBy<A>(xs: A[], keyFn: (x: A) => string): Record<string, A[]
   }
   return ret;
 }
+
+export function isDefined<A>(x: A): x is NonNullable<A> {
+  return x !== undefined;
+}
+
+export function indexBy<A>(xs: A[], fn: (x: A) => string): Record<string, A> {
+  return mkDict(xs.map((x) => [fn(x), x] as const));
+}

--- a/packages/jsii-rosetta/test/commands/infuse.test.ts
+++ b/packages/jsii-rosetta/test/commands/infuse.test.ts
@@ -1,7 +1,8 @@
+import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { LanguageTablet } from '../../lib';
+import { LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
 import { extractSnippets } from '../../lib/commands/extract';
 import { infuse, DEFAULT_INFUSION_RESULTS_NAME } from '../../lib/commands/infuse';
 import { loadAssemblies } from '../../lib/jsii/assemblies';
@@ -10,7 +11,7 @@ import { TestJsiiModule, DUMMY_JSII_CONFIG } from '../testutil';
 const DUMMY_README = `
   Here is an example of how to use ClassA:
 
-  \`\`\`ts
+  \`\`\`ts some=metadata
   import * as ass from 'my_assembly';
   const aClass = new ass.ClassA();
   aClass.someMethod();
@@ -47,7 +48,7 @@ beforeEach(async () => {
 
   // Create a tabletFile in the same directory
   await extractSnippets([assembly.moduleDirectory], {
-    outputFile: path.join(assembly.moduleDirectory, TABLET_FILE),
+    cacheToFile: path.join(assembly.moduleDirectory, TABLET_FILE),
     includeCompilerDiagnostics: false,
     validateAssemblies: false,
   });
@@ -56,7 +57,7 @@ beforeEach(async () => {
 afterEach(async () => assembly.cleanup());
 
 test('examples are added in the assembly', async () => {
-  await infuse([assembly.moduleDirectory], path.join(assembly.moduleDirectory, TABLET_FILE));
+  await infuse([assembly.moduleDirectory]);
 
   const assemblies = await loadAssemblies([assembly.moduleDirectory], false);
   const types = assemblies[0].assembly.types;
@@ -64,24 +65,38 @@ test('examples are added in the assembly', async () => {
   expect(types!['my_assembly.ClassA'].docs?.example).toBeDefined();
 });
 
+test('infuse copies example metadata', async () => {
+  await infuse([assembly.moduleDirectory]);
+
+  // THEN: the metadata that used to be on the README snippet is also on the class example
+  const updatedAssembly = (await fs.readJson(path.join(assembly.moduleDirectory, '.jsii'))) as spec.Assembly;
+
+  const typeDocs = updatedAssembly.types?.['my_assembly.ClassA']?.docs;
+  expect(typeDocs?.custom?.exampleMetadata).toEqual('some=metadata');
+});
+
 test('examples are added to the tablet under new keys', async () => {
   const originalTabletFile = path.join(assembly.moduleDirectory, TABLET_FILE);
   const updatedTabletFile = path.join(assembly.moduleDirectory, 'tablet2.tabl.json');
+  const originalDefaultTablet = await LanguageTablet.fromFile(path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME));
 
-  await infuse([assembly.moduleDirectory], originalTabletFile, {
-    tabletOutputFile: updatedTabletFile,
+  await infuse([assembly.moduleDirectory], {
+    cacheFromFile: originalTabletFile,
+    cacheToFile: updatedTabletFile,
   });
 
-  const original = await LanguageTablet.fromFile(originalTabletFile);
-  const updated = await LanguageTablet.fromFile(updatedTabletFile);
+  const originalCache = await LanguageTablet.fromFile(originalTabletFile);
+  const updatedCache = await LanguageTablet.fromFile(updatedTabletFile);
+  const updatedDefaultTablet = await LanguageTablet.fromFile(path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME));
 
-  expect(updated.count).toEqual(original.count + 1);
+  expect(updatedDefaultTablet.count).toEqual(originalDefaultTablet.count + 1);
+  expect(updatedCache.count).toEqual(originalCache.count);
+  expect(updatedCache.snippetKeys).not.toEqual(originalCache.snippetKeys);
 });
 
 test('can log to output file', async () => {
-  await infuse([assembly.moduleDirectory], path.join(assembly.moduleDirectory, TABLET_FILE), {
-    log: true,
-    outputFile: path.join(assembly.moduleDirectory, DEFAULT_INFUSION_RESULTS_NAME),
+  await infuse([assembly.moduleDirectory], {
+    logFile: path.join(assembly.moduleDirectory, DEFAULT_INFUSION_RESULTS_NAME),
   });
 
   // assert that the output file exists and there is some information in the file.

--- a/packages/jsii-rosetta/test/commands/trim-cache.test.ts
+++ b/packages/jsii-rosetta/test/commands/trim-cache.test.ts
@@ -1,0 +1,85 @@
+import * as path from 'path';
+
+import { TranslatedSnippet, typeScriptSnippetFromVisibleSource, LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
+import { extractSnippets } from '../../lib/commands/extract';
+import { trimCache } from '../../lib/commands/trim-cache';
+import { TestJsiiModule, DUMMY_JSII_CONFIG, testSnippetLocation } from '../testutil';
+
+const DUMMY_README = `
+  Here is an example of how to use ClassA:
+
+  \`\`\`ts
+  import * as ass from 'my_assembly';
+  const aClass = new ass.ClassA();
+  aClass.someMethod();
+  \`\`\`
+`;
+
+let assembly: TestJsiiModule;
+beforeEach(async () => {
+  // Create an assembly in a temp directory
+  assembly = await TestJsiiModule.fromSource(
+    {
+      'index.ts': `
+      export class ClassA {
+        public someMethod() {
+        }
+      }
+      export class ClassB {
+        public anotherMethod() {
+        }
+      }
+      `,
+      'README.md': DUMMY_README,
+    },
+    {
+      name: 'my_assembly',
+      jsii: DUMMY_JSII_CONFIG,
+    },
+  );
+});
+
+afterEach(async () => assembly.cleanup());
+
+test('trim-cache removes unused snippets', async () => {
+  const cacheFile = path.join(assembly.moduleDirectory, 'dummy.tabl.json');
+
+  // GIVEN
+  const tbl = new LanguageTablet();
+  tbl.addSnippet(bogusTranslatedSnippet());
+  await tbl.save(cacheFile);
+
+  // WHEN
+  await trimCache({
+    assemblyLocations: [assembly.moduleDirectory],
+    cacheFile,
+  });
+
+  // THEN
+  const updated = await LanguageTablet.fromFile(cacheFile);
+  expect(updated.count).toEqual(0);
+});
+
+test('trim-cache leaves used snippets', async () => {
+  const defaultTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME);
+
+  // GIVEN
+  await extractSnippets([assembly.moduleDirectory]);
+
+  // WHEN
+  await trimCache({
+    assemblyLocations: [assembly.moduleDirectory],
+    cacheFile: defaultTablet,
+  });
+
+  // THEN
+  const updated = await LanguageTablet.fromFile(defaultTablet);
+  expect(updated.count).toEqual(1);
+});
+
+function bogusTranslatedSnippet() {
+  return TranslatedSnippet.fromTypeScript(
+    typeScriptSnippetFromVisibleSource('console.log("hello");', testSnippetLocation('x.ts'), true),
+    true,
+  );
+}


### PR DESCRIPTION
Rather than write our Rosetta translations to a single tablet file which
we throw away at the end of the build, `rosetta extract` will now write
translations to individual `.jsii.tabl.json` files, located next to
the assemblies themselves.

Construct library authors can publish these to NPM, so that downstream
tools that process JSII modules for documentation have access to the
translations and don't need to redo the work (especially relevant
for large libraries with lots of examples, where otherwise a lot
of CPU time would be wasted).

The "single output tablet" can still be used, but is now intended to be
used as a cache to speed up repeated runs of `rosetta extract` (to skip
translating unchanged snippets). Add options to trim the cache files
down so they won't grow without bounds.

This PR also contains a bugfix: `infuse` did not re-inject a copied
snippet's metadata into the assembly's `exampleMetadata` field. This
is strictly speaking not a problem as long as the tablet always stays
with the assembly, but better to fix anyway.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
