### PR TITLE
chore: excluding setuptools from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,8 @@ updates:
     labels:
       - dependencies
       - language/python
+    ignore:
+      - dependency-name: "setuptools"
 
   - package-ecosystem: gomod
     directory: '/packages/@jsii/go-runtime'


### PR DESCRIPTION
`setuptools` version 60.2.0 and above require Python >= 3.7. If dependabot updates it, the build will fail, as we have jobs that run on Python 3.6.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
