### PR TITLE
fix(jsii): dependencies' README files are unnecessarily re-rendered

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -725,7 +725,7 @@ export class Assembler implements Emitter {
       // external (i.e: from a dependency), as these will not be emitted in the
       // assembly. That'd be wasted effort, and could fail if the README file
       // refers to literate examples that are not packaged in the dependency.
-      const readme = !ts.isExternalModule(sourceFile)
+      const readme = packageRoot === this.projectInfo.projectRoot
         ? await loadSubmoduleReadMe(
             sourceFile.fileName,
             this.projectInfo.projectRoot,

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -721,10 +721,16 @@ export class Assembler implements Emitter {
         symbol,
       );
       const targets = await loadSubmoduleTargetConfig(sourceFile.fileName);
-      const readme = await loadSubmoduleReadMe(
-        sourceFile.fileName,
-        this.projectInfo.projectRoot,
-      );
+      // There is no need to process the README file for submodules that are
+      // external (i.e: from a dependency), as these will not be emitted in the
+      // assembly. That'd be wasted effort, and could fail if the README file
+      // refers to literate examples that are not packaged in the dependency.
+      const readme = !ts.isExternalModule(sourceFile)
+        ? await loadSubmoduleReadMe(
+            sourceFile.fileName,
+            this.projectInfo.projectRoot,
+          )
+        : undefined;
 
       this._submodules.set(symbol, {
         fqn,

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -725,12 +725,13 @@ export class Assembler implements Emitter {
       // external (i.e: from a dependency), as these will not be emitted in the
       // assembly. That'd be wasted effort, and could fail if the README file
       // refers to literate examples that are not packaged in the dependency.
-      const readme = packageRoot === this.projectInfo.projectRoot
-        ? await loadSubmoduleReadMe(
-            sourceFile.fileName,
-            this.projectInfo.projectRoot,
-          )
-        : undefined;
+      const readme =
+        packageRoot === this.projectInfo.projectRoot
+          ? await loadSubmoduleReadMe(
+              sourceFile.fileName,
+              this.projectInfo.projectRoot,
+            )
+          : undefined;
 
       this._submodules.set(symbol, {
         fqn,


### PR DESCRIPTION
The compiler un-necesarily re-renders `README.md` documents from
dependencies to inline `.lit.ts` references in there. This is wasted
effort as those doucments will not be emitted to the output assembly.

Stop processing `README.md` documents for any module coming from a
dependency.

Fixes https://github.com/aws/jsii/issues/3379



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
