### PR TITLE
chore: automated node runtime deprecation warnings

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['12', '14', '16', '18']
     env:
       # Node version whose images will be aliased without the -nodeXX segment
       DEFAULT_NODE_MAJOR_VERSION: 12

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,12 @@ jobs:
         dotnet: ['3.1.x']
         go: ['1.16']
         java: ['8']
-        node: ['12', '14', '16', '17']
+        node:
+          - '12' # EOL 2022-04-30
+          - '14' # EOL 2023-04-30
+          - '16' # EOL 2024-04-30
+          - '17' # EOL 2022-06-01
+          - '18' # EOL 2025-04-30
         os: [ubuntu-latest]
         python: ['3.7']
         # Add specific combinations to be tested against "node 12" (to restrict cardinality)

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -12,6 +12,7 @@ queue_rules:
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
       - status-success~=^Test \(.* node 17 .*$
+      - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -62,6 +63,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
       - status-success~=^Test \(.* node 17 .*$
+      - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -112,6 +114,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
       - status-success~=^Test \(.* node 17 .*$
+      - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$
@@ -162,6 +165,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 14 .*$
       - status-success~=^Test \(.* node 16 .*$
       - status-success~=^Test \(.* node 17 .*$
+      - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
       - status-success~=^Test \(.* dotnet 5\.0\.x .*$

--- a/gh-pages/content/user-guides/lib-author/index.md
+++ b/gh-pages/content/user-guides/lib-author/index.md
@@ -17,7 +17,7 @@ to produce releasable artifacts.
 | Language/Platform | SDK Requirement              |
 | ----------------- | ---------------------------- |
 | .NET              | .NET Core ≥ 3.1 / .NET ≥ 5.0 |
-| Go                | Go ≥ 1.15                    |
+| Go                | Go ≥ 1.16                    |
 | Java              | JDK ≥ 8 *and* Maven ≥ 3.6    |
 | Python            | Python ≥ 3.7                 |
 

--- a/gh-pages/partials/node-support-table.md
+++ b/gh-pages/partials/node-support-table.md
@@ -1,11 +1,14 @@
-| Release   | Status                       |
-| --------- | ---------------------------- |
-| `<12.7.0` | :x: Defunct                  |
-| `^12.7.0` | :white_check_mark: Supported |
-| `^13.0.0` | :x: Defunct                  |
-| `^14.0.0` | :white_check_mark: Supported |
-| `^15.0.0` | :x: Defunct                  |
-| `^16.0.0` | :white_check_mark: Supported |
+The following node releases are part of our test matrix. Releases not in the matrix might work, but are not guaranteed
+to: they can be considered to fall under the **:test_tube: Best Effort** umbrella, unless they are end-of-life. Releases
+past end-of-life are unlikely to work, or may stop working with any future release.
+
+| Release   | Status                       | End-of-Life  |
+| --------- | ---------------------------- | ------------ |
+| `^12.7.0` | :white_check_mark: Supported | `2022-04-30` |
+| `^14.0.0` | :white_check_mark: Supported | `2023-04-30` |
+| `^16.3.0` | :white_check_mark: Supported | `2024-04-30` |
+| `^17.3.0` | :test_tube: Best effort      | `2022-06-01` |
+| `^18.0.0` | :white_check_mark: Supported | `2025-04-30` |
 
 ??? question "Status Definitions"
     - **:white_check_mark: Supported**: Long Term Support (LTS) releases  (those with an even major version) are
@@ -13,9 +16,6 @@
       automatically tested against those releases.
     - **:test_tube: Best effort**: Development releases (those with an odd major version) are supported on a best-effort
       basis. No automated testing is performed against those releases.
-    - **:warning: Unsupported**: End-of-Life releases are not supported. Bugs affecting those may not be fixed, and
-      users are strongly advised to migrate to more recent releases.
-    - **:x: Defunct**: Very old releases (these have been End-of-Live for a while now) are unlikely to work at all.
 
     The [node releases schedule][node-releases] provides up-to-date information on the current status of all active
     releases, and indicates the timelines for support (including planned End-of-Life dates for each).

--- a/gh-pages/partials/node-support-table.md
+++ b/gh-pages/partials/node-support-table.md
@@ -1,23 +1,28 @@
-The following node releases are part of our test matrix. Releases not in the matrix might work, but are not guaranteed
-to: they can be considered to fall under the **:test_tube: Best Effort** umbrella, unless they are end-of-life. Releases
-past end-of-life are unlikely to work, or may stop working with any future release.
+!!! info "The following node releases are part of our test matrix:"
 
-| Release   | Status                       | End-of-Life  |
-| --------- | ---------------------------- | ------------ |
-| `^12.7.0` | :white_check_mark: Supported | `2022-04-30` |
-| `^14.0.0` | :white_check_mark: Supported | `2023-04-30` |
-| `^16.3.0` | :white_check_mark: Supported | `2024-04-30` |
-| `^17.3.0` | :test_tube: Best effort      | `2022-06-01` |
-| `^18.0.0` | :white_check_mark: Supported | `2025-04-30` |
+    | Release   | Status                       | End-of-Life  |
+    | --------- | ---------------------------- | ------------ |
+    | `^12.7.0` | :white_check_mark: Supported | `2022-04-30` |
+    | `^14.5.0` | :white_check_mark: Supported | `2023-04-30` |
+    | `^16.3.0` | :white_check_mark: Supported | `2024-04-30` |
+    | `^17.3.0` | :test_tube: Best effort      | `2022-06-01` |
+    | `^18.0.0` | :white_check_mark: Supported | `2025-04-30` |
 
-??? question "Status Definitions"
-    - **:white_check_mark: Supported**: Long Term Support (LTS) releases  (those with an even major version) are
-      supported and bugs specific to those releases are addressed with the highest priority. Every `jsii` release is
-      automatically tested against those releases.
-    - **:test_tube: Best effort**: Development releases (those with an odd major version) are supported on a best-effort
-      basis. No automated testing is performed against those releases.
+    ??? question "Status Definitions"
+        - **:white_check_mark: Supported**: Long Term Support (LTS) releases  (those with an even major version) are
+          supported and bugs specific to those releases are addressed with the highest priority. Every `jsii` release is
+          automatically tested against those releases.
+        - **:test_tube: Best effort**: Development releases (those with an odd major version) are supported on a
+          best-effort basis. Some of these releases may include breaking changes or bugs that may cause runtime errors
+          that we may not be able to fix.
+
+    Releases not in the matrix might work, but are not guaranteed to: they can be considered to fall under the
+    **:test_tube: Best Effort** umbrella, unless they are end-of-life. Releases past end-of-life are unlikely to work,
+    or may stop working with any future release.
 
     The [node releases schedule][node-releases] provides up-to-date information on the current status of all active
     releases, and indicates the timelines for support (including planned End-of-Life dates for each).
 
     [node-releases]: https://nodejs.org/en/about/releases/
+
+

--- a/packages/@jsii/check-node/package.json
+++ b/packages/@jsii/check-node/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@jsii/check-node"
   },
   "engines": {
-    "node": ">= 10.3.0"
+    "node": ">= 12.7.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/check-node/src/constants.test.ts
+++ b/packages/@jsii/check-node/src/constants.test.ts
@@ -1,0 +1,74 @@
+import { NodeRelease } from './constants';
+
+test('supported release', () => {
+  const endOfLife = new Date(Date.now() + 31 * 86_400_000);
+  const subject = new NodeRelease(42, { endOfLife });
+
+  expect(subject).toMatchObject({
+    deprecated: false,
+    endOfLife: false,
+    endOfLifeDate: endOfLife,
+    pending: false,
+    supported: true,
+    supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
+  });
+});
+
+test('supported release with range', () => {
+  const endOfLife = new Date(Date.now() + 31 * 86_400_000);
+  const subject = new NodeRelease(42, {
+    endOfLife,
+    supportedRange: '^42.1337.0',
+  });
+
+  expect(subject).toMatchObject({
+    deprecated: false,
+    endOfLife: false,
+    endOfLifeDate: endOfLife,
+    pending: false,
+    supported: true,
+    supportedRange: expect.objectContaining({ raw: '^42.1337.0' }),
+  });
+});
+
+test('pending release', () => {
+  const endOfLife = new Date(Date.now() + 31 * 86_400_000);
+  const subject = new NodeRelease(42, { endOfLife, pending: true });
+
+  expect(subject).toMatchObject({
+    deprecated: false,
+    endOfLife: false,
+    endOfLifeDate: endOfLife,
+    pending: true,
+    supported: false,
+    supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
+  });
+});
+
+test('deprecated release', () => {
+  const endOfLife = new Date(Date.now() + 25 * 86_400_000);
+  const subject = new NodeRelease(42, { endOfLife });
+
+  expect(subject).toMatchObject({
+    deprecated: true,
+    endOfLife: false,
+    endOfLifeDate: endOfLife,
+    pending: false,
+    supported: true,
+    supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
+  });
+});
+
+test('EOL release', () => {
+  const endOfLife = new Date();
+  const subject = new NodeRelease(42, { endOfLife });
+
+  expect(subject).toMatchObject({
+    deprecated: false,
+    endOfLife: true,
+    endOfLifeDate: endOfLife,
+    pending: false,
+    supported: false,
+    supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
+  });
+});

--- a/packages/@jsii/check-node/src/constants.test.ts
+++ b/packages/@jsii/check-node/src/constants.test.ts
@@ -8,7 +8,7 @@ test('supported release', () => {
     deprecated: false,
     endOfLife: false,
     endOfLifeDate: endOfLife,
-    pending: false,
+    untested: false,
     supported: true,
     supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
   });
@@ -25,21 +25,21 @@ test('supported release with range', () => {
     deprecated: false,
     endOfLife: false,
     endOfLifeDate: endOfLife,
-    pending: false,
+    untested: false,
     supported: true,
     supportedRange: expect.objectContaining({ raw: '^42.1337.0' }),
   });
 });
 
-test('pending release', () => {
+test('untested release', () => {
   const endOfLife = new Date(Date.now() + 31 * 86_400_000);
-  const subject = new NodeRelease(42, { endOfLife, pending: true });
+  const subject = new NodeRelease(42, { endOfLife, untested: true });
 
   expect(subject).toMatchObject({
     deprecated: false,
     endOfLife: false,
     endOfLifeDate: endOfLife,
-    pending: true,
+    untested: true,
     supported: false,
     supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
   });
@@ -53,7 +53,7 @@ test('deprecated release', () => {
     deprecated: true,
     endOfLife: false,
     endOfLifeDate: endOfLife,
-    pending: false,
+    untested: false,
     supported: true,
     supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
   });
@@ -67,7 +67,7 @@ test('EOL release', () => {
     deprecated: false,
     endOfLife: true,
     endOfLifeDate: endOfLife,
-    pending: false,
+    untested: false,
     supported: false,
     supportedRange: expect.objectContaining({ raw: '^42.0.0' }),
   });

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -1,69 +1,159 @@
-export const enum SupportLevel {
-  /**
-   * Soft-deprecated, removed as of releases made starting at DEADLINE. This
-   * will output a yellow warning to the console, until the DEADLINE has been
-   * reached, at which point it'll be a SCARY RED WARNING.
-   */
-  DEPRECATED = 'deprecated',
-
-  /**
-   * Supported releases, nothing to see. No message will be output.
-   */
-  SUPPORTED = 'supported',
-
-  /**
-   * EOL releases are unsupported, so this will emit a SCARY RED WARNING.
-   */
-  END_OF_LIFE = 'end-of-life',
-
-  /**
-   * Not end-of-life, but also not supported. This is usually the case for early
-   * releases on a new major train, where some of the features are not available
-   * yet. These emit a SCARY RED WARNING, but the messaging is slightly
-   * different than that of END_OF_LIFE.
-   */
-  UNSUPPORTED = 'unsupported',
-
-  /**
-   * Those releases are newer than the current software package, so we have not
-   * tested with it. People may encounter all kinds of weird bugs, especially
-   * early in the release cycle... So we'll issue a yellow warning here.
-   */
-  UNTESTED = 'untested',
-}
+import { version } from 'process';
+import { Range, SemVer } from 'semver';
 
 /**
- * The deadline after which deprecated releases will move to
- * `SupportLevel.END_OF_LIFE`.
- */
-export const DEADLINE = '2021-09-01';
-/**
- * The DEADLINE, expressed in milliseconds since the epoch.
- */
-export const DEADLINE_EPOCH_MS = new Date(
-  `${DEADLINE}T00:00:00.000Z`,
-).getTime();
-
-/**
- * For each SemVer range, what is the support level for such versions of Node.
- * The ranges are checked in declaration order (so it is a good idea to keep the
- * left-open ranges at the beginning, and the right-open ranges at the end.
- * First match wins.
+ * The support information for a given node release range.
  *
- * Also, if you are setting a new entry to `SupportLevel.DEPRECATED`, do not
- * forget to also change the `DEADLINE` value.
+ * @see https://nodejs.org/en/about/releases/
  */
-export const VERSION_SUPPORT: { readonly [range: string]: SupportLevel } = {
-  '<12.0.0-0': SupportLevel.END_OF_LIFE,
-  '<12.7.0': SupportLevel.UNSUPPORTED,
-  '^12.7.0': SupportLevel.SUPPORTED,
-  '^13.0.0-0': SupportLevel.END_OF_LIFE,
-  '<14.5.0': SupportLevel.UNSUPPORTED,
-  '^14.5.0': SupportLevel.SUPPORTED,
-  '^15.0.0-0': SupportLevel.END_OF_LIFE,
-  '<16.3.0': SupportLevel.UNSUPPORTED,
-  '^16.3.0': SupportLevel.SUPPORTED,
-  '<17.3.0': SupportLevel.UNSUPPORTED,
-  '^17.3.0': SupportLevel.SUPPORTED,
-  // Anything else will be treated as SupportLevel.UNTESTED.
-};
+export class NodeRelease {
+  /**
+   * How long before enf-of-life do we start warning customers? Expressed in
+   * milliseconds to make it easier to deal with JS dates.
+   */
+  private static readonly DEPRECATION_WINDOW_MS = 30 * 86_400_000;
+
+  /**
+   * All registered node releases.
+   */
+  public static readonly ALL_RELEASES: readonly NodeRelease[] = [
+    // Historical releases (not relevant at time of writing this as they're all EOL now...)
+    ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(
+      (majorVersion) => new NodeRelease(majorVersion, { endOfLife: true }),
+    ),
+
+    // Past end-of-life releases
+    new NodeRelease(13, { endOfLife: new Date('2020-06-01') }),
+    new NodeRelease(15, { endOfLife: new Date('2021-06-01') }),
+
+    // Deprecated releases
+    new NodeRelease(12, {
+      endOfLife: new Date('2022-04-30'),
+      supportedRange: '^12.7.0',
+    }),
+
+    // Currently active releases
+    new NodeRelease(14, {
+      endOfLife: new Date('2023-04-30'),
+      supportedRange: '^14.5.0',
+    }),
+    new NodeRelease(16, {
+      endOfLife: new Date('2024-04-30'),
+      supportedRange: '^16.3.0',
+    }),
+    new NodeRelease(17, {
+      endOfLife: new Date('2022-06-01'),
+      supportedRange: '^17.3.0',
+    }),
+    new NodeRelease(18, { endOfLife: new Date('2025-04-30') }),
+
+    // Future (planned releases)
+    new NodeRelease(19, { endOfLife: new Date('2023-06-01'), pending: true }),
+    new NodeRelease(20, { endOfLife: new Date('2026-04-30'), pending: true }),
+  ];
+
+  /**
+   * @returns the `NodeRelease` corresponding to the version of the node runtime
+   *          executing this code (as provided by `process.version`), and a
+   *          boolean indicating whether this version is known to be broken. If
+   *          the runtime does not correspond to a known node major, this
+   *          returns and `undefined` release object.
+   */
+  public static forThisRuntime(): {
+    nodeRelease: NodeRelease | undefined;
+    knownBroken: boolean;
+  } {
+    const semver = new SemVer(version);
+    const majorVersion = semver.major;
+
+    for (const nodeRelease of this.ALL_RELEASES) {
+      if (nodeRelease.majorVersion === majorVersion) {
+        return {
+          nodeRelease,
+          knownBroken: !nodeRelease.supportedRange.test(semver),
+        };
+      }
+    }
+
+    return { nodeRelease: undefined, knownBroken: false };
+  }
+
+  /**
+   * The major version of this node release.
+   */
+  public readonly majorVersion: number;
+
+  /**
+   * The date on which this release range starts to be considered end-of-life.
+   * Can also be `true` to denote that this is already end-of-life, without
+   * specifying a particular date.
+   */
+  public readonly endOfLifeDate: Date | undefined;
+
+  /**
+   * Determines whether this release is currently considered end-of-life.
+   */
+  public readonly endOfLife: boolean;
+
+  /**
+   * Determines whether this release is within the deprecation window ahead of
+   * it's end-of-life date.
+   */
+  public readonly deprecated: boolean;
+
+  /**
+   * If `true` denotes that this version of node has not been added to the test
+   * matrix yet. This is used when adding not-yet-released versions of node that
+   * are already planned (typically one or two years out).
+   *
+   * @default false
+   */
+  public readonly pending: boolean;
+
+  /**
+   * The range of versions from this release line that are supported (early
+   * releases in a new line often lack essential features, and some have known
+   * bugs).
+   */
+  public readonly supportedRange: Range;
+
+  private constructor(
+    majorVersion: number,
+    opts: {
+      endOfLife: Date | true;
+      pending?: boolean;
+      supportedRange?: string;
+    },
+  ) {
+    this.majorVersion = majorVersion;
+    this.endOfLifeDate = opts.endOfLife === true ? undefined : opts.endOfLife;
+    this.pending = opts.pending ?? false;
+    this.supportedRange = new Range(
+      opts.supportedRange ?? `^${majorVersion}.0.0`,
+    );
+
+    this.endOfLife =
+      opts.endOfLife === true || opts.endOfLife.getTime() <= Date.now();
+    this.deprecated =
+      opts.endOfLife !== true &&
+      opts.endOfLife.getTime() - NodeRelease.DEPRECATION_WINDOW_MS <=
+        Date.now();
+  }
+
+  /**
+   * Determines whether this major version line is currently "in support",
+   * meaning it is not end-of-life, deprecated or pending.
+   */
+  public get supported(): boolean {
+    return !this.pending && !this.deprecated && !this.endOfLife;
+  }
+
+  public toString(): string {
+    const eolInfo = this.endOfLifeDate
+      ? ` (Planned end-of-life: ${this.endOfLifeDate
+          .toISOString()
+          .slice(0, 10)})`
+      : '';
+    return `${this.supportedRange.raw}${eolInfo}`;
+  }
+}

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -117,7 +117,14 @@ export class NodeRelease {
    */
   public readonly supportedRange: Range;
 
-  private constructor(
+  /**
+   * Determines whether this major version line is currently "in support",
+   * meaning it is not end-of-life nor pending.
+   */
+  public readonly supported: boolean;
+
+  /** @internal */
+  constructor(
     majorVersion: number,
     opts: {
       endOfLife: Date | true;
@@ -135,17 +142,12 @@ export class NodeRelease {
     this.endOfLife =
       opts.endOfLife === true || opts.endOfLife.getTime() <= Date.now();
     this.deprecated =
+      !this.endOfLife &&
       opts.endOfLife !== true &&
       opts.endOfLife.getTime() - NodeRelease.DEPRECATION_WINDOW_MS <=
         Date.now();
-  }
 
-  /**
-   * Determines whether this major version line is currently "in support",
-   * meaning it is not end-of-life, deprecated or pending.
-   */
-  public get supported(): boolean {
-    return !this.pending && !this.deprecated && !this.endOfLife;
+    this.supported = !this.pending && !this.endOfLife;
   }
 
   public toString(): string {

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -123,8 +123,8 @@ export class NodeRelease {
    */
   public readonly supported: boolean;
 
-  /** @internal */
-  constructor(
+  /** @internal visible for testing */
+  public constructor(
     majorVersion: number,
     opts: {
       endOfLife: Date | true;

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -1,5 +1,7 @@
-import { version } from 'process';
+import * as process from 'process';
 import { Range, SemVer } from 'semver';
+
+const ONE_DAY_IN_MILLISECONDS = 86_400_000;
 
 /**
  * The support information for a given node release range.
@@ -11,14 +13,14 @@ export class NodeRelease {
    * How long before enf-of-life do we start warning customers? Expressed in
    * milliseconds to make it easier to deal with JS dates.
    */
-  private static readonly DEPRECATION_WINDOW_MS = 30 * 86_400_000;
+  private static readonly DEPRECATION_WINDOW_MS = 30 * ONE_DAY_IN_MILLISECONDS;
 
   /**
    * All registered node releases.
    */
   public static readonly ALL_RELEASES: readonly NodeRelease[] = [
     // Historical releases (not relevant at time of writing this as they're all EOL now...)
-    ...[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(
+    ...([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const).map(
       (majorVersion) => new NodeRelease(majorVersion, { endOfLife: true }),
     ),
 
@@ -48,8 +50,8 @@ export class NodeRelease {
     new NodeRelease(18, { endOfLife: new Date('2025-04-30') }),
 
     // Future (planned releases)
-    new NodeRelease(19, { endOfLife: new Date('2023-06-01'), pending: true }),
-    new NodeRelease(20, { endOfLife: new Date('2026-04-30'), pending: true }),
+    new NodeRelease(19, { endOfLife: new Date('2023-06-01'), untested: true }),
+    new NodeRelease(20, { endOfLife: new Date('2026-04-30'), untested: true }),
   ];
 
   /**
@@ -57,13 +59,13 @@ export class NodeRelease {
    *          executing this code (as provided by `process.version`), and a
    *          boolean indicating whether this version is known to be broken. If
    *          the runtime does not correspond to a known node major, this
-   *          returns and `undefined` release object.
+   *          returns an `undefined` release object.
    */
   public static forThisRuntime(): {
     nodeRelease: NodeRelease | undefined;
     knownBroken: boolean;
   } {
-    const semver = new SemVer(version);
+    const semver = new SemVer(process.version);
     const majorVersion = semver.major;
 
     for (const nodeRelease of this.ALL_RELEASES) {
@@ -85,8 +87,7 @@ export class NodeRelease {
 
   /**
    * The date on which this release range starts to be considered end-of-life.
-   * Can also be `true` to denote that this is already end-of-life, without
-   * specifying a particular date.
+   * May be `undefined` for "ancient" releases (before Node 12).
    */
   public readonly endOfLifeDate: Date | undefined;
 
@@ -108,7 +109,7 @@ export class NodeRelease {
    *
    * @default false
    */
-  public readonly pending: boolean;
+  public readonly untested: boolean;
 
   /**
    * The range of versions from this release line that are supported (early
@@ -125,16 +126,30 @@ export class NodeRelease {
 
   /** @internal visible for testing */
   public constructor(
+    majorVersion: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11,
+    opts: { endOfLife: true },
+  );
+  /** @internal visible for testing */
+  public constructor(
+    majorVersion: number,
+    opts: {
+      endOfLife: Date;
+      untested?: boolean;
+      supportedRange?: string;
+    },
+  );
+  /** @internal visible for testing */
+  public constructor(
     majorVersion: number,
     opts: {
       endOfLife: Date | true;
-      pending?: boolean;
+      untested?: boolean;
       supportedRange?: string;
     },
   ) {
     this.majorVersion = majorVersion;
     this.endOfLifeDate = opts.endOfLife === true ? undefined : opts.endOfLife;
-    this.pending = opts.pending ?? false;
+    this.untested = opts.untested ?? false;
     this.supportedRange = new Range(
       opts.supportedRange ?? `^${majorVersion}.0.0`,
     );
@@ -147,7 +162,7 @@ export class NodeRelease {
       opts.endOfLife.getTime() - NodeRelease.DEPRECATION_WINDOW_MS <=
         Date.now();
 
-    this.supported = !this.pending && !this.endOfLife;
+    this.supported = !this.untested && !this.endOfLife;
   }
 
   public toString(): string {

--- a/packages/@jsii/check-node/src/index.test.ts
+++ b/packages/@jsii/check-node/src/index.test.ts
@@ -1,16 +1,19 @@
-import { DEADLINE_EPOCH_MS, SupportLevel, VERSION_SUPPORT } from './constants';
+import { NodeRelease } from './constants';
 
-// This test is there to ensure house-keeping happens when it should. Deprecated
-// node releases should move to `SupportLevel.END_OF_LIFE` once the `DEADLINE`
-// has been reached.
-test('no deprecated version is past deadline', () => {
-  const deprecated = Object.entries(VERSION_SUPPORT).filter(
-    ([, supportLevel]) => supportLevel === SupportLevel.DEPRECATED,
+// This test is there to ensure house-keeping happens when it should. If we are
+// testing a given node release, it must be registered in constants.ts, and it
+// must not be a "known broken" release.
+test('tested node releases are correctly registered & supported', () => {
+  const { nodeRelease, knownBroken } = NodeRelease.forThisRuntime();
+  expect(nodeRelease).toBeDefined();
+  expect(knownBroken).toBeFalsy();
+});
+
+// This test is there to ensure house-keeping happens when it should. If we are
+// testing a given node release, it must not have been EOL for over 30 days.
+test('tested node release have not ben EOL for more than 30 days', () => {
+  const { nodeRelease } = NodeRelease.forThisRuntime();
+  expect(nodeRelease?.endOfLifeDate?.getTime()).toBeGreaterThan(
+    Date.now() - 30 * 86_400_000,
   );
-  expect(
-    // Either there are no deprecated ranges
-    deprecated.length === 0 ||
-      // Or the deadline is in the future
-      DEADLINE_EPOCH_MS > Date.now(),
-  ).toBeTruthy();
 });

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -26,7 +26,7 @@ export function checkNode(): void {
       bgRed.white.bold,
       `Node ${version} is unsupported and has known compatibility issues with this software.`,
     );
-  } else if (!nodeRelease || nodeRelease.pending) {
+  } else if (!nodeRelease || nodeRelease.untested) {
     veryVisibleMessage(
       bgYellow.black,
       `This software has not been tested with node ${version}.`,

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -58,7 +58,12 @@ export function checkNode(): void {
             (r.endOfLifeDate?.getTime() ?? 0) -
             (l.endOfLifeDate?.getTime() ?? 0),
         )
-        .map((release) => `- ${release.toString()}`),
+        .map(
+          (release) =>
+            `- ${release.toString()}${
+              release.deprecated ? ' [DEPRECATED]' : ''
+            }`,
+        ),
     ];
     const len = Math.max(...lines.map((l) => l.length));
     const border = chalk('!'.repeat(len + 8));

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -1,14 +1,8 @@
 import { Chalk, bgYellow, bgYellowBright, bgRed } from 'chalk';
 import { error } from 'console';
 import { version } from 'process';
-import { Range, SemVer } from 'semver';
 
-import {
-  DEADLINE,
-  DEADLINE_EPOCH_MS,
-  SupportLevel,
-  VERSION_SUPPORT,
-} from './constants';
+import { NodeRelease } from './constants';
 
 /**
  * Checks the current process' node runtime version against the release support
@@ -16,46 +10,34 @@ import {
  * supported (i.e: it is deprecated, end-of-life, or untested).
  */
 export function checkNode(): void {
-  const runtimeVersion = new SemVer(version);
-  let versionSupportLevel = SupportLevel.UNTESTED;
-  for (const [rangeExpr, supportLevel] of Object.entries(VERSION_SUPPORT)) {
-    const range = new Range(rangeExpr);
-    if (range.test(runtimeVersion)) {
-      versionSupportLevel = supportLevel;
-      break;
-    }
-  }
+  const { nodeRelease, knownBroken } = NodeRelease.forThisRuntime();
 
-  switch (versionSupportLevel) {
-    case SupportLevel.DEPRECATED:
-      const deadlinePast = Date.now() > DEADLINE_EPOCH_MS;
-      veryVisibleMessage(
-        deadlinePast ? bgRed.white.bold : bgYellowBright.black,
-        `Node ${version} has reached end-of-life and will no longer be supported in new releases after ${DEADLINE}.`,
-        `Please upgrade to a supported node version as soon as possible.`,
-      );
-      break;
-    case SupportLevel.END_OF_LIFE:
-      veryVisibleMessage(
-        bgRed.white.bold,
-        `Node ${version} has reached end-of-life and is not supported.`,
-      );
-      break;
-    case SupportLevel.UNSUPPORTED:
-      veryVisibleMessage(
-        bgRed.white.bold,
-        `Node ${version} is not supported. Early releases a node major often lack essential features of that line.`,
-      );
-      break;
-    case SupportLevel.SUPPORTED:
-      // Nothing to do
-      break;
-    case SupportLevel.UNTESTED:
-      veryVisibleMessage(
-        bgYellow.black,
-        `This software has not been tested with node ${version}.`,
-      );
-      break;
+  if (nodeRelease?.endOfLife) {
+    const qualifier = nodeRelease.endOfLifeDate
+      ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
+      : '';
+    veryVisibleMessage(
+      bgRed.white.bold,
+      `Node ${nodeRelease.majorVersion} has reached end-of-life${qualifier} and is not supported.`,
+      `Please upgrade to a supported node version as soon as possible.`,
+    );
+  } else if (knownBroken) {
+    veryVisibleMessage(
+      bgRed.white.bold,
+      `Node ${version} is unsupported and has known compatibility issues with this software.`,
+    );
+  } else if (!nodeRelease || nodeRelease.pending) {
+    veryVisibleMessage(
+      bgYellow.black,
+      `This software has not been tested with node ${version}.`,
+    );
+  } else if (nodeRelease?.deprecated) {
+    const deadline = nodeRelease.endOfLifeDate!.toISOString().slice(0, 10);
+    veryVisibleMessage(
+      bgYellowBright.black,
+      `Node ${nodeRelease.majorVersion} is approaching end-of-life and will no longer be supported in new releases after ${deadline}.`,
+      `Please upgrade to a supported node version as soon as possible.`,
+    );
   }
 
   function veryVisibleMessage(
@@ -67,10 +49,16 @@ export function checkNode(): void {
       message,
       callToAction,
       '',
-      'As of the current release, supported versions of node are:',
-      ...Object.entries(VERSION_SUPPORT)
-        .filter(([, supportLevel]) => supportLevel === SupportLevel.SUPPORTED)
-        .map(([rangeExpr]) => `- ${rangeExpr}`),
+      `This software is currently running on node ${version}.`,
+      'As of the current release of this software, supported node releases are:',
+      ...NodeRelease.ALL_RELEASES.filter((release) => release.supported)
+        // We display those from longest remaining support to shortest (to incitate people to be ahead of future derepcations).
+        .sort(
+          (l, r) =>
+            (r.endOfLifeDate?.getTime() ?? 0) -
+            (l.endOfLifeDate?.getTime() ?? 0),
+        )
+        .map((release) => `- ${release.toString()}`),
     ];
     const len = Math.max(...lines.map((l) => l.length));
     const border = chalk('!'.repeat(len + 8));

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -34,6 +34,7 @@ jsii/superchain:<JSII-MAJOR>-<BASE>(-node<NODE-MAJOR>)(-nightly)
   - `12` corresponds to node 12.x, this is the default
   - `14` corresponds to node 14.x
   - `16` corresponds to node 16.x
+  - `18` corresponds to node 18.x
 - `-nightly` images are released from the `HEAD` of the [`aws/jsii`][jsii]
   repository and should typically not be used for production workloads
 
@@ -55,6 +56,7 @@ We build multiple versions of this image, for different versions of Node. They a
 * `jsii/superchain:1-buster-slim-node12(-nightly)`
 * `jsii/superchain:1-buster-slim-node14(-nightly)`
 * `jsii/superchain:1-buster-slim-node16(-nightly)`
+* `jsii/superchain:1-buster-slim-node18(-nightly)`
 
 If you are building this image from source, you can control the Node version with the
 `NODE_MAJOR_VERSION` build argument:


### PR DESCRIPTION
This changes how the node release support information is modeled so that
the end-of-life dates are configured, so that `@jsii/check-node` can
automatically start warning a month ahead of a runtime's EOL date, so we
can drop support right on EOL day if needed wihtout taking users by
surprise.

This also includes tweaks of the messages that get printed out to STDERR
when an unsupported/untested/deprecated/end-of-life version is being
used, to increase clarity of provide more information about migration
options.

Finally, this adds node 18 (initial release `2022-04-19`) to the test
matrix.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
