### PR TITLE
feat: prepare ground for proactive .d.ts down-leveling

### DIFF
--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -21,7 +21,7 @@ export interface TSCompilerOptions {
 
 export interface ProjectInfo {
   readonly projectRoot: string;
-  readonly packageJson: any;
+  readonly packageJson: Record<string, any>;
 
   readonly name: string;
   readonly version: string;
@@ -66,7 +66,6 @@ export interface ProjectInfoResult {
 
 export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
   const packageJsonPath = path.join(projectRoot, 'package.json');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-require-imports
   const pkg = fs.readJsonSync(packageJsonPath);
 
   const diagnostics: ts.Diagnostic[] = [];

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -40,6 +40,7 @@
     "case": "^1.6.3",
     "chalk": "^4",
     "deep-equal": "^2.0.5",
+    "downlevel-dts": "^0.10.0",
     "fs-extra": "^9.1.0",
     "log4js": "^6.4.5",
     "semver": "^7.3.7",

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -153,7 +153,7 @@ describe(Compiler, () => {
 function _makeProjectInfo(sourceDir: string, types: string): ProjectInfo {
   return {
     projectRoot: sourceDir,
-    packageJson: undefined,
+    packageJson: {},
     types,
     main: types.replace(/(?:\.d)?\.ts(x?)/, '.js$1'),
     name: 'jsii', // That's what package.json would tell if we look up...

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -92,7 +92,7 @@ function _makeProjectInfo(types: string): ProjectInfo {
   const outDir = '.build';
   return {
     projectRoot: SOURCE_DIR,
-    packageJson: undefined,
+    packageJson: {},
     types: path.join(outDir, types.replace(/\.d\.ts(x?)/, '.d.ts$1')),
     main: path.join(outDir, types.replace(/(?:\.d)?\.ts(x?)/, '.js$1')),
     name: 'jsii', // That's what package.json would tell if we look up...

--- a/packages/jsii/vendor/downlevel-dts.d.ts
+++ b/packages/jsii/vendor/downlevel-dts.d.ts
@@ -1,0 +1,19 @@
+/// Hand-written declaration for the downlevel-dts module
+declare module 'downlevel-dts' {
+  import { SemVer } from 'semver';
+
+  /**
+   * Rewrite .d.ts files created by any version of TypeScript so that they work
+   * with TypeScript 3.4 or later. It does this by converting code with new
+   * features into code that uses equivalent old features.
+   *
+   * @param src           the directory containing the original .d.ts files
+   * @param target        the directory in which to place re-written files
+   * @param targetVersion the target TypeScript version compatibility
+   */
+  export function main(
+    src: string,
+    target: string,
+    targetVersion: string | SemVer,
+  ): void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,6 +3186,15 @@ dotgitignore@^2.1.0:
     find-up "^3.0.0"
     minimatch "^3.0.4"
 
+downlevel-dts@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.10.0.tgz#d2be7b4408a1f9eb3a39e15a361f8ea4f175facc"
+  integrity sha512-AZ7tnUy4XJArsjv6Bcuivvxx+weMvOGHF6seu7e7PVOqMDHMSlfgMl1kt+F4Y2+5TmDwKWHOdimM1DZKihQs8Q==
+  dependencies:
+    semver "^7.3.2"
+    shelljs "^0.8.3"
+    typescript next
+
 duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
@@ -3946,7 +3955,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -4245,6 +4254,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^2.2.0:
   version "2.2.0"
@@ -6511,6 +6525,13 @@ readdir-scoped-modules@^1.0.0:
     graceful-fs "^4.1.2"
     once "^1.3.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 rechoir@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.1.tgz#9478a96a1ca135b5e88fc027f03ee92d6c645686"
@@ -6603,7 +6624,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.9.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -6773,6 +6794,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shelljs@^0.8.3:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"
@@ -7511,6 +7541,11 @@ typescript-json-schema@^0.53.0:
     ts-node "^10.2.1"
     typescript "~4.5.0"
     yargs "^17.1.1"
+
+typescript@next:
+  version "4.7.0-dev.20220427"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.0-dev.20220427.tgz#4f9c5b880f077f17de287c73b75cc41862894865"
+  integrity sha512-hF8uZdb8/p4O+U6fl1J+H1sMlu/IW+GAoRDWXKjAjTVilit2Su4jJQxlP962nDkE5uu+VJPRrqESdusNxuberw==
 
 typescript@~3.9.10:
   version "3.9.10"


### PR DESCRIPTION
Adds a dependency on `downlevel-dts` to produce down-leveled
declarations file when we start publishing compilers that use modern
versions of TypeScript, to maximize compatibility in between compiler
versions.

This emits down-leveled declarations file and maintains the
`typesVersions` field in `package.json` up-to-date with the
requirements.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
