### PR TITLE
chore: add UX tests around @jsii/kernel serializer errors

### DIFF
--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -344,7 +344,7 @@ defineTest('fails for invalid enum member name', (sandbox) => {
         '$jsii.enum': '@scope/jsii-calc-lib.EnumFromScopedModule/ValueX',
       },
     });
-  }).toThrow(/No enum member named ValueX/);
+  }).toThrow(/No such enum member: 'ValueX'/);
 });
 
 defineTest('set for a non existing property', (sandbox) => {
@@ -1688,7 +1688,7 @@ defineTest(
         args: [123, { incomplete: true }],
       });
     }).toThrow(
-      /Missing required properties for jsii-calc.TopLevelStruct: required, secondLevel/,
+      /Missing required properties for jsii-calc\.TopLevelStruct: 'required', 'secondLevel'/,
     );
   },
 );
@@ -1709,7 +1709,7 @@ defineTest(
         ],
       });
     }).toThrow(
-      /Missing required properties for jsii-calc.SecondLevelStruct: deeperRequiredProp/,
+      /\[as jsii-calc.SecondLevelStruct\] Missing required properties for jsii-calc\.SecondLevelStruct: 'deeperRequiredProp'/,
     );
   },
 );
@@ -1721,7 +1721,7 @@ defineTest('notice when an array is passed instead of varargs', (sandbox) => {
       method: 'howManyVarArgsDidIPass',
       args: [123, [{ required: 'abc', secondLevel: 6 }]],
     });
-  }).toThrow(/Got an array where a jsii-calc.TopLevelStruct was expected/);
+  }).toThrow(/Value is an array \(varargs may have been incorrectly supplied\)/);
 });
 
 defineTest(
@@ -2020,7 +2020,7 @@ defineTest('ANY serializer: null/undefined', (sandbox) => {
 
 defineTest('ANY serializer: function (fails)', (sandbox) => {
   expect(() => serializeAny(sandbox, 'anyFunction')).toThrow(
-    /JSII Kernel is unable to serialize `function`. An instance with methods might have been returned by an `any` method\?/,
+    /Functions cannot be passed across language boundaries/,
   );
 });
 

--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -1721,7 +1721,9 @@ defineTest('notice when an array is passed instead of varargs', (sandbox) => {
       method: 'howManyVarArgsDidIPass',
       args: [123, [{ required: 'abc', secondLevel: 6 }]],
     });
-  }).toThrow(/Value is an array \(varargs may have been incorrectly supplied\)/);
+  }).toThrow(
+    /Value is an array \(varargs may have been incorrectly supplied\)/,
+  );
 });
 
 defineTest(

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -210,7 +210,7 @@ export class Kernel {
     );
 
     this._debug('value:', value);
-    const ret = this._fromSandbox(value, ti);
+    const ret = this._fromSandbox(value, ti, `of static property ${symbol}`);
     this._debug('ret', ret);
     return { value: ret };
   }
@@ -233,7 +233,12 @@ export class Kernel {
 
     this._ensureSync(`property ${property}`, () =>
       this._wrapSandboxCode(
-        () => (prototype[property] = this._toSandbox(value, ti)),
+        () =>
+          (prototype[property] = this._toSandbox(
+            value,
+            ti,
+            `assigned to static property ${symbol}`,
+          )),
       ),
     );
 
@@ -260,7 +265,7 @@ export class Kernel {
       () => this._wrapSandboxCode(() => instance[propertyToGet]),
     );
     this._debug('value:', value);
-    const ret = this._fromSandbox(value, ti);
+    const ret = this._fromSandbox(value, ti, `of property ${fqn}.${property}`);
     this._debug('ret:', ret);
     return { value: ret };
   }
@@ -282,7 +287,12 @@ export class Kernel {
 
     this._ensureSync(`property '${objref[TOKEN_REF]}.${propertyToSet}'`, () =>
       this._wrapSandboxCode(
-        () => (instance[propertyToSet] = this._toSandbox(value, propInfo)),
+        () =>
+          (instance[propertyToSet] = this._toSandbox(
+            value,
+            propInfo,
+            `assigned to property ${fqn}.${property}`,
+          )),
       ),
     );
 
@@ -310,7 +320,11 @@ export class Kernel {
       },
     );
 
-    const result = this._fromSandbox(ret, ti.returns ?? 'void');
+    const result = this._fromSandbox(
+      ret,
+      ti.returns ?? 'void',
+      `returned by method ${method}`,
+    );
     this._debug('invoke result', result);
 
     return { result };
@@ -343,7 +357,13 @@ export class Kernel {
     });
 
     this._debug('method returned:', ret);
-    return { result: this._fromSandbox(ret, ti.returns ?? 'void') };
+    return {
+      result: this._fromSandbox(
+        ret,
+        ti.returns ?? 'void',
+        `returned by static method ${fqn}.${method}`,
+      ),
+    };
   }
 
   public begin(req: api.BeginRequest): api.BeginResponse {
@@ -402,7 +422,13 @@ export class Kernel {
       throw e;
     }
 
-    return { result: this._fromSandbox(result, method.returns ?? 'void') };
+    return {
+      result: this._fromSandbox(
+        result,
+        method.returns ?? 'void',
+        `returned by async method ${method.name}`,
+      ),
+    };
   }
 
   public callbacks(_req?: api.CallbacksRequest): api.CallbacksResponse {
@@ -444,6 +470,7 @@ export class Kernel {
       const sandoxResult = this._toSandbox(
         result,
         cb.expectedReturnType ?? 'void',
+        `returned by callback ${cbid}`,
       );
       this._debug('completed with result:', sandoxResult);
       cb.succeed(sandoxResult);
@@ -682,7 +709,11 @@ export class Kernel {
           get: { objref, property: propertyName },
         });
         this._debug('callback returned', result);
-        return this._toSandbox(result, propInfo);
+        return this._toSandbox(
+          result,
+          propInfo,
+          `returned by callback property ${propertyName}`,
+        );
       },
       set: (value: any) => {
         this._debug('virtual set', objref, propertyName, {
@@ -694,7 +725,11 @@ export class Kernel {
           set: {
             objref,
             property: propertyName,
-            value: this._fromSandbox(value, propInfo),
+            value: this._fromSandbox(
+              value,
+              propInfo,
+              `assigned to callback property ${propertyName}`,
+            ),
           },
         });
       },
@@ -822,7 +857,11 @@ export class Kernel {
             },
           });
           this._debug('Result', result);
-          return this._toSandbox(result, methodInfo.returns ?? 'void');
+          return this._toSandbox(
+            result,
+            methodInfo.returns ?? 'void',
+            `returned by callback method ${methodName}`,
+          );
         },
       });
     }
@@ -1063,72 +1102,41 @@ export class Kernel {
     return typeInfo;
   }
 
-  private _toSandbox(v: any, expectedType: wire.OptionalValueOrVoid, context?: string): any {
-    const serTypes = wire.serializationType(
+  private _toSandbox(
+    v: any,
+    expectedType: wire.OptionalValueOrVoid,
+    context: string,
+  ): any {
+    return wire.process(
+      {
+        objects: this.objects,
+        debug: this._debug.bind(this),
+        findSymbol: this._findSymbol.bind(this),
+        lookupType: this._typeInfoForFqn.bind(this),
+      },
+      'deserialize',
+      v,
       expectedType,
-      this._typeInfoForFqn.bind(this),
-    );
-    this._debug('toSandbox', v, JSON.stringify(serTypes));
-
-    const host: wire.SerializerHost = {
-      objects: this.objects,
-      debug: this._debug.bind(this),
-      findSymbol: this._findSymbol.bind(this),
-      lookupType: this._typeInfoForFqn.bind(this),
-      recurse: this._toSandbox.bind(this),
-    };
-
-    const errors = new Array<any>();
-    for (const { serializationClass, typeRef } of serTypes) {
-      try {
-        return wire.SERIALIZERS[serializationClass].deserialize(
-          v,
-          typeRef,
-          host,
-        );
-      } catch (e: any) {
-        errors.push(e);
-      }
-    }
-    if (errors.length === 1 && context == null) {
-      throw errors[0];
-    }
-
-    throw new Error(
-      `Value${context ? ` ${context}` : ''} did not match any type in union: ${errors.map(e => e.message).join(', ')}`,
+      context,
     );
   }
 
-  private _fromSandbox(v: any, targetType: wire.OptionalValueOrVoid, context?: string): any {
-    const serTypes = wire.serializationType(
+  private _fromSandbox(
+    v: any,
+    targetType: wire.OptionalValueOrVoid,
+    context: string,
+  ): any {
+    return wire.process(
+      {
+        objects: this.objects,
+        debug: this._debug.bind(this),
+        findSymbol: this._findSymbol.bind(this),
+        lookupType: this._typeInfoForFqn.bind(this),
+      },
+      'serialize',
+      v,
       targetType,
-      this._typeInfoForFqn.bind(this),
-    );
-    this._debug('fromSandbox', v, JSON.stringify(serTypes));
-
-    const host: wire.SerializerHost = {
-      objects: this.objects,
-      debug: this._debug.bind(this),
-      findSymbol: this._findSymbol.bind(this),
-      lookupType: this._typeInfoForFqn.bind(this),
-      recurse: this._fromSandbox.bind(this),
-    };
-
-    const errors = new Array<string>();
-    for (const { serializationClass, typeRef } of serTypes) {
-      try {
-        return wire.SERIALIZERS[serializationClass].serialize(v, typeRef, host);
-      } catch (e: any) {
-        // If no union (99% case), rethrow immediately to preserve stack trace
-        if (serTypes.length === 1) {
-          throw e;
-        }
-        errors.push(e.message);
-      }
-    }
-
-    throw new Error(
-      `Value${context ? ` ${context}` : ''} did not match any type in union: ${errors.join(', ')}`,
+      context,
     );
   }
 
@@ -1147,7 +1155,7 @@ export class Kernel {
   private _boxUnboxParameters(
     xs: any[],
     parameters: spec.Parameter[] | undefined,
-    boxUnbox: (x: any, t: wire.OptionalValueOrVoid) => any,
+    boxUnbox: (x: any, t: wire.OptionalValueOrVoid, context: string) => any,
   ) {
     parameters = [...(parameters ?? [])];
     const variadic =
@@ -1165,7 +1173,9 @@ export class Kernel {
         })`,
       );
     }
-    return xs.map((x, i) => boxUnbox(x, parameters![i]));
+    return xs.map((x, i) =>
+      boxUnbox(x, parameters![i], `of parameter ${parameters![i].name}`),
+    );
   }
 
   private _debug(...args: any[]) {

--- a/packages/@jsii/kernel/src/serialization.test.ts
+++ b/packages/@jsii/kernel/src/serialization.test.ts
@@ -28,7 +28,6 @@ const host: SerializerHost = {
   findSymbol: jest.fn().mockName('host.findSymbol'),
   lookupType,
   objects: new ObjectTable(lookupType),
-  recurse: jest.fn().mockName('host.recurse'),
 };
 
 describe(SerializationClass.Any, () => {
@@ -40,16 +39,6 @@ describe(SerializationClass.Any, () => {
       return this.randomValue;
     }
   }
-
-  beforeEach((done) => {
-    (host.recurse as jest.Mock<any, any>).mockImplementation(
-      (x: any, type: OptionalValue) => {
-        expect(type).toEqual(TYPE_ANY);
-        return anySerializer.serialize(x, type, host);
-      },
-    );
-    done();
-  });
 
   describe(anySerializer.serialize, () => {
     test('by-value object literal', () => {

--- a/packages/@jsii/kernel/src/serialization.test.ts
+++ b/packages/@jsii/kernel/src/serialization.test.ts
@@ -4,6 +4,7 @@ import { TOKEN_REF } from './api';
 import { ObjectTable } from './objects';
 import {
   SerializationClass,
+  SerializationError,
   SerializerHost,
   SERIALIZERS,
 } from './serialization';
@@ -83,7 +84,7 @@ describe(SerializationClass.Scalar, () => {
       test('rejects any value', () =>
         expect(() =>
           scalarSerializer.deserialize('nothing!', TYPE_VOID, host),
-        ).toThrow(/Encountered unexpected `void` type/));
+        ).toThrow(/Encountered unexpected void type!/));
     });
 
     const scalarTypes = [
@@ -104,7 +105,7 @@ describe(SerializationClass.Scalar, () => {
               example.type,
               host,
             ),
-          ).toThrow(`Expected a ${example.name}, got {`);
+          ).toThrow(SerializationError);
         });
 
         for (const validValue of example.validValues) {
@@ -122,11 +123,7 @@ describe(SerializationClass.Scalar, () => {
           test(`rejects: ${invalidValue}`, () =>
             expect(() =>
               scalarSerializer.deserialize(invalidValue, example.type, host),
-            ).toThrow(
-              `Expected a ${example.name}, got ${JSON.stringify(
-                invalidValue,
-              )} (${typeof invalidValue})`,
-            ));
+            ).toThrow(SerializationError));
         }
       });
     }

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -1119,6 +1119,9 @@ export function process(
     try {
       return SERIALIZERS[serializationClass][serde](value, typeRef, host);
     } catch (error: any) {
+      error.context = `as ${
+        typeRef === VOID ? VOID : spec.describeTypeReference(typeRef.type)
+      }`;
       errors.push(error);
     }
   }
@@ -1181,7 +1184,9 @@ export class SerializationError extends Error {
                   `    ${
                     idx < causes.length - 1 ? '\u{251C}' : '\u{2570}'
                   }\u{2500}${
-                    causes.length > 1 ? ` [${inspect(idx)}]` : ''
+                    causes.length > 1
+                      ? ` [${cause.context ?? inspect(idx)}]`
+                      : ''
                   } ${cause.message.split('\n').join('\n        ')}`,
               ),
             ]

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -433,8 +433,12 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
       }
       assert(optionalValue !== VOID, 'Encountered unexpected void type!');
 
-      if (typeof value !== 'object' || value == null) {
+      if (typeof value !== 'object' || value == null || value instanceof Date) {
         throw new SerializationError(`Value is not an object`, value);
+      }
+
+      if (Array.isArray(value)) {
+        throw new SerializationError(`Value is an array`, value);
       }
 
       /*
@@ -1032,9 +1036,9 @@ function validateRequiredProps(
 
   if (missingRequiredProps.length > 0) {
     throw new SerializationError(
-      `Missing required properties for ${typeName}: ${missingRequiredProps.join(
-        ', ',
-      )}`,
+      `Missing required properties for ${typeName}: ${missingRequiredProps
+        .map((p) => inspect(p))
+        .join(', ')}`,
       actualProps,
     );
   }

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -545,8 +545,12 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
       }
       assert(optionalValue !== VOID, 'Encountered unexpected void type!');
 
-      if (typeof value !== 'object' || value == null) {
+      if (typeof value !== 'object' || value == null || Array.isArray(value)) {
         throw new SerializationError(`Value is not an object`, value);
+      }
+
+      if (value instanceof Date) {
+        throw new SerializationError(`Value is a Date`, value);
       }
 
       const expectedType = host.lookupType(

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -269,7 +269,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           {
             type: { primitive: spec.PrimitiveType.Json },
           },
-          typeof key === 'string' ? `key ${key}` : `index ${key}`,
+          typeof key === 'string' ? `of key ${key}` : `at index ${key}`,
         );
       }
     },
@@ -338,7 +338,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'serialize',
           x,
           { type: arrayType.collection.elementtype },
-          `index ${idx}`,
+          `at index ${idx}`,
         ),
       );
     },
@@ -360,7 +360,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           x,
           { type: arrayType.collection.elementtype },
-          `index ${idx}`,
+          `at index ${idx}`,
         ),
       );
     },
@@ -382,7 +382,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'serialize',
             v,
             { type: mapType.collection.elementtype },
-            `key ${JSON.stringify(key)}`,
+            `of key ${JSON.stringify(key)}`,
           ),
         ),
       };
@@ -402,7 +402,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'deserialize',
             v,
             { type: mapType.collection.elementtype },
-            `key ${JSON.stringify(key)}`,
+            `of key ${JSON.stringify(key)}`,
           ),
         );
       }
@@ -412,7 +412,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           v,
           { type: mapType.collection.elementtype },
-          `key ${JSON.stringify(key)}`,
+          `of key ${JSON.stringify(key)}`,
         ),
       );
       Object.defineProperty(result, SYMBOL_WIRE_TYPE, {
@@ -527,7 +527,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           v,
           props[key],
-          `property ${JSON.stringify(key)}`,
+          `of property ${JSON.stringify(key)}`,
         );
       });
     },
@@ -621,7 +621,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'serialize',
             e,
             { type: spec.CANONICAL_ANY },
-            `index ${idx}`,
+            `at index ${idx}`,
           ),
         );
       }
@@ -700,7 +700,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'serialize',
           v,
           { type: spec.CANONICAL_ANY },
-          `key ${JSON.stringify(key)}`,
+          `of key ${JSON.stringify(key)}`,
         ),
       );
     },
@@ -726,7 +726,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'deserialize',
             e,
             { type: spec.CANONICAL_ANY },
-            `index ${idx}`,
+            `at index ${idx}`,
           ),
         );
       }
@@ -775,7 +775,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           v,
           { type: spec.CANONICAL_ANY },
-          `key ${key}`,
+          `of key ${key}`,
         ),
       );
     },
@@ -936,6 +936,10 @@ function mapValues(
 ): { [key: string]: any } {
   if (typeof value !== 'object' || value == null) {
     throw new SerializationError(`Value is not an object`, value);
+  }
+
+  if (Array.isArray(value)) {
+    throw new SerializationError(`Value is an array`, value);
   }
 
   const out: { [key: string]: any } = {};

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -824,7 +824,11 @@ function nullAndOk(x: unknown, type: OptionalValueOrVoid): boolean {
 
   if (type !== 'void' && !type.optional) {
     throw new Error(
-      `Got 'undefined' for non-optional instance of ${JSON.stringify(type)}`,
+      `Got '${JSON.stringify(
+        x,
+      )}' where a non-optional '${spec.describeTypeReference(
+        type.type,
+      )}' value was expected`,
     );
   }
 

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -196,13 +196,13 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
 
       if (!isScalar(value)) {
         throw new SerializationError(
-          `Expected a ${spec.describeTypeReference(optionalValue.type)}`,
+          `Value is not a ${spec.describeTypeReference(optionalValue.type)}`,
           value,
         );
       }
       if (typeof value !== primitiveType.primitive) {
         throw new SerializationError(
-          `Expected a ${spec.describeTypeReference(optionalValue.type)}`,
+          `Value is not a ${spec.describeTypeReference(optionalValue.type)}`,
           value,
         );
       }
@@ -284,7 +284,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
       assert(optionalValue !== VOID, 'Encountered unexpected void type!');
 
       if (typeof value !== 'string' && typeof value !== 'number') {
-        throw new SerializationError(`Expected a string or number`, value);
+        throw new SerializationError(`Value is not a string or number`, value);
       }
 
       host.debug('Serializing enum');

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -217,7 +217,12 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
 
   // ----------------------------------------------------------------------
   [SerializationClass.Json]: {
-    serialize(value) {
+    serialize(value, optionalValue) {
+      // /!\ Top-level "null" will turn to undefined, but any null nested in the value is valid JSON, so it'll stay!
+      if (nullAndOk(value, optionalValue)) {
+        return undefined;
+      }
+
       // Just whatever. Dates will automatically serialize themselves to strings.
       return value;
     },

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -42,43 +42,37 @@ describe(SerializationClass.Array, () => {
         'serialize',
         "I'm array-like, but not quite an array",
         arrayType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is a string
       │      "I'm array-like, but not quite an array"
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an array
-              ╰── 🛑 Failing value is a string
-                     "I'm array-like, but not quite an array"
+          ╰─ Value is not an array
     `);
   });
 
   test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, arrayType, `of test`))
+    expect(() => process(host, 'serialize', 1337, arrayType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is a number
       │      1337
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an array
-              ╰── 🛑 Failing value is a number
-                     1337
+          ╰─ Value is not an array
     `);
   });
 
   test('when provided with a date', () => {
     expect(() =>
-      process(host, 'serialize', new Date(65_535), arrayType, `of test`),
+      process(host, 'serialize', new Date(65_535), arrayType, `dummy value`),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is an instance of Date
       │      1970-01-01T00:01:05.535Z
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an array
-              ╰── 🛑 Failing value is an instance of Date
-                     1970-01-01T00:01:05.535Z
+          ╰─ Value is not an array
     `);
   });
 
@@ -89,56 +83,51 @@ describe(SerializationClass.Array, () => {
         'serialize',
         { this: ['is', 'not', 'an', 'Array'] },
         arrayType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is an object
       │      { this: [Array] }
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an array
-              ╰── 🛑 Failing value is an object
-                     { this: [Array] }
+          ╰─ Value is not an array
     `);
   });
 
   test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, arrayType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+    expect(() =>
+      process(host, 'serialize', undefined, arrayType, `dummy value`),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is undefined
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is undefined
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, arrayType, `of test`))
+    expect(() => process(host, 'serialize', null, arrayType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is null
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is null
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with an array including a bad value', () => {
     expect(() =>
-      process(host, 'serialize', ['Not a number'], arrayType, `of test`),
+      process(host, 'serialize', ['Not a number'], arrayType, `dummy value`),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as array<number>
+      Dummy value: Unable to serialize value as array<number>
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Unable to serialize value at index 0 as number
+          ╰─ Index 0: Unable to serialize value as number
               ├── 🛑 Failing value is a string
               │      'Not a number'
               ╰── 🔍 Failure reason(s):
-                  ╰─ [0] Value is not a number
-                      ╰── 🛑 Failing value is a string
-                             'Not a number'
+                  ╰─ Value is not a number
     `);
   });
 });
@@ -158,29 +147,25 @@ describe(SerializationClass.Date, () => {
         'serialize',
         "I'm array-like, but not quite an array",
         dateType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is a string
       │      "I'm array-like, but not quite an array"
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an instance of Date
-              ╰── 🛑 Failing value is a string
-                     "I'm array-like, but not quite an array"
+          ╰─ Value is not an instance of Date
     `);
   });
 
   test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, dateType, `of test`))
+    expect(() => process(host, 'serialize', 1337, dateType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is a number
       │      1337
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an instance of Date
-              ╰── 🛑 Failing value is a number
-                     1337
+          ╰─ Value is not an instance of Date
     `);
   });
 
@@ -191,52 +176,46 @@ describe(SerializationClass.Date, () => {
         'serialize',
         { this: ['is', 'not', 'an', 'Array'] },
         dateType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is an object
       │      { this: [Array] }
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an instance of Date
-              ╰── 🛑 Failing value is an object
-                     { this: [Array] }
+          ╰─ Value is not an instance of Date
     `);
   });
 
   test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, dateType, `of test`))
+    expect(() => process(host, 'serialize', undefined, dateType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is undefined
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is undefined
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, dateType, `of test`))
+    expect(() => process(host, 'serialize', null, dateType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is null
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is null
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with an array', () => {
     expect(() =>
-      process(host, 'serialize', ['Not a number'], dateType, `of test`),
+      process(host, 'serialize', ['Not a number'], dateType, `dummy value`),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as date
+      Dummy value: Unable to serialize value as date
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an instance of Date
-              ╰── 🛑 Failing value is an array
-                     [ 'Not a number' ]
+          ╰─ Value is not an instance of Date
     `);
   });
 });
@@ -250,24 +229,22 @@ describe(SerializationClass.Json, () => {
   };
 
   test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, jsonType, `of test`))
+    expect(() => process(host, 'serialize', undefined, jsonType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as json
+      Dummy value: Unable to serialize value as json
       ├── 🛑 Failing value is undefined
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is undefined
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, jsonType, `of test`))
+    expect(() => process(host, 'serialize', null, jsonType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as json
+      Dummy value: Unable to serialize value as json
       ├── 🛑 Failing value is null
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is null
+          ╰─ A value is required (type is non-optional)
     `);
   });
 });
@@ -289,29 +266,25 @@ describe(SerializationClass.Map, () => {
         'serialize',
         "I'm array-like, but not quite an array",
         mapType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Dummy value: Unable to serialize value as map<number>
       ├── 🛑 Failing value is a string
       │      "I'm array-like, but not quite an array"
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an object
-              ╰── 🛑 Failing value is a string
-                     "I'm array-like, but not quite an array"
+          ╰─ Value is not an object
     `);
   });
 
   test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, mapType, `of test`))
+    expect(() => process(host, 'serialize', 1337, mapType, `dummy value`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Dummy value: Unable to serialize value as map<number>
       ├── 🛑 Failing value is a number
       │      1337
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not an object
-              ╰── 🛑 Failing value is a number
-                     1337
+          ╰─ Value is not an object
     `);
   });
 
@@ -322,42 +295,38 @@ describe(SerializationClass.Map, () => {
         'serialize',
         { this: ['is', 'not', 'an', 'Array'] },
         mapType,
-        `of test`,
+        `dummy value`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Dummy value: Unable to serialize value as map<number>
       ├── 🛑 Failing value is an object
       │      { this: [Array] }
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Unable to serialize value of key "this" as number
+          ╰─ Key 'this': Unable to serialize value as number
               ├── 🛑 Failing value is an array
               │      [ 'is', 'not', 'an', 'Array' ]
               ╰── 🔍 Failure reason(s):
-                  ╰─ [0] Value is not a number
-                      ╰── 🛑 Failing value is an array
-                             [ 'is', 'not', 'an', 'Array' ]
+                  ╰─ Value is not a number
     `);
   });
 
   test('when provided with undefined', () => {
     expect(() => process(host, 'serialize', undefined, mapType, `of test`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Of test: Unable to serialize value as map<number>
       ├── 🛑 Failing value is undefined
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is undefined
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with null', () => {
     expect(() => process(host, 'serialize', null, mapType, `of test`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Of test: Unable to serialize value as map<number>
       ├── 🛑 Failing value is null
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is null
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
@@ -365,13 +334,11 @@ describe(SerializationClass.Map, () => {
     expect(() =>
       process(host, 'serialize', ['Not a number'], mapType, `of test`),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as map<number>
+      Of test: Unable to serialize value as map<number>
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is an array
-              ╰── 🛑 Failing value is an array
-                     [ 'Not a number' ]
+          ╰─ Value is an array
     `);
   });
 });
@@ -387,13 +354,11 @@ describe(SerializationClass.Scalar, () => {
   test('when provided with a number', () => {
     expect(() => process(host, 'serialize', 1337, stringType, `of test`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as string
+      Of test: Unable to serialize value as string
       ├── 🛑 Failing value is a number
       │      1337
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not a string
-              ╰── 🛑 Failing value is a number
-                     1337
+          ╰─ Value is not a string
     `);
   });
 
@@ -407,35 +372,31 @@ describe(SerializationClass.Scalar, () => {
         `of test`,
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as string
+      Of test: Unable to serialize value as string
       ├── 🛑 Failing value is an object
       │      { this: [Array] }
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not a string
-              ╰── 🛑 Failing value is an object
-                     { this: [Array] }
+          ╰─ Value is not a string
     `);
   });
 
   test('when provided with undefined', () => {
     expect(() => process(host, 'serialize', undefined, stringType, `of test`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as string
+      Of test: Unable to serialize value as string
       ├── 🛑 Failing value is undefined
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is undefined
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
   test('when provided with null', () => {
     expect(() => process(host, 'serialize', null, stringType, `of test`))
       .toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as string
+      Of test: Unable to serialize value as string
       ├── 🛑 Failing value is null
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] A value is required (type is non-optional)
-              ╰── 🛑 Failing value is null
+          ╰─ A value is required (type is non-optional)
     `);
   });
 
@@ -443,13 +404,11 @@ describe(SerializationClass.Scalar, () => {
     expect(() =>
       process(host, 'serialize', ['Not a number'], stringType, `of test`),
     ).toThrowErrorMatchingInlineSnapshot(`
-      Unable to serialize value of test as string
+      Of test: Unable to serialize value as string
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Value is not a string
-              ╰── 🛑 Failing value is an array
-                     [ 'Not a number' ]
+          ╰─ Value is not a string
     `);
   });
 });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -24,391 +24,812 @@ const host: SerializerHost = {
   objects,
 };
 
-describe(SerializationClass.Array, () => {
-  const arrayType: spec.OptionalValue = {
-    optional: false,
-    type: {
-      collection: {
-        kind: spec.CollectionKind.Array,
-        elementtype: { primitive: spec.PrimitiveType.Number },
+describe('serialize errors', () => {
+  describe(SerializationClass.Array, () => {
+    const arrayType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        collection: {
+          kind: spec.CollectionKind.Array,
+          elementtype: { primitive: spec.PrimitiveType.Number },
+        },
       },
-    },
-  };
+    };
 
-  test('when provided with a string', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        "I'm array-like, but not quite an array",
-        arrayType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is a string
-      │      "I'm array-like, but not quite an array"
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an array
-    `);
-  });
-
-  test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, arrayType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is a number
-      │      1337
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an array
-    `);
-  });
-
-  test('when provided with a date', () => {
-    expect(() =>
-      process(host, 'serialize', new Date(65_535), arrayType, `dummy value`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is an instance of Date
-      │      1970-01-01T00:01:05.535Z
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an array
-    `);
-  });
-
-  test('when provided with an object', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        { this: ['is', 'not', 'an', 'Array'] },
-        arrayType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is an object
-      │      { this: [Array] }
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an array
-    `);
-  });
-
-  test('when provided with undefined', () => {
-    expect(() =>
-      process(host, 'serialize', undefined, arrayType, `dummy value`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is undefined
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
-
-  test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, arrayType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is null
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
-
-  test('when provided with an array including a bad value', () => {
-    expect(() =>
-      process(host, 'serialize', ['Not a number'], arrayType, `dummy value`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as array<number>
-      ├── 🛑 Failing value is an array
-      │      [ 'Not a number' ]
-      ╰── 🔍 Failure reason(s):
-          ╰─ Index 0: Unable to serialize value as number
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          "I'm array-like, but not quite an array",
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
               ├── 🛑 Failing value is a string
-              │      'Not a number'
+              │      "I'm array-like, but not quite an array"
               ╰── 🔍 Failure reason(s):
-                  ╰─ Value is not a number
-    `);
-  });
-});
+                  ╰─ Value is not an array
+          `);
+    });
 
-describe(SerializationClass.Date, () => {
-  const dateType: spec.OptionalValue = {
-    optional: false,
-    type: {
-      primitive: spec.PrimitiveType.Date,
-    },
-  };
+    test('when provided with a number', () => {
+      expect(() => process(host, 'serialize', 1337, arrayType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
+              ├── 🛑 Failing value is a number
+              │      1337
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an array
+          `);
+    });
 
-  test('when provided with a string', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        "I'm array-like, but not quite an array",
-        dateType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is a string
-      │      "I'm array-like, but not quite an array"
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an instance of Date
-    `);
-  });
+    test('when provided with a date', () => {
+      expect(() =>
+        process(host, 'serialize', new Date(65_535), arrayType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
+              ├── 🛑 Failing value is an instance of Date
+              │      1970-01-01T00:01:05.535Z
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an array
+          `);
+    });
 
-  test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, dateType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is a number
-      │      1337
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an instance of Date
-    `);
-  });
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
+              ├── 🛑 Failing value is an object
+              │      { this: [Array] }
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an array
+          `);
+    });
 
-  test('when provided with an object', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        { this: ['is', 'not', 'an', 'Array'] },
-        dateType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is an object
-      │      { this: [Array] }
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an instance of Date
-    `);
-  });
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, arrayType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
+              ├── 🛑 Failing value is undefined
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
 
-  test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, dateType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is undefined
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, arrayType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
+              ├── 🛑 Failing value is null
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
 
-  test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, dateType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is null
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
-
-  test('when provided with an array', () => {
-    expect(() =>
-      process(host, 'serialize', ['Not a number'], dateType, `dummy value`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as date
-      ├── 🛑 Failing value is an array
-      │      [ 'Not a number' ]
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an instance of Date
-    `);
-  });
-});
-
-describe(SerializationClass.Json, () => {
-  const jsonType: spec.OptionalValue = {
-    optional: false,
-    type: {
-      primitive: spec.PrimitiveType.Json,
-    },
-  };
-
-  test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, jsonType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as json
-      ├── 🛑 Failing value is undefined
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
-
-  test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, jsonType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as json
-      ├── 🛑 Failing value is null
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
-  });
-});
-
-describe(SerializationClass.Map, () => {
-  const mapType: spec.OptionalValue = {
-    optional: false,
-    type: {
-      collection: {
-        kind: spec.CollectionKind.Map,
-        elementtype: { primitive: spec.PrimitiveType.Number },
-      },
-    },
-  };
-  test('when provided with a string', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        "I'm array-like, but not quite an array",
-        mapType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is a string
-      │      "I'm array-like, but not quite an array"
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an object
-    `);
-  });
-
-  test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, mapType, `dummy value`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is a number
-      │      1337
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not an object
-    `);
-  });
-
-  test('when provided with an object with invalid values', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        { this: ['is', 'not', 'an', 'Array'] },
-        mapType,
-        `dummy value`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Dummy value: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is an object
-      │      { this: [Array] }
-      ╰── 🔍 Failure reason(s):
-          ╰─ Key 'this': Unable to serialize value as number
+    test('when provided with an array including a bad value', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], arrayType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as array<number>
               ├── 🛑 Failing value is an array
-              │      [ 'is', 'not', 'an', 'Array' ]
+              │      [ 'Not a number' ]
               ╰── 🔍 Failure reason(s):
-                  ╰─ Value is not a number
-    `);
+                  ╰─ Index 0: Unable to serialize value as number
+                      ├── 🛑 Failing value is a string
+                      │      'Not a number'
+                      ╰── 🔍 Failure reason(s):
+                          ╰─ Value is not a number
+          `);
+    });
   });
 
-  test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, mapType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is undefined
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
+  describe(SerializationClass.Date, () => {
+    const dateType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.Date,
+      },
+    };
+
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          "I'm array-like, but not quite an array",
+          dateType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is a string
+              │      "I'm array-like, but not quite an array"
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an instance of Date
+          `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'serialize', 1337, dateType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is a number
+              │      1337
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an instance of Date
+          `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          dateType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is an object
+              │      { this: [Array] }
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an instance of Date
+          `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, dateType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is undefined
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, dateType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is null
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], dateType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as date
+              ├── 🛑 Failing value is an array
+              │      [ 'Not a number' ]
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an instance of Date
+          `);
+    });
   });
 
-  test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, mapType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is null
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
+  describe(SerializationClass.Json, () => {
+    const jsonType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.Json,
+      },
+    };
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, jsonType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as json
+              ├── 🛑 Failing value is undefined
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, jsonType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as json
+              ├── 🛑 Failing value is null
+              ╰── 🔍 Failure reason(s):
+                  ╰─ A value is required (type is non-optional)
+          `);
+    });
   });
 
-  test('when provided with an array', () => {
-    expect(() =>
-      process(host, 'serialize', ['Not a number'], mapType, `of test`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as map<number>
-      ├── 🛑 Failing value is an array
-      │      [ 'Not a number' ]
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is an array
-    `);
+  describe(SerializationClass.Map, () => {
+    const mapType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        collection: {
+          kind: spec.CollectionKind.Map,
+          elementtype: { primitive: spec.PrimitiveType.Number },
+        },
+      },
+    };
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          "I'm array-like, but not quite an array",
+          mapType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as map<number>
+              ├── 🛑 Failing value is a string
+              │      "I'm array-like, but not quite an array"
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an object
+          `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'serialize', 1337, mapType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as map<number>
+              ├── 🛑 Failing value is a number
+              │      1337
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Value is not an object
+          `);
+    });
+
+    test('when provided with an object with invalid values', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          mapType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+              Dummy value: Unable to serialize value as map<number>
+              ├── 🛑 Failing value is an object
+              │      { this: [Array] }
+              ╰── 🔍 Failure reason(s):
+                  ╰─ Key 'this': Unable to serialize value as number
+                      ├── 🛑 Failing value is an array
+                      │      [ 'is', 'not', 'an', 'Array' ]
+                      ╰── 🔍 Failure reason(s):
+                          ╰─ Value is not a number
+          `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, mapType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as map<number>
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, mapType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as map<number>
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], mapType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as map<number>
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is an array
+      `);
+    });
+  });
+
+  describe(SerializationClass.Scalar, () => {
+    const stringType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.String,
+      },
+    };
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'serialize', 1337, stringType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as string
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          stringType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as string
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, stringType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as string
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, stringType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as string
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], stringType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as string
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
   });
 });
 
-describe(SerializationClass.Scalar, () => {
-  const stringType: spec.OptionalValue = {
-    optional: false,
-    type: {
-      primitive: spec.PrimitiveType.String,
-    },
-  };
+describe('deserialize errors', () => {
+  describe(SerializationClass.Array, () => {
+    const arrayType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        collection: {
+          kind: spec.CollectionKind.Array,
+          elementtype: { primitive: spec.PrimitiveType.Number },
+        },
+      },
+    };
 
-  test('when provided with a number', () => {
-    expect(() => process(host, 'serialize', 1337, stringType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as string
-      ├── 🛑 Failing value is a number
-      │      1337
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not a string
-    `);
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          "I'm array-like, but not quite an array",
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an array
+      `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'deserialize', 1337, arrayType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an array
+      `);
+    });
+
+    test('when provided with a date', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          new Date(65_535),
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is an instance of Date
+        │      1970-01-01T00:01:05.535Z
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an array
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an array
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, arrayType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'deserialize', null, arrayType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array including a bad value', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          ['Not a number'],
+          arrayType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as array<number>
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Index 0: Unable to deserialize value as number
+                ├── 🛑 Failing value is a string
+                │      'Not a number'
+                ╰── 🔍 Failure reason(s):
+                    ╰─ Value is not a number
+      `);
+    });
   });
 
-  test('when provided with an object', () => {
-    expect(() =>
-      process(
-        host,
-        'serialize',
-        { this: ['is', 'not', 'an', 'Array'] },
-        stringType,
-        `of test`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as string
-      ├── 🛑 Failing value is an object
-      │      { this: [Array] }
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not a string
-    `);
+  describe(SerializationClass.Date, () => {
+    const dateType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.Date,
+      },
+    };
+
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          "I'm array-like, but not quite an array",
+          dateType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.date" key
+      `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'deserialize', 1337, dateType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.date" key
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          dateType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.date" key
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, dateType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'deserialize', null, dateType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(host, 'deserialize', ['Not a number'], dateType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as date
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.date" key
+      `);
+    });
   });
 
-  test('when provided with undefined', () => {
-    expect(() => process(host, 'serialize', undefined, stringType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as string
-      ├── 🛑 Failing value is undefined
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
+  describe(SerializationClass.Json, () => {
+    const jsonType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.Json,
+      },
+    };
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, jsonType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as json
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'deserialize', null, jsonType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as json
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
   });
 
-  test('when provided with null', () => {
-    expect(() => process(host, 'serialize', null, stringType, `of test`))
-      .toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as string
-      ├── 🛑 Failing value is null
-      ╰── 🔍 Failure reason(s):
-          ╰─ A value is required (type is non-optional)
-    `);
+  describe(SerializationClass.Map, () => {
+    const mapType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        collection: {
+          kind: spec.CollectionKind.Map,
+          elementtype: { primitive: spec.PrimitiveType.Number },
+        },
+      },
+    };
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          "I'm array-like, but not quite an array",
+          mapType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'deserialize', 1337, mapType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when provided with an object with invalid values', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          mapType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Key 'this': Unable to deserialize value as number
+                ├── 🛑 Failing value is an array
+                │      [ 'is', 'not', 'an', 'Array' ]
+                ╰── 🔍 Failure reason(s):
+                    ╰─ Value is not a number
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, mapType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'deserialize', null, mapType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(host, 'deserialize', ['Not a number'], mapType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as map<number>
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is an array
+      `);
+    });
   });
 
-  test('when provided with an array', () => {
-    expect(() =>
-      process(host, 'serialize', ['Not a number'], stringType, `of test`),
-    ).toThrowErrorMatchingInlineSnapshot(`
-      Of test: Unable to serialize value as string
-      ├── 🛑 Failing value is an array
-      │      [ 'Not a number' ]
-      ╰── 🔍 Failure reason(s):
-          ╰─ Value is not a string
-    `);
+  describe(SerializationClass.Scalar, () => {
+    const stringType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        primitive: spec.PrimitiveType.String,
+      },
+    };
+
+    test('when provided with a number', () => {
+      expect(() =>
+        process(host, 'deserialize', 1337, stringType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as string
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          stringType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as string
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, stringType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as string
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() =>
+        process(host, 'deserialize', null, stringType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as string
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          ['Not a number'],
+          stringType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as string
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string
+      `);
+    });
   });
 });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -1,0 +1,114 @@
+import * as spec from '@jsii/spec';
+
+import { ObjectTable } from './objects';
+import {
+  SERIALIZERS,
+  SerializerHost,
+  SerializationClass,
+  serializationType,
+} from './serialization';
+
+const findSymbol: jest.MockedFn<SerializerHost['findSymbol']> = jest
+  .fn()
+  .mockName('SerializerHost.findSymbol');
+const lookupType: jest.MockedFn<SerializerHost['lookupType']> = jest
+  .fn()
+  .mockName('SerializerHost.lookupType');
+
+const objects = new ObjectTable(lookupType);
+const host: SerializerHost = {
+  debug: () => void undefined,
+  findSymbol,
+  lookupType,
+  objects,
+  recurse: (x, type) => {
+    const errors = new Array<any>();
+    for (const { serializationClass, typeRef } of serializationType(
+      type,
+      lookupType,
+    )) {
+      try {
+        return SERIALIZERS[serializationClass].deserialize(x, typeRef, host);
+      } catch (error: any) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    } else {
+      throw new Error(`Unable to serialize value:\n- ${errors.map(e => e.message).join('\n- ')}`);
+    }
+  },
+};
+
+describe(SerializationClass.Array, () => {
+  const arrayType: spec.OptionalValue = {
+    optional: false,
+    type: {
+      collection: {
+        kind: spec.CollectionKind.Array,
+        elementtype: { primitive: spec.PrimitiveType.Number },
+      },
+    },
+  };
+
+  test('when provided with a string', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(
+        "I'm array-like, but not quite an array",
+        arrayType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected array type, got \\"I'm array-like, but not quite an array\\""`,
+    );
+  });
+
+  test('when provided with a number', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(1337, arrayType, host),
+    ).toThrowErrorMatchingInlineSnapshot(`"Expected array type, got 1337"`);
+  });
+
+  test('when provided with an object', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(
+        { this: ['is', 'not', 'an', 'Array'] },
+        arrayType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected array type, got {\\"this\\":[\\"is\\",\\"not\\",\\"an\\",\\"Array\\"]}"`,
+    );
+  });
+
+  test('when provided with undefined', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(undefined, arrayType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'undefined' where a non-optional 'array<number>' value was expected"`,
+    );
+  });
+
+  test('when provided with null', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(null, arrayType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'null' where a non-optional 'array<number>' value was expected"`,
+    );
+  });
+
+  test('when provided with an array including a bad value', () => {
+    const arraySerializer = SERIALIZERS[SerializationClass.Array];
+    expect(() =>
+      arraySerializer.serialize(['Not a number'], arrayType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a number, got \\"Not a number\\" (string)"`,
+    );
+  });
+});

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -801,7 +801,6 @@ describe('serialize errors', () => {
 
     test('when passed and invalid value', () => {
       expect(() => {
-        debugger;
         process(host, 'serialize', { not: 'valid' }, unionType, 'dummy value');
       }).toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as boolean | date | number | string | array<any> | map<boolean> | phony.module.Enum
@@ -1738,7 +1737,6 @@ describe('deserialize errors', () => {
 
     test('when passed and invalid value', () => {
       expect(() => {
-        debugger;
         process(
           host,
           'deserialize',

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -36,7 +36,7 @@ describe('serialize errors', () => {
       },
     };
 
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -54,7 +54,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'serialize', 1337, arrayType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as array<number>
@@ -65,7 +65,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with a date', () => {
+    test('when passed a date', () => {
       expect(() =>
         process(host, 'serialize', new Date(65_535), arrayType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -77,7 +77,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -95,7 +95,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, arrayType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -106,7 +106,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, arrayType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as array<number>
@@ -116,7 +116,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with an array including a bad value', () => {
+    test('when passed an array including a bad value', () => {
       expect(() =>
         process(host, 'serialize', ['Not a number'], arrayType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -141,7 +141,7 @@ describe('serialize errors', () => {
       },
     };
 
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -159,7 +159,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'serialize', 1337, dateType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as date
@@ -170,7 +170,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -188,7 +188,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, dateType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -199,7 +199,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, dateType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as date
@@ -209,7 +209,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'serialize', ['Not a number'], dateType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -250,7 +250,7 @@ describe('serialize errors', () => {
       done();
     });
 
-    test('when provided with a string that is not in the enum', () => {
+    test('when passed a string that is not in the enum', () => {
       expect(() =>
         process(
           host,
@@ -268,7 +268,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with a number that is not in the enum', () => {
+    test('when passed a number that is not in the enum', () => {
       expect(() => process(host, 'serialize', 1337, enumType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as phony.module.EnumType
@@ -279,7 +279,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with a date', () => {
+    test('when passed a date', () => {
       expect(() =>
         process(host, 'serialize', new Date(65_535), enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -291,7 +291,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -309,7 +309,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -320,7 +320,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, enumType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as phony.module.EnumType
@@ -330,7 +330,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with an array including a bad value', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'serialize', ['Not a number'], enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -351,7 +351,7 @@ describe('serialize errors', () => {
       },
     };
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, jsonType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -362,7 +362,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, jsonType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as json
@@ -383,7 +383,7 @@ describe('serialize errors', () => {
         },
       },
     };
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -401,7 +401,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'serialize', 1337, mapType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
               Dummy value: Unable to serialize value as map<number>
@@ -412,7 +412,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with an object with invalid values', () => {
+    test('when passed an object with invalid values', () => {
       expect(() =>
         process(
           host,
@@ -434,7 +434,7 @@ describe('serialize errors', () => {
           `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, mapType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -445,7 +445,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, mapType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as map<number>
@@ -455,7 +455,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'serialize', ['Not a number'], mapType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -476,7 +476,7 @@ describe('serialize errors', () => {
       },
     };
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'serialize', 1337, stringType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as string
@@ -487,7 +487,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -505,7 +505,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'serialize', undefined, stringType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -516,7 +516,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'serialize', null, stringType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to serialize value as string
@@ -526,7 +526,7 @@ describe('serialize errors', () => {
       `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'serialize', ['Not a number'], stringType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -535,6 +535,106 @@ describe('serialize errors', () => {
         │      [ 'Not a number' ]
         ╰── 🔍 Failure reason(s):
             ╰─ Value is not a string
+      `);
+    });
+  });
+
+  describe(SerializationClass.Struct, () => {
+    const STRUCT_FQN = 'phony.module.Struct';
+    const STRUCT_TYPE: spec.InterfaceType = {
+      assembly: 'phony',
+      fqn: STRUCT_FQN,
+      kind: spec.TypeKind.Interface,
+      name: 'Struct',
+      datatype: true,
+      properties: [],
+    };
+    const structType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        fqn: STRUCT_FQN,
+      },
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(STRUCT_FQN);
+        return STRUCT_TYPE;
+      });
+      done();
+    });
+
+    test('when passed a string', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          "I'm array-like, but not quite an array",
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when passed a number', () => {
+      expect(() => process(host, 'serialize', 1337, structType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when passed a date', () => {
+      expect(() =>
+        process(host, 'serialize', new Date(65_535), structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is an instance of Date
+        │      1970-01-01T00:01:05.535Z
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when passed undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when passed null', () => {
+      expect(() => process(host, 'serialize', null, structType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when passed an array', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.Struct
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is an array
       `);
     });
   });
@@ -552,7 +652,7 @@ describe('deserialize errors', () => {
       },
     };
 
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -570,7 +670,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'deserialize', 1337, arrayType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as array<number>
@@ -581,7 +681,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a date', () => {
+    test('when passed a date', () => {
       expect(() =>
         process(
           host,
@@ -599,7 +699,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -617,7 +717,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, arrayType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -628,7 +728,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'deserialize', null, arrayType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as array<number>
@@ -638,7 +738,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an array including a bad value', () => {
+    test('when passed an array including a bad value', () => {
       expect(() =>
         process(
           host,
@@ -669,7 +769,7 @@ describe('deserialize errors', () => {
       },
     };
 
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -687,7 +787,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'deserialize', 1337, dateType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as date
@@ -698,7 +798,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -716,7 +816,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, dateType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -727,7 +827,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'deserialize', null, dateType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as date
@@ -737,7 +837,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'deserialize', ['Not a number'], dateType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -778,7 +878,7 @@ describe('deserialize errors', () => {
       done();
     });
 
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -796,7 +896,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'deserialize', 1337, enumType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as phony.module.EnumType
@@ -807,7 +907,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a date', () => {
+    test('when passed a date', () => {
       expect(() =>
         process(host, 'deserialize', new Date(65_535), enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -819,7 +919,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -837,7 +937,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -848,7 +948,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'deserialize', null, enumType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as phony.module.EnumType
@@ -858,7 +958,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an array including a bad value', () => {
+    test('when passed an array including a bad value', () => {
       expect(() =>
         process(host, 'deserialize', ['Not a number'], enumType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -879,7 +979,7 @@ describe('deserialize errors', () => {
       },
     };
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, jsonType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -890,7 +990,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'deserialize', null, jsonType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as json
@@ -911,7 +1011,7 @@ describe('deserialize errors', () => {
         },
       },
     };
-    test('when provided with a string', () => {
+    test('when passed a string', () => {
       expect(() =>
         process(
           host,
@@ -929,7 +1029,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() => process(host, 'deserialize', 1337, mapType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as map<number>
@@ -940,7 +1040,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an object with invalid values', () => {
+    test('when passed an object with invalid values', () => {
       expect(() =>
         process(
           host,
@@ -962,7 +1062,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, mapType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -973,7 +1073,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() => process(host, 'deserialize', null, mapType, `dummy value`))
         .toThrowErrorMatchingInlineSnapshot(`
         Dummy value: Unable to deserialize value as map<number>
@@ -983,7 +1083,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(host, 'deserialize', ['Not a number'], mapType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -1004,7 +1104,7 @@ describe('deserialize errors', () => {
       },
     };
 
-    test('when provided with a number', () => {
+    test('when passed a number', () => {
       expect(() =>
         process(host, 'deserialize', 1337, stringType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -1016,7 +1116,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an object', () => {
+    test('when passed an object', () => {
       expect(() =>
         process(
           host,
@@ -1034,7 +1134,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with undefined', () => {
+    test('when passed undefined', () => {
       expect(() =>
         process(host, 'deserialize', undefined, stringType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -1045,7 +1145,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with null', () => {
+    test('when passed null', () => {
       expect(() =>
         process(host, 'deserialize', null, stringType, `dummy value`),
       ).toThrowErrorMatchingInlineSnapshot(`
@@ -1056,7 +1156,7 @@ describe('deserialize errors', () => {
       `);
     });
 
-    test('when provided with an array', () => {
+    test('when passed an array', () => {
       expect(() =>
         process(
           host,
@@ -1071,6 +1171,175 @@ describe('deserialize errors', () => {
         │      [ 'Not a number' ]
         ╰── 🔍 Failure reason(s):
             ╰─ Value is not a string
+      `);
+    });
+  });
+
+  describe(SerializationClass.Struct, () => {
+    const STRUCT_FQN = 'phony.module.Struct';
+    const STRUCT_TYPE: spec.InterfaceType = {
+      assembly: 'phony',
+      fqn: STRUCT_FQN,
+      kind: spec.TypeKind.Interface,
+      name: 'Struct',
+      datatype: true,
+      properties: [
+        {
+          name: 'this',
+          type: {
+            collection: {
+              kind: spec.CollectionKind.Array,
+              elementtype: { primitive: spec.PrimitiveType.String },
+            },
+          },
+          optional: true,
+        },
+        {
+          name: 'that',
+          type: { primitive: spec.PrimitiveType.Number },
+        },
+      ],
+    };
+    const structType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        fqn: STRUCT_FQN,
+      },
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(STRUCT_FQN);
+        return STRUCT_TYPE;
+      });
+      done();
+    });
+
+    test('when passed a string', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          "I'm array-like, but not quite an array",
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when passed a number', () => {
+      expect(() =>
+        process(host, 'deserialize', 1337, structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not an object
+      `);
+    });
+
+    test('when passed a date', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          new Date(65_535),
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is an instance of Date
+        │      1970-01-01T00:01:05.535Z
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when passed undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when passed null', () => {
+      expect(() =>
+        process(host, 'deserialize', null, structType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when passed an array', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          ['Not a number'],
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is an array (varargs may have been incorrectly supplied)
+      `);
+    });
+
+    test('when passed an object missing a required property', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is not a serialized', 'struct'] },
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Missing required properties for phony.module.Struct: 'that'
+      `);
+    });
+
+    test('when passed an object with a bad property value', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { that: 'is not a number' },
+          structType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.Struct
+        ├── 🛑 Failing value is an object
+        │      { that: 'is not a number' }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Key 'that': Unable to deserialize value as number
+                ├── 🛑 Failing value is a string
+                │      'is not a number'
+                ╰── 🔍 Failure reason(s):
+                    ╰─ Value is not a number
       `);
     });
   });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -36,7 +36,11 @@ const host: SerializerHost = {
     if (errors.length === 1) {
       throw errors[0];
     } else {
-      throw new Error(`Unable to serialize value:\n- ${errors.map(e => e.message).join('\n- ')}`);
+      throw new Error(
+        `Unable to serialize value:\n- ${errors
+          .map((e) => e.message)
+          .join('\n- ')}`,
+      );
     }
   },
 };

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -55,9 +55,9 @@ describe(SerializationClass.Array, () => {
       },
     },
   };
+  const arraySerializer = SERIALIZERS[SerializationClass.Array];
 
   test('when provided with a string', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(
         "I'm array-like, but not quite an array",
@@ -70,14 +70,20 @@ describe(SerializationClass.Array, () => {
   });
 
   test('when provided with a number', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(1337, arrayType, host),
     ).toThrowErrorMatchingInlineSnapshot(`"Expected array type, got 1337"`);
   });
 
+  test('when provided with a date', () => {
+    expect(() =>
+      arraySerializer.serialize(new Date(65_535), arrayType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected array type, got \\"1970-01-01T00:01:05.535Z\\""`,
+    );
+  });
+
   test('when provided with an object', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(
         { this: ['is', 'not', 'an', 'Array'] },
@@ -90,7 +96,6 @@ describe(SerializationClass.Array, () => {
   });
 
   test('when provided with undefined', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(undefined, arrayType, host),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -99,7 +104,6 @@ describe(SerializationClass.Array, () => {
   });
 
   test('when provided with null', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(null, arrayType, host),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -108,11 +112,221 @@ describe(SerializationClass.Array, () => {
   });
 
   test('when provided with an array including a bad value', () => {
-    const arraySerializer = SERIALIZERS[SerializationClass.Array];
     expect(() =>
       arraySerializer.serialize(['Not a number'], arrayType, host),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Expected a number, got \\"Not a number\\" (string)"`,
+    );
+  });
+});
+
+describe(SerializationClass.Date, () => {
+  const dateType: spec.OptionalValue = {
+    optional: false,
+    type: {
+      primitive: spec.PrimitiveType.Date,
+    },
+  };
+  const dateSerializer = SERIALIZERS[SerializationClass.Date];
+
+  test('when provided with a string', () => {
+    expect(() =>
+      dateSerializer.serialize(
+        "I'm array-like, but not quite an array",
+        dateType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected Date, got \\"I'm array-like, but not quite an array\\""`,
+    );
+  });
+
+  test('when provided with a number', () => {
+    expect(() =>
+      dateSerializer.serialize(1337, dateType, host),
+    ).toThrowErrorMatchingInlineSnapshot(`"Expected Date, got 1337"`);
+  });
+
+  test('when provided with an object', () => {
+    expect(() =>
+      dateSerializer.serialize(
+        { this: ['is', 'not', 'an', 'Array'] },
+        dateType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected Date, got {\\"this\\":[\\"is\\",\\"not\\",\\"an\\",\\"Array\\"]}"`,
+    );
+  });
+
+  test('when provided with undefined', () => {
+    expect(() =>
+      dateSerializer.serialize(undefined, dateType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'undefined' where a non-optional 'date' value was expected"`,
+    );
+  });
+
+  test('when provided with null', () => {
+    expect(() =>
+      dateSerializer.serialize(null, dateType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'null' where a non-optional 'date' value was expected"`,
+    );
+  });
+
+  test('when provided with an array', () => {
+    expect(() =>
+      dateSerializer.serialize(['Not a number'], dateType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected Date, got [\\"Not a number\\"]"`,
+    );
+  });
+});
+
+describe(SerializationClass.Json, () => {
+  const jsonType: spec.OptionalValue = {
+    optional: false,
+    type: {
+      primitive: spec.PrimitiveType.Json,
+    },
+  };
+  const jsonSerializer = SERIALIZERS[SerializationClass.Json];
+
+  test('when provided with undefined', () => {
+    expect(() =>
+      jsonSerializer.serialize(undefined, jsonType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'undefined' where a non-optional 'json' value was expected"`,
+    );
+  });
+
+  test('when provided with null', () => {
+    expect(() =>
+      jsonSerializer.serialize(null, jsonType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'null' where a non-optional 'json' value was expected"`,
+    );
+  });
+});
+
+describe(SerializationClass.Map, () => {
+  const mapType: spec.OptionalValue = {
+    optional: false,
+    type: {
+      collection: {
+        kind: spec.CollectionKind.Map,
+        elementtype: { primitive: spec.PrimitiveType.Number },
+      },
+    },
+  };
+  const mapSerializer = SERIALIZERS[SerializationClass.Map];
+
+  test('when provided with a string', () => {
+    expect(() =>
+      mapSerializer.serialize(
+        "I'm array-like, but not quite an array",
+        mapType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected object type, got \\"I'm array-like, but not quite an array\\""`,
+    );
+  });
+
+  test('when provided with a number', () => {
+    expect(() =>
+      mapSerializer.serialize(1337, mapType, host),
+    ).toThrowErrorMatchingInlineSnapshot(`"Expected object type, got 1337"`);
+  });
+
+  test('when provided with an object with invalid values', () => {
+    expect(() =>
+      mapSerializer.serialize(
+        { this: ['is', 'not', 'an', 'Array'] },
+        mapType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a number, got [\\"is\\",\\"not\\",\\"an\\",\\"Array\\"]"`,
+    );
+  });
+
+  test('when provided with undefined', () => {
+    expect(() =>
+      mapSerializer.serialize(undefined, mapType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'undefined' where a non-optional 'map<number>' value was expected"`,
+    );
+  });
+
+  test('when provided with null', () => {
+    expect(() =>
+      mapSerializer.serialize(null, mapType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'null' where a non-optional 'map<number>' value was expected"`,
+    );
+  });
+
+  test('when provided with an array', () => {
+    expect(() =>
+      mapSerializer.serialize(['Not a number'], mapType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a number, got \\"Not a number\\" (string)"`,
+    );
+  });
+});
+
+describe(SerializationClass.Scalar, () => {
+  const stringType: spec.OptionalValue = {
+    optional: false,
+    type: {
+      primitive: spec.PrimitiveType.String,
+    },
+  };
+  const scalarSerializer = SERIALIZERS[SerializationClass.Scalar];
+
+  test('when provided with a number', () => {
+    expect(() =>
+      scalarSerializer.serialize(1337, stringType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected a string, got 1337 (number)"`,
+    );
+  });
+
+  test('when provided with an object', () => {
+    expect(() =>
+      scalarSerializer.serialize(
+        { this: ['is', 'not', 'an', 'Array'] },
+        stringType,
+        host,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected string, got {\\"this\\":[\\"is\\",\\"not\\",\\"an\\",\\"Array\\"]}"`,
+    );
+  });
+
+  test('when provided with undefined', () => {
+    expect(() =>
+      scalarSerializer.serialize(undefined, stringType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'undefined' where a non-optional 'string' value was expected"`,
+    );
+  });
+
+  test('when provided with null', () => {
+    expect(() =>
+      scalarSerializer.serialize(null, stringType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Got 'null' where a non-optional 'string' value was expected"`,
+    );
+  });
+
+  test('when provided with an array', () => {
+    expect(() =>
+      scalarSerializer.serialize(['Not a number'], stringType, host),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Expected string, got [\\"Not a number\\"]"`,
     );
   });
 });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -222,6 +222,127 @@ describe('serialize errors', () => {
     });
   });
 
+  describe(SerializationClass.Enum, () => {
+    const ENUM_TYPE_FQN = 'phony.module.EnumType';
+    const ENUM_TYPE: spec.EnumType = {
+      assembly: 'phony',
+      fqn: ENUM_TYPE_FQN,
+      kind: spec.TypeKind.Enum,
+      members: [],
+      name: 'EnumType',
+      namespace: 'module',
+    };
+    const ENUM_MAP = {} as const;
+    const enumType: spec.OptionalValue = {
+      optional: false,
+      type: { fqn: ENUM_TYPE_FQN },
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_TYPE_FQN);
+        return ENUM_TYPE;
+      });
+      findSymbol.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_TYPE_FQN);
+        return ENUM_MAP;
+      });
+      done();
+    });
+
+    test('when provided with a string that is not in the enum', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          "I'm array-like, but not quite an array",
+          enumType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not present in enum phony.module.EnumType
+      `);
+    });
+
+    test('when provided with a number that is not in the enum', () => {
+      expect(() => process(host, 'serialize', 1337, enumType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not present in enum phony.module.EnumType
+      `);
+    });
+
+    test('when provided with a date', () => {
+      expect(() =>
+        process(host, 'serialize', new Date(65_535), enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an instance of Date
+        │      1970-01-01T00:01:05.535Z
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string or number
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'serialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          enumType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string or number
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'serialize', undefined, enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'serialize', null, enumType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array including a bad value', () => {
+      expect(() =>
+        process(host, 'serialize', ['Not a number'], enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value is not a string or number
+      `);
+    });
+  });
+
   describe(SerializationClass.Json, () => {
     const jsonType: spec.OptionalValue = {
       optional: false,
@@ -625,6 +746,127 @@ describe('deserialize errors', () => {
         │      [ 'Not a number' ]
         ╰── 🔍 Failure reason(s):
             ╰─ Value does not have the "$jsii.date" key
+      `);
+    });
+  });
+
+  describe(SerializationClass.Enum, () => {
+    const ENUM_TYPE_FQN = 'phony.module.EnumType';
+    const ENUM_TYPE: spec.EnumType = {
+      assembly: 'phony',
+      fqn: ENUM_TYPE_FQN,
+      kind: spec.TypeKind.Enum,
+      members: [],
+      name: 'EnumType',
+      namespace: 'module',
+    };
+    const ENUM_MAP = {} as const;
+    const enumType: spec.OptionalValue = {
+      optional: false,
+      type: { fqn: ENUM_TYPE_FQN },
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_TYPE_FQN);
+        return ENUM_TYPE;
+      });
+      findSymbol.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_TYPE_FQN);
+        return ENUM_MAP;
+      });
+      done();
+    });
+
+    test('when provided with a string', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          "I'm array-like, but not quite an array",
+          enumType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is a string
+        │      "I'm array-like, but not quite an array"
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.enum" key
+      `);
+    });
+
+    test('when provided with a number', () => {
+      expect(() => process(host, 'deserialize', 1337, enumType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is a number
+        │      1337
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.enum" key
+      `);
+    });
+
+    test('when provided with a date', () => {
+      expect(() =>
+        process(host, 'deserialize', new Date(65_535), enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an instance of Date
+        │      1970-01-01T00:01:05.535Z
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.enum" key
+      `);
+    });
+
+    test('when provided with an object', () => {
+      expect(() =>
+        process(
+          host,
+          'deserialize',
+          { this: ['is', 'not', 'an', 'Array'] },
+          enumType,
+          `dummy value`,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an object
+        │      { this: [Array] }
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.enum" key
+      `);
+    });
+
+    test('when provided with undefined', () => {
+      expect(() =>
+        process(host, 'deserialize', undefined, enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is undefined
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with null', () => {
+      expect(() => process(host, 'deserialize', null, enumType, `dummy value`))
+        .toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is null
+        ╰── 🔍 Failure reason(s):
+            ╰─ A value is required (type is non-optional)
+      `);
+    });
+
+    test('when provided with an array including a bad value', () => {
+      expect(() =>
+        process(host, 'deserialize', ['Not a number'], enumType, `dummy value`),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as phony.module.EnumType
+        ├── 🛑 Failing value is an array
+        │      [ 'Not a number' ]
+        ╰── 🔍 Failure reason(s):
+            ╰─ Value does not have the "$jsii.enum" key
       `);
     });
   });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -132,7 +132,7 @@ describe(SerializationClass.Array, () => {
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Unable to serialize value index 0 as number
+          ╰─ [0] Unable to serialize value at index 0 as number
               ├── 🛑 Failing value is a string
               │      'Not a number'
               ╰── 🔍 Failure reason(s):
@@ -329,7 +329,7 @@ describe(SerializationClass.Map, () => {
       ├── 🛑 Failing value is an object
       │      { this: [Array] }
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Unable to serialize value key "this" as number
+          ╰─ [0] Unable to serialize value of key "this" as number
               ├── 🛑 Failing value is an array
               │      [ 'is', 'not', 'an', 'Array' ]
               ╰── 🔍 Failure reason(s):
@@ -369,13 +369,9 @@ describe(SerializationClass.Map, () => {
       ├── 🛑 Failing value is an array
       │      [ 'Not a number' ]
       ╰── 🔍 Failure reason(s):
-          ╰─ [0] Unable to serialize value key "0" as number
-              ├── 🛑 Failing value is a string
-              │      'Not a number'
-              ╰── 🔍 Failure reason(s):
-                  ╰─ [0] Value is not a number
-                      ╰── 🛑 Failing value is a string
-                             'Not a number'
+          ╰─ [0] Value is an array
+              ╰── 🛑 Failing value is an array
+                     [ 'Not a number' ]
     `);
   });
 });

--- a/packages/@jsii/kernel/src/serialization.ux.test.ts
+++ b/packages/@jsii/kernel/src/serialization.ux.test.ts
@@ -1,4 +1,5 @@
 import * as spec from '@jsii/spec';
+import { CollectionKind } from '@jsii/spec';
 
 import { ObjectTable } from './objects';
 import { process, SerializerHost, SerializationClass } from './serialization';
@@ -745,6 +746,79 @@ describe('serialize errors', () => {
         │      [ 'Not a number' ]
         ╰── 🔍 Failure reason(s):
             ╰─ Value is an array
+      `);
+    });
+  });
+
+  describe('The impossible type union', () => {
+    const ENUM_FQN = 'phony.module.Enum';
+
+    const unionType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        union: {
+          types: [
+            // { primitive: spec.PrimitiveType.Any }, // Would allow ANYTHING, so we can't have that
+            { primitive: spec.PrimitiveType.Boolean },
+            { primitive: spec.PrimitiveType.Date },
+            // { primitive: spec.PrimitiveType.Json }, // Would allow nearly anything, so we can't have that
+            { primitive: spec.PrimitiveType.Number },
+            { primitive: spec.PrimitiveType.String },
+            {
+              collection: {
+                kind: CollectionKind.Array,
+                elementtype: { primitive: spec.PrimitiveType.Any },
+              },
+            },
+            {
+              collection: {
+                kind: CollectionKind.Map,
+                elementtype: { primitive: spec.PrimitiveType.Boolean },
+              },
+            },
+            { fqn: ENUM_FQN },
+          ],
+        },
+      },
+    };
+
+    const ENUM_TYPE: spec.EnumType = {
+      assembly: 'phony',
+      fqn: 'phony.module.Enum',
+      kind: spec.TypeKind.Enum,
+      name: 'Enum',
+      namespace: 'module',
+      members: [],
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_FQN);
+        return ENUM_TYPE;
+      });
+      done();
+    });
+
+    test('when passed and invalid value', () => {
+      expect(() => {
+        debugger;
+        process(host, 'serialize', { not: 'valid' }, unionType, 'dummy value');
+      }).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to serialize value as boolean | date | number | string | array<any> | map<boolean> | phony.module.Enum
+        ├── 🛑 Failing value is an object
+        │      { not: 'valid' }
+        ╰── 🔍 Failure reason(s):
+            ├─ [as date] Value is not an instance of Date
+            ├─ [as boolean] Value is not a boolean
+            ├─ [as number] Value is not a number
+            ├─ [as string] Value is not a string
+            ├─ [as phony.module.Enum] Value is not a string or number
+            ├─ [as array<any>] Value is not an array
+            ╰─ [as map<boolean>] Key 'not': Unable to serialize value as boolean
+                ├── 🛑 Failing value is a string
+                │      'valid'
+                ╰── 🔍 Failure reason(s):
+                    ╰─ Value is not a boolean
       `);
     });
   });
@@ -1609,6 +1683,85 @@ describe('deserialize errors', () => {
                 │      'is not a number'
                 ╰── 🔍 Failure reason(s):
                     ╰─ Value is not a number
+      `);
+    });
+  });
+
+  describe('The impossible type union', () => {
+    const ENUM_FQN = 'phony.module.Enum';
+
+    const unionType: spec.OptionalValue = {
+      optional: false,
+      type: {
+        union: {
+          types: [
+            // { primitive: spec.PrimitiveType.Any }, // Would allow ANYTHING, so we can't have that
+            { primitive: spec.PrimitiveType.Boolean },
+            { primitive: spec.PrimitiveType.Date },
+            // { primitive: spec.PrimitiveType.Json }, // Would allow nearly anything, so we can't have that
+            { primitive: spec.PrimitiveType.Number },
+            { primitive: spec.PrimitiveType.String },
+            {
+              collection: {
+                kind: CollectionKind.Array,
+                elementtype: { primitive: spec.PrimitiveType.Any },
+              },
+            },
+            {
+              collection: {
+                kind: CollectionKind.Map,
+                elementtype: { primitive: spec.PrimitiveType.Boolean },
+              },
+            },
+            { fqn: ENUM_FQN },
+          ],
+        },
+      },
+    };
+
+    const ENUM_TYPE: spec.EnumType = {
+      assembly: 'phony',
+      fqn: 'phony.module.Enum',
+      kind: spec.TypeKind.Enum,
+      name: 'Enum',
+      namespace: 'module',
+      members: [],
+    };
+
+    beforeEach((done) => {
+      lookupType.mockImplementation((fqn) => {
+        expect(fqn).toBe(ENUM_FQN);
+        return ENUM_TYPE;
+      });
+      done();
+    });
+
+    test('when passed and invalid value', () => {
+      expect(() => {
+        debugger;
+        process(
+          host,
+          'deserialize',
+          { not: 'valid' },
+          unionType,
+          'dummy value',
+        );
+      }).toThrowErrorMatchingInlineSnapshot(`
+        Dummy value: Unable to deserialize value as boolean | date | number | string | array<any> | map<boolean> | phony.module.Enum
+        ├── 🛑 Failing value is an object
+        │      { not: 'valid' }
+        ╰── 🔍 Failure reason(s):
+            ├─ [as date] Value does not have the "$jsii.date" key
+            ├─ [as boolean] Value is not a boolean
+            ├─ [as number] Value is not a number
+            ├─ [as string] Value is not a string
+            ├─ [as phony.module.Enum] Value does not have the "$jsii.enum" key
+            ├─ [as array<any>] Value is not an array
+            ╰─ [as map<boolean>] Key 'not': Unable to deserialize value as boolean
+                ├── 🛑 Failing value is a string
+                │      'valid'
+                ╰── 🔍 Failure reason(s):
+                    ╰─ Value is not a boolean
       `);
     });
   });


### PR DESCRIPTION
Bring attention to error messages as part of the contract of the
`@jsii/kernel` serialization component, as such messages are currently a
known pain point (not specific enough, confusing, overloaded, ...).

Introducing snapshot tests, and quick win improvements to the existing
error messages where possible.

Fixes #3636 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
