### PR TITLE
fix(rosetta): diagnostics from infused snippets were not ignored

### DIFF
--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -57,7 +57,7 @@ export class Translator {
       }),
     );
 
-    if (snip.strict) {
+    if (snip.parameters?.infused === undefined) {
       this.#diagnostics.push(...translator.diagnostics);
     }
 

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -57,7 +57,9 @@ export class Translator {
       }),
     );
 
-    this.#diagnostics.push(...translator.diagnostics);
+    if (snip.strict) {
+      this.#diagnostics.push(...translator.diagnostics);
+    }
 
     return TranslatedSnippet.fromSchema({
       translations: {

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -490,7 +490,7 @@ test('infused examples have no diagnostics', async () => {
       /**
        * ClassA
        * 
-       * @exampleMetadata lit=integ.test.ts infused
+       * @exampleMetadata infused
        * @example x
        */
       export class ClassA {


### PR DESCRIPTION
Recently we implemented the `infused` metadata that turns `strict=false`
and `loose=true` for the specific snippet. However we still output the
diagnostics along with other snippets (with `isError=true`). One thing we
could do is make these diagnostics `isError=false`, but I argue that we
want to ignore these diagnostics entirely. They aren't actually diagnostics;
we will find them in the cache and they do compile.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
