### PR TITLE
chore: run benchmarks in separate VMs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -388,7 +388,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: '14'
+          node-version: '18'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Run Benchmark

--- a/packages/@jsii/benchmarks/lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/index.ts
@@ -1,175 +1,19 @@
-import * as cp from 'child_process';
-import * as fs from 'fs-extra';
-import { Compiler } from 'jsii/lib/compiler';
-import { loadProjectInfo } from 'jsii/lib/project-info';
-import * as os from 'os';
-import * as path from 'path';
-import * as ts from 'typescript-3.9';
-
 import { Benchmark } from './benchmark';
-import { cdkv2_21_1, cdkTagv2_21_1 } from './constants';
-import { inDirectory, streamUntar } from './util';
-
-// Using the local `npm` package (from dependencies)
-const npm = path.resolve(__dirname, '..', 'node_modules', '.bin', 'npm');
+import { cdkTagv2_21_1 } from './constants';
+import * as awsCdkLib from './suite/aws-cdk-lib';
 
 export const benchmarks = [
   // Reference comparison using the TypeScript compiler
   new Benchmark(`Compile aws-cdk-lib@${cdkTagv2_21_1} (tsc)`)
-    .setup(async () => {
-      const sourceDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'jsii-cdk-bench-snapshot'),
-      );
-      await streamUntar(cdkv2_21_1, { cwd: sourceDir });
-      cp.execSync(`${npm} ci`, { cwd: sourceDir });
-
-      // Working directory for benchmark
-      const workingDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `tsc-cdk-bench@${cdkTagv2_21_1}`),
-      );
-
-      return {
-        workingDir,
-        sourceDir,
-      } as const;
-    })
-    .beforeEach(({ workingDir, sourceDir }) => {
-      fs.removeSync(workingDir);
-      fs.copySync(sourceDir, workingDir);
-    })
-    .subject(({ workingDir }) =>
-      inDirectory(workingDir, () => {
-        const { host, options, rootNames } = (function () {
-          const parsed = ts.parseJsonConfigFileContent(
-            fs.readJsonSync(path.join(workingDir, 'tsconfig.json')),
-            ts.sys,
-            workingDir,
-            {
-              module: ts.ModuleKind.CommonJS,
-              moduleResolution: ts.ModuleResolutionKind.NodeJs,
-              newLine: ts.NewLineKind.LineFeed,
-              tsBuildInfoFile: 'tsconfig.tsbuildinfo',
-            },
-            'tsconfig.json',
-          );
-
-          const host = ts.createIncrementalCompilerHost(parsed.options, ts.sys);
-
-          return {
-            host,
-            options: parsed.options,
-            rootNames: [
-              ...parsed.fileNames,
-              ...(parsed.options.lib && host.getDefaultLibLocation != null
-                ? parsed.options.lib.map((lib) =>
-                    path.join(host.getDefaultLibLocation!(), lib),
-                  )
-                : []),
-            ],
-          };
-        })();
-
-        const program = ts
-          .createIncrementalProgram({
-            createProgram: ts.createEmitAndSemanticDiagnosticsBuilderProgram,
-            host,
-            options,
-            rootNames,
-          })
-          .getProgram();
-
-        const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
-        if (
-          preEmitDiagnostics.some(
-            (diag) => diag.category === ts.DiagnosticCategory.Error,
-          )
-        ) {
-          console.error(
-            ts.formatDiagnosticsWithColorAndContext(
-              preEmitDiagnostics
-                .filter((diag) => diag.category === ts.DiagnosticCategory.Error)
-                .slice(0, 10),
-              host,
-            ),
-          );
-          throw new Error(`TypeScript compiler emitted pre-emit errors!`);
-        }
-
-        const emitResult = program.emit();
-        if (
-          emitResult.diagnostics.some(
-            (diag) => diag.category === ts.DiagnosticCategory.Error,
-          )
-        ) {
-          console.error(
-            ts.formatDiagnosticsWithColorAndContext(
-              emitResult.diagnostics.filter(
-                (diag) => diag.category === ts.DiagnosticCategory.Error,
-              ),
-              host,
-            ),
-          );
-          throw new Error(`TypeScript compiler emitted errors!`);
-        }
-      }),
-    )
-    .teardown(({ workingDir, sourceDir }) => {
-      fs.removeSync(workingDir);
-      fs.removeSync(sourceDir);
-    }),
+    .setup(awsCdkLib.setup)
+    .beforeEach(awsCdkLib.beforeEach)
+    .teardown(awsCdkLib.teardown)
+    .subject(awsCdkLib.buildWithTsc),
 
   // Always run against the same version of CDK source
   new Benchmark(`Compile aws-cdk-lib@${cdkTagv2_21_1}`)
-    .setup(async () => {
-      const sourceDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'jsii-cdk-bench-snapshot'),
-      );
-      await streamUntar(cdkv2_21_1, { cwd: sourceDir });
-      cp.execSync(`${npm} ci`, { cwd: sourceDir });
-
-      // Working directory for benchmark
-      const workingDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `jsii-cdk-bench@${cdkTagv2_21_1}`),
-      );
-
-      return {
-        workingDir,
-        sourceDir,
-      } as const;
-    })
-    .beforeEach(({ workingDir, sourceDir }) => {
-      fs.removeSync(workingDir);
-      fs.copySync(sourceDir, workingDir);
-    })
-    .subject(({ workingDir }) =>
-      inDirectory(workingDir, () => {
-        const { projectInfo } = loadProjectInfo(workingDir);
-        const compiler = new Compiler({ projectInfo });
-
-        const result = compiler.emit();
-        if (
-          result.diagnostics.some(
-            (diag) => diag.category === ts.DiagnosticCategory.Error,
-          )
-        ) {
-          console.error(
-            ts.formatDiagnosticsWithColorAndContext(
-              result.diagnostics.filter(
-                (diag) => diag.category === ts.DiagnosticCategory.Error,
-              ),
-              {
-                getCurrentDirectory: () => workingDir,
-                getCanonicalFileName: path.resolve,
-                getNewLine: () => ts.sys.newLine,
-              },
-            ),
-          );
-          throw new Error(`jsii compiler emitted errors!`);
-        }
-      }),
-    )
-    .teardown(({ workingDir, sourceDir }) => {
-      fs.removeSync(workingDir);
-      fs.removeSync(sourceDir);
-    }),
+    .setup(awsCdkLib.setup)
+    .beforeEach(awsCdkLib.beforeEach)
+    .teardown(awsCdkLib.teardown)
+    .subject(awsCdkLib.buildWithJsii),
 ];

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-jsii.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-jsii.ts
@@ -1,0 +1,38 @@
+import { Compiler } from 'jsii/lib/compiler';
+import { loadProjectInfo } from 'jsii/lib/project-info';
+import * as path from 'node:path';
+import * as process from 'node:process';
+import * as ts from 'typescript-3.9';
+
+import type { Context } from '.';
+
+process.once('message', ({ workingDir }: Context) => {
+  try {
+    const { projectInfo } = loadProjectInfo(workingDir);
+    const compiler = new Compiler({ projectInfo });
+
+    const result = compiler.emit();
+    if (
+      result.diagnostics.some(
+        (diag) => diag.category === ts.DiagnosticCategory.Error,
+      )
+    ) {
+      console.error(
+        ts.formatDiagnosticsWithColorAndContext(
+          result.diagnostics.filter(
+            (diag) => diag.category === ts.DiagnosticCategory.Error,
+          ),
+          {
+            getCurrentDirectory: () => workingDir,
+            getCanonicalFileName: path.resolve,
+            getNewLine: () => ts.sys.newLine,
+          },
+        ),
+      );
+      throw new Error(`jsii compiler emitted errors!`);
+    }
+    process.send!({ success: true });
+  } catch (error) {
+    process.send!({ error });
+  }
+});

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-tsc.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-tsc.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs-extra';
+import * as path from 'node:path';
+import * as process from 'node:process';
+import * as ts from 'typescript-3.9';
+
+import type { Context } from '.';
+
+process.once('message', ({ workingDir }: Context) => {
+  try {
+    const { host, options, rootNames } = (function () {
+      const parsed = ts.parseJsonConfigFileContent(
+        fs.readJsonSync(path.join(workingDir, 'tsconfig.json')),
+        ts.sys,
+        workingDir,
+        {
+          module: ts.ModuleKind.CommonJS,
+          moduleResolution: ts.ModuleResolutionKind.NodeJs,
+          newLine: ts.NewLineKind.LineFeed,
+          tsBuildInfoFile: 'tsconfig.tsbuildinfo',
+        },
+        'tsconfig.json',
+      );
+
+      const host = ts.createIncrementalCompilerHost(parsed.options, ts.sys);
+
+      return {
+        host,
+        options: parsed.options,
+        rootNames: [
+          ...parsed.fileNames,
+          ...(parsed.options.lib && host.getDefaultLibLocation != null
+            ? parsed.options.lib.map((lib) =>
+                path.join(host.getDefaultLibLocation!(), lib),
+              )
+            : []),
+        ],
+      };
+    })();
+
+    const program = ts
+      .createIncrementalProgram({
+        createProgram: ts.createEmitAndSemanticDiagnosticsBuilderProgram,
+        host,
+        options,
+        rootNames,
+      })
+      .getProgram();
+
+    const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
+    if (
+      preEmitDiagnostics.some(
+        (diag) => diag.category === ts.DiagnosticCategory.Error,
+      )
+    ) {
+      console.error(
+        ts.formatDiagnosticsWithColorAndContext(
+          preEmitDiagnostics
+            .filter((diag) => diag.category === ts.DiagnosticCategory.Error)
+            .slice(0, 10),
+          host,
+        ),
+      );
+      throw new Error(`TypeScript compiler emitted pre-emit errors!`);
+    }
+
+    const emitResult = program.emit();
+    if (
+      emitResult.diagnostics.some(
+        (diag) => diag.category === ts.DiagnosticCategory.Error,
+      )
+    ) {
+      console.error(
+        ts.formatDiagnosticsWithColorAndContext(
+          emitResult.diagnostics.filter(
+            (diag) => diag.category === ts.DiagnosticCategory.Error,
+          ),
+          host,
+        ),
+      );
+      throw new Error(`TypeScript compiler emitted errors!`);
+    }
+
+    process.send!({ success: true });
+  } catch (error) {
+    process.send!({ error });
+  }
+});

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs-extra';
+import * as cp from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { cdkTagv2_21_1, cdkv2_21_1 } from '../../constants';
+import { inDirectory, streamUntar } from '../../util';
+
+// Using the local `npm` package (from dependencies)
+const npm = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'node_modules',
+  '.bin',
+  'npm',
+);
+
+export interface Context {
+  readonly workingDir: string;
+  readonly sourceDir: string;
+}
+
+export async function setup(): Promise<Context> {
+  const sourceDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'jsii-cdk-bench-snapshot'),
+  );
+  await streamUntar(cdkv2_21_1, { cwd: sourceDir });
+  cp.execSync(`${npm} ci`, { cwd: sourceDir });
+
+  // Working directory for benchmark
+  const workingDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), `tsc-cdk-bench@${cdkTagv2_21_1}`),
+  );
+
+  return {
+    workingDir,
+    sourceDir,
+  };
+}
+
+export async function beforeEach({ workingDir, sourceDir }: Context) {
+  await fs.remove(workingDir);
+  await fs.copy(sourceDir, workingDir);
+}
+
+export async function teardown({ workingDir, sourceDir }: Context) {
+  await Promise.all([fs.remove(workingDir), fs.remove(sourceDir)]);
+}
+
+export async function buildWithTsc({ workingDir }: Context): Promise<void> {
+  return inDirectory(
+    workingDir,
+    () =>
+      new Promise((ok, ko) =>
+        cp
+          .fork(require.resolve('./build-with-tsc'), { stdio: 'inherit' })
+          .once('close', ko)
+          .once('message', (result: { success: any } | { error: unknown }) => {
+            if ('error' in result) {
+              ko(result.error);
+            } else {
+              ok(result.success);
+            }
+          })
+          .send({ workingDir }),
+      ),
+  );
+}
+
+export async function buildWithJsii({ workingDir }: Context): Promise<void> {
+  return inDirectory(
+    workingDir,
+    () =>
+      new Promise((ok, ko) =>
+        cp
+          .fork(require.resolve('./build-with-jsii'), { stdio: 'inherit' })
+          .once('close', ko)
+          .once('message', (result: { success: any } | { error: unknown }) => {
+            if ('error' in result) {
+              ko(result.error);
+            } else {
+              ok(result.success);
+            }
+          })
+          .send({ workingDir }),
+      ),
+  );
+}

--- a/packages/@jsii/benchmarks/lib/util.ts
+++ b/packages/@jsii/benchmarks/lib/util.ts
@@ -10,11 +10,14 @@ export async function streamUntar(file: string, config: tar.ExtractOptions) {
   });
 }
 
-export function inDirectory<T>(newWorkDir: string, cb: () => T) {
+export async function inDirectory<T>(
+  newWorkDir: string,
+  cb: () => T | Promise<T>,
+) {
   const cwd = process.cwd();
   try {
     process.chdir(newWorkDir);
-    return cb();
+    return await cb();
   } finally {
     process.chdir(cwd);
   }


### PR DESCRIPTION
The idea is to try and achieve a situation where iteration
times are not tainted by different memory situations (caches
may cause memory pressure and will skew the benchmark results).

Running in node sub-processes should allow removing this unknown
from the picture.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
