### PR TITLE
fix(jsii): some submodules are not exported from `aws-cdk-lib`

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1637,7 +1637,19 @@ class PythonModule implements PythonType {
     }
 
     // Whatever names we've exported, we'll write out our __all__ that lists them.
-    const exportedMembers = this.members.map((m) => `"${m.pythonName}"`);
+    //
+    // __all__ is normally used for when users write `from library import *`, but we also
+    // use it with the `publication` module to hide everything that's NOT in the list.
+    //
+    // Normally adding submodules to `__all__` has the (negative?) side-effect
+    // that all submodules get loaded when the user does `import *`, but we
+    // already load submodules anyway so it doesn't make a difference, and in combination
+    // with the `publication` module NOT having them in this list hides any submodules
+    // we import as part of typechecking.
+    const exportedMembers = [
+      ...this.members.map((m) => `"${m.pythonName}"`),
+      ...this.modules.map((m) => `"${m.pythonName}"`),
+    ];
     if (this.loadAssembly) {
       exportedMembers.push('"__jsii_assembly__"');
     }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.ts.snap
@@ -1825,6 +1825,7 @@ __all__ = [
     "NumericValue",
     "Operation",
     "StructWithOnlyOptionals",
+    "custom_submodule_name",
 ]
 
 publication.publish()
@@ -10251,6 +10252,22 @@ __all__ = [
     "VirtualMethodPlayground",
     "VoidCallback",
     "WithPrivatePropertyInConstructor",
+    "cdk16625",
+    "composition",
+    "derived_class_has_no_properties",
+    "interface_in_namespace_includes_classes",
+    "interface_in_namespace_only_interface",
+    "module2530",
+    "module2617",
+    "module2647",
+    "module2689",
+    "module2692",
+    "module2700",
+    "module2702",
+    "nodirect",
+    "onlystatic",
+    "python_self",
+    "submodule",
 ]
 
 publication.publish()


### PR DESCRIPTION
This bug is due to a crazy interaction between the `publication`
module, the `__all__` array, and imports we might generate to do
type checking in a package that uses submodules.

Context
-------

Here's what you need to know:

- `__all__` is normally used to define the symbols and submodules
  that should be imported when a consumer does `from mymod import *`.
- `publication` is used to hide non-public symbols from library
  consumers. It will move all symbols that are NOT in `__all__` to
  a `_private` submodule at runtime (it's overloading `__all__` a
  little here, but this seems generally okay).
- We generate `imports` at the top of the file for the modules that are
  referenced in a module, so that we can use them in type annotations.

Example
-------

This is what the currently generated code for the `aws_cdk` module
(of CDK's v2 library) currently (roughly) looks like:

```python
import publication
from .cloud_assembly_schema import AmiContextQuery as _AmiContextQuery_74bf4b1b

__all__ = ['Annotations', 'App', ..., 'ValidationResults']

publication.publish()

from . import aws_s3
from . import cloud_assembly_schema
...
```

Given this setup, the following happens:

```
$ python3
Python 3.9.5 (default, Jun 27 2021, 10:29:41)
>>> import aws_cdk
>>> print(aws_cdk.aws_s3)
<module 'aws_cdk.aws_s3' from '.../aws_cdk/aws_s3/__init__.py'>
>>> print(aws_cdk.cloud_assembly_schema)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'aws_cdk' has no attribute 'cloud_assembly_schema'
```

Explanation
-----------

Why does this happen?

- `__all__` does not contain any submodules
- When `publication.publish()` is called, all symbols in the calling
  namespace that are missing from `__all__` are hidden.
- Crucially, this *does* include `cloud_assembly_schema` (because we
  imported that submodule to import some symbols for type checking
  purposes) but it doesn't include modules that haven't been imported
  yet.
- Most modules get imported *after* `publication.publish()` is called,
  and so are not subject to hiding anymore. This is why we never noticed
  this problem before.
- Every module only gets imported once, so even though we generate a
  second `from . import cloud_assembly_schema` line underneath
  `publication.publish()`, at that point the line doesn't do anything
  anymore.

Solution
--------

Potential solutions are:

- Add submodules to `__all__`.
- Remove the call to `publication.publish()`.
- Make a variant of `publication` that doesn't hide submodules.
- Don't generate actual imports for the type annotations.

This PR picks the first solution, as it seems simplest. The only
downside would have been that `import *` would then start importing all
of the CDKv2 library, but that's happening already anyway because of all
the `import`s we generate ourselves.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
