### PR TITLE
chore: auto approve workflow broken

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -23,34 +23,32 @@ jobs:
       # approval if the PR currently has no reviews on it. Dismissed reviews are ignored in the
       # context of this check. This way, the automated workflow will not do anything if a manual
       # review has already been done for the PR (implicit opt-out).
-      - uses: actions/github-script@0.3.0
+      - uses: actions/github-script@v5.0.0
         id: needs-approving
         with:
           script: |-
             const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            const reviews = github.pulls.listReviews({ owner, repo, pull_number })
+            const reviews = (await github.rest.pulls.listReviews({ owner, repo, pull_number })).data
               .filter((review) => review.state !== 'DISMISSED');
             core.setOutput('result', `${reviews.length === 0}`);
 
       # If this is NOT a dependabot PR, just approve it.
-      - uses: actions/github-script@0.3.0
+      - uses: actions/github-script@v5.0.0
         if: steps.needs-approving.outputs.result == 'true' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |-
             const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            github.pulls.createReview({
+            github.rest.pulls.createReview({
               owner, repo, pull_number,
               event: 'APPROVE',
             });
       # If this IS a dependabot PR, approve it and ask dependabot to squash-and-merge it when CI passes.
-      - uses: actions/github-script@0.3.0
+      - uses: actions/github-script@v5.0.0
         if: steps.needs-approving.outputs.result == 'true' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |-
             const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            github.pulls.createReview({
+            github.rest.pulls.createReview({
               owner, repo, pull_number,
               body: '@dependabot squash and merge',
               event: 'APPROVE',

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -30,8 +30,7 @@ jobs:
             const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
             const reviews = (await github.rest.pulls.listReviews({ owner, repo, pull_number })).data
               .filter((review) => review.state !== 'DISMISSED');
-            console.log(`Found ${reviews.length} reviews`);
-            core.setOutput('result', `${reviews.length === 0}`);
+            return reviews.length === 0;
 
       # If this is NOT a dependabot PR, just approve it.
       - uses: actions/github-script@v5.0.0

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -30,6 +30,7 @@ jobs:
             const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
             const reviews = (await github.rest.pulls.listReviews({ owner, repo, pull_number })).data
               .filter((review) => review.state !== 'DISMISSED');
+            console.log(`Found ${reviews.length} reviews`);
             core.setOutput('result', `${reviews.length === 0}`);
 
       # If this is NOT a dependabot PR, just approve it.


### PR DESCRIPTION
The auto-approve workflow is currently [failing](https://github.com/aws/jsii/runs/4618073266?check_suite_focus=true) with:

```console
Error: Input required and not supplied: github-token
Error: Input required and not supplied: github-token
    at Object.getInput (/home/runner/work/_actions/actions/github-script/0.3.0/node_modules/@actions/core/lib/core.js:73:15)
    at main (/home/runner/work/_actions/actions/github-s
```

This because version `0.3.0` of the action requires a `github-token`, and we don't always provide it. 

Instead of adding it, I upgraded to version `5.0.0` of the action, which no longer requires it.
Some adjustments to the implementation were also necessary due to [breaking changes](https://github.com/actions/github-script#breaking-changes-in-v5). 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
