### PR TITLE
feat: specify output directory for assemblies

### DIFF
--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -32,6 +32,13 @@ export interface TransliterateAssemblyOptions {
    * @default - Only the default tablet (`.jsii.tabl.json`) files will be used.
    */
   readonly tablet?: string;
+
+  /**
+   * A directory to output translated assemblies to
+   *
+   * @default - assembly location
+   */
+  readonly outdir?: string;
 }
 
 /**
@@ -97,7 +104,7 @@ export async function transliterateAssembly(
         transliterateType(type, rosetta, language);
       }
       // eslint-disable-next-line no-await-in-loop
-      await writeJson(resolve(location, `${SPEC_FILE_NAME}.${language}`), result, { spaces: 2 });
+      await writeJson(resolve(options?.outdir ?? location, `${SPEC_FILE_NAME}.${language}`), result, { spaces: 2 });
       const then = new Date().getTime();
       debug(`Done transliterating ${result.name}@${result.version} to ${language} after ${then - now} milliseconds`);
     }


### PR DESCRIPTION
Allows passing an option `outdir` option to `transliterateAssembly`
command. This allows users to generate transliterated assemblies without
polluting the package directory if so desired.

Enables fixing of https://github.com/cdklabs/jsii-docgen/issues/390

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
