### PR TITLE
chore: transition from using colors to chalk

### DIFF
--- a/packages/jsii-reflect/bin/jsii-tree.ts
+++ b/packages/jsii-reflect/bin/jsii-tree.ts
@@ -1,6 +1,6 @@
 import '@jsii/check-node/run';
 
-import * as colors from 'colors/safe';
+import * as chalk from 'chalk';
 import * as yargs from 'yargs';
 
 import { TypeSystem, TypeSystemTree } from '../lib';
@@ -109,6 +109,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.log(colors.red(e));
+  console.log(chalk.red(e));
   process.exit(1);
 });

--- a/packages/jsii-reflect/lib/tree.ts
+++ b/packages/jsii-reflect/lib/tree.ts
@@ -1,5 +1,5 @@
 import { Stability } from '@jsii/spec';
-import * as colors from 'colors/safe';
+import * as chalk from 'chalk';
 import { AsciiTree } from 'oo-ascii-tree';
 
 import { Assembly } from './assembly';
@@ -98,7 +98,7 @@ export class TypeSystemTree extends AsciiTree {
 
 class AssemblyNode extends AsciiTree {
   public constructor(assembly: Assembly, options: TypeSystemTreeOptions) {
-    super(colors.green(assembly.name));
+    super(chalk.green(assembly.name));
 
     if (options.dependencies && assembly.dependencies.length > 0) {
       const deps = new TitleNode('dependencies');
@@ -129,7 +129,7 @@ class AssemblyNode extends AsciiTree {
 
 class SubmoduleNode extends AsciiTree {
   public constructor(submodule: Submodule, options: TypeSystemTreeOptions) {
-    super(colors.green(submodule.name));
+    super(chalk.green(submodule.name));
 
     const submodules = submodule.submodules;
     if (submodules.length > 0) {
@@ -154,7 +154,7 @@ class MethodNode extends AsciiTree {
   public constructor(method: Method, options: TypeSystemTreeOptions) {
     const args = method.parameters.map((p) => p.name).join(',');
     super(
-      `${maybeStatic(method)}${method.name}(${args}) ${colors.gray(
+      `${maybeStatic(method)}${method.name}(${args}) ${chalk.gray(
         'method',
       )}${describeStability(method, options)}`,
     );
@@ -197,7 +197,7 @@ class InitializerNode extends AsciiTree {
   public constructor(initializer: Initializer, options: TypeSystemTreeOptions) {
     const args = initializer.parameters.map((p) => p.name).join(',');
     super(
-      `${initializer.name}(${args}) ${colors.gray(
+      `${initializer.name}(${args}) ${chalk.gray(
         'initializer',
       )}${describeStability(initializer, options)}`,
     );
@@ -236,7 +236,7 @@ class ParameterNode extends AsciiTree {
 class PropertyNode extends AsciiTree {
   public constructor(property: Property, options: TypeSystemTreeOptions) {
     super(
-      `${maybeStatic(property)}${property.name} ${colors.gray(
+      `${maybeStatic(property)}${property.name} ${chalk.gray(
         'property',
       )}${describeStability(property, options)}`,
     );
@@ -277,14 +277,14 @@ class OptionalValueNode extends AsciiTree {
     if (asPromise) {
       type = `Promise<${type}>`;
     }
-    super(`${colors.underline(name)}: ${type}`);
+    super(`${chalk.underline(name)}: ${type}`);
   }
 }
 
 class ClassNode extends AsciiTree {
   public constructor(type: ClassType, options: TypeSystemTreeOptions) {
     super(
-      `${colors.gray('class')} ${colors.cyan(type.name)}${describeStability(
+      `${chalk.gray('class')} ${chalk.cyan(type.name)}${describeStability(
         type,
         options,
       )}`,
@@ -320,7 +320,7 @@ class ClassNode extends AsciiTree {
 class InterfaceNode extends AsciiTree {
   public constructor(type: InterfaceType, options: TypeSystemTreeOptions) {
     super(
-      `${colors.gray('interface')} ${colors.cyan(type.name)}${describeStability(
+      `${chalk.gray('interface')} ${chalk.cyan(type.name)}${describeStability(
         type,
         options,
       )}`,
@@ -346,7 +346,7 @@ class InterfaceNode extends AsciiTree {
 class EnumNode extends AsciiTree {
   public constructor(enumType: EnumType, options: TypeSystemTreeOptions) {
     super(
-      `${colors.gray('enum')} ${colors.cyan(enumType.name)}${describeStability(
+      `${chalk.gray('enum')} ${chalk.cyan(enumType.name)}${describeStability(
         enumType,
         options,
       )}`,
@@ -368,13 +368,13 @@ class DependencyNode extends AsciiTree {
 
 class TitleNode extends AsciiTree {
   public constructor(name: string, children: AsciiTree[] = []) {
-    super(colors.underline(name), ...children);
+    super(chalk.underline(name), ...children);
   }
 }
 
 class KeyValueNode extends AsciiTree {
   public constructor(key: string, value: any) {
-    super(`${colors.underline(key)}: ${value}`);
+    super(`${chalk.underline(key)}: ${value}`);
   }
 }
 
@@ -382,7 +382,7 @@ class TextNode extends AsciiTree {}
 
 class FlagNode extends AsciiTree {
   public constructor(flag: string) {
-    super(colors.italic(flag));
+    super(chalk.italic(flag));
   }
 }
 
@@ -390,21 +390,15 @@ class FlagNode extends AsciiTree {
  * Invokes `block` with colors enabled/disabled and reverts to old value afterwards.
  */
 function withColors(enabled: boolean, block: () => void) {
-  const oldEnabled = colors.enabled;
+  const oldChalkColorValue = process.env.FORCE_COLOR;
   try {
-    if (enabled) {
-      colors.enable();
-    } else {
-      colors.disable();
+    if (!enabled) {
+      process.env.FORCE_COLOR = '0';
     }
 
     block();
   } finally {
-    if (oldEnabled) {
-      colors.enable();
-    } else {
-      colors.disable();
-    }
+    process.env.FORCE_COLOR = oldChalkColorValue;
   }
 }
 
@@ -418,13 +412,13 @@ function describeStability(
 
   switch (thing.docs.stability) {
     case Stability.Stable:
-      return ` (${colors.green('stable')})`;
+      return ` (${chalk.green('stable')})`;
     case Stability.External:
-      return ` (${colors.green('external')})`;
+      return ` (${chalk.green('external')})`;
     case Stability.Experimental:
-      return ` (${colors.yellow('experimental')})`;
+      return ` (${chalk.yellow('experimental')})`;
     case Stability.Deprecated:
-      return ` (${colors.red('deprecated')})`;
+      return ` (${chalk.red('deprecated')})`;
     default:
       return '';
   }
@@ -439,5 +433,5 @@ function maybeStatic(mem: Property | Method) {
     isStatic = !!mem.static;
   }
 
-  return isStatic ? `${colors.grey('static')} ` : '';
+  return isStatic ? `${chalk.grey('static')} ` : '';
 }

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@jsii/check-node": "0.0.0",
     "@jsii/spec": "^0.0.0",
-    "colors": "1.4.0",
+    "chalk": "^4",
     "fs-extra": "^9.1.0",
     "oo-ascii-tree": "^0.0.0",
     "yargs": "^16.2.0"

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1227,9 +1227,9 @@ export class Assembler implements Emitter {
   ): Promise<spec.ClassType | undefined> {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing class: ${chalk.gray(
-          ctx.namespace.join('.'),
-        )}.${chalk.cyan(type.symbol.name)}`,
+        `Processing class: ${chalk.gray(ctx.namespace.join('.'))}.${chalk.cyan(
+          type.symbol.name,
+        )}`,
       );
     }
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1,7 +1,7 @@
 import * as spec from '@jsii/spec';
 import { PackageJson } from '@jsii/spec';
 import * as Case from 'case';
-import * as colors from 'colors/safe';
+import * as chalk from 'chalk';
 import * as crypto from 'crypto';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import deepEqual = require('deep-equal');
@@ -183,7 +183,7 @@ export class Assembler implements Emitter {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          `Processing source file: ${colors.blue(
+          `Processing source file: ${chalk.blue(
             path.relative(this.projectInfo.projectRoot, sourceFile.fileName),
           )}`,
         );
@@ -291,7 +291,7 @@ export class Assembler implements Emitter {
     const validationResult = await validator.emit();
     if (!validationResult.emitSkipped) {
       const assemblyPath = path.join(this.projectInfo.projectRoot, '.jsii');
-      LOG.trace(`Emitting assembly: ${colors.blue(assemblyPath)}`);
+      LOG.trace(`Emitting assembly: ${chalk.blue(assemblyPath)}`);
       await fs.writeJson(assemblyPath, _fingerprint(assembly), {
         encoding: 'utf8',
         spaces: 2,
@@ -917,7 +917,7 @@ export class Assembler implements Emitter {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          `Entering submodule: ${colors.cyan(
+          `Entering submodule: ${chalk.cyan(
             [...context.namespace, symbol.name].join('.'),
           )}`,
         );
@@ -932,7 +932,7 @@ export class Assembler implements Emitter {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          `Leaving submodule: ${colors.cyan(
+          `Leaving submodule: ${chalk.cyan(
             [...context.namespace, symbol.name].join('.'),
           )}`,
         );
@@ -994,7 +994,7 @@ export class Assembler implements Emitter {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          `Entering namespace: ${colors.cyan(
+          `Entering namespace: ${chalk.cyan(
             [...context.namespace, name].join('.'),
           )}`,
         );
@@ -1013,7 +1013,7 @@ export class Assembler implements Emitter {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          `Leaving namespace:  ${colors.cyan(
+          `Leaving namespace:  ${chalk.cyan(
             [...context.namespace, name].join('.'),
           )}`,
         );
@@ -1069,7 +1069,7 @@ export class Assembler implements Emitter {
 
     if (LOG.isInfoEnabled()) {
       LOG.info(
-        `Registering JSII ${colors.magenta(jsiiType.kind)}: ${colors.green(
+        `Registering JSII ${chalk.magenta(jsiiType.kind)}: ${chalk.green(
           jsiiType.fqn,
         )}`,
       );
@@ -1227,9 +1227,9 @@ export class Assembler implements Emitter {
   ): Promise<spec.ClassType | undefined> {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing class: ${colors.gray(
+        `Processing class: ${chalk.gray(
           ctx.namespace.join('.'),
-        )}.${colors.cyan(type.symbol.name)}`,
+        )}.${chalk.cyan(type.symbol.name)}`,
       );
     }
 
@@ -1274,7 +1274,7 @@ export class Assembler implements Emitter {
       // erased, and identify the closest exported base class, should there be one.
       while (base && this._isPrivateOrInternal(base.symbol)) {
         LOG.debug(
-          `Base class of ${colors.green(jsiiType.fqn)} named ${colors.green(
+          `Base class of ${chalk.green(jsiiType.fqn)} named ${chalk.green(
             base.symbol.name,
           )} is not exported, erasing it...`,
         );
@@ -1688,7 +1688,7 @@ export class Assembler implements Emitter {
 
     if (_isPrivate(symbol)) {
       LOG.trace(
-        `${colors.cyan(
+        `${chalk.cyan(
           symbol.name,
         )} is marked "private", or is an unexported type declaration`,
       );
@@ -1729,7 +1729,7 @@ export class Assembler implements Emitter {
   ): Promise<spec.EnumType | undefined> {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing enum: ${colors.gray(ctx.namespace.join('.'))}.${colors.cyan(
+        `Processing enum: ${chalk.gray(ctx.namespace.join('.'))}.${chalk.cyan(
           type.symbol.name,
         )}`,
       );
@@ -1880,9 +1880,9 @@ export class Assembler implements Emitter {
   ): Promise<spec.InterfaceType | undefined> {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing interface: ${colors.gray(
+        `Processing interface: ${chalk.gray(
           ctx.namespace.join('.'),
-        )}.${colors.cyan(type.symbol.name)}`,
+        )}.${chalk.cyan(type.symbol.name)}`,
       );
     }
 
@@ -2120,7 +2120,7 @@ export class Assembler implements Emitter {
   ) {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing method: ${colors.green(type.fqn)}#${colors.cyan(
+        `Processing method: ${chalk.green(type.fqn)}#${chalk.cyan(
           symbol.name,
         )}`,
       );
@@ -2241,7 +2241,7 @@ export class Assembler implements Emitter {
       ) != null
     ) {
       LOG.trace(
-        `Dropping re-declaration of ${colors.green(type.fqn)}#${colors.cyan(
+        `Dropping re-declaration of ${chalk.green(type.fqn)}#${chalk.cyan(
           method.name,
         )}`,
       );
@@ -2285,7 +2285,7 @@ export class Assembler implements Emitter {
 
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        `Processing property: ${colors.green(type.fqn)}#${colors.cyan(
+        `Processing property: ${chalk.green(type.fqn)}#${chalk.cyan(
           symbol.name,
         )}`,
       );
@@ -2373,7 +2373,7 @@ export class Assembler implements Emitter {
       ) != null
     ) {
       LOG.trace(
-        `Dropping re-declaration of ${colors.green(type.fqn)}#${colors.cyan(
+        `Dropping re-declaration of ${chalk.green(type.fqn)}#${chalk.cyan(
           property.name,
         )}`,
       );
@@ -2388,7 +2388,7 @@ export class Assembler implements Emitter {
     ctx: EmitContext,
   ): Promise<spec.Parameter> {
     if (LOG.isTraceEnabled()) {
-      LOG.trace(`Processing parameter: ${colors.cyan(paramSymbol.name)}`);
+      LOG.trace(`Processing parameter: ${chalk.cyan(paramSymbol.name)}`);
     }
     const paramDeclaration =
       paramSymbol.valueDeclaration as ts.ParameterDeclaration;

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1,5 +1,5 @@
 import * as Case from 'case';
-import * as colors from 'colors/safe';
+import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
@@ -413,7 +413,7 @@ export class Compiler implements Emitter {
       },
     };
 
-    LOG.debug(`Creating or updating ${colors.blue(this.configPath)}`);
+    LOG.debug(`Creating or updating ${chalk.blue(this.configPath)}`);
     await fs.writeJson(this.configPath, outputConfig, {
       encoding: 'utf8',
       spaces: 2,

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -38,7 +38,7 @@
     "@jsii/check-node": "0.0.0",
     "@jsii/spec": "^0.0.0",
     "case": "^1.6.3",
-    "colors": "1.4.0",
+    "chalk": "^4",
     "deep-equal": "^2.0.5",
     "fs-extra": "^9.1.0",
     "log4js": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,7 +2454,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2606,11 +2606,6 @@ colorette@^2.0.14:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
-
-colors@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 columnify@^1.5.4:
   version "1.5.4"


### PR DESCRIPTION
The stability and long-term prospects of colors is unclear; remove our
dependency and start using chalk instead.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
