### PR TITLE
chore: switch dotnet feed to avoid CDN caching

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eo pipefail                                                            
 
 # Prepare .NET Core distribution
 ARG DOTNET_CHANNEL="3.1"
-ENV DOTNET_FEED="https://dotnetcli.azureedge.net/dotnet"
+ENV DOTNET_FEED="https://dotnetcli.blob.core.windows.net/dotnet"
 RUN DOTNET_VERSION=$(curl -fSsL "${DOTNET_FEED}/Sdk/${DOTNET_CHANNEL}/latest.version")                                  \
   && DOTNET_ASSET="dotnet-sdk-${DOTNET_VERSION}-linux-${${TARGETPLATFORM#linux/}/amd64/x64}.tar.gz"                     \
   && curl -fSsL "${DOTNET_FEED}/Sdk/${DOTNET_VERSION}/${DOTNET_ASSET}"                                                  \


### PR DESCRIPTION
The current feed points to a CDN endpoint that may not include the latest version of the SDK.

This PR changes the feed to the one used by https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script, which is the recommended way of installing the SDK in CI environments. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
