### PR TITLE
chore: move away from mergify commit_message

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -82,7 +82,10 @@ pull_request_rules:
       queue:
         name: default
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
       comment:
         message: Merging (with squash)...
     conditions:
@@ -130,7 +133,10 @@ pull_request_rules:
       queue:
         name: default
         method: merge
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
       comment:
         message: Merging (no-squash)...
     conditions:


### PR DESCRIPTION
`commit_message` is deprecated and being replaced with `commit_message_template`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
