### PR TITLE
fix(go): replace uses of CanConvert to Type.AssignableTo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '5.0.x'
-      - name: Set up Go 1.17
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.16'
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
@@ -125,10 +125,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '5.0.x'
-      - name: Set up Go 1.17
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.16'
       - name: Set up Java 8
         uses: actions/setup-java@v2
         with:
@@ -211,7 +211,7 @@ jobs:
       matrix:
         # All currently supported node versions (Maintenance LTS, Active LTS, Current)
         dotnet: ['3.1.x']
-        go: ['1.17']
+        go: ['1.16']
         java: ['8']
         node: ['12', '14', '16', '17']
         os: [ubuntu-latest]
@@ -221,53 +221,53 @@ jobs:
           # Test using Windows
           - os: windows-latest
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             java: '8'
             node: '12'
             python: '3.6'
           # Test using macOS
           - os: macos-latest
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             java: '8'
             node: '12'
             python: '3.6'
           # Test alternate .NETs
           - java: '8'
             dotnet: '5.0.x'
-            go: '1.17'
+            go: '1.16'
             node: '12'
             os: ubuntu-latest
             python: '3.6'
           - java: '8'
             dotnet: '6.0.x'
-            go: '1.17'
+            go: '1.16'
             node: '12'
             os: ubuntu-latest
             python: '3.6'
           # Test alternate Javas
           - java: '11'
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             node: '12'
             os: ubuntu-latest
             python: '3.6'
           # Test alternate Pythons
           - python: '3.7'
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             java: '8'
             node: '12'
             os: ubuntu-latest
           - python: '3.8'
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             java: '8'
             node: '12'
             os: ubuntu-latest
           - python: '3.9'
             dotnet: '3.1.x'
-            go: '1.17'
+            go: '1.16'
             java: '8'
             node: '12'
             os: ubuntu-latest

--- a/packages/@jsii/go-runtime/go.mod
+++ b/packages/@jsii/go-runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/jsii
 
-go 1.15
+go 1.16
 
 require (
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5

--- a/packages/@jsii/go-runtime/jsii-runtime-go/cast.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/cast.go
@@ -34,7 +34,7 @@ func UnsafeCast(from interface{}, into interface{}) {
 	}
 
 	// If rfrom can be directly converted to rinto, just do it.
-	if rfrom.CanConvert(rinto.Type()) {
+	if rfrom.Type().AssignableTo(rinto.Type()) {
 		rfrom = rfrom.Convert(rinto.Type())
 		rinto.Set(rfrom)
 		return

--- a/packages/@jsii/go-runtime/jsii-runtime-go/go.mod
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/jsii-runtime-go
 
-go 1.17
+go 1.16
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
@@ -9,7 +9,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/internal/objectstore/objectstore.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/internal/objectstore/objectstore.go
@@ -195,7 +195,7 @@ func (o *ObjectStore) GetObjectAs(instanceID string, typ reflect.Type) (value re
 	found = false
 	if values, exists := o.idToObjects[instanceID]; exists {
 		for value = range values {
-			if value.CanConvert(typ) {
+			if value.Type().AssignableTo(typ) {
 				value = value.Convert(typ)
 				found = true
 				return


### PR DESCRIPTION
This preserves compatibility with Go 1.16, as `CanConvert` was introduced
in go 1.17 only.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
