### PR TITLE
fix: make jsii --watch work

### DIFF
--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -14,7 +14,7 @@ import { enabledWarnings } from '../lib/warnings';
 
 const warningTypes = Object.keys(enabledWarnings);
 
-(() => {
+(async () => {
   const argv = yargs
     .env('JSII')
     .command(
@@ -117,7 +117,7 @@ const warningTypes = Object.keys(enabledWarnings);
     generateTypeScriptConfig: argv['generate-tsconfig'],
   });
 
-  const emitResult = argv.watch ? compiler.watch() : compiler.emit();
+  const emitResult = argv.watch ? await compiler.watch() : compiler.emit();
 
   const allDiagnostics = [...projectInfoDiagnostics, ...emitResult.diagnostics];
 
@@ -127,7 +127,10 @@ const warningTypes = Object.keys(enabledWarnings);
   if (emitResult.emitSkipped) {
     process.exitCode = 1;
   }
-})();
+})().catch((e) => {
+  console.error(`Error: ${e.stack}`);
+  process.exitCode = -1;
+});
 
 function _configureLog4js(verbosity: number) {
   const stderrColor = !!process.stderr.isTTY;

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -118,15 +118,15 @@ export class Compiler implements Emitter {
    *
    * @internal
    */
-  public watch(opts: NonBlockingWatchOptions): ts.Watch<ts.BuilderProgram>;
+  public async watch(opts: NonBlockingWatchOptions): Promise<ts.Watch<ts.BuilderProgram>>;
   /**
    * Watches for file-system changes and dynamically recompiles the project as needed. In blocking mode, this results
    * in a never-resolving promise.
    */
-  public watch(): never;
-  public watch(
+  public async watch(): Promise<never>;
+  public async watch(
     opts?: NonBlockingWatchOptions,
-  ): ts.Watch<ts.BuilderProgram> | never {
+  ): Promise<ts.Watch<ts.BuilderProgram> | never> {
     this._prepareForBuild();
 
     const pi = this.options.projectInfo;
@@ -184,7 +184,7 @@ export class Compiler implements Emitter {
       return watch;
     }
     // In blocking mode, returns a never-resolving promise.
-    return undefined as never;
+    return new Promise<never>(() => null);
   }
 
   /**

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -72,7 +72,7 @@ describe(Compiler, () => {
         onWatchClosed = ok;
         onWatchFailed = ko;
       });
-      const watch = compiler.watch({
+      const watch = await compiler.watch({
         nonBlocking: true,
         // Ignore diagnostics reporting (not to pollute test console output)
         reportDiagnostics: () => null,


### PR DESCRIPTION
In #3467 the comiler was made fully synchronous which also removed a never resolving promise used by --watch. When the compile is run in watch mode, the watcher is started in the background and control is returned back with watcher. For the compiler watcher to keep running the control should not be yeilded back to the caller



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
