### PR TITLE
fix(jsii): symbolid for single-valued enums is incorrect

### DIFF
--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -11760,7 +11760,7 @@
         }
       ],
       "name": "SingletonIntEnum",
-      "symbolId": "lib/compliance:SingletonIntEnum.SINGLETON_INT"
+      "symbolId": "lib/compliance:SingletonIntEnum"
     },
     "jsii-calc.SingletonString": {
       "assembly": "jsii-calc",
@@ -11825,7 +11825,7 @@
         }
       ],
       "name": "SingletonStringEnum",
-      "symbolId": "lib/compliance:SingletonStringEnum.SINGLETON_STRING"
+      "symbolId": "lib/compliance:SingletonStringEnum"
     },
     "jsii-calc.SmellyStruct": {
       "assembly": "jsii-calc",
@@ -16363,7 +16363,7 @@
       ],
       "name": "Awesomeness",
       "namespace": "submodule.child",
-      "symbolId": "lib/submodule/child/index:Awesomeness.AWESOME"
+      "symbolId": "lib/submodule/child/index:Awesomeness"
     },
     "jsii-calc.submodule.child.Goodness": {
       "assembly": "jsii-calc",
@@ -16541,7 +16541,7 @@
       ],
       "name": "SomeEnum",
       "namespace": "submodule.child",
-      "symbolId": "lib/submodule/child/index:SomeEnum.SOME"
+      "symbolId": "lib/submodule/child/index:SomeEnum"
     },
     "jsii-calc.submodule.child.SomeStruct": {
       "assembly": "jsii-calc",
@@ -16807,5 +16807,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "wBGhJE4ZhvVb8R2qk5FWg49mt+ZKqW60TjlMMtT1Klo="
+  "fingerprint": "w6AJ35Nh9lBusQyMGP28WJp5MNbg527uO9TsHaP+DiE="
 }

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -127,7 +127,6 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
 
   if (ts.isSourceFile(decl)) {
     // This is a module.
-    // FIXME: for now assume this is the assembly root. Handle the case where it isn't later.
     const sourceAssembly = findTypeLookupAssembly(decl.fileName);
     return fmap(
       sourceAssembly,
@@ -138,10 +137,7 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
               symbolIdentifier(
                 typeChecker,
                 sym,
-                //sourceAssembly ? { assembly: sourceAssembly.assembly } : undefined,
-                fmap(sourceAssembly, (sa) => {
-                  return { assembly: sa.assembly };
-                }),
+                fmap(sourceAssembly, (sa) => ({ assembly: sa.assembly })),
               ),
               (symbolId) => sourceAssembly?.symbolIdMap[symbolId],
             ) ?? sourceAssembly?.assembly.name,
@@ -166,10 +162,23 @@ export function lookupJsiiSymbol(typeChecker: ts.TypeChecker, sym: ts.Symbol): J
   }
 
   const fileName = decl.getSourceFile().fileName;
-  if (hasAnyFlag(declSym.flags, ts.SymbolFlags.Method | ts.SymbolFlags.Property | ts.SymbolFlags.EnumMember)) {
-    return lookupMemberSymbol(typeChecker, sym, fileName);
+  const sourceAssembly = findTypeLookupAssembly(fileName);
+  const symbolId = symbolIdentifier(typeChecker, declSym, { assembly: sourceAssembly?.assembly });
+  if (!symbolId) {
+    return undefined;
   }
-  return lookupTypeSymbol(typeChecker, sym, fileName);
+
+  return fmap(/([^#]*)(#.*)?/.exec(symbolId), ([, typeSymbolId, memberFragment]) => {
+    if (memberFragment) {
+      return fmap(sourceAssembly?.symbolIdMap[typeSymbolId], (fqn) => ({
+        fqn: `${fqn}${memberFragment}`,
+        sourceAssembly,
+        symbolType: 'member',
+      }));
+    }
+
+    return fmap(sourceAssembly?.symbolIdMap[typeSymbolId], (fqn) => ({ fqn, sourceAssembly, symbolType: 'type' }));
+  });
 }
 
 function isDeclaration(x: ts.Node): x is ts.Declaration {
@@ -186,48 +195,6 @@ function isDeclaration(x: ts.Node): x is ts.Declaration {
     ts.isPropertyDeclaration(x) ||
     ts.isPropertySignature(x)
   );
-}
-
-/**
- * Look up the jsii fqn for a given type symbol
- */
-function lookupTypeSymbol(
-  typeChecker: ts.TypeChecker,
-  typeSymbol: ts.Symbol,
-  fileName: string,
-): JsiiSymbol | undefined {
-  const sourceAssembly = findTypeLookupAssembly(fileName);
-  const symbolId = symbolIdentifier(
-    typeChecker,
-    typeSymbol,
-    fmap(sourceAssembly, (sa) => {
-      return { assembly: sa.assembly };
-    }),
-  );
-  if (!symbolId) {
-    return undefined;
-  }
-
-  return fmap(sourceAssembly?.symbolIdMap[symbolId], (fqn) => ({ fqn, sourceAssembly, symbolType: 'type' }));
-}
-
-function lookupMemberSymbol(
-  typeChecker: ts.TypeChecker,
-  memberSymbol: ts.Symbol,
-  fileName: string,
-): JsiiSymbol | undefined {
-  const declParent = memberSymbol.declarations?.[0]?.parent;
-  if (!declParent || !isDeclaration(declParent)) {
-    return undefined;
-  }
-
-  const declParentSym = getSymbolFromDeclaration(declParent, typeChecker);
-  if (!declParentSym) {
-    return undefined;
-  }
-
-  const result = lookupTypeSymbol(typeChecker, declParentSym, fileName);
-  return fmap(result, (result) => ({ ...result, fqn: `${result.fqn}#${memberSymbol.name}`, symbolType: 'member' }));
 }
 
 /**

--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -122,10 +122,10 @@ export function mkDict<A extends string, B>(xs: Array<readonly [A, B]>): Record<
  * only for the `Maybe` Functor).
  */
 export function fmap<A, B>(value: NonNullable<A>, fn: (x: NonNullable<A>) => B): B;
-export function fmap<A, B>(value: undefined, fn: (x: NonNullable<A>) => B): undefined;
-export function fmap<A, B>(value: A | undefined, fn: (x: A) => B): B | undefined;
+export function fmap<A, B>(value: undefined | null, fn: (x: NonNullable<A>) => B): undefined;
+export function fmap<A, B>(value: A | undefined | null, fn: (x: A) => B): B | undefined;
 export function fmap<A, B>(value: A, fn: (x: A) => B): B | undefined {
-  if (value === undefined) {
+  if (value == null) {
     return undefined;
   }
   return fn(value);

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -28,7 +28,7 @@ import * as ts from 'typescript';
  * We used to build this identifier ourselves. Turns out there was a built-in
  * way to get pretty much the same, by calling `typeChecker.getFullyQualifiedName()`.
  * Whoops ^_^ (this historical accident is why the format is similar to but
- * different from what the TS checker erturns).
+ * different from what the TS checker returns).
  */
 export function symbolIdentifier(
   typeChecker: ts.TypeChecker,

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -82,7 +82,7 @@ export function symbolIdentifier(
   // If this is a member symbol, replace the final '.' with a '#'
   const typeSymbol = isMember
     ? (inFileName ?? '').replace(/\.([^.]+)$/, '#$1')
-    : inFileName;
+    : inFileName ?? '';
 
   return `${relFile}:${typeSymbol}`;
 }

--- a/packages/jsii/test/symbol-identifiers.test.ts
+++ b/packages/jsii/test/symbol-identifiers.test.ts
@@ -29,6 +29,23 @@ test('Symbol map is generated', async () => {
   expect(types['testpkg.Baz'].symbolId).toEqual('some/nested/file:Baz');
 });
 
+test('Symbol id for single-value enum correctly identifies enum', async () => {
+  const result = await compileJsiiForTest(
+    {
+      'index.ts': `
+        export enum SomeEnum {
+          SINGLETON_VALUE = 'value',
+        }
+      `,
+    },
+    undefined /* callback */,
+    { stripDeprecated: true },
+  );
+
+  const types = result.assembly.types ?? {};
+  expect(types['testpkg.SomeEnum'].symbolId).toEqual('index:SomeEnum');
+});
+
 test('Module declarations are included in symbolId', async () => {
   const result = await compileJsiiForTest(
     {


### PR DESCRIPTION
We used to be doing our own `symbolId` calculations, but this was silly:
TS has a perfectly cromulent function built-in to do the same.

Implement ours in terms of theirs.

This uncovered a bug in calculating symbolIds for single-valued enums, which is rectified as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
