### PR TITLE
fix(@jsii/spec): speed up assembly validation by 20x for large libraries

### DIFF
--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -31,7 +31,7 @@
     "package": "package-js"
   },
   "dependencies": {
-    "jsonschema": "^1.4.1"
+    "ajv": "^8.11.0"
   },
   "devDependencies": {
     "jsii-build-tools": "^0.0.0",

--- a/packages/@jsii/spec/src/validate-assembly.ts
+++ b/packages/@jsii/spec/src/validate-assembly.ts
@@ -1,16 +1,22 @@
-import { Schema, Validator } from 'jsonschema';
+import Ajv from 'ajv';
 
 import { Assembly } from './assembly';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-export const schema: Schema = require('../schema/jsii-spec.schema.json');
+export const schema = require('../schema/jsii-spec.schema.json');
 
 export function validateAssembly(obj: any): Assembly {
-  const validator = new Validator();
-  validator.addSchema(schema); // For definitions
-  const result = validator.validate(obj, schema, { nestedErrors: true });
-  if (result.valid) {
-    return obj;
+  const ajv = new Ajv();
+  const validate = ajv.compile(schema);
+  validate(obj);
+
+  if (validate.errors) {
+    throw new Error(
+      `Invalid assembly:\n${validate.errors
+        .map((e) => ` * ${e.message}`)
+        .join('\n')
+        .toString()}`,
+    );
   }
-  throw new Error(`Invalid assembly:\n${result.toString()}`);
+  return obj;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,6 +2085,16 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 all-contributors-cli@^6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-6.20.0.tgz#9bc98dda38cb29cfe8afc8a78c004e14af25d2f6"
@@ -4998,6 +5008,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
@@ -5038,11 +5053,6 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
-
-jsonschema@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
-  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -6505,6 +6515,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Switch from jsonschema to ajv to improve assembly validation performance.

Previously, loading the type system for aws-cdk-lib and constructs (combined) took around 15-17 seconds on my local development machine, using node v16.8.0. When I ran it with the updated version of @jsii/spec, it only took 750-800ms.

Both ajv and jsonschema are popular npm libraries (we also currently leverage it in the cdk8s-cli). ajv has one downside which is that introduces has a larger bundle size (1.02 MB vs 81.8kB), but I think it's worth it for the performance improvement.

Closes cdklabs/decdk#7

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
