### PR TITLE
chore: add sam cli to the superchain image to execute the sam cdk integration testing

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -120,6 +120,7 @@ RUN apt-get update                                                              
   sudo                                                                                                                  \
   unzip                                                                                                                 \
   zip                                                                                                                   \
+  wget                                                                                                                  \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono
@@ -205,6 +206,14 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
   && apt-get update                                                                                                     \
   && apt-get -y install nodejs yarn                                                                                     \
   && rm -rf /var/lib/apt/lists/*
+
+# Install SAM CLI
+ARG SAM_CLI_SOURCE="https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
+RUN wget -O /tmp/aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                         \
+  && unzip /tmp/aws-sam-cli-linux-x86_64.zip -d /tmp/sam-installation                                                   \
+  && sudo ./tmp/sam-installation/install                                                                                \
+  && rm -rf /tmp/aws-sam-cli-linux-x86_64.zip /tmp/sam-installation                                                     \
+  && sam --version
 
 # Install some configuration
 COPY superchain/ssh_config /root/.ssh/config

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -208,10 +208,10 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 
 # Install SAM CLI
 ARG SAM_CLI_SOURCE="https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-RUN curl -L -o /tmp/aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                      \
-  && unzip /tmp/aws-sam-cli-linux-x86_64.zip -d /tmp/sam-installation                                                   \
-  && sudo ./tmp/sam-installation/install                                                                                \
-  && rm -rf /tmp/aws-sam-cli-linux-x86_64.zip /tmp/sam-installation                                                     \
+RUN curl -L -o aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                      \
+  && unzip -qq aws-sam-cli-linux-x86_64.zip -d sam-installation                                                   \
+  && sudo ./sam-installation/install                                                                                \
+  && rm -rf aws-sam-cli-linux-x86_64.zip sam-installation                                                     \
   && sam --version
 
 # Install some configuration

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -208,10 +208,10 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 
 # Install SAM CLI
 ARG SAM_CLI_SOURCE="https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-RUN curl -L -o aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                      \
-  && unzip -qq aws-sam-cli-linux-x86_64.zip -d sam-installation                                                   \
-  && sudo ./sam-installation/install                                                                                \
-  && rm -rf aws-sam-cli-linux-x86_64.zip sam-installation                                                     \
+RUN curl -fSsL ${SAM_CLI_SOURCE} -o aws-sam-cli-linux-x86_64.zip                                                        \
+  && unzip -qq aws-sam-cli-linux-x86_64.zip -d sam-installation                                                         \
+  && sudo ./sam-installation/install                                                                                    \
+  && rm -rf aws-sam-cli-linux-x86_64.zip sam-installation                                                               \
   && sam --version
 
 # Install some configuration

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -207,11 +207,7 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
   && rm -rf /var/lib/apt/lists/*
 
 # Install SAM CLI
-ARG SAM_CLI_SOURCE="https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-RUN curl -fSsL ${SAM_CLI_SOURCE} -o aws-sam-cli-linux-x86_64.zip                                                        \
-  && unzip -qq aws-sam-cli-linux-x86_64.zip -d sam-installation                                                         \
-  && sudo ./sam-installation/install                                                                                    \
-  && rm -rf aws-sam-cli-linux-x86_64.zip sam-installation                                                               \
+RUN pip install aws-sam-cli                                                                                             \
   && sam --version
 
 # Install some configuration

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -120,7 +120,6 @@ RUN apt-get update                                                              
   sudo                                                                                                                  \
   unzip                                                                                                                 \
   zip                                                                                                                   \
-  wget                                                                                                                  \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono
@@ -209,7 +208,7 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 
 # Install SAM CLI
 ARG SAM_CLI_SOURCE="https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-RUN wget -O /tmp/aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                         \
+RUN curl -L -o /tmp/aws-sam-cli-linux-x86_64.zip ${SAM_CLI_SOURCE}                                                      \
   && unzip /tmp/aws-sam-cli-linux-x86_64.zip -d /tmp/sam-installation                                                   \
   && sudo ./tmp/sam-installation/install                                                                                \
   && rm -rf /tmp/aws-sam-cli-linux-x86_64.zip /tmp/sam-installation                                                     \

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -81,6 +81,7 @@ Tool / Utility | Version
 `yarn`         | `>= 1.21.1`
 `zip` & `unzip`| `>= 6.0-19`
 `gh`           | `>= 1.9.2`
+`sam`          | `>= 1.37.0` 
 
 ## License
 

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -81,7 +81,7 @@ Tool / Utility | Version
 `yarn`         | `>= 1.21.1`
 `zip` & `unzip`| `>= 6.0-19`
 `gh`           | `>= 1.9.2`
-`sam`          | `>= 1.37.0` 
+`sam`          | `>= 1.37.0`
 
 ## License
 


### PR DESCRIPTION
To test the SAM CDK integration test cases
- Build the docker image by running [this script](https://github.com/aws/jsii/blob/ceb66a6d60eb3c17867f5b823efec8236ddd5505/superchain/build-local.sh)
- Run the built image using the following command:
```
docker run --net=host \
    --rm -it \
    -v $HOME:$HOME \
    -v /var/run/docker.sock:/var/run/docker.sock \
    -v $PWD:$PWD -w $PWD \
    -v /tmp:/tmp \
    -e HOME=$HOME \
    -e NPM_CONFIG_UNSAFE_PERM=true \
    jsii/superchain:local
```
- Then you can run the following command inside the container:
```
cd packages/aws-cdk
test/integ/run-against-repo test/integ/cli/test.sh
```
Expected output
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CLI Integration Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
27.5.1
Using regions: us-east-1
Using framework version: * (major version 1)
 PASS  ./bootstrapping.integtest.js (1805.252 s)t to 600000 ms
  ✓ can bootstrap without execution (131602 ms)
  ✓ upgrade legacy bootstrap stack to new bootstrap stack while in use (270126 ms)
  ✓ can and deploy if omitting execution policies (167916 ms)
  ✓ deploy new style synthesis to new style bootstrap (220405 ms)
  ✓ deploy new style synthesis to new style bootstrap (with docker image) (142873 ms)
  ✓ deploy old style synthesis to new style bootstrap (175787 ms)
  ✓ can create a legacy bootstrap stack with --public-access-block-configuration=false (72791 ms)
  ✓ can create multiple legacy bootstrap stacks (126609 ms)
  ✓ can dump the template, modify and use it to deploy a custom bootstrap stack (99182 ms)
  ✓ switch on termination protection, switch is left alone on re-bootstrap (105412 ms)
  ✓ add tags, left alone on re-bootstrap (104909 ms)
  ✓ can deploy modern-synthesized stack even if bootstrap stack name is unknown (183258 ms)

Using regions: us-east-1
Using framework version: * (major version 1)
 PASS  ./cli.integtest.js (2568.018 s)
  ✓ VPC Lookup (351788 ms)
  ✓ Construct with builtin Lambda function (110560 ms)
  ✓ Two ways of shoing the version (8944 ms)
  ✓ Termination protection (68245 ms)
  ✓ cdk synth (15441 ms)
  ✓ ssm parameter provider error (14294 ms)
  ✓ automatic ordering (91828 ms)
  ✓ context setting (14378 ms)
  ✓ context in stage propagates to top (8229 ms)
  ✓ deploy (49670 ms)
  ✓ deploy all (86664 ms)
  ✓ nested stack with parameters (78751 ms)
  ✓ deploy without execute a named change set (26935 ms)
  ✓ security related changes without a CLI are expected to fail (12349 ms)
  ✓ deploy wildcard with outputs (92077 ms)
  ✓ deploy with parameters (49808 ms)
  ✓ update to stack in ROLLBACK_COMPLETE state will delete stack and create a new one (96850 ms)
  ✓ stack in UPDATE_ROLLBACK_COMPLETE state can be updated (149875 ms)
  ✓ deploy with wildcard and parameters (131022 ms)
  ✓ deploy with parameters multi (50777 ms)
  ✓ deploy with notification ARN (50968 ms)
  ✓ deploy with role (73594 ms)
  ✓ cdk diff (21196 ms)
  ✓ cdk diff --fail on multiple stacks exits with error if any of the stacks contains a diff (59886 ms)
  ✓ cdk diff --fail with multiple stack exits with if any of the stacks contains a diff (65559 ms)
  ✓ cdk diff --security-only --fail exits when security changes are present (11855 ms)
  ✓ deploy stack with docker asset (39063 ms)
  ✓ deploy and test stack with lambda asset (78964 ms)
  ✓ cdk ls (11300 ms)
  ✓ synthing a stage with errors leads to failure (8129 ms)
  ✓ synthing a stage with errors can be suppressed (7974 ms)
  ✓ deploy stack without resource (81512 ms)
  ✓ IAM diff (11978 ms)
  ✓ fast deploy (159905 ms)
  ✓ failed deploy does not hang (55232 ms)
  ✓ can still load old assemblies (16135 ms)
  ✓ generating and loading assembly (159005 ms)
  ✓ templates on disk contain metadata resource, also in nested assemblies (11629 ms)
  ✓ CDK synth add the metadata properties expected by sam (45091 ms)
  ✓ CDK synth bundled functions as expected (43210 ms)
  ✓ sam can locally test the synthesized cdk application (46520 ms)

Test Suites: 2 passed, 2 total
Tests:       53 passed, 53 total
Snapshots:   0 total
Time:        4373.77 s
Ran all test suites.
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
