### PR TITLE
fix(jsii): breaks due to faulty version of `colors`

### DIFF
--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@jsii/check-node": "0.0.0",
     "@jsii/spec": "^0.0.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "fs-extra": "^9.1.0",
     "oo-ascii-tree": "^0.0.0",
     "yargs": "^16.2.0"

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -38,7 +38,7 @@
     "@jsii/check-node": "0.0.0",
     "@jsii/spec": "^0.0.0",
     "case": "^1.6.3",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "deep-equal": "^2.0.5",
     "fs-extra": "^9.1.0",
     "log4js": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2597,7 +2597,7 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.4.0:
+colors@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
See https://github.com/Marak/colors.js/issues/289.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
