### PR TITLE
chore: merge dependabot with mergify

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -12,44 +12,11 @@ on:
 
 jobs:
   auto-approve:
-    if: contains(github.event.pull_request.labels.*.name, 'pr/auto-approve') || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
-
+    if: contains(github.event.pull_request.labels.*.name, 'pr/auto-approve')
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-
     steps:
-      # Check whether the PR needs an automated approval or not. We will only add an automated
-      # approval if the PR currently has no reviews on it. Dismissed reviews are ignored in the
-      # context of this check. This way, the automated workflow will not do anything if a manual
-      # review has already been done for the PR (implicit opt-out).
-      - uses: actions/github-script@v5.0.0
-        id: needs-approving
-        with:
-          script: |-
-            const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            const reviews = (await github.rest.pulls.listReviews({ owner, repo, pull_number })).data
-              .filter((review) => review.state !== 'DISMISSED');
-            return reviews.length === 0;
-
-      # If this is NOT a dependabot PR, just approve it.
-      - uses: actions/github-script@v5.0.0
-        if: steps.needs-approving.outputs.result == 'true' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-        with:
-          script: |-
-            const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            github.rest.pulls.createReview({
-              owner, repo, pull_number,
-              event: 'APPROVE',
-            });
-      # If this IS a dependabot PR, approve it and ask dependabot to squash-and-merge it when CI passes.
-      - uses: actions/github-script@v5.0.0
-        if: steps.needs-approving.outputs.result == 'true' && (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')
-        with:
-          script: |-
-            const { issue: { number: pull_number }, repo: { owner, repo }  } = context;
-            github.rest.pulls.createReview({
-              owner, repo, pull_number,
-              body: '@dependabot squash and merge',
-              event: 'APPROVE',
-            });
+    - uses: hmarr/auto-approve-action@v2.1.0
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,18 @@
+# Apply various labels on PRs
+
+name: pr-labeler
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+    - run: gh pr edit ${{ github.event.pull_request.number }} --add-label "pr/auto-approve" -R ${{ github.repository }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -39,8 +39,6 @@ pull_request_rules:
       label:
         add: [pr/ready-to-merge]
     conditions:
-      - author!=dependabot[bot]
-      - author!=dependabot-preview[bot]
       - -title~=(WIP|wip)
       - label!=pr/blocked
       - label!=pr/do-not-merge
@@ -89,8 +87,6 @@ pull_request_rules:
       comment:
         message: Merging (with squash)...
     conditions:
-      - author!=dependabot[bot]
-      - author!=dependabot-preview[bot]
       - -title~=(WIP|wip)
       - label!=pr/blocked
       - label!=pr/do-not-merge
@@ -140,8 +136,6 @@ pull_request_rules:
       comment:
         message: Merging (no-squash)...
     conditions:
-      - author!=dependabot[bot]
-      - author!=dependabot-preview[bot]
       - -title~=(WIP|wip)
       - label!=pr/blocked
       - label!=pr/do-not-merge


### PR DESCRIPTION
Currently, we are (trying) to merge dependabot PR's by automatically approving them with a comment saying `@dependabot squash and merge`.

The problem is that the entity approving the PR, which is the default github token, doesn't have write permissions to the repo, resulting in:

<img width="1035" alt="Screen Shot 2021-12-25 at 2 42 38 PM" src="https://user-images.githubusercontent.com/1428812/147385011-3ce8d920-4a52-4da0-b881-e6365301c905.png">

This might be fixable with granting the token in this specific job with `content: write` permissions. 
However, dependabot doing the merge also has other downsides:

- No observability. Its impossible to understand if dependabot is actually doing something, or what PR's are scheduled for merge. This is as opposed to mergify, where we can always look at the merge queue.
- I've noticed that sometimes dependabot will either ignore or take a long time rebasing the PR. Since there is no observability, its hard to understand what is happening. 
- Fairly complex workflow setup. To make this work properly, we need several workflows to be explicitly aware of dependabot. As opposed to the proposed solution, where only the labeler needs to know about dependabot. 

Instead, I propose to simply let mergify handle these PR's as all other PR's. 

The only potential problem with this is that once mergify rebases the PR, dependabot will no longer take any action on it, including fixing merge conflicts that might arise. However, I believe these occurrences were more prolific when dependabot did our npm upgrades, but will be rare in the current form where it only updates specific non npm dependencies that should cause conflicts. 

Let's give this a try, if we see it doesn't workout we'll consider alternatives. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
