### PR TITLE
chore(jsii-rosetta): export `GoVisitor` from index

### DIFF
--- a/packages/jsii-rosetta/lib/index.ts
+++ b/packages/jsii-rosetta/lib/index.ts
@@ -4,6 +4,7 @@ export { TargetLanguage } from './languages/target-language';
 export { CSharpVisitor } from './languages/csharp';
 export { JavaVisitor } from './languages/java';
 export { PythonVisitor } from './languages/python';
+export { GoVisitor } from './languages/go';
 export * from './tablets/tablets';
 export * from './rosetta-reader';
 export * from './rosetta-translator';


### PR DESCRIPTION
Exports the `GoVisitor` class to allow Go doc generation
programatically.

Fixes: #3552

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
