### PR TITLE
fix(python): cannot call a method that takes an empty struct

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_kernel/__init__.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/__init__.py
@@ -169,7 +169,7 @@ def _make_reference_for_native(kernel, d):
         from .._runtime import python_jsii_mapping
 
         mapping = python_jsii_mapping(d)
-        if mapping:  # This means we are handling a data_type (aka Struct)
+        if mapping is not None:  # This means we are handling a data_type (aka Struct)
             return {
                 "$jsii.struct": {
                     "fqn": typeFqn,


### PR DESCRIPTION
Empty dictionaries are false-y in Python, so the test that checked for
structs via the existence of a property mapping table was incorrect, as
it only checked truthiness of the mapping, instead of checking for it
being non-`None`.

Fixes #2846



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
