### PR TITLE
fix(rosetta): transliterate command does not translate in parallel

### DIFF
--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -38,17 +38,30 @@ export interface ExtractOptions {
   readonly trimCache?: boolean;
 
   /**
+   * Write translations to implicit tablets (`.jsii.tabl.json`)
+   *
+   * @default true
+   */
+  readonly writeToImplicitTablets?: boolean;
+
+  /**
    * Make a translator (just for testing)
    */
   readonly translatorFactory?: (opts: RosettaTranslatorOptions) => RosettaTranslator;
+
+  /**
+   * Turn on 'loose mode' or not
+   *
+   * Loose mode ignores failures during fixturizing, and undoes 'strict mode' for
+   * diagnostics.
+   *
+   * @default false
+   */
+  readonly loose?: boolean;
 }
 
-export async function extractAndInfuse(
-  assemblyLocations: string[],
-  options: ExtractOptions,
-  loose = false,
-): Promise<ExtractResult> {
-  const result = await extractSnippets(assemblyLocations, options, loose);
+export async function extractAndInfuse(assemblyLocations: string[], options: ExtractOptions): Promise<ExtractResult> {
+  const result = await extractSnippets(assemblyLocations, options);
   await infuse(assemblyLocations, {
     cacheFromFile: options.cacheFromFile,
     cacheToFile: options.cacheToFile,
@@ -60,16 +73,15 @@ export async function extractAndInfuse(
  * Extract all samples from the given assemblies into a tablet
  */
 export async function extractSnippets(
-  assemblyLocations: string[],
+  assemblyLocations: readonly string[],
   options: ExtractOptions = {},
-  loose = false,
 ): Promise<ExtractResult> {
   const only = options.only ?? [];
 
   logging.info(`Loading ${assemblyLocations.length} assemblies`);
   const assemblies = await loadAssemblies(assemblyLocations, options.validateAssemblies ?? false);
 
-  let snippets = Array.from(allTypeScriptSnippets(assemblies, loose));
+  let snippets = Array.from(allTypeScriptSnippets(assemblies, options.loose));
   if (only.length > 0) {
     snippets = filterSnippets(snippets, only);
   }
@@ -123,17 +135,19 @@ export async function extractSnippets(
   }
 
   // Save to individual tablet files, and optionally append to the output file
-  await Promise.all(
-    Object.entries(snippetsPerAssembly).map(async ([location, snips]) => {
-      const asmTabletFile = path.join(location, DEFAULT_TABLET_NAME);
-      logging.debug(`Writing ${snips.length} translations to ${asmTabletFile}`);
-      const translations = snips.map(({ key }) => translator.tablet.tryGetSnippet(key)).filter(isDefined);
+  if (options.writeToImplicitTablets ?? true) {
+    await Promise.all(
+      Object.entries(snippetsPerAssembly).map(async ([location, snips]) => {
+        const asmTabletFile = path.join(location, DEFAULT_TABLET_NAME);
+        logging.debug(`Writing ${snips.length} translations to ${asmTabletFile}`);
+        const translations = snips.map(({ key }) => translator.tablet.tryGetSnippet(key)).filter(isDefined);
 
-      const asmTablet = new LanguageTablet();
-      asmTablet.addSnippets(...translations);
-      await asmTablet.save(asmTabletFile);
-    }),
-  );
+        const asmTablet = new LanguageTablet();
+        asmTablet.addSnippets(...translations);
+        await asmTablet.save(asmTabletFile);
+      }),
+    );
+  }
 
   if (options.cacheToFile) {
     logging.info(`Adding translations to ${options.cacheToFile}`);

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -10,6 +10,7 @@ import { RosettaTabletReader, UnknownSnippetMode } from '../rosetta-reader';
 import { SnippetParameters, typeScriptSnippetFromVisibleSource, ApiLocation, parseMetadataLine } from '../snippet';
 import { Translation } from '../tablets/tablets';
 import { fmap } from '../util';
+import { extractSnippets } from './extract';
 
 export interface TransliterateAssemblyOptions {
   /**
@@ -53,15 +54,33 @@ export async function transliterateAssembly(
   targetLanguages: readonly TargetLanguage[],
   options: TransliterateAssemblyOptions = {},
 ): Promise<void> {
+  // Start by doing an 'extract' for all these assemblies
+  //
+  // This will locate all examples that haven't been translated yet and translate
+  // them. Importantly: it will translate them in parallel, which is going to improve
+  // performance a lot. We ignore diagnostics.
+  const { tablet } = await extractSnippets(assemblyLocations, {
+    includeCompilerDiagnostics: true,
+    loose: options.loose,
+    cacheFromFile: options.tablet,
+    writeToImplicitTablets: false,
+  });
+
+  // Now do a regular "tablet reader" cycle, expecting everything to be translated already,
+  // and therefore it doesn't matter that we do this all in a single-threaded loop.
   const rosetta = new RosettaTabletReader({
     includeCompilerDiagnostics: true,
-    unknownSnippets: UnknownSnippetMode.TRANSLATE,
+    unknownSnippets: UnknownSnippetMode.FAIL,
     loose: options.loose,
     targetLanguages,
   });
+  // Put in the same caching tablet here
   if (options.tablet) {
     await rosetta.loadTabletFromFile(options.tablet);
   }
+  // Any fresh translations we just came up with
+  rosetta.addTablet(tablet);
+
   const assemblies = await loadAssemblies(assemblyLocations, rosetta);
 
   for (const [location, loadAssembly] of assemblies.entries()) {

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -69,9 +69,7 @@ export async function transliterateAssembly(
   // Now do a regular "tablet reader" cycle, expecting everything to be translated already,
   // and therefore it doesn't matter that we do this all in a single-threaded loop.
   const rosetta = new RosettaTabletReader({
-    includeCompilerDiagnostics: true,
     unknownSnippets: UnknownSnippetMode.FAIL,
-    loose: options.loose,
     targetLanguages,
   });
   // Put in the same caching tablet here

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -12,6 +12,7 @@ import {
   SnippetParameters,
   ApiLocation,
   parseMetadataLine,
+  INITIALIZER_METHOD_NAME,
 } from '../snippet';
 import { enforcesStrictMode } from '../strict';
 import { LanguageTablet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
@@ -119,14 +120,33 @@ export function allSnippetSources(assembly: spec.Assembly): AssemblySnippetSourc
       if (spec.isEnumType(type)) {
         type.members.forEach((m) => emitDocs(m.docs, { api: 'member', fqn: type.fqn, memberName: m.name }));
       }
+      if (spec.isClassType(type)) {
+        emitDocsForCallable(type.initializer, type.fqn);
+      }
       if (spec.isClassOrInterfaceType(type)) {
-        (type.methods ?? []).forEach((m) => emitDocs(m.docs, { api: 'member', fqn: type.fqn, memberName: m.name }));
+        (type.methods ?? []).forEach((m) => emitDocsForCallable(m, type.fqn, m.name));
         (type.properties ?? []).forEach((m) => emitDocs(m.docs, { api: 'member', fqn: type.fqn, memberName: m.name }));
       }
     });
   }
 
   return ret;
+
+  function emitDocsForCallable(callable: spec.Callable | undefined, fqn: string, memberName?: string) {
+    if (!callable) {
+      return;
+    }
+    emitDocs(callable.docs, memberName ? { api: 'member', fqn, memberName } : { api: 'initializer', fqn });
+
+    for (const parameter of callable.parameters ?? []) {
+      emitDocs(parameter.docs, {
+        api: 'parameter',
+        fqn: fqn,
+        methodName: memberName ?? INITIALIZER_METHOD_NAME,
+        parameterName: parameter.name,
+      });
+    }
+  }
 
   function emitDocs(docs: spec.Docs | undefined, location: ApiLocation) {
     if (!docs) {

--- a/packages/jsii-rosetta/lib/rosetta-reader.ts
+++ b/packages/jsii-rosetta/lib/rosetta-reader.ts
@@ -121,9 +121,7 @@ export class RosettaTabletReader {
   }
 
   /**
-   * Directly add a tablet
-   *
-   * Should only be needed for testing, use `loadTabletFromFile` and `addAssembly` instead.
+   * Directly add a tablet to the list of tablets to load translations from
    */
   public addTablet(tablet: LanguageTablet) {
     this.loadedTablets.push(tablet);

--- a/packages/jsii-rosetta/lib/rosetta-translator.ts
+++ b/packages/jsii-rosetta/lib/rosetta-translator.ts
@@ -42,7 +42,13 @@ export interface RosettaTranslatorOptions {
  * be achieved by the rosetta CLI, use this class.
  */
 export class RosettaTranslator {
+  /**
+   * Tablet with fresh translations
+   *
+   * All new translations (not read from cache) are added to this tablet.
+   */
   public readonly tablet = new LanguageTablet();
+
   private readonly fingerprinter: TypeFingerprinter;
   private readonly cache = new LanguageTablet();
   private readonly includeCompilerDiagnostics: boolean;

--- a/packages/jsii-rosetta/lib/snippet.ts
+++ b/packages/jsii-rosetta/lib/snippet.ts
@@ -58,7 +58,7 @@ export interface SnippetLocation {
 /**
  * How to represent the initializer in a 'parameter' type.
  *
- * (Don't feel like making everyone's `case` statement worse wby adding an
+ * (Don't feel like making everyone's `case` statement worse by adding an
  * 'initializer-parameter' variant).
  */
 export const INITIALIZER_METHOD_NAME = '<initializer>';

--- a/packages/jsii-rosetta/lib/snippet.ts
+++ b/packages/jsii-rosetta/lib/snippet.ts
@@ -55,13 +55,26 @@ export interface SnippetLocation {
   readonly field?: FieldLocation;
 }
 
+/**
+ * How to represent the initializer in a 'parameter' type.
+ *
+ * (Don't feel like making everyone's `case` statement worse wby adding an
+ * 'initializer-parameter' variant).
+ */
+export const INITIALIZER_METHOD_NAME = '<initializer>';
+
 export type ApiLocation =
   | { readonly api: 'file'; readonly fileName: string }
   | { readonly api: 'moduleReadme'; readonly moduleFqn: string }
   | { readonly api: 'type'; readonly fqn: string }
   | { readonly api: 'initializer'; readonly fqn: string }
   | { readonly api: 'member'; readonly fqn: string; readonly memberName: string }
-  | { readonly api: 'parameter'; readonly fqn: string; readonly methodName: string; readonly parameterName: string };
+  | {
+      readonly api: 'parameter';
+      readonly fqn: string;
+      readonly methodName: string | typeof INITIALIZER_METHOD_NAME;
+      readonly parameterName: string;
+    };
 
 export type FieldLocation = { readonly field: 'markdown'; readonly line: number } | { readonly field: 'example' };
 


### PR DESCRIPTION
Make the `rosetta transliterate` command do translations in parallel.

Achieve this by effectively running `rosetta extract` beforehand, which
does to translations in parallel using worker threads, but don't save
the results anywhere. Instead, use those results as an in-memory cache
when doing the single pass.

Since there shouldn't be any untranslated snippets left between
extract and transliterate, set the `UnknownSnippetMode` to `FAIL`,
which netted me errors showing that `extract` and `transliterate`
don't look at the same fields! Specifically, initializer and parameters!



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
