### PR TITLE
chore: cache heavy elements in assemblyRelativeSourceFile

### DIFF
--- a/packages/@jsii/benchmarks/lib/benchmark.ts
+++ b/packages/@jsii/benchmarks/lib/benchmark.ts
@@ -62,7 +62,7 @@ interface Result {
  * teardown, stubbing, etc.
  */
 export class Benchmark<C> {
-  #iterations = 5;
+  #iterations = 20;
   #profile = false;
 
   public constructor(private readonly name: string) {}

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -74,7 +74,10 @@ export function symbolIdentifier(
 
   const [, fileName, inFileName] = groups; // inFileName may be absent
 
-  const relFile = Helper.for(typeChecker).assemblyRelativeSourceFile(fileName, options?.assembly);
+  const relFile = Helper.for(typeChecker).assemblyRelativeSourceFile(
+    fileName,
+    options?.assembly,
+  );
   if (!relFile) {
     return undefined;
   }
@@ -117,8 +120,7 @@ class Helper {
 
     // Modify the namespace if we send in the assembly.
     if (asm) {
-      const tscRootDir =
-        packageInfo.tscRootDir ?? asm.metadata?.tscRootDir;
+      const tscRootDir = packageInfo.tscRootDir ?? asm.metadata?.tscRootDir;
       const tscOutDir = packageInfo.tscOutDir;
       sourcePath = normalizePath(sourcePath, tscRootDir, tscOutDir);
     }
@@ -154,9 +156,7 @@ class Helper {
       return this.packageInfo.get(packageJsonDir);
     }
 
-    const { jsii } = fs.readJsonSync(
-      path.join(packageJsonDir, 'package.json'),
-    );
+    const { jsii } = fs.readJsonSync(path.join(packageJsonDir, 'package.json'));
 
     const result = {
       packageJsonDir,
@@ -176,7 +176,6 @@ interface PackageInfo {
   readonly tscRootDir: string | undefined;
   readonly tscOutDir: string | undefined;
 }
-
 
 /**
  * Ensures that the sourcePath is pointing to the source code

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -74,7 +74,7 @@ export function symbolIdentifier(
 
   const [, fileName, inFileName] = groups; // inFileName may be absent
 
-  const relFile = assemblyRelativeSourceFile(fileName, options?.assembly);
+  const relFile = Helper.for(typeChecker).assemblyRelativeSourceFile(fileName, options?.assembly);
   if (!relFile) {
     return undefined;
   }
@@ -87,44 +87,96 @@ export function symbolIdentifier(
   return `${relFile}:${typeSymbol}`;
 }
 
-function assemblyRelativeSourceFile(sourceFileName: string, asm?: Assembly) {
-  const packageJsonDir = findUp(path.dirname(sourceFileName), (dir) =>
-    fs.pathExistsSync(path.join(dir, 'package.json')),
-  );
+class Helper {
+  private static readonly INSTANCES = new WeakMap<ts.TypeChecker, Helper>();
 
-  if (!packageJsonDir) {
-    return undefined;
-  }
-
-  const packageJson = fs.readJsonSync(
-    path.join(packageJsonDir, 'package.json'),
-  );
-
-  let sourcePath = removePrefix(
-    packageJson.jsii?.outdir ?? '',
-    path.relative(packageJsonDir, sourceFileName),
-  );
-
-  // Modify the namespace if we send in the assembly.
-  if (asm) {
-    const tscRootDir =
-      packageJson.jsii?.tsc?.rootDir ?? asm.metadata?.tscRootDir;
-    const tscOutDir = packageJson.jsii?.tsc?.outDir;
-    sourcePath = normalizePath(sourcePath, tscRootDir, tscOutDir);
-  }
-
-  return sourcePath.replace(/(\.d)?\.ts$/, '');
-
-  function removePrefix(prefix: string, filePath: string) {
-    const prefixParts = prefix.split(/[/\\]/g);
-    const pathParts = filePath.split(/[/\\]/g);
-    let i = 0;
-    while (prefixParts[i] === pathParts[i]) {
-      i++;
+  public static for(typeChecker: ts.TypeChecker) {
+    const cached = this.INSTANCES.get(typeChecker);
+    if (cached != null) {
+      return cached;
     }
-    return pathParts.slice(i).join('/');
+    const helper = new Helper();
+    this.INSTANCES.set(typeChecker, helper);
+    return helper;
+  }
+
+  private readonly packageInfo = new Map<string, PackageInfo | undefined>();
+
+  private constructor() {}
+
+  public assemblyRelativeSourceFile(sourceFileName: string, asm?: Assembly) {
+    const packageInfo = this.findPackageInfo(path.dirname(sourceFileName));
+    if (!packageInfo) {
+      return undefined;
+    }
+
+    let sourcePath = removePrefix(
+      packageInfo.outdir ?? '',
+      path.relative(packageInfo.packageJsonDir, sourceFileName),
+    );
+
+    // Modify the namespace if we send in the assembly.
+    if (asm) {
+      const tscRootDir =
+        packageInfo.tscRootDir ?? asm.metadata?.tscRootDir;
+      const tscOutDir = packageInfo.tscOutDir;
+      sourcePath = normalizePath(sourcePath, tscRootDir, tscOutDir);
+    }
+
+    return sourcePath.replace(/(\.d)?\.ts$/, '');
+
+    function removePrefix(prefix: string, filePath: string) {
+      const prefixParts = prefix.split(/[/\\]/g);
+      const pathParts = filePath.split(/[/\\]/g);
+      let i = 0;
+      while (prefixParts[i] === pathParts[i]) {
+        i++;
+      }
+      return pathParts.slice(i).join('/');
+    }
+  }
+
+  private findPackageInfo(from: string): PackageInfo | undefined {
+    if (this.packageInfo.has(from)) {
+      return this.packageInfo.get(from);
+    }
+
+    const packageJsonDir = findUp(from, (dir) =>
+      fs.pathExistsSync(path.join(dir, 'package.json')),
+    );
+
+    if (!packageJsonDir) {
+      this.packageInfo.set(from, undefined);
+      return undefined;
+    }
+
+    if (this.packageInfo.has(packageJsonDir)) {
+      return this.packageInfo.get(packageJsonDir);
+    }
+
+    const { jsii } = fs.readJsonSync(
+      path.join(packageJsonDir, 'package.json'),
+    );
+
+    const result = {
+      packageJsonDir,
+      outdir: jsii?.outdir,
+      tscRootDir: jsii?.tsc?.rootDir,
+      tscOutDir: jsii?.tsc?.outDir,
+    };
+    this.packageInfo.set(from, result);
+    this.packageInfo.set(packageJsonDir, result);
+    return result;
   }
 }
+
+interface PackageInfo {
+  readonly packageJsonDir: string;
+  readonly outdir: string | undefined;
+  readonly tscRootDir: string | undefined;
+  readonly tscOutDir: string | undefined;
+}
+
 
 /**
  * Ensures that the sourcePath is pointing to the source code

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -227,15 +227,16 @@ export function findUp(
 ): string | undefined {
   const result = pred(directory);
 
-  return result ? directory : recurse();
-
-  function recurse() {
-    const parent = path.dirname(directory);
-    if (parent === directory) {
-      return undefined;
-    }
-    return findUp(parent, pred as any);
+  if (result) {
+    return directory;
   }
+
+  const parent = path.dirname(directory);
+  if (parent === directory) {
+    return undefined;
+  }
+
+  return findUp(parent, pred);
 }
 
 const ANSI_REGEX =


### PR DESCRIPTION
The readFileSync calls there tend to process large JSON documents, which
is time-consuming. Basic profiling showed this is called repeatedly with
similar directories, so the time spent can be greatly reduced.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
