### PR TITLE
fix(pacmak): fails on bundled dependency without entry point

### DIFF
--- a/packages/jsii-pacmak/lib/dependency-graph.ts
+++ b/packages/jsii-pacmak/lib/dependency-graph.ts
@@ -58,6 +58,7 @@ export interface TraverseDependencyGraphHost {
 export interface PackageJson {
   readonly dependencies?: { readonly [name: string]: string };
   readonly peerDependencies?: { readonly [name: string]: string };
+  readonly bundleDependencies?: string[];
   readonly bundledDependencies?: string[];
 
   readonly [key: string]: unknown;
@@ -93,7 +94,7 @@ async function real$traverseDependencyGraph(
       .filter(
         (m) =>
           !util.isBuiltinModule(m) &&
-          !(meta.bundledDependencies ?? []).includes(m),
+          (meta.bundledDependencies ?? meta.bundleDependencies)?.includes(m),
       )
       .map(async (dep) => {
         const dependencyDir = await host.findDependencyDirectory(

--- a/packages/jsii-pacmak/lib/dependency-graph.ts
+++ b/packages/jsii-pacmak/lib/dependency-graph.ts
@@ -94,7 +94,7 @@ async function real$traverseDependencyGraph(
       .filter(
         (m) =>
           !util.isBuiltinModule(m) &&
-          (meta.bundledDependencies ?? meta.bundleDependencies)?.includes(m),
+          !(meta.bundledDependencies ?? meta.bundleDependencies)?.includes(m),
       )
       .map(async (dep) => {
         const dependencyDir = await host.findDependencyDirectory(

--- a/packages/jsii-pacmak/lib/dependency-graph.ts
+++ b/packages/jsii-pacmak/lib/dependency-graph.ts
@@ -58,6 +58,7 @@ export interface TraverseDependencyGraphHost {
 export interface PackageJson {
   readonly dependencies?: { readonly [name: string]: string };
   readonly peerDependencies?: { readonly [name: string]: string };
+  readonly bundledDependencies?: string[];
 
   readonly [key: string]: unknown;
 }
@@ -88,7 +89,12 @@ async function real$traverseDependencyGraph(
   ]);
   return Promise.all(
     Array.from(deps)
-      .filter((m) => !util.isBuiltinModule(m))
+      // No need to pacmak the dependency if it's built-in, or if it's bundled
+      .filter(
+        (m) =>
+          !util.isBuiltinModule(m) &&
+          !(meta.bundledDependencies ?? []).includes(m),
+      )
       .map(async (dep) => {
         const dependencyDir = await host.findDependencyDirectory(
           dep,

--- a/packages/jsii-pacmak/lib/dependency-graph.ts
+++ b/packages/jsii-pacmak/lib/dependency-graph.ts
@@ -94,7 +94,8 @@ async function real$traverseDependencyGraph(
       .filter(
         (m) =>
           !util.isBuiltinModule(m) &&
-          !(meta.bundledDependencies ?? meta.bundleDependencies)?.includes(m),
+          !meta.bundledDependencies?.includes(m) &&
+          !meta.bundleDependencies?.includes(m),
       )
       .map(async (dep) => {
         const dependencyDir = await host.findDependencyDirectory(


### PR DESCRIPTION
`projen` uses a bundled dependency called `shx`, and this library does
not have an entry point. It exposes some command-line tools and nothing
else.

This conflicts with our dependency finding mechanism, which performs
a `require()` on the library to find it.

Ignore bundled dependencies in `pacmak`, it never needs to pack them
individually anyway.


Fixes #3275.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
