### PR TITLE
fix(rosetta): infuse drops first assembly

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -66,7 +66,7 @@ function main() {
       }),
     )
     .command(
-      'infuse <TABLET> [ASSEMBLY..]',
+      'infuse [ASSEMBLY..]',
       '(EXPERIMENTAL) mutates one or more assemblies by adding documentation examples to top-level types',
       (command) =>
         command


### PR DESCRIPTION
As part of a refactor, `rosetta infuse` no longer utilizes a single tablet file in favor of tablets at the assembly level. However the `infuse` command still takes in a positional argument `TABLET` that goes unused. This means that the first argument sent into the command gets dropped.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
