### PR TITLE
chore: fix issues encountered during CDK build

### DIFF
--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -551,6 +551,13 @@ export class Compiler implements Emitter {
   private async findMonorepoPeerTsconfig(
     depName: string,
   ): Promise<string | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
+    const { builtinModules } = require('module');
+    if ((builtinModules ?? []).includes(depName)) {
+      // Can happen for modules like 'punycode' which are declared as dependency for polyfill purposes
+      return undefined;
+    }
+
     try {
       const depDir = await utils.findDependencyDirectory(
         depName,
@@ -571,7 +578,9 @@ export class Compiler implements Emitter {
       return dependencyRealPath;
     } catch (e) {
       // @types modules cannot be required, for example
-      if (e.code === 'MODULE_NOT_FOUND') {
+      if (
+        ['MODULE_NOT_FOUND', 'ERR_PACKAGE_PATH_NOT_EXPORTED'].includes(e.code)
+      ) {
         return undefined;
       }
       throw e;

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -182,10 +182,6 @@ export async function findDependencyDirectory(
     paths: [searchStart],
   });
 
-  if (dependencyName === 'punycode') {
-    console.log(searchStart, entryPoint);
-  }
-
   // Search up from the given directory, looking for a package.json that matches
   // the dependency name (so we don't accidentally find stray 'package.jsons').
   const depPkgJsonPath = await findPackageJsonUp(

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -182,6 +182,10 @@ export async function findDependencyDirectory(
     paths: [searchStart],
   });
 
+  if (dependencyName === 'punycode') {
+    console.log(searchStart, entryPoint);
+  }
+
   // Search up from the given directory, looking for a package.json that matches
   // the dependency name (so we don't accidentally find stray 'package.jsons').
   const depPkgJsonPath = await findPackageJsonUp(


### PR DESCRIPTION
Fixes for some cases that were introduced in #3205, that cropped
up during a full CDK build:

- Some `@types/xxx` modules use an `exports` field, changing the
  error we get when trying (and failing) to import it.
- `punycode` is both an NPM dependency and a built-in. The built-in
  takes precedence and changes the return value of `require.resolve()`
  to something unexpected.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
