### PR TITLE
fix(jsii): fail compilation when two or more enum members have same val

### DIFF
--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -292,6 +292,12 @@ export class JsiiDiagnostic implements ts.Diagnostic {
     name: 'typescript-restrictions/unsupported-type',
   });
 
+  public static readonly JSII_1004_DUPLICATE_ENUM_VALUE = Code.error({
+    code: 1004,
+    formatter: (messageText) => messageText,
+    name: 'typescript-restrictions/duplicate-enum-value',
+  });
+
   //////////////////////////////////////////////////////////////////////////////
   // 2000 => 2999 -- RESERVED
 

--- a/packages/jsii/test/enums.test.ts
+++ b/packages/jsii/test/enums.test.ts
@@ -57,3 +57,16 @@ test('enums can have a mix of letters and number', async () => {
     { name: 'IB3M' },
   ]);
 });
+
+test('enums with the same assigned value should fail', async () => {
+  await expect(() =>
+    sourceToAssemblyHelper(`
+    export enum Foo {
+      BAR = 'Bar',
+      BAR_DUPE = 'Bar',
+      BAZ = 'Baz',
+      BAZ_DUPE = 'Baz',
+    }
+  `),
+  ).rejects.toThrowError('There were compiler errors');
+});


### PR DESCRIPTION
If two enum members have the same value, only the first one will be retained.

This is a bit of an issue as we are renaming enum members: the named version will never appear in the assembly, and so not work over jsii.

What's worse, if we deprecate-and-strip the original one, neither of the enum members will appear.

Addressing the issue by failing the compilation by adding validation for enum values

Fixes #2782.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
