### PR TITLE
fix(jsii): submodule READMEs don't have literate examples

### DIFF
--- a/packages/jsii/lib/literate.ts
+++ b/packages/jsii/lib/literate.ts
@@ -106,7 +106,7 @@ export async function includeAndRenderExamples(
       // 'lit' source attribute will make snippet compiler know to extract the same source
       // Needs to be relative to the project root.
       const imported = typescriptSourceToMarkdown(source, [
-        `lit=${path.relative(projectRoot, fullPath)}`,
+        `lit=${path.posix.relative(projectRoot, fullPath)}`,
       ]);
       ret.push(...imported);
     } else {

--- a/packages/jsii/lib/literate.ts
+++ b/packages/jsii/lib/literate.ts
@@ -106,7 +106,7 @@ export async function includeAndRenderExamples(
       // 'lit' source attribute will make snippet compiler know to extract the same source
       // Needs to be relative to the project root.
       const imported = typescriptSourceToMarkdown(source, [
-        `lit=${path.posix.relative(projectRoot, fullPath)}`,
+        `lit=${toUnixPath(path.relative(projectRoot, fullPath))}`,
       ]);
       ret.push(...imported);
     } else {
@@ -228,4 +228,8 @@ function markdownify(
       typescriptLines.splice(0); // Clear
     }
   }
+}
+
+function toUnixPath(x: string) {
+  return x.replace(/\\/g, '/');
 }

--- a/packages/jsii/test/literate.test.ts
+++ b/packages/jsii/test/literate.test.ts
@@ -99,10 +99,17 @@ test('can do example inclusion', async () => {
 
   const fakeLoader = (fileName: string) => {
     expect(fileName).toBe('test/something.lit.ts');
-    return ['const x = 1;', '/// This is how we print x', 'console.log(x);'];
+    return {
+      fullPath: fileName,
+      lines: ['const x = 1;', '/// This is how we print x', 'console.log(x);'],
+    };
   };
 
-  const rendered = await includeAndRenderExamples(inputMarkDown, fakeLoader);
+  const rendered = await includeAndRenderExamples(
+    inputMarkDown,
+    fakeLoader,
+    '.',
+  );
 
   expect(rendered).toEqual([
     'This is a preamble',

--- a/packages/jsii/test/submodules.test.ts
+++ b/packages/jsii/test/submodules.test.ts
@@ -64,7 +64,8 @@ test('submodule READMEs can have literate source references', async () => {
   const assembly = await sourceToAssemblyHelper({
     'index.ts': 'export * as submodule from "./subdir"',
     'subdir/index.ts': 'export class Foo { }',
-    'subdir/README.md': 'This is the README\n\n[includable](./test/includeme.lit.ts)',
+    'subdir/README.md':
+      'This is the README\n\n[includable](./test/includeme.lit.ts)',
     'subdir/test/includeme.lit.ts': '// Include me',
   });
 

--- a/packages/jsii/test/submodules.test.ts
+++ b/packages/jsii/test/submodules.test.ts
@@ -60,6 +60,29 @@ test('submodules loaded from directories can have targets', async () => {
   );
 });
 
+test('submodule READMEs can have literate source references', async () => {
+  const assembly = await sourceToAssemblyHelper({
+    'index.ts': 'export * as submodule from "./subdir"',
+    'subdir/index.ts': 'export class Foo { }',
+    'subdir/README.md': 'This is the README\n\n[includable](./test/includeme.lit.ts)',
+    'subdir/test/includeme.lit.ts': '// Include me',
+  });
+
+  expect(assembly.submodules!['testpkg.submodule']).toEqual(
+    expect.objectContaining({
+      readme: {
+        markdown: [
+          'This is the README',
+          '',
+          '```ts lit=subdir/test/includeme.lit.ts',
+          '// Include me',
+          '```',
+        ].join('\n'),
+      },
+    }),
+  );
+});
+
 type ImportStyle = 'directly' | 'as namespace' | 'with alias';
 
 test.each(['directly', 'as namespace', 'with alias'] as ImportStyle[])(


### PR DESCRIPTION
The code literally was not there to extract literate examples for
submodule READMEs.

Fixes aws/aws-cdk#18589.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
