### PR TITLE
fix(rosetta): incorrect transliteration for selective imports

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go/documentation.ts
+++ b/packages/jsii-pacmak/lib/targets/go/documentation.ts
@@ -75,6 +75,17 @@ export class Documentation {
     }
   }
 
+  public emitReadme(moduleFqn: string, readme: string, directory: string) {
+    const goReadme = this.rosetta.translateSnippetsInMarkdown({ api: 'moduleReadme', moduleFqn }, readme, TargetLanguage.GO, false);
+
+    const readmeFile = `${directory}/README.md`;
+    this.code.openFile(readmeFile);
+    for (const line of goReadme.split('\n')) {
+      this.code.line(line);
+    }
+    this.code.closeFile(readmeFile);
+  }
+
   private emitComment(text = '') {
     const lines = text.trim().split('\n');
 

--- a/packages/jsii-pacmak/lib/targets/go/readme-file.ts
+++ b/packages/jsii-pacmak/lib/targets/go/readme-file.ts
@@ -1,44 +1,16 @@
-import { join } from 'path';
-
 import { EmitContext } from './emit-context';
-// import { Translation } from 'jsii-rosetta';
-// import { INCOMPLETE_DISCLAIMER_COMPILING, INCOMPLETE_DISCLAIMER_NONCOMPILING } from '..';
 
 export class ReadmeFile {
   public constructor(
     private readonly packageName: string,
     private readonly document: string,
+    private readonly directory: string,
   ) {}
 
-  public emit({ code /*, rosetta */ }: EmitContext) {
-    const nameParts = this.packageName.split('.');
-    const file = join(
-      ...nameParts.slice(0, nameParts.length - 11),
-      'README.md',
-    );
-
-    code.openFile(file);
-    const translated = this.document; // rosetta.translateSnippetsInMarkdown(this.document, 'go', prependDisclaimer);
-    for (const line of translated.split('\n')) {
-      code.line(line);
+  public emit({ documenter }: EmitContext) {
+    if (!this.document) {
+      return;
     }
-    code.closeFile(file);
+    documenter.emitReadme(this.packageName, this.document, this.directory)
   }
-
-  /*
-  function prependDisclaimer(translation: Translation) {
-    const source = addDisclaimerIfNeeded();
-    return { language: translation.language, source };
-
-    function addDisclaimerIfNeeded(): string {
-      if (translation.didCompile && INCOMPLETE_DISCLAIMER_COMPILING) {
-        return `// ${INCOMPLETE_DISCLAIMER_COMPILING}\n\n${translation.source}`;
-      }
-      if (!translation.didCompile && INCOMPLETE_DISCLAIMER_NONCOMPILING) {
-        return `// ${INCOMPLETE_DISCLAIMER_NONCOMPILING}\n\n${translation.source}`;
-      }
-      return translation.source;
-    }
-  }
-  */
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.ts.snap
@@ -883,7 +883,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
     ┗━ 📁 scopejsiicalclib
        ┣━ 📁 customsubmodulename
        ┃  ┣━ 📄 customsubmodulename.go
-       ┃  ┗━ 📄 customsubmodulename.init.go
+       ┃  ┣━ 📄 customsubmodulename.init.go
+       ┃  ┗━ 📄 README.md
        ┣━ 📄 go.mod
        ┣━ 📁 internal
        ┃  ┗━ 📄 types.go
@@ -1105,6 +1106,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/NOTICE 1`] = `
 jsii
 Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/README.md 1`] = `
+# Submodule Readme
+
+This is a submodule readme.
 
 `;
 
@@ -2050,7 +2058,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃  ┃  ┗━ 📄 types.go
        ┃  ┣━ 📁 isolated
        ┃  ┃  ┣━ 📄 isolated.go
-       ┃  ┃  ┗━ 📄 isolated.init.go
+       ┃  ┃  ┣━ 📄 isolated.init.go
+       ┃  ┃  ┗━ 📄 README.md
        ┃  ┣━ 📁 nestedsubmodule
        ┃  ┃  ┣━ 📁 deeplynested
        ┃  ┃  ┃  ┣━ 📄 deeplynested.go
@@ -2062,6 +2071,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃  ┣━ 📁 param
        ┃  ┃  ┣━ 📄 param.go
        ┃  ┃  ┗━ 📄 param.init.go
+       ┃  ┣━ 📄 README.md
        ┃  ┣━ 📁 returnsparam
        ┃  ┃  ┣━ 📄 returnsparam.go
        ┃  ┃  ┗━ 📄 returnsparam.init.go
@@ -2290,24 +2300,22 @@ This library is used to demonstrate and test the features of JSII
 
 First, create a calculator:
 
-\`\`\`ts
-const calculator = new calc.Calculator();
+\`\`\`go
+calculator := calc.NewCalculator()
 \`\`\`
 
 Then call some operations:
 
-
-\`\`\`ts fixture=with-calculator
-calculator.add(10);
+\`\`\`go
+calculator.add(jsii.Number(10))
 \`\`\`
 
 ## Code Samples
 
-\`\`\`ts
+\`\`\`go
 /* This is totes a magic comment in here, just you wait! */
-const foo = 'bar';
+foo := "bar"
 \`\`\`
-
 
 `;
 
@@ -18958,6 +18966,13 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/README.md 1`] = `
+# Read you, read me
+
+This is the readme of the \`jsii-calc.submodule\` module.
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/backreferences.go 1`] = `
 package backreferences
 
@@ -19201,6 +19216,13 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/nestedsubmodule/deeplynested"
 )
 type Type__deeplynestedINamespaced = deeplynested.INamespaced
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/README.md 1`] = `
+# Read you, read me
+
+This is the readme of the \`jsii-calc.submodule.isolated\` module.
 
 `;
 

--- a/packages/jsii-rosetta/test/translations/imports/multiple-imports.cs
+++ b/packages/jsii-rosetta/test/translations/imports/multiple-imports.cs
@@ -1,0 +1,2 @@
+using Aws.Cdk.Lib;
+using Constructs;

--- a/packages/jsii-rosetta/test/translations/imports/multiple-imports.go
+++ b/packages/jsii-rosetta/test/translations/imports/multiple-imports.go
@@ -1,0 +1,2 @@
+import cdk "github.com/aws-samples/dummy/awscdklib"
+import "github.com/aws-samples/dummy/constructs"

--- a/packages/jsii-rosetta/test/translations/imports/multiple-imports.java
+++ b/packages/jsii-rosetta/test/translations/imports/multiple-imports.java
@@ -1,0 +1,3 @@
+import aws.cdk.lib.*;
+import constructs.Construct;
+import constructs.IConstruct;

--- a/packages/jsii-rosetta/test/translations/imports/multiple-imports.py
+++ b/packages/jsii-rosetta/test/translations/imports/multiple-imports.py
@@ -1,0 +1,2 @@
+import aws_cdk_lib as cdk
+from constructs import Construct, IConstruct

--- a/packages/jsii-rosetta/test/translations/imports/multiple-imports.ts
+++ b/packages/jsii-rosetta/test/translations/imports/multiple-imports.ts
@@ -1,0 +1,2 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct, IConstruct } from 'constructs';

--- a/packages/jsii-rosetta/test/translations/imports/selective_import.go
+++ b/packages/jsii-rosetta/test/translations/imports/selective_import.go
@@ -1,0 +1,3 @@
+import "github.com/aws-samples/dummy/scopesomemodule"
+scopesomemodule.NewTwo()
+scopesomemodule.Four()


### PR DESCRIPTION
Go does nto support "selective" imports, and has limited symbol aliasing
support. Instead of attempting to transliterate selective imports with
a one-to-one semantic mapping, resolve the imported symbols and emit the
correct qualified original name instead.

This results in more idiomatic (and likely more correct) go code.

For example:

```ts
import { Foo as RenamedFoo, Bar } from 'baz';

const foo = new RenamedFoo();
Bar.baz(foo);
```

Should transliterate to something looking like:

```go
import "github.com/aws-samples/dummy/baz"

foo := baz.NewFoo()
Bar_baz(foo)
```

---

Bonus content:
- Now emits README.md for submodules, too (was previously ignored).
- Missing newlines between go import statements are now inserted.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
