### PR TITLE
chore(jsii): cache results of case conversions

### DIFF
--- a/gh-pages/partials/node-support-table.md
+++ b/gh-pages/partials/node-support-table.md
@@ -2,10 +2,8 @@
 
     | Release   | Status                       | End-of-Life  |
     | --------- | ---------------------------- | ------------ |
-    | `^12.7.0` | :white_check_mark: Supported | `2022-04-30` |
-    | `^14.5.0` | :white_check_mark: Supported | `2023-04-30` |
+    | `^14.6.0` | :white_check_mark: Supported | `2023-04-30` |
     | `^16.3.0` | :white_check_mark: Supported | `2024-04-30` |
-    | `^17.3.0` | :test_tube: Best effort      | `2022-06-01` |
     | `^18.0.0` | :white_check_mark: Supported | `2025-04-30` |
 
     ??? question "Status Definitions"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@jest/types": "^28.1.1",
     "@types/jest": "^28.1.1",
-    "@types/node": "^12.20.55",
+    "@types/node": "^14.18.21",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "all-contributors-cli": "^6.20.0",

--- a/packages/@fixtures/jsii-calc-bundled/package.json
+++ b/packages/@fixtures/jsii-calc-bundled/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@fixtures/jsii-calc-bundled"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "index.js"
 }

--- a/packages/@jsii/benchmarks/package.json
+++ b/packages/@jsii/benchmarks/package.json
@@ -16,8 +16,8 @@
     "glob": "^8.0.3"
   },
   "scripts": {
-    "build": "tsc --build && npm run lint",
-    "watch": "tsc -w",
+    "build": "yarn --silent tsc --build && npm run lint",
+    "watch": "yarn --silent tsc -w",
     "bench": "node bin/benchmark.js",
     "snapshot": "node scripts/snapshot-package.js",
     "lint": "eslint . --ext .ts --ignore-path=.gitignore",

--- a/packages/@jsii/benchmarks/package.json
+++ b/packages/@jsii/benchmarks/package.json
@@ -8,6 +8,7 @@
     "fs-extra": "^10.1.0",
     "jsii": "^0.0.0",
     "tar": "^6.1.11",
+    "typescript-3.9": "npm:typescript@~3.9.10",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/packages/@jsii/check-node/package.json
+++ b/packages/@jsii/check-node/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@jsii/check-node"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -35,7 +35,7 @@ export class NodeRelease {
     // Currently active releases
     new NodeRelease(14, {
       endOfLife: new Date('2023-04-30'),
-      supportedRange: '^14.5.0',
+      supportedRange: '^14.6.0',
     }),
     new NodeRelease(16, {
       endOfLife: new Date('2024-04-30'),

--- a/packages/@jsii/dotnet-runtime-test/package.json
+++ b/packages/@jsii/dotnet-runtime-test/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/@jsii/dotnet-runtime-test"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/dotnet-runtime/package.json
+++ b/packages/@jsii/dotnet-runtime/package.json
@@ -25,7 +25,7 @@
     "directory": "packages/@jsii/dotnet-runtime"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/java-runtime-test/package.json
+++ b/packages/@jsii/java-runtime-test/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/@jsii/java-runtime-test"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/java-runtime/package.json
+++ b/packages/@jsii/java-runtime/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/@jsii/java-runtime"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/kernel/package.json
+++ b/packages/@jsii/kernel/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@jsii/kernel"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/python-runtime/package.json
+++ b/packages/@jsii/python-runtime/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/@jsii/python-runtime"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/@jsii/runtime/package.json
+++ b/packages/@jsii/runtime/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@jsii/runtime"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@jsii/spec"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@scope/jsii-calc-base-of-base/package.json
+++ b/packages/@scope/jsii-calc-base-of-base/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/@scope/jsii-calc-base-of-base"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -19,7 +19,7 @@
     "directory": "packages/@scope/jsii-calc-base"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/@scope/jsii-calc-lib"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/codemaker/package.json
+++ b/packages/codemaker/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/codemaker"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -28,7 +28,7 @@
     "test"
   ],
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/jsii-diff/package.json
+++ b/packages/jsii-diff/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/jsii-diff"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "bin": {

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/jsii-pacmak"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/jsii-reflect"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { createSourceFile, ScriptKind, ScriptTarget, SyntaxKind } from 'typescript';
+import { createSourceFile, ScriptKind, ScriptTarget, SyntaxKind } from 'typescript-3.9';
 
 import { TypeScriptSnippet, SnippetParameters, ApiLocation } from './snippet';
 

--- a/packages/jsii-rosetta/lib/jsii/jsii-types.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-types.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { inferredTypeOfExpression, BuiltInType, builtInTypeName, mapElementType } from '../typescript/types';
 import { hasAnyFlag, analyzeStructType, JsiiSymbol } from './jsii-utils';

--- a/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
+++ b/packages/jsii-rosetta/lib/jsii/jsii-utils.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import { symbolIdentifier } from 'jsii';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { AstRenderer } from '../renderer';
 import { typeContainsUndefined } from '../typescript/types';

--- a/packages/jsii-rosetta/lib/languages/csharp.ts
+++ b/packages/jsii-rosetta/lib/languages/csharp.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { determineJsiiType, JsiiType, ObjectLiteralStruct } from '../jsii/jsii-types';
 import { JsiiSymbol, simpleName, namespaceName } from '../jsii/jsii-utils';

--- a/packages/jsii-rosetta/lib/languages/default.ts
+++ b/packages/jsii-rosetta/lib/languages/default.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { analyzeObjectLiteral, ObjectLiteralStruct } from '../jsii/jsii-types';
 import { isNamedLikeStruct, isJsiiProtocolType } from '../jsii/jsii-utils';

--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -1,7 +1,7 @@
 // import { JsiiSymbol, simpleName, namespaceName } from '../jsii/jsii-utils';
 // import { jsiiTargetParameter } from '../jsii/packages';
 import { AssertionError } from 'assert';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { analyzeObjectLiteral, determineJsiiType, JsiiType, ObjectLiteralStruct } from '../jsii/jsii-types';
 import { OTree } from '../o-tree';

--- a/packages/jsii-rosetta/lib/languages/java.ts
+++ b/packages/jsii-rosetta/lib/languages/java.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { determineJsiiType, JsiiType, analyzeObjectLiteral, ObjectLiteralStruct } from '../jsii/jsii-types';
 import { JsiiSymbol, simpleName, namespaceName } from '../jsii/jsii-utils';

--- a/packages/jsii-rosetta/lib/languages/python.ts
+++ b/packages/jsii-rosetta/lib/languages/python.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { determineJsiiType, JsiiType, ObjectLiteralStruct } from '../jsii/jsii-types';
 import {

--- a/packages/jsii-rosetta/lib/languages/record-references.ts
+++ b/packages/jsii-rosetta/lib/languages/record-references.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { lookupJsiiSymbol } from '../jsii/jsii-utils';
 import { TargetLanguage } from '../languages/target-language';

--- a/packages/jsii-rosetta/lib/languages/visualize.ts
+++ b/packages/jsii-rosetta/lib/languages/visualize.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { OTree } from '../o-tree';
 import { AstRenderer, AstHandler, nimpl, CommentSyntax } from '../renderer';

--- a/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
+++ b/packages/jsii-rosetta/lib/markdown/replace-typescript-transform.ts
@@ -11,7 +11,7 @@ export class ReplaceTypeScriptTransform extends ReplaceCodeTransform {
   public constructor(api: ApiLocation, strict: boolean, replacer: TypeScriptReplacer) {
     super((block, line) => {
       const languageParts = block.language ? block.language.split(' ') : [];
-      if (languageParts[0] !== 'typescript' && languageParts[0] !== 'ts') {
+      if (languageParts[0] !== 'typescript-3.9' && languageParts[0] !== 'ts') {
         return block;
       }
 

--- a/packages/jsii-rosetta/lib/renderer.ts
+++ b/packages/jsii-rosetta/lib/renderer.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { TargetLanguage } from './languages';
 import { NO_SYNTAX, OTree, UnknownSyntax, Span } from './o-tree';

--- a/packages/jsii-rosetta/lib/rosetta-reader.ts
+++ b/packages/jsii-rosetta/lib/rosetta-reader.ts
@@ -259,7 +259,7 @@ export class RosettaTabletReader {
 
     const translated = this.translateSnippet(snippet, targetLang);
 
-    return translated ?? { language: 'typescript', source: example };
+    return translated ?? { language: 'typescript-3.9', source: example };
   }
 
   /**

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -206,7 +206,7 @@ export class TranslatedSnippet {
   public get originalSource(): Translation {
     return {
       source: this.snippet.translations[ORIGINAL_SNIPPET_KEY].source,
-      language: 'typescript',
+      language: 'typescript-3.9',
       didCompile: this.snippet.didCompile,
     };
   }

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 import { inspect } from 'util';
 
 import { TARGET_LANGUAGES, TargetLanguage } from './languages';

--- a/packages/jsii-rosetta/lib/typescript/ast-utils.ts
+++ b/packages/jsii-rosetta/lib/typescript/ast-utils.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { AstRenderer } from '../renderer';
 

--- a/packages/jsii-rosetta/lib/typescript/imports.ts
+++ b/packages/jsii-rosetta/lib/typescript/imports.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { JsiiSymbol, parentSymbol, lookupJsiiSymbolFromNode } from '../jsii/jsii-utils';
 import { AstRenderer } from '../renderer';

--- a/packages/jsii-rosetta/lib/typescript/syntax-kind-counter.ts
+++ b/packages/jsii-rosetta/lib/typescript/syntax-kind-counter.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { Spans } from './visible-spans';
 

--- a/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
+++ b/packages/jsii-rosetta/lib/typescript/ts-compiler.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 export class TypeScriptCompiler {
   private readonly realHost = ts.createCompilerHost(STANDARD_COMPILER_OPTIONS, true);

--- a/packages/jsii-rosetta/lib/typescript/types.ts
+++ b/packages/jsii-rosetta/lib/typescript/types.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { hasAllFlags, hasAnyFlag, resolveEnumLiteral, resolvedSymbolAtLocation } from '../jsii/jsii-utils';
 import { isDefined } from '../util';

--- a/packages/jsii-rosetta/lib/typescript/visible-spans.ts
+++ b/packages/jsii-rosetta/lib/typescript/visible-spans.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { Span } from '../o-tree';
 

--- a/packages/jsii-rosetta/lib/util.ts
+++ b/packages/jsii-rosetta/lib/util.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { RosettaDiagnostic } from './translate';
 

--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -30,7 +30,7 @@
     "@jsii/spec": "0.0.0",
     "commonmark": "^0.30.0",
     "fs-extra": "^10.1.0",
-    "typescript": "~3.9.10",
+    "typescript-3.9": "npm:typescript@~3.9.10",
     "sort-json": "^2.0.1",
     "@xmldom/xmldom": "^0.8.2",
     "workerpool": "^6.2.1",
@@ -53,6 +53,6 @@
     "directory": "packages/jsii-rosetta"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   }
 }

--- a/packages/jsii-rosetta/test/util.test.ts
+++ b/packages/jsii-rosetta/test/util.test.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { annotateStrictDiagnostic, hasStrictBranding } from '../lib/util';
 

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -2,6 +2,7 @@ import '@jsii/check-node/run';
 
 import * as log4js from 'log4js';
 import * as path from 'path';
+import { version as tsVersion } from 'typescript-3.9/package.json';
 import * as util from 'util';
 import * as yargs from 'yargs';
 
@@ -78,10 +79,7 @@ const warningTypes = Object.keys(enabledWarnings);
       global: true,
     })
     .help()
-    .version(
-      // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-      `${VERSION}, typescript ${require('typescript/package.json').version}`,
-    ).argv;
+    .version(`${VERSION}, typescript ${tsVersion}`).argv;
 
   _configureLog4js(argv.verbose);
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1,14 +1,14 @@
 import * as spec from '@jsii/spec';
 import { PackageJson } from '@jsii/spec';
-import * as Case from 'case';
 import * as chalk from 'chalk';
 import * as crypto from 'crypto';
 import * as deepEqual from 'fast-deep-equal/es6';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
+import * as Case from './case';
 import {
   getReferencedDocParams,
   parseSymbolDocumentation,

--- a/packages/jsii/lib/case.ts
+++ b/packages/jsii/lib/case.ts
@@ -1,0 +1,57 @@
+import * as Case from 'case';
+
+const cached =
+  (func: (text: string) => string): ((text: string) => string) =>
+  (text: string) =>
+    Cache.fetch(text, func);
+
+export const camel = cached(Case.camel);
+export const constant = cached(Case.constant);
+export const pascal = cached(Case.pascal);
+export const snake = cached(Case.snake);
+
+class Cache {
+  // Cache is indexed on a weak CacheKey so the cache can be purged under memory pressure
+  private static readonly CACHES = new WeakMap<CacheKey, Map<string, string>>();
+
+  public static fetch(text: string, func: (text: string) => string): string {
+    // Check whether we have a cache for this function...
+    const cacheKey = CacheKey.for(func);
+    let cache = this.CACHES.get(cacheKey);
+    if (cache == null) {
+      // If not, create one...
+      cache = new Map<string, string>();
+      this.CACHES.set(cacheKey, cache);
+    }
+
+    // Check if the current cache has a value for this text...
+    const cached = cache.get(text);
+    if (cached != null) {
+      return cached;
+    }
+
+    // If not, compute one...
+    const result = func(text);
+    cache.set(text, result);
+    return result;
+  }
+
+  private constructor() {}
+}
+
+class CacheKey {
+  // Storing cache keys as weak references to allow garbage collection if there is memory pressure.
+  private static readonly STORE = new Map<any, WeakRef<CacheKey>>();
+
+  public static for(data: any) {
+    const entry = this.STORE.get(data)?.deref();
+    if (entry != null) {
+      return entry;
+    }
+    const newKey = new CacheKey();
+    this.STORE.set(data, new WeakRef(newKey));
+    return newKey;
+  }
+
+  private constructor() {}
+}

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1,11 +1,11 @@
-import * as Case from 'case';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { Assembler } from './assembler';
+import * as Case from './case';
 import { Emitter } from './emitter';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { ProjectInfo } from './project-info';

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -31,7 +31,7 @@
  * https://github.com/Microsoft/tsdoc/blob/master/api-demo/src/advancedDemo.ts
  */
 import * as spec from '@jsii/spec';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 /**
  * Tags that we recognize

--- a/packages/jsii/lib/emitter.ts
+++ b/packages/jsii/lib/emitter.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 /**
  * An object that is capable of emitting stuff.

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -11,7 +11,7 @@ import { PackageJson } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { DiagnosticCategory } from 'typescript';
+import { DiagnosticCategory } from 'typescript-3.9';
 
 import { Compiler, CompilerOptions } from './compiler';
 import { loadProjectInfo, ProjectInfo } from './project-info';

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import { camel, constant, pascal } from 'case';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { TypeSystemHints } from './docs';
 import { WARNINGSCODE_FILE_NAME } from './transforms/deprecation-warnings';

--- a/packages/jsii/lib/node-bindings.ts
+++ b/packages/jsii/lib/node-bindings.ts
@@ -1,5 +1,5 @@
 import * as spec from '@jsii/spec';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 /**
  * This module provides typed method that can be used to access TypeScript Nodes

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
 import * as semver from 'semver';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { parsePerson, parseRepository, findDependencyDirectory } from './utils';

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -1,7 +1,7 @@
 import { Assembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { findUp } from './utils';
 

--- a/packages/jsii/lib/transforms/deprecated-remover.ts
+++ b/packages/jsii/lib/transforms/deprecated-remover.ts
@@ -18,7 +18,7 @@ import {
   TypeReference,
 } from '@jsii/spec';
 import { basename, dirname, relative } from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { JsiiDiagnostic } from '../jsii-diagnostic';
 import * as bindings from '../node-bindings';

--- a/packages/jsii/lib/transforms/deprecation-warnings.ts
+++ b/packages/jsii/lib/transforms/deprecation-warnings.ts
@@ -2,7 +2,7 @@ import * as spec from '@jsii/spec';
 import { Assembly } from '@jsii/spec';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { ProjectInfo } from '../project-info';
 import { symbolIdentifier } from '../symbol-id';

--- a/packages/jsii/lib/transforms/runtime-info.ts
+++ b/packages/jsii/lib/transforms/runtime-info.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 /**
  * Provides a TransformerFactory to annotate classes with runtime information

--- a/packages/jsii/lib/transforms/utils.ts
+++ b/packages/jsii/lib/transforms/utils.ts
@@ -1,4 +1,4 @@
-import { CustomTransformers } from 'typescript';
+import { CustomTransformers } from 'typescript-3.9';
 
 /**
  * Combines a collection of `CustomTransformers` configurations into a single

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { JsiiDiagnostic } from './jsii-diagnostic';
 

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,9 +1,9 @@
 import * as spec from '@jsii/spec';
 import * as assert from 'assert';
-import * as Case from 'case';
 import * as deepEqual from 'fast-deep-equal';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
+import * as Case from './case';
 import { Emitter } from './emitter';
 import { JsiiDiagnostic } from './jsii-diagnostic';
 import { getRelatedNode } from './node-bindings';

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/jsii"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -46,7 +46,7 @@
     "semver-intersect": "^1.4.0",
     "sort-json": "^2.0.1",
     "spdx-license-list": "^6.5.0",
-    "typescript": "~3.9.10",
+    "typescript-3.9": "npm:typescript@~3.9.10",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/packages/jsii/test/__snapshots__/negatives.test.js.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.js.snap
@@ -573,7 +573,7 @@ neg.omit.1.ts:7:33 - error JSII3004: Illegal extends clause for an exported API:
 7 export interface BarBaz extends Omit<FooBar, 'foo'> {
                                   ~~~~~~~~~~~~~~~~~~~
 
-  ../../node_modules/typescript/lib/lib.es5.d.ts:1462:35
+  ../../../../node_modules/typescript-3.9/lib/lib.es5.d.ts:1462:35
     1462 type Pick<T, K extends keyof T> = {
                                            ~
     1463     [P in K]: T[P];
@@ -590,7 +590,7 @@ neg.omit.2.ts:7:32 - error JSII3004: Illegal implements clause for an exported A
 7 export class BarBaz implements Omit<FooBar, 'foo'> {
                                  ~~~~~~~~~~~~~~~~~~~
 
-  ../../node_modules/typescript/lib/lib.es5.d.ts:1462:35
+  ../../../../node_modules/typescript-3.9/lib/lib.es5.d.ts:1462:35
     1462 type Pick<T, K extends keyof T> = {
                                            ~
     1463     [P in K]: T[P];

--- a/packages/jsii/test/jsii-diagnostic.test.ts
+++ b/packages/jsii/test/jsii-diagnostic.test.ts
@@ -1,4 +1,4 @@
-import { DiagnosticCategory } from 'typescript';
+import { DiagnosticCategory } from 'typescript-3.9';
 
 import { Code, configureCategories } from '../lib/jsii-diagnostic';
 

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { Compiler } from '../lib/compiler';
 import { ProjectInfo } from '../lib/project-info';

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -3,7 +3,7 @@ import * as clone from 'clone';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { loadProjectInfo } from '../lib/project-info';
 import { VERSION } from '../lib/version';

--- a/packages/jsii/test/transforms/runtime-info.test.ts
+++ b/packages/jsii/test/transforms/runtime-info.test.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 import { RuntimeTypeInfoInjector } from '../../lib/transforms/runtime-info';
 
@@ -102,7 +102,7 @@ function mockedTypeInfoForClasses(
  */
 
 const EXAMPLE_NO_CLASS = `
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 interface Foo {
   readonly foobar: string;
@@ -110,7 +110,7 @@ interface Foo {
 `;
 
 const EXAMPLE_SINGLE_CLASS = `
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 class Foo {
   constructor(public readonly bar: string) {}
@@ -144,7 +144,7 @@ export default class {
 `;
 
 const EXAMPLE_CONFLICTING_NAME = `
-import * as ts from 'typescript';
+import * as ts from 'typescript-3.9';
 
 const JSII_RTTI_SYMBOL_1 = 42;
 

--- a/packages/oo-ascii-tree/package.json
+++ b/packages/oo-ascii-tree/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/oo-ascii-tree"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tools/jsii-build-tools/package.json
+++ b/tools/jsii-build-tools/package.json
@@ -18,7 +18,7 @@
     "directory": "tools/jsii-build-tools"
   },
   "engines": {
-    "node": ">= 14.5.0"
+    "node": ">= 14.6.0"
   },
   "bin": {
     "diff-test": "bin/diff-test",

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",                    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "commonjs",                  /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2020"],                     /* Specify library files to be included in the compilation:  */
+    "lib": ["es2020", "es2021.WeakRef"],   /* Specify library files to be included in the compilation:  */
     "strict": true,                        /* Enable all strict type-checking options. */
     "strictPropertyInitialization": true,  /* Require all properties be initialized in the constructor. */
     "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.41.tgz#1607b2fd3da014ae5d4d1b31bc792a39348dfb9b"
   integrity sha512-xA6drNNeqb5YyV5fO3OAEsnXLfO7uF0whiOfPTz5AeDo8KeZFmODKnvwPymMNO8qE/an8pVY/O50tig2SQCrGw==
 
-"@types/node@^12.20.55":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+"@types/node@^14.18.21":
+  version "14.18.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
+  integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
 
 "@types/node@^16.9.2":
   version "16.11.39"
@@ -7280,6 +7280,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+"typescript-3.9@npm:typescript@~3.9.10", typescript@~3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
 typescript-json-schema@^0.53.1:
   version "0.53.1"
   resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.53.1.tgz#9204547f3e145169b40928998366ff6d28b81d32"
@@ -7293,11 +7298,6 @@ typescript-json-schema@^0.53.1:
     ts-node "^10.2.1"
     typescript "~4.6.0"
     yargs "^17.1.1"
-
-typescript@~3.9.10:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@~4.6.0:
   version "4.6.4"


### PR DESCRIPTION
The `Case` library appears on top of the heavy weights when profiling
`jsii` compilation runs on `aws-cdk-lib`, accounting for about `9.6%` of
the overall execution time (`6,712` out of `68,935` ms). This is quite
significant.

Faster libraries performing case conversions exist, however they do not
offer the same level of functinoality that `Case` does, and often
require knowing which casing the string is presently at, when `Case`
performs normalization before conversion (this likely explains why these
conversions are somewhat expensive), which is convenient in our
use-case. It does not seem to be possible to replace `Case` with a
faster implementation, as there does not seem to be any.

Running a survey on the usage of all functions from `Case` being used
during usch a compilation resulted in the following results:

```
Case.camel: 1881755 cached out of 1893235 (99.39%) - 11480 entries / 164.9 hits per entry
Case.pascal: 1890795 cached out of 1909959 (99.00%) - 19164 entries / 99.7 hits per entry
Case.snake: 1882773 cached out of 1895359 (99.34%) - 12586 entries / 150.6 hits per entry
```

Since there is a cache hit rate of `99%` and entries are re-used `100`
times each on average, it appears that adding a cache on those functions
will help alleviate that cost. Indeed, after making this change, `Case`
is no longer present above the `100ms` mark in the list of heavy
weights produced by the profiler.

In order to avoid possibly trading performance for out-of-memory errors,
the caches are keyed off of weak references, so that the caches can be
garbage collected when under memory pressure.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
