### PR TITLE
fix(jsii): move sourceMaps into separate files

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -18,7 +18,7 @@ const BASE_COMPILER_OPTIONS: ts.CompilerOptions = {
   declaration: true,
   experimentalDecorators: true,
   incremental: true,
-  inlineSourceMap: true,
+  sourceMap: true,
   inlineSources: true,
   lib: ['lib.es2019.d.ts'],
   module: ts.ModuleKind.CommonJS,


### PR DESCRIPTION
Importing the `aws-cdk-lib` in NodeJS may be quite slow as it is a massive library with a lot of files.

Yes, it is a good idea to import only a part which you need, like `aws-cdk-lib/aws-lambda`.

Unfortunately, developers ofter forget about it and they import the whole CDK instead.

As NodeJs needs to parse all imported JS files. It is a good idea to reduce the number of characters which needs to be parsed/loaded to minimum.

For example, moving inline source maps from each JS file into separate MAP file may reduce the import time by 30%.

On my machine (Macbook Pro 2017 15inch), just a plain import could took a 1200ms. So, every CDK command is slowed down by importing the whole CDK by 1200ms. 

It turns out, I was able to reduce it to 850ms by removing the inlined source maps from JS files and moving them into separate `*.js.map` files.

To really use the source maps, user needs to use `--enable-source-maps` flag to enable them. It works both with inlined source maps and with external source maps, so I think there is no reason to keep them inlined.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
