### PR TITLE
chore: use fast-deep-equal instead of deep-equal

### DIFF
--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -3,8 +3,7 @@ import { PackageJson } from '@jsii/spec';
 import * as Case from 'case';
 import * as chalk from 'chalk';
 import * as crypto from 'crypto';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import deepEqual = require('deep-equal');
+import * as deepEqual from 'fast-deep-equal/es6';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
@@ -46,6 +45,8 @@ export class Assembler implements Emitter {
   private readonly mainFile: string;
   private readonly tscRootDir?: string;
 
+  private readonly _typeChecker: ts.TypeChecker;
+
   private _diagnostics = new Array<JsiiDiagnostic>();
   private _deferred = new Array<DeferredRecord>();
   private readonly _types = new Map<string, spec.Type>();
@@ -78,6 +79,8 @@ export class Assembler implements Emitter {
     public readonly stdlib: string,
     options: AssemblerOptions = {},
   ) {
+    this._typeChecker = this.program.getTypeChecker();
+
     if (options.stripDeprecated) {
       let allowlistedDeprecations: Set<string> | undefined;
       if (options.stripDeprecatedAllowListFile) {
@@ -135,10 +138,6 @@ export class Assembler implements Emitter {
       this.runtimeTypeInfoInjector.makeTransformers(),
       this.warningsInjector?.customTransformers ?? {},
     );
-  }
-
-  private get _typeChecker(): ts.TypeChecker {
-    return this.program.getTypeChecker();
   }
 
   /**
@@ -453,7 +452,6 @@ export class Assembler implements Emitter {
     isThisType: boolean,
   ): string {
     const sym = symbolFromType(type, this._typeChecker);
-
     const typeDeclaration = sym.valueDeclaration ?? sym.declarations?.[0];
 
     // Set to true to prevent further adding of Error diagnostics for known-bad reference
@@ -981,14 +979,10 @@ export class Assembler implements Emitter {
         );
       }
 
+      const nsContext = context.appendNamespace(node.name.getText());
       const allTypes = this._typeChecker
         .getExportsOfModule(symbol)
-        .flatMap((prop) =>
-          this._visitNode(
-            prop.declarations[0],
-            context.appendNamespace(node.name.getText()),
-          ),
-        );
+        .flatMap((prop) => this._visitNode(prop.declarations[0], nsContext));
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
@@ -1221,6 +1215,17 @@ export class Assembler implements Emitter {
     const fqn = `${[this.projectInfo.name, ...ctx.namespace].join('.')}.${
       type.symbol.name
     }`;
+
+    if (Case.pascal(type.symbol.name) !== type.symbol.name) {
+      this._diagnostics.push(
+        JsiiDiagnostic.JSII_8000_PASCAL_CASED_TYPE_NAMES.create(
+          (type.symbol.valueDeclaration as ts.ClassDeclaration).name ??
+            type.symbol.valueDeclaration ??
+            type.symbol.declarations[0],
+          type.symbol.name,
+        ),
+      );
+    }
 
     const jsiiType: spec.ClassType = bindings.setClassRelatedNode(
       {
@@ -1744,6 +1749,15 @@ export class Assembler implements Emitter {
     const typeContext = ctx.replaceStability(docs?.stability);
     const members = type.isUnion() ? type.types : [type];
 
+    if (Case.pascal(symbol.name) !== symbol.name) {
+      this._diagnostics.push(
+        JsiiDiagnostic.JSII_8000_PASCAL_CASED_TYPE_NAMES.create(
+          (symbol.valueDeclaration as ts.EnumDeclaration).name,
+          symbol.name,
+        ),
+      );
+    }
+
     const jsiiType: spec.EnumType = bindings.setEnumRelatedNode(
       {
         assembly: this.projectInfo.name,
@@ -1981,6 +1995,21 @@ export class Assembler implements Emitter {
           );
         }
 
+        // NOTE: We need to be careful with the `I` prefix for behavioral interfaces, as this can mess with PascalCase
+        // transformations, especially with short names such as `IA`, ...
+        const expectedName = interfaceName
+          ? `I${Case.pascal(type.symbol.name.slice(1))}`
+          : Case.pascal(type.symbol.name);
+        if (expectedName !== type.symbol.name) {
+          this._diagnostics.push(
+            JsiiDiagnostic.JSII_8000_PASCAL_CASED_TYPE_NAMES.create(
+              (type.symbol.declarations[0] as ts.InterfaceDeclaration).name,
+              type.symbol.name,
+              expectedName,
+            ),
+          );
+        }
+
         // If the name starts with an "I" it is not intended as a datatype, so switch that off,
         // unless a TSDoc hint was set to force this to be considered a behavioral interface.
         if (jsiiType.datatype && interfaceName && !hints.struct) {
@@ -2095,7 +2124,7 @@ export class Assembler implements Emitter {
       return;
     }
 
-    if (Case.pascal(type.name) === Case.pascal(symbol.name)) {
+    if (type.name === Case.pascal(symbol.name)) {
       this._diagnostics.push(
         JsiiDiagnostic.JSII_5019_MEMBER_TYPE_NAME_CONFLICT.create(
           declaration.name,
@@ -2245,7 +2274,7 @@ export class Assembler implements Emitter {
       | ts.AccessorDeclaration
       | ts.ParameterPropertyDeclaration;
 
-    if (Case.pascal(type.name) === Case.pascal(symbol.name)) {
+    if (type.name === Case.pascal(symbol.name)) {
       this._diagnostics.push(
         JsiiDiagnostic.JSII_5019_MEMBER_TYPE_NAME_CONFLICT.create(
           signature.name,
@@ -2548,7 +2577,7 @@ export class Assembler implements Emitter {
         }
         // eslint-disable-next-line no-await-in-loop
         const resolvedType = this._typeReference(subType, declaration, purpose);
-        if (types.find((ref) => deepEqual(ref, resolvedType)) != null) {
+        if (types.some((ref) => deepEqual(ref, resolvedType))) {
           continue;
         }
         types.push(resolvedType);

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -1,5 +1,5 @@
 import * as spec from '@jsii/spec';
-import { camel, constant as allCaps, pascal } from 'case';
+import { camel, constant, pascal } from 'case';
 import * as ts from 'typescript';
 
 import { TypeSystemHints } from './docs';
@@ -672,17 +672,15 @@ export class JsiiDiagnostic implements ts.Diagnostic {
 
   public static readonly JSII_8000_PASCAL_CASED_TYPE_NAMES = Code.error({
     code: 8000,
-    formatter: (badName: string) =>
-      `Type names must be CamelCased. Rename "${badName}" to "${pascal(
-        badName,
-      )}"`,
+    formatter: (badName: string, expectedName: string = pascal(badName)) =>
+      `Type names must be PascalCased. Rename "${badName}" to "${expectedName}"`,
     name: 'code-style/type-names-must-use-pascal-case',
   });
 
   public static readonly JSII_8001_ALL_CAPS_ENUM_MEMBERS = Code.error({
     code: 8001,
     formatter: (badName: string, typeName: string) =>
-      `Enum members must be ALL_CAPS. Rename "${typeName}.${badName}" to "${allCaps(
+      `Enum members must be ALL_CAPS. Rename "${typeName}.${badName}" to "${constant(
         badName,
       )}"`,
     name: 'code-style/enum-members-must-use-all-caps',
@@ -700,7 +698,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public static readonly JSII_8003_STATIC_CONST_CASING = Code.error({
     code: 8003,
     formatter: (badName: string, typeName: string) =>
-      `Static constant names must use ALL_CAPS, PascalCase, or camelCase. Rename "${typeName}.${badName}" to "${allCaps(
+      `Static constant names must use ALL_CAPS, PascalCase, or camelCase. Rename "${typeName}.${badName}" to "${constant(
         badName,
       )}"`,
     name: 'code-style/static-readonly-property-casing',

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,8 +1,7 @@
 import * as spec from '@jsii/spec';
 import * as assert from 'assert';
 import * as Case from 'case';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import deepEqual = require('deep-equal');
+import * as deepEqual from 'fast-deep-equal';
 import * as ts from 'typescript';
 
 import { Emitter } from './emitter';
@@ -44,7 +43,6 @@ export type ValidationFunction = (
 
 function _defaultValidations(): ValidationFunction[] {
   return [
-    _typeNamesMustUsePascalCase,
     _enumMembersMustUserUpperSnakeCase,
     _memberNamesMustUseCamelCase,
     _staticConstantNamesMustUseUpperSnakeCase,
@@ -53,22 +51,6 @@ function _defaultValidations(): ValidationFunction[] {
     _inehritanceDoesNotChangeContracts,
     _staticMembersAndNestedTypesMustNotSharePascalCaseName,
   ];
-
-  function _typeNamesMustUsePascalCase(
-    _: Validator,
-    assembly: spec.Assembly,
-    diagnostic: DiagnosticEmitter,
-  ) {
-    for (const type of _allTypes(assembly)) {
-      if (type.name !== Case.pascal(type.name)) {
-        diagnostic(
-          JsiiDiagnostic.JSII_8000_PASCAL_CASED_TYPE_NAMES.createDetached(
-            type.name,
-          ),
-        );
-      }
-    }
-  }
 
   function _enumMembersMustUserUpperSnakeCase(
     _: Validator,

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -39,7 +39,7 @@
     "@jsii/spec": "^0.0.0",
     "case": "^1.6.3",
     "chalk": "^4",
-    "deep-equal": "^2.0.5",
+    "fast-deep-equal": "^3.1.3",
     "fs-extra": "^10.1.0",
     "log4js": "^6.5.2",
     "semver": "^7.3.7",

--- a/packages/jsii/test/__snapshots__/negatives.test.js.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.js.snap
@@ -10,12 +10,20 @@ neg.behavior-requires-iprefix.ts:1:18 - error JSII8007: Interface contains behav
 `;
 
 exports[`class-name 1`] = `
-error JSII8000: Type names must be CamelCased. Rename "myclass" to "Myclass"
+neg.class-name.ts:1:14 - error JSII8000: Type names must be PascalCased. Rename "myclass" to "Myclass"
+
+1 export class myclass {}
+               ~~~~~~~
+
 
 `;
 
 exports[`class-name.1 1`] = `
-error JSII8000: Type names must be CamelCased. Rename "My_class" to "MyClass"
+neg.class-name.1.ts:1:14 - error JSII8000: Type names must be PascalCased. Rename "My_class" to "MyClass"
+
+1 export class My_class {}
+               ~~~~~~~~
+
 
 `;
 
@@ -108,12 +116,20 @@ error JSII8001: Enum members must be ALL_CAPS. Rename "jsii.MyEnum.Goo" to "GOO"
 `;
 
 exports[`enum-name.1 1`] = `
-error JSII8000: Type names must be CamelCased. Rename "myEnum" to "MyEnum"
+neg.enum-name.1.ts:1:13 - error JSII8000: Type names must be PascalCased. Rename "myEnum" to "MyEnum"
+
+1 export enum myEnum {
+              ~~~~~~
+
 
 `;
 
 exports[`enum-name.2 1`] = `
-error JSII8000: Type names must be CamelCased. Rename "My_Enum" to "MyEnum"
+neg.enum-name.2.ts:1:13 - error JSII8000: Type names must be PascalCased. Rename "My_Enum" to "MyEnum"
+
+1 export enum My_Enum {
+              ~~~~~~~
+
 
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2379,11 +2379,6 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
 babel-jest@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-28.1.1.tgz#2a3a4ae50964695b2d694ccffe4bec537c5a3586"
@@ -3130,27 +3125,6 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
-deep-equal@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.0.5.tgz#55cd2fe326d83f9cbf7261ef0e060b3f724c5cb9"
-  integrity sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==
-  dependencies:
-    call-bind "^1.0.0"
-    es-get-iterator "^1.1.1"
-    get-intrinsic "^1.0.1"
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.2"
-    is-regex "^1.1.1"
-    isarray "^2.0.5"
-    object-is "^1.1.4"
-    object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    regexp.prototype.flags "^1.3.0"
-    side-channel "^1.0.3"
-    which-boxed-primitive "^1.0.1"
-    which-collection "^1.0.1"
-    which-typed-array "^1.1.2"
-
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -3359,7 +3333,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5, es-abstract@^1.20.0:
+es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.1.tgz#027292cd6ef44bd12b1913b828116f54787d1814"
   integrity sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==
@@ -3387,20 +3361,6 @@ es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
-
-es-get-iterator@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
-  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.0"
-    has-symbols "^1.0.1"
-    is-arguments "^1.1.0"
-    is-map "^2.0.2"
-    is-set "^2.0.2"
-    is-string "^1.0.5"
-    isarray "^2.0.5"
 
 es-module-lexer@^0.9.0:
   version "0.9.3"
@@ -3787,13 +3747,6 @@ flatted@^3.1.0, flatted@^3.2.5:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
-
 fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
@@ -3893,7 +3846,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -4323,14 +4276,6 @@ ip@^1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
   integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
-is-arguments@^1.0.4, is-arguments@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4351,7 +4296,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
+is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
@@ -4370,7 +4315,7 @@ is-core-module@^2.5.0, is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
-is-date-object@^1.0.1, is-date-object@^1.0.2:
+is-date-object@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
@@ -4410,11 +4355,6 @@ is-lambda@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
   integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
-
-is-map@^2.0.1, is-map@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
-  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
 is-negative-zero@^2.0.2:
   version "2.0.2"
@@ -4460,18 +4400,13 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
-is-regex@^1.1.1, is-regex@^1.1.4:
+is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
-
-is-set@^2.0.1, is-set@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
-  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
@@ -4513,26 +4448,10 @@ is-text-path@^1.0.1:
   dependencies:
     text-extensions "^1.0.0"
 
-is-typed-array@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.9.tgz#246d77d2871e7d9f5aeb1d54b9f52c71329ece67"
-  integrity sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.20.0"
-    for-each "^0.3.3"
-    has-tostringtag "^1.0.0"
-
 is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
-
-is-weakmap@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
-  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -4541,23 +4460,10 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
-is-weakset@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
-  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.1"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -5886,14 +5792,6 @@ object-inspect@^1.12.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
-object-is@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -6528,7 +6426,7 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-regexp.prototype.flags@^1.3.0, regexp.prototype.flags@^1.4.3:
+regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
   integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
@@ -6736,7 +6634,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel@^1.0.3, side-channel@^1.0.4:
+side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
   integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
@@ -7640,7 +7538,7 @@ whatwg-url@^8.4.0:
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
 
-which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
+which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
@@ -7651,32 +7549,10 @@ which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
-which-collection@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
-  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
-  dependencies:
-    is-map "^2.0.1"
-    is-set "^2.0.1"
-    is-weakmap "^2.0.1"
-    is-weakset "^2.0.1"
-
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
-which-typed-array@^1.1.2:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.8.tgz#0cfd53401a6f334d90ed1125754a42ed663eb01f"
-  integrity sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-abstract "^1.20.0"
-    for-each "^0.3.3"
-    has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.9"
 
 which@^2.0.1, which@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
It turns out `fast-deep-equal` is *significantly* faster than
`deep-equal` and appears to produce consistent results. Migrating to
this allows us to yield faster compile times as `deepEqual` is
frequently used when resolving type union references.

Also de-duplicated a couple of calls to `Case.pascal`, which is also
a pretty significant time consumer (but `fast-case` is not iso-functional
with `case`, so this isn't as easy to replace as `deep-equal`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
