### PR TITLE
fix: Status icon for Go language that it is generally available.

### DIFF
--- a/gh-pages/content/overview/features.md
+++ b/gh-pages/content/overview/features.md
@@ -33,7 +33,7 @@ The following target languages are currently offered by `jsii-pacmak`, or are cu
 | Language   | Status                                         |
 | ---------- | ---------------------------------------------- |
 | C#         | :octicons-check-circle-24: Generally Available |
-| Go         | :octicons-tools-24:        Generally Available |
+| Go         | :octicons-check-circle-24: Generally Available |
 | Java       | :octicons-check-circle-24: Generally Available |
 | JavaScript | :octicons-check-circle-24: Generally Available |
 | Kotlin     | :octicons-tools-24:        Development         |


### PR DESCRIPTION
Since Go language  is generally available, change the status icon, too.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
