### PR TITLE
fix(rosetta): non-compiling snippets not reported on subsequent extracts

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -99,7 +99,7 @@ export async function extractSnippets(
   translator.addTabletsToCache(...Object.values(await loadAllDefaultTablets(assemblies)));
 
   if (translator.hasCache()) {
-    const { translations, remaining } = translator.readFromCache(snippets);
+    const { translations, remaining } = translator.readFromCache(snippets, true, options.includeCompilerDiagnostics);
     logging.info(`Reused ${translations.length} translations from cache`);
     snippets = remaining;
   }

--- a/packages/jsii-rosetta/lib/rosetta-translator.ts
+++ b/packages/jsii-rosetta/lib/rosetta-translator.ts
@@ -83,14 +83,15 @@ export class RosettaTranslator {
    *
    * Will remove the cached snippets from the input array.
    */
-  public readFromCache(snippets: TypeScriptSnippet[], addToTablet = true): ReadFromCacheResults {
+  public readFromCache(snippets: TypeScriptSnippet[], addToTablet = true, compiledOnly = false): ReadFromCacheResults {
     const remaining = [...snippets];
     const translations = new Array<TranslatedSnippet>();
 
     let i = 0;
     while (i < remaining.length) {
       const fromCache = tryReadFromCache(remaining[i], this.cache, this.fingerprinter);
-      if (fromCache) {
+      // If compiledOnly is set, do not consider cached snippets that do not compile
+      if (fromCache && (!compiledOnly || fromCache.snippet.didCompile)) {
         if (addToTablet) {
           this.tablet.addSnippet(fromCache);
         }


### PR DESCRIPTION
Picture this scenario: there is a non-compiling snippet in a README.md file.
I run `yarn rosetta:extract --compile` and it returns diagnostics as expected.
Behind the scenes, `.jsii.tabl.json` gets created as a cache, and this snippet
is inserted into that file with `didCompile = false`.

_Without making any changes_, I run `yarn rosetta:extract --compile` again.
This time, no diagnostics are returned, and it looks like my errors have
magically fixed themselves. However what is really happening is that `extract`
is finding a snippet in the cache that matches the offending snippet (since
I changed nothing). It is then filtering out that cached snippet, meaning we
do not actually try to compile the snippet again. This is bad; `extract` should
honor the `--compile` flag and return errors the second time around too.

There are two ways to solve this (that I can think of): we can return
diagnostics for cached snippets as well, or we can ignore non-compiling
cached snippets when `--compile` is set. I have opted for the second solution
for this reason: it is possible that I am intending to rerun the same snippet
with the expectation that I have changed _something else_ that will result
in a successful compilation (for example, I add an import to the fixture).
Open to dialogue about this.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
