### PR TITLE
fix(go): object type not recognized

### DIFF
--- a/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/conversions.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/conversions.go
@@ -65,7 +65,7 @@ func (c *Client) castAndSetToPtr(ptr reflect.Value, data reflect.Value) {
 
 		targetType := ptr.Type()
 		if typ, ok := c.Types().FindType(ref.TypeFQN()); ok && typ.AssignableTo(ptr.Type()) {
-            // Specialize the return type to be the dynamic value type
+			// Specialize the return type to be the dynamic value type
 			targetType = typ
 		}
 
@@ -191,6 +191,11 @@ func (c *Client) CastPtrToRef(dataVal reflect.Value) interface{} {
 					},
 				}
 			}
+		} else if dataVal.Elem().Kind() == reflect.Ptr {
+			// Typically happens when a struct pointer is passed into an interface{}
+			// typed API (such as a place where a union is accepted).
+			elemVal := dataVal.Elem()
+			return c.CastPtrToRef(elemVal)
 		}
 
 		if ref, err := c.ManageObject(dataVal); err != nil {


### PR DESCRIPTION
When a struct pointer was passed in an `interface{}` position, the
converter would trip and register a new opaque instance of `Object`
instead of correctly serializing a struct.

This is because hte pointer is double-indirected (the `interface{}` is a
reference to the `&struct`, which is a reference to the `struct`). This
change adds a condition to detect such cases (`interface{}` abstracts
another pointer), and properly serialize that.

Fixes #2880



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
