### PR TITLE
chore(jsii): revert to using Set

### DIFF
--- a/packages/jsii/lib/transforms/deprecation-warnings.ts
+++ b/packages/jsii/lib/transforms/deprecation-warnings.ts
@@ -356,7 +356,7 @@ function ${GET_PROPERTY_DESCRIPTOR}(obj, prop) {
   return {};
 }
 
-const ${VISITED_OBJECTS_SET_NAME} = new WeakSet();
+const ${VISITED_OBJECTS_SET_NAME} = new Set();
 
 class ${DEPRECATION_ERROR} extends Error {
   constructor(...args) {

--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -40,7 +40,7 @@ function getPropertyDescriptor(obj, prop) {
     }
     return {};
 }
-const visitedObjects = new WeakSet();
+const visitedObjects = new Set();
 class DeprecationError extends Error {
     constructor(...args) {
         super(...args);


### PR DESCRIPTION
Not everything can be added to a WeakSet, in particular, only objects
can be added there, no `undefined`, `null`, ...

This is causing an integration test failure at the moment.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
