### PR TITLE
chore: tweak mergify configuration

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -11,6 +11,7 @@ queue_rules:
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
+      - status-success~=^Test \(.* node 17 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -60,6 +61,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
+      - status-success~=^Test \(.* node 17 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -109,6 +111,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
+      - status-success~=^Test \(.* node 17 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -158,6 +161,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 12 .*$
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
+      - status-success~=^Test \(.* node 17 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -202,4 +206,4 @@ pull_request_rules:
 
           [Conventional Commits]: https://www.conventionalcommits.org
     conditions:
-      - -status-success=Semantic Pull Request
+      - status-failure=Semantic Pull Request


### PR DESCRIPTION
- Add requirement to wait on node 17 tests before merging
- Only comment about semantic pull request failures when the check has
  failed (currently it comments when the test is still pending, too)



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
