### PR TITLE
chore(superchain): change default node version to 14

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -21,7 +21,7 @@ jobs:
         node: ['12', '14', '16', '18']
     env:
       # Node version whose images will be aliased without the -nodeXX segment
-      DEFAULT_NODE_MAJOR_VERSION: 12
+      DEFAULT_NODE_MAJOR_VERSION: 14
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -199,10 +199,10 @@ COPY superchain/m2-settings.xml /root/.m2/settings.xml
 # Install Go
 COPY --from=bindist /opt/golang/go ${GOROOT}
 
-# Install Node 10+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
+# Install Node 12+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
 # (Put this as late as possible in the Dockerfile so we get to reuse the layer cache
 # for most of the multiple builds).
-ARG NODE_MAJOR_VERSION="12"
+ARG NODE_MAJOR_VERSION="14"
 COPY superchain/gpg/nodesource.asc /tmp/nodesource.asc
 COPY superchain/gpg/yarn.asc /tmp/yarn.asc
 RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                                                           \

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -31,8 +31,8 @@ jsii/superchain:<JSII-MAJOR>-<BASE>(-node<NODE-MAJOR>)(-nightly)
 - `<BASE>` is the base image tag (e.g: `buster-slim`)
   - The only supported value is `buster-slim`
 - `<NODE-MAJOR>` is the major version of node contained in the image
-  - `12` corresponds to node 12.x, this is the default
-  - `14` corresponds to node 14.x
+  - `12` corresponds to node 12.x
+  - `14` corresponds to node 14.x, this is the default
   - `16` corresponds to node 16.x
   - `18` corresponds to node 18.x
 - `-nightly` images are released from the `HEAD` of the [`aws/jsii`][jsii]


### PR DESCRIPTION
Changes the version of node that ships with the `1-buster-slim` and
`1-buster-slim-snapshot` images to node 14, as node 12 is now EOL.

This change should be transparent to the vast majority of users, as
node 14 is largely backwards-compatible with node 12.

This is a prerequisite to https://github.com/cdklabs/cdk-ops/pull/2010

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
