### PR TITLE
chore(check-node): update Node 16 EOL date

### DIFF
--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -38,7 +38,7 @@ export class NodeRelease {
       supportedRange: '^14.6.0',
     }),
     new NodeRelease(16, {
-      endOfLife: new Date('2024-04-30'),
+      endOfLife: new Date('2023-09-11'),
       supportedRange: '^16.3.0',
     }),
     new NodeRelease(17, {


### PR DESCRIPTION
According to this announcement, the Node 16 EOL date has been pushed forward: https://nodejs.org/en/blog/announcements/nodejs16-eol/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
