### PR TITLE
chore: test against node 17.3+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,7 @@ jobs:
         dotnet: ['3.1.x']
         go: ['1.17']
         java: ['8']
-        node: ['12', '14', '16']
+        node: ['12', '14', '16', '17']
         os: [ubuntu-latest]
         python: ['3.6']
         # Add specific combinations to be tested against "node 12" (to restrict cardinality)

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -63,5 +63,7 @@ export const VERSION_SUPPORT: { readonly [range: string]: SupportLevel } = {
   '^15.0.0-0': SupportLevel.END_OF_LIFE,
   '<16.3.0': SupportLevel.UNSUPPORTED,
   '^16.3.0': SupportLevel.SUPPORTED,
+  '<17.3.0': SupportLevel.UNSUPPORTED,
+  '^17.3.0': SupportLevel.SUPPORTED,
   // Anything else will be treated as SupportLevel.UNTESTED.
 };


### PR DESCRIPTION
As node 17.3+ is the 'current' release, it should be tested
and ideally supported. This is an odd-major version, so it
will EOL shortly after node 18 gets released.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
