### PR TITLE
feat: expose unknownSnippets config

### DIFF
--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -39,6 +39,13 @@ export interface TransliterateAssemblyOptions {
    * @default - assembly location
    */
   readonly outdir?: string;
+
+  /**
+   * Whether or not to live-convert samples
+   *
+   * @default UnknownSnippetMode.FAIL
+   */
+  readonly unknownSnippets?: UnknownSnippetMode;
 }
 
 /**
@@ -74,7 +81,7 @@ export async function transliterateAssembly(
   // Now do a regular "tablet reader" cycle, expecting everything to be translated already,
   // and therefore it doesn't matter that we do this all in a single-threaded loop.
   const rosetta = new RosettaTabletReader({
-    unknownSnippets: UnknownSnippetMode.FAIL,
+    unknownSnippets: options?.unknownSnippets ?? UnknownSnippetMode.FAIL,
     targetLanguages,
     prefixDisclaimer: true,
   });


### PR DESCRIPTION
Exposes the `unknownSnippets` configuration option on
`transliterateAssembly` to allow callers to choose how to handle
snippets missing from the tablet file.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
