### PR TITLE
chore(rosetta): change how python shows declared types and include module name

### DIFF
--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -501,7 +501,7 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
         (node.initializer && context.typeOfExpression(node.initializer));
 
       const renderedType = type ? this.renderType(node, type, context, fallback) : fallback;
-      return new OTree(['# ', context.convert(node.name), ' is of type ', renderedType], []);
+      return new OTree(['# ', context.convert(node.name), ': ', renderedType], []);
     }
 
     return new OTree([context.convert(node.name), ' = ', context.convert(node.initializer)], [], {
@@ -731,22 +731,22 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
           renderer.report(owningNode, jsiiType.message);
           return fallback;
         case 'map':
-          return `dictionary of string to ${doRender(jsiiType.elementType)}`;
+          return `Dict[str, ${doRender(jsiiType.elementType)}]`;
         case 'list':
-          return `list of ${doRender(jsiiType.elementType)}`;
+          return `List[${doRender(jsiiType.elementType)}]`;
         case 'namedType':
           // in this case, the fallback will hold more information than jsiiType.name
           return fallback;
         case 'builtIn':
           switch (jsiiType.builtIn) {
             case 'boolean':
-              return 'boolean';
+              return 'bool';
             case 'number':
               return 'number';
             case 'string':
-              return 'string';
+              return 'str';
             case 'any':
-              return 'object';
+              return 'Any';
             default:
               return jsiiType.builtIn;
           }

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -720,7 +720,9 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
    * Not usually a thing in Python, but useful for declared variables.
    */
   private renderType(owningNode: ts.Node, type: ts.Type, renderer: PythonVisitorContext, fallback: string): string {
-    return doRender(determineJsiiType(renderer.typeChecker, type));
+    const r = doRender(determineJsiiType(renderer.typeChecker, type));
+    console.log(r);
+    return r;
 
     // eslint-disable-next-line consistent-return
     function doRender(jsiiType: JsiiType): string {
@@ -735,7 +737,8 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
         case 'list':
           return `list of ${doRender(jsiiType.elementType)}`;
         case 'namedType':
-          return jsiiType.name;
+          // in this case, the fallback will hold more information than jsiiType.name
+          return fallback;
         case 'builtIn':
           switch (jsiiType.builtIn) {
             case 'boolean':

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -720,9 +720,7 @@ export class PythonVisitor extends DefaultVisitor<PythonLanguageContext> {
    * Not usually a thing in Python, but useful for declared variables.
    */
   private renderType(owningNode: ts.Node, type: ts.Type, renderer: PythonVisitorContext, fallback: string): string {
-    const r = doRender(determineJsiiType(renderer.typeChecker, type));
-    console.log(r);
-    return r;
+    return doRender(determineJsiiType(renderer.typeChecker, type));
 
     // eslint-disable-next-line consistent-return
     function doRender(jsiiType: JsiiType): string {

--- a/packages/jsii-rosetta/test/jsii-imports.test.ts
+++ b/packages/jsii-rosetta/test/jsii-imports.test.ts
@@ -493,7 +493,7 @@ const DEFAULT_CSHARP_CODE = [
 ];
 
 /**
- * Verify the Java output. All expected Java outputs look the same.
+ * Verify the output in the given language. All expected outputs look the same.
  */
 function expectTranslation(trans: TranslatedSnippet, lang: TargetLanguage, expected: string[]) {
   expect(trans.get(lang)?.source.split('\n')).toEqual(expected);

--- a/packages/jsii-rosetta/test/translate.test.ts
+++ b/packages/jsii-rosetta/test/translate.test.ts
@@ -210,7 +210,7 @@ test('declarations are translated correctly in all jsii languages', async () => 
     );
 
     expect(ts.get(TargetLanguage.PYTHON)?.source).toEqual(
-      ['import example_test_demo as masm', '# class_a is of type masm.ClassA'].join('\n'),
+      ['import example_test_demo as masm', '# class_a: masm.ClassA'].join('\n'),
     );
     expect(ts.get(TargetLanguage.JAVA)?.source).toEqual(['import example.test.demo.*;', 'ClassA classA;'].join('\n'));
     expect(ts.get(TargetLanguage.CSHARP)?.source).toEqual(['using Example.Test.Demo;', 'ClassA classA;'].join('\n'));

--- a/packages/jsii-rosetta/test/translate.test.ts
+++ b/packages/jsii-rosetta/test/translate.test.ts
@@ -1,6 +1,7 @@
-import { SnippetTranslator, TypeScriptSnippet, PythonVisitor } from '../lib';
+import { SnippetTranslator, TypeScriptSnippet, PythonVisitor, TargetLanguage } from '../lib';
 import { VisualizeAstVisitor } from '../lib/languages/visualize';
 import { snippetKey } from '../lib/tablets/key';
+import { TestJsiiModule, DUMMY_JSII_CONFIG } from './testutil';
 
 const location = {
   api: { api: 'moduleReadme', moduleFqn: '@aws-cdk/aws-apigateway' },
@@ -181,4 +182,39 @@ test('refuse to translate object literal with function member in shorthand prope
       messageText: expect.stringMatching(/You cannot use an object literal/),
     }),
   );
+});
+
+test('declarations are translated correctly in all jsii languages', async () => {
+  // Create an assembly in a temp directory
+  const assembly = await TestJsiiModule.fromSource(
+    {
+      'index.ts': `
+      export class ClassA {
+        public someMethod() {
+        }
+      }
+      export class ClassB {
+        public anotherMethod() {
+        }
+      }
+      `,
+    },
+    {
+      name: 'my_assembly',
+      jsii: DUMMY_JSII_CONFIG,
+    },
+  );
+  try {
+    const ts = assembly.translateHere(
+      ["import * as masm from 'my_assembly';", 'declare const classA: masm.ClassA;'].join('\n'),
+    );
+
+    expect(ts.get(TargetLanguage.PYTHON)?.source).toEqual(
+      ['import example_test_demo as masm', '# class_a is of type masm.ClassA'].join('\n'),
+    );
+    expect(ts.get(TargetLanguage.JAVA)?.source).toEqual(['import example.test.demo.*;', 'ClassA classA;'].join('\n'));
+    expect(ts.get(TargetLanguage.CSHARP)?.source).toEqual(['using Example.Test.Demo;', 'ClassA classA;'].join('\n'));
+  } finally {
+    await assembly.cleanup();
+  }
 });

--- a/packages/jsii-rosetta/test/translations/expressions/array_index.py
+++ b/packages/jsii-rosetta/test/translations/expressions/array_index.py
@@ -1,3 +1,3 @@
-# array is of type list of string
+# array: List[str]
 
 print(array[3])

--- a/packages/jsii-rosetta/test/translations/statements/declare_var.py
+++ b/packages/jsii-rosetta/test/translations/statements/declare_var.py
@@ -1,1 +1,1 @@
-# variable is of type Type
+# variable: Type


### PR DESCRIPTION
Currently, Python type declarations are rendered as such:

```python
# get_book_handler is of type Function
# get_book_integration is of type LambdaIntegration


get_book_integration = apigateway.LambdaIntegration(get_book_handler,
    content_handling=apigateway.ContentHandling.CONVERT_TO_TEXT,  # convert to base64
    credentials_passthrough=True
)
```

This PR adds information on what module the type came from (if possible), and changes the way these type declarations are shown:

```python
# get_book_handler: lambda.Function
# get_book_integration: apigateway.LambdaIntegration


get_book_integration = apigateway.LambdaIntegration(get_book_handler,
    content_handling=apigateway.ContentHandling.CONVERT_TO_TEXT,  # convert to base64
    credentials_passthrough=True
)
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
