### PR TITLE
fix(rosetta): classes are not correctly identified if package uses an outDir

### DIFF
--- a/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
@@ -19,7 +19,8 @@
       "rosetta": {
         "strict": true
       }
-    }
+    },
+    "tscRootDir": "."
   },
   "name": "@scope/jsii-calc-base-of-base",
   "repository": {
@@ -165,5 +166,5 @@
     }
   },
   "version": "2.1.1",
-  "fingerprint": "6Qes5fbC/YvlKQaK6Oqw0RGgsr/feI/vaRWDYXJJaU8="
+  "fingerprint": "BYVFW3VSnno85aN3BfEZ3Px9cEKhgfteosHUXjQW0rw="
 }

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -80,7 +80,8 @@
       "rosetta": {
         "strict": true
       }
-    }
+    },
+    "tscRootDir": "lib"
   },
   "name": "@scope/jsii-calc-lib",
   "repository": {
@@ -952,5 +953,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "BJ528BPiptJdqvxyoh4Ax2l2Knaz2KcuNYBYhVpyTw8="
+  "fingerprint": "wtswDMhtuMcC4+ami5KddQIznqdpVjt8qc7Ba2QnnHk="
 }

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -33,7 +33,7 @@
     "test": "npm run test:unit && npm run test:build",
     "test:unit": "jest",
     "test:build": "bash test/build-test.sh",
-    "test:update": "jest -u && npm run test:build",
+    "test:update": "true",
     "package": "package-js"
   },
   "dependencies": {

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -129,13 +129,16 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
     // This is a module.
     // FIXME: for now assume this is the assembly root. Handle the case where it isn't later.
     const sourceAssembly = findTypeLookupAssembly(decl.fileName);
+    const tscRootDir = sourceAssembly?.assembly.metadata?.tscRootDir;
     return fmap(
       sourceAssembly,
       (asm) =>
         ({
           fqn:
-            fmap(symbolIdentifier(typeChecker, sym), (symbolId) => sourceAssembly?.symbolIdMap[symbolId]) ??
-            sourceAssembly?.assembly.name,
+            fmap(
+              symbolIdentifier(typeChecker, sym, false, tscRootDir),
+              (symbolId) => sourceAssembly?.symbolIdMap[symbolId],
+            ) ?? sourceAssembly?.assembly.name,
           sourceAssembly: asm,
           symbolType: 'module',
         } as JsiiSymbol),
@@ -187,12 +190,13 @@ function lookupTypeSymbol(
   typeSymbol: ts.Symbol,
   fileName: string,
 ): JsiiSymbol | undefined {
-  const symbolId = symbolIdentifier(typeChecker, typeSymbol);
+  const sourceAssembly = findTypeLookupAssembly(fileName);
+  const tscRootDir = sourceAssembly?.assembly.metadata?.tscRootDir;
+  const symbolId = symbolIdentifier(typeChecker, typeSymbol, false, tscRootDir);
   if (!symbolId) {
     return undefined;
   }
 
-  const sourceAssembly = findTypeLookupAssembly(fileName);
   return fmap(sourceAssembly?.symbolIdMap[symbolId], (fqn) => ({ fqn, sourceAssembly, symbolType: 'type' }));
 }
 

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -129,14 +129,20 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
     // This is a module.
     // FIXME: for now assume this is the assembly root. Handle the case where it isn't later.
     const sourceAssembly = findTypeLookupAssembly(decl.fileName);
-    const tscRootDir = sourceAssembly?.assembly.metadata?.tscRootDir;
     return fmap(
       sourceAssembly,
       (asm) =>
         ({
           fqn:
             fmap(
-              symbolIdentifier(typeChecker, sym, false, tscRootDir),
+              symbolIdentifier(
+                typeChecker,
+                sym,
+                //sourceAssembly ? { assembly: sourceAssembly.assembly } : undefined,
+                fmap(sourceAssembly, (sa) => {
+                  return { assembly: sa.assembly };
+                }),
+              ),
               (symbolId) => sourceAssembly?.symbolIdMap[symbolId],
             ) ?? sourceAssembly?.assembly.name,
           sourceAssembly: asm,
@@ -191,8 +197,13 @@ function lookupTypeSymbol(
   fileName: string,
 ): JsiiSymbol | undefined {
   const sourceAssembly = findTypeLookupAssembly(fileName);
-  const tscRootDir = sourceAssembly?.assembly.metadata?.tscRootDir;
-  const symbolId = symbolIdentifier(typeChecker, typeSymbol, false, tscRootDir);
+  const symbolId = symbolIdentifier(
+    typeChecker,
+    typeSymbol,
+    fmap(sourceAssembly, (sa) => {
+      return { assembly: sa.assembly };
+    }),
+  );
   if (!symbolId) {
     return undefined;
   }

--- a/packages/jsii-rosetta/lib/languages/record-references.ts
+++ b/packages/jsii-rosetta/lib/languages/record-references.ts
@@ -45,7 +45,7 @@ export class RecordReferencesVisitor extends DefaultVisitor<RecordReferencesCont
         (node.type && renderer.typeOfType(node.type)) ||
         (node.initializer && renderer.typeOfExpression(node.initializer));
 
-      this.recordSymbol(type?.symbol, renderer);
+      this.recordSymbol(type.symbol, renderer);
     }
 
     return super.variableDeclaration(node, renderer);

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -301,7 +301,7 @@ describe('can find fqns via symbolId when ', () => {
     try {
       const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
       await extract.extractSnippets([otherAssembly.moduleDirectory], {
-        outputFile,
+        cacheToFile: outputFile,
         ...defaultExtractOptions,
       });
 
@@ -320,7 +320,7 @@ describe('can find fqns via symbolId when ', () => {
     try {
       const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
       await extract.extractSnippets([otherAssembly.moduleDirectory], {
-        outputFile,
+        cacheToFile: outputFile,
         ...defaultExtractOptions,
       });
 

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -186,6 +186,45 @@ test('do not ignore example strings', async () => {
   }
 });
 
+describe('can find fqns via symbolId when ', () => {
+  test('there is an outDir', async () => {
+    const outDir = 'jsii-outDir';
+    const otherAssembly = await createAssemblyWithDirectories(undefined, outDir);
+    try {
+      const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
+      await extract.extractSnippets([otherAssembly.moduleDirectory], {
+        outputFile,
+        ...defaultExtractOptions,
+      });
+
+      const tablet = await LanguageTablet.fromFile(outputFile);
+      const tr = tablet.tryGetSnippet(tablet.snippetKeys[0]);
+      expect(tr?.fqnsReferenced()).toEqual(['my_assembly.ClassA']);
+    } finally {
+      await otherAssembly.cleanup();
+    }
+  });
+
+  test('there is an outDir and rootDir', async () => {
+    const outDir = 'jsii-outDir';
+    const rootDir = '.';
+    const otherAssembly = await createAssemblyWithDirectories(rootDir, outDir);
+    try {
+      const outputFile = path.join(otherAssembly.moduleDirectory, 'test.tabl.json');
+      await extract.extractSnippets([otherAssembly.moduleDirectory], {
+        outputFile,
+        ...defaultExtractOptions,
+      });
+
+      const tablet = await LanguageTablet.fromFile(outputFile);
+      const tr = tablet.tryGetSnippet(tablet.snippetKeys[0]);
+      expect(tr?.fqnsReferenced()).toEqual(['my_assembly.ClassA']);
+    } finally {
+      await otherAssembly.cleanup();
+    }
+  });
+});
+
 test('extract and infuse in one command', async () => {
   const outputFile = path.join(assembly.moduleDirectory, 'test.tabl.json');
   await extract.extractAndInfuse([assembly.moduleDirectory], {
@@ -221,4 +260,37 @@ class MockTranslator extends RosettaTranslator {
     super(opts);
     this.translateAll = translatorFn;
   }
+}
+
+async function createAssemblyWithDirectories(rootDir?: string, outDir?: string) {
+  return TestJsiiModule.fromSource(
+    {
+      'index.ts': `
+      export class ClassA {
+        /**
+         * Some method
+         *
+         * @example
+         * import * as ass from 'my_assembly';
+         * new ass.ClassA.someMethod();
+         */
+        public someMethod() {
+        }
+      }
+      `,
+      'README.md': '',
+    },
+    {
+      name: 'my_assembly',
+      main: `${outDir}/index.js`,
+      types: `${outDir}/index.d.ts`,
+      jsii: {
+        ...DUMMY_JSII_CONFIG,
+        tsc: {
+          outDir,
+          rootDir,
+        },
+      },
+    },
+  );
 }

--- a/packages/jsii-rosetta/test/testutil.ts
+++ b/packages/jsii-rosetta/test/testutil.ts
@@ -21,7 +21,7 @@ export type MultipleSources = { [key: string]: string; 'index.ts': string };
 export class TestJsiiModule {
   public static async fromSource(
     source: string | MultipleSources,
-    packageInfo: Partial<PackageInfo> & { name: string },
+    packageInfo: Partial<PackageInfo> & { name: string; main?: string; types?: string },
   ) {
     const { assembly, files } = await compileJsiiForTest(source, (pi) => {
       Object.assign(pi, packageInfo);
@@ -41,6 +41,8 @@ export class TestJsiiModule {
     await fs.writeJSON(path.join(modDir, '.jsii'), assembly);
     await fs.writeJSON(path.join(modDir, 'package.json'), {
       name: packageInfo.name,
+      main: packageInfo.main,
+      types: packageInfo.types,
       jsii: packageInfo.jsii,
     });
     for (const [fileName, fileContents] of Object.entries(files)) {

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -46,6 +46,7 @@ export class Assembler implements Emitter {
   private readonly warningsInjector?: DeprecationWarningsInjector;
 
   private readonly mainFile: string;
+  private readonly tscRootDir?: string;
 
   private _diagnostics = new Array<JsiiDiagnostic>();
   private _deferred = new Array<DeferredRecord>();
@@ -113,10 +114,10 @@ export class Assembler implements Emitter {
 
       // rootDir may be set explicitly or not. If not, inferRootDir replicates
       // tsc's behavior of using the longest prefix of all built source files.
-      const tscRootDir =
+      this.tscRootDir =
         program.getCompilerOptions().rootDir ?? inferRootDir(program);
-      if (tscRootDir != null) {
-        mainFile = path.join(tscRootDir, mainFile);
+      if (this.tscRootDir != null) {
+        mainFile = path.join(this.tscRootDir, mainFile);
       }
     }
 
@@ -253,7 +254,10 @@ export class Assembler implements Emitter {
       types: this._types,
       submodules: noEmptyDict(toSubmoduleDeclarations(this.mySubmodules())),
       targets: this.projectInfo.targets,
-      metadata: this.projectInfo.metadata,
+      metadata: {
+        ...this.projectInfo.metadata,
+        tscRootDir: this.tscRootDir,
+      },
       docs,
       readme,
       jsiiVersion,

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -256,6 +256,9 @@ export class Assembler implements Emitter {
       targets: this.projectInfo.targets,
       metadata: {
         ...this.projectInfo.metadata,
+
+        // Downstream consumers need this to map a symbolId in the outDir to a
+        // symbolId in the rootDir.
         tscRootDir: this.tscRootDir,
       },
       docs,

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -97,8 +97,12 @@ export async function compileJsiiForTest(
     const files: Record<string, string> = {};
 
     for (const filename of Object.keys(source)) {
-      const jsFile = filename.replace(/\.ts$/, '.js');
-      const dtsFile = filename.replace(/\.ts$/, '.d.ts');
+      let jsFile = filename.replace(/\.ts$/, '.js');
+      let dtsFile = filename.replace(/\.ts$/, '.d.ts');
+      if (projectInfo.tsc?.outDir && filename !== 'README.md') {
+        jsFile = path.join(projectInfo.tsc.outDir, jsFile);
+        dtsFile = path.join(projectInfo.tsc.outDir, dtsFile);
+      }
 
       // eslint-disable-next-line no-await-in-loop
       files[jsFile] = await fs.readFile(jsFile, { encoding: 'utf-8' });

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -150,11 +150,18 @@ export function normalizePath(
     sourcePath =
       rootDir === '.' ? paths.join('/') : `${rootDir}/${paths.join('/')}`;
   }
-  return sourcePath;
+  return unixize(sourcePath);
 
   function removeEndSlash(filePath: string) {
     return filePath.endsWith(path.sep)
       ? filePath.slice(0, filePath.length - 1)
       : filePath;
   }
+}
+
+/**
+ * Turn backslashes in a path into forward slashes
+ */
+function unixize(p: string) {
+  return p.replace(/\\/g, '/');
 }

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -120,6 +120,13 @@ function assemblyRelativeSourceFile(
   }
 }
 
+/**
+ * Ensures that the sourcePath is pointing to the source code
+ * and not compiled code. This can happen if the root directory
+ * and/or out directory is set for the project. We check to see
+ * if the out directory is present in the sourcePath, and if so,
+ * we replace it with the root directory.
+ */
 export function normalizePath(
   sourcePath: string,
   rootDir?: string,

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -14,7 +14,7 @@ interface SymbolIdOptions {
    * the root directory is used to ensure that the
    * symbolId comes from source code and not compiled code.
    */
-  readonly assembly: Assembly;
+  readonly assembly?: Assembly;
 }
 
 export function symbolIdentifier(

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -20,7 +20,7 @@ interface SymbolIdOptions {
 export function symbolIdentifier(
   typeChecker: ts.TypeChecker,
   sym: ts.Symbol,
-  options?: SymbolIdOptions,
+  options: SymbolIdOptions = {},
 ): string | undefined {
   // If this symbol happens to be an alias, resolve it first
   while ((sym.flags & ts.SymbolFlags.Alias) !== 0) {
@@ -58,7 +58,7 @@ export function symbolIdentifier(
 
   const namespace = assemblyRelativeSourceFile(
     decl.getSourceFile().fileName,
-    options,
+    options?.assembly,
   );
 
   if (!namespace) {
@@ -68,10 +68,7 @@ export function symbolIdentifier(
   return `${namespace}:${inFileNameParts.join('.')}`;
 }
 
-function assemblyRelativeSourceFile(
-  sourceFileName: string,
-  options?: SymbolIdOptions,
-) {
+function assemblyRelativeSourceFile(sourceFileName: string, asm?: Assembly) {
   const packageJsonLocation = findPackageJsonLocation(
     path.dirname(sourceFileName),
   );
@@ -90,8 +87,9 @@ function assemblyRelativeSourceFile(
   );
 
   // Modify the namespace if we send in the assembly.
-  if (options) {
-    const tscRootDir = packageJson.jsii?.tsc?.rootDir ?? options?.assembly.metadata?.tscRootDir;
+  if (asm) {
+    const tscRootDir =
+      packageJson.jsii?.tsc?.rootDir ?? asm.metadata?.tscRootDir;
     const tscOutDir = packageJson.jsii?.tsc?.outDir;
     sourcePath = normalizePath(sourcePath, tscRootDir, tscOutDir);
   }

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -141,8 +141,9 @@ describe(Compiler, () => {
       await compiler.emit();
 
       const assembly = await readJson(join(sourceDir, '.jsii'), 'utf-8');
-      expect(assembly.metadata).toEqual(expect.objectContaining({
-        tscRootDir: rootDir,
+      expect(assembly.metadata).toEqual(
+        expect.objectContaining({
+          tscRootDir: rootDir,
         }),
       );
     } finally {

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -1,4 +1,11 @@
-import { ensureDir, mkdtemp, remove, writeFile, readFile, readJson } from 'fs-extra';
+import {
+  ensureDir,
+  mkdtemp,
+  remove,
+  writeFile,
+  readFile,
+  readJson,
+} from 'fs-extra';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -134,7 +141,6 @@ describe(Compiler, () => {
       await compiler.emit();
 
       const assembly = await readJson(join(sourceDir, '.jsii'), 'utf-8');
-      console.log(assembly);
       expect(assembly.metadata).toEqual({
         tscRootDir: rootDir,
       });

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -141,9 +141,10 @@ describe(Compiler, () => {
       await compiler.emit();
 
       const assembly = await readJson(join(sourceDir, '.jsii'), 'utf-8');
-      expect(assembly.metadata).toEqual({
+      expect(assembly.metadata).toEqual(expect.objectContaining({
         tscRootDir: rootDir,
-      });
+        }),
+      );
     } finally {
       await remove(sourceDir);
     }

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, remove, writeFile, readFile, readJson } from 'fs-extra';
+import { ensureDir, mkdtemp, remove, writeFile, readFile, readJson } from 'fs-extra';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -40,6 +40,7 @@ describe(Compiler, () => {
       ).toEqual(expectedTypeScriptConfig());
     });
   });
+
   test('"watch" mode', async () => {
     // This can be a little slow, allowing 15 seconds maximum here (default is 5 seconds)
     jest.setTimeout(15_000);
@@ -99,6 +100,44 @@ describe(Compiler, () => {
         },
       });
       await watchClosed;
+    } finally {
+      await remove(sourceDir);
+    }
+  });
+
+  test('rootDir is added to assembly', async () => {
+    const outDir = 'jsii-outdir';
+    const rootDir = 'jsii-rootdir';
+    const sourceDir = await mkdtemp(join(tmpdir(), 'jsii-tmpdir'));
+    await ensureDir(join(sourceDir, rootDir));
+
+    try {
+      await writeFile(
+        join(sourceDir, rootDir, 'index.ts'),
+        'export class MarkerA {}',
+      );
+      // Intentionally using lower case name - it should be case-insensitive
+      await writeFile(join(sourceDir, rootDir, 'readme.md'), '# Test Package');
+
+      const compiler = new Compiler({
+        projectInfo: {
+          ..._makeProjectInfo(sourceDir, join(outDir, 'index.d.ts')),
+          tsc: {
+            outDir,
+            rootDir,
+          },
+        },
+        failOnWarnings: true,
+        projectReferences: false,
+      });
+
+      await compiler.emit();
+
+      const assembly = await readJson(join(sourceDir, '.jsii'), 'utf-8');
+      console.log(assembly);
+      expect(assembly.metadata).toEqual({
+        tscRootDir: rootDir,
+      });
     } finally {
       await remove(sourceDir);
     }

--- a/packages/jsii/test/symbol-identifiers.test.ts
+++ b/packages/jsii/test/symbol-identifiers.test.ts
@@ -1,4 +1,4 @@
-import { compileJsiiForTest } from '../lib';
+import { compileJsiiForTest, normalizePath } from '../lib';
 
 test('Symbol map is generated', async () => {
   const result = await compileJsiiForTest(
@@ -91,4 +91,83 @@ test('Submodules also have symbol identifiers', async () => {
   expect(result.assembly.submodules?.['testpkg.cookie']?.symbolId).toEqual(
     'index:cookie',
   );
+});
+
+describe(normalizePath, () => {
+  test('basic rootDir and outDir', () => {
+    expect(normalizePath('out/filename.ts', 'root', 'out')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', undefined, 'out')).toEqual(
+      'out/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', 'root', undefined)).toEqual(
+      'out/filename.ts',
+    );
+  });
+
+  test('extra slashes in directories', () => {
+    expect(normalizePath('out/filename.ts', 'root/', 'out/')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', 'root////', 'out////')).toEqual(
+      'root/filename.ts',
+    );
+    // eslint-disable-next-line prettier/prettier
+    expect(normalizePath('out/lib/filename.ts', 'root///', 'out//lib//')).toEqual(
+      'root/filename.ts',
+    );
+  });
+
+  test('additional paths in directories', () => {
+    expect(normalizePath('out/filename.ts', './root', 'out')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', 'root', './out')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', 'root', './here/../out')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/filename.ts', 'root/../root/..', '.')).toEqual(
+      'out/filename.ts',
+    );
+  });
+
+  test('empty paths', () => {
+    expect(normalizePath('out/lib/filename.ts', '', 'out')).toEqual(
+      'lib/filename.ts',
+    );
+    expect(normalizePath('out/lib/filename.ts', '.', 'out')).toEqual(
+      'lib/filename.ts',
+    );
+    expect(normalizePath('lib/filename.ts', 'root', '')).toEqual(
+      'root/lib/filename.ts',
+    );
+    expect(normalizePath('lib/filename.ts', 'root', '.')).toEqual(
+      'root/lib/filename.ts',
+    );
+    // eslint-disable-next-line prettier/prettier
+    expect(normalizePath('lib/filename.ts', '', '')).toEqual(
+      'lib/filename.ts',
+    );
+    expect(normalizePath('lib/filename.ts', '.', '.')).toEqual(
+      'lib/filename.ts',
+    );
+  });
+
+  test('specify multiple directories', () => {
+    expect(normalizePath('out/lib/filename.ts', 'root', 'out/lib')).toEqual(
+      'root/filename.ts',
+    );
+    expect(normalizePath('out/lib/filename.ts', 'root/extra', 'out')).toEqual(
+      'root/extra/lib/filename.ts',
+    );
+    expect(normalizePath('out/lib/filename.ts', '.', 'out/lib')).toEqual(
+      'filename.ts',
+    );
+    expect(normalizePath('lib/filename.ts', 'root/extra', '.')).toEqual(
+      'root/extra/lib/filename.ts',
+    );
+  });
 });

--- a/packages/jsii/test/symbol-identifiers.test.ts
+++ b/packages/jsii/test/symbol-identifiers.test.ts
@@ -104,6 +104,9 @@ describe(normalizePath, () => {
     expect(normalizePath('out/filename.ts', 'root', undefined)).toEqual(
       'out/filename.ts',
     );
+    expect(normalizePath('out/filename.ts', undefined, undefined)).toEqual(
+      'out/filename.ts',
+    );
   });
 
   test('extra slashes in directories', () => {


### PR DESCRIPTION
`rosetta extract` breaks down when a project structure includes `outDir` or `rootDir` in the `tsconfig` file. Given such a project structure, `extract` may find symbolIds that look like `outDir/index:ClassA` or `rootDir/index:ClassA`. Since the jsii assembly is created from the source files in the `rootDir`, `rootDir/index:ClassA` is the symbolId we want. So if the `outDir` is specified, we swap it with the specified `rootDir` (and if `rootDir` is not specified, we guess at it the same way node does). This ensures that `rosetta extract` is structure agnostic.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
