### PR TITLE
chore: centralize disclaimers to extract

### DIFF
--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
@@ -185,8 +185,8 @@ export class DotNetDocGenerator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
-      return `// ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
+    if (translated.disclaimer) {
+      return `// ${translated.disclaimer}\n${translated.source}`;
     }
     return translated.source;
   }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -3004,8 +3004,8 @@ class JavaGenerator extends Generator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
-      return `// ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
+    if (translated.disclaimer) {
+      return `// ${translated.disclaimer}\n${translated.source}`;
     }
     return translated.source;
   }

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -2416,8 +2416,8 @@ class PythonGenerator extends Generator {
   }
 
   private prefixDisclaimer(translated: Translation) {
-    if (!translated.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
-      return `# ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n${translated.source}`;
+    if (translated.disclaimer) {
+      return `# ${translated.disclaimer}\n${translated.source}`;
     }
     return translated.source;
   }

--- a/packages/jsii-rosetta/lib/tablets/schema.ts
+++ b/packages/jsii-rosetta/lib/tablets/schema.ts
@@ -1,4 +1,5 @@
 import { SnippetLocation } from '../snippet';
+import { Disclaimer } from '../translate';
 
 /**
  * Tablet file schema
@@ -45,6 +46,11 @@ export interface TranslatedSnippetSchema {
    * A description of the location this code snippet was found
    */
   readonly location: SnippetLocation;
+
+  /**
+   * Optionally add a disclaimer to the top of the snippet
+   */
+  readonly disclaimer?: Disclaimer;
 
   /**
    * Whether this was compiled without errors

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { TargetLanguage } from '../languages';
 import * as logging from '../logging';
 import { TypeScriptSnippet, SnippetLocation, completeSource } from '../snippet';
+import { Disclaimer } from '../translate';
 import { mapValues } from '../util';
 import { snippetKey } from './key';
 import { TabletSchema, TranslatedSnippetSchema, ORIGINAL_SNIPPET_KEY } from './schema';
@@ -175,11 +176,12 @@ export class TranslatedSnippet {
     return new TranslatedSnippet(schema);
   }
 
-  public static fromTypeScript(original: TypeScriptSnippet, didCompile?: boolean) {
+  public static fromTypeScript(original: TypeScriptSnippet, didCompile?: boolean, disclaimer?: Disclaimer) {
     return new TranslatedSnippet({
       translations: {
         [ORIGINAL_SNIPPET_KEY]: { source: original.visibleSource, version: '0' },
       },
+      disclaimer: disclaimer,
       didCompile: didCompile,
       location: original.location,
       fullSource: completeSource(original),
@@ -208,6 +210,7 @@ export class TranslatedSnippet {
       source: this.snippet.translations[ORIGINAL_SNIPPET_KEY].source,
       language: 'typescript',
       didCompile: this.snippet.didCompile,
+      disclaimer: this.snippet.disclaimer,
     };
   }
 
@@ -218,6 +221,7 @@ export class TranslatedSnippet {
       source: translation,
       language,
       didCompile: this.snippet.didCompile,
+      disclaimer: this.snippet.disclaimer,
     };
   }
 
@@ -241,7 +245,14 @@ export class TranslatedSnippet {
 
   public get(language: TargetLanguage): Translation | undefined {
     const t = this.snippet.translations[language];
-    return t && { source: t.source, language, didCompile: this.snippet.didCompile };
+    return (
+      t && {
+        source: t.source,
+        language,
+        didCompile: this.snippet.didCompile,
+        disclaimer: this.snippet.disclaimer,
+      }
+    );
   }
 
   public mergeTranslations(other: TranslatedSnippet) {
@@ -281,6 +292,7 @@ export interface Translation {
   source: string;
   language: string;
   didCompile?: boolean;
+  disclaimer?: Disclaimer;
 }
 
 type Mutable<T> = { -readonly [P in keyof T]: Mutable<T[P]> };


### PR DESCRIPTION
Draft PR; no tests because I am not sure if we want to continue down this road.

Currently we have two disclaimers -- one for non-compiling examples and the 
other for generated examples. The former is appended in `pacmak`, while the
latter is appended to the actual source code.

The idea proposed in this PR is to centralize disclaimers to `extract` as a property
of `TranslatedSnippet`. They then get rendered when the target language code
gets rendered.

Since the TypeScript doc workflow does not include `pacmak` or `extract`, so 
the non-compiling disclaimer does not show. If we add the generated disclaimer
to the central `extract` location as well, it will not show in the TypeScript docs
either.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
