### PR TITLE
feat(@jsii/spec): add loadAssemblyFromBuffer function

### DIFF
--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "fs-extra": "^10.1.0",
-    "tar": "^6.1.11"
+    "fs-extra": "^10.1.0"
   },
   "devDependencies": {
     "jsii-build-tools": "^0.0.0",

--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "fs-extra": "^10.1.0"
+    "fs-extra": "^10.1.0",
+    "tar": "^6.1.11"
   },
   "devDependencies": {
     "jsii-build-tools": "^0.0.0",

--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { create } from 'tar';
 
 import {
   SPEC_FILE_NAME,
@@ -12,7 +11,7 @@ import {
   loadAssemblyFromPath,
   getAssemblyFile,
   writeAssembly,
-  loadAssemblyFromTarball,
+  loadAssemblyFromBuffer,
 } from './assembly-utils';
 import { makeTempDir } from './utils';
 
@@ -151,32 +150,22 @@ describe('loadAssemblyFromPath', () => {
   });
 });
 
-describe('loadAssemblyFromTarball', () => {
-  test('loads uncompressed assembly', () => {
+describe('loadAssemblyFromBuffer', () => {
+  test('loads uncompressed assembly buffer', () => {
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
-    const tarball = path.join(tmpdir, 'tar.tgz');
-    create(
-      {
-        file: tarball,
-        sync: true,
-      },
-      [tmpdir],
-    );
-
-    expect(loadAssemblyFromTarball(tarball, tmpdir)).toEqual(TEST_ASSEMBLY);
+    const buf = fs.readFileSync(path.join(tmpdir, SPEC_FILE_NAME));
+    expect(loadAssemblyFromBuffer(buf)).toEqual(TEST_ASSEMBLY);
   });
 
-  test('loads compressed assembly', () => {
+  test('loads compressed assembly buffer', () => {
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: true });
-    const tarball = 'tar.tgz'; //path.join(tmpdir, 'tar.tgz');
-    create(
-      {
-        file: tarball,
-        sync: true,
-      },
-      [tmpdir],
+    const assemblyBuf = fs.readFileSync(path.join(tmpdir, SPEC_FILE_NAME));
+    const compAssemblyBuf = fs.readFileSync(
+      path.join(tmpdir, SPEC_FILE_NAME_COMPRESSED),
     );
 
-    expect(loadAssemblyFromTarball(tarball, tmpdir)).toEqual(TEST_ASSEMBLY);
+    expect(loadAssemblyFromBuffer(assemblyBuf, compAssemblyBuf)).toEqual(
+      TEST_ASSEMBLY,
+    );
   });
 });

--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -37,9 +37,17 @@ const TEST_ASSEMBLY: Assembly = {
   jsiiVersion: '1.0.0',
 };
 
+let tmpdir: string;
+beforeEach(() => {
+  tmpdir = makeTempDir();
+});
+
+afterEach(() => {
+  fs.removeSync(tmpdir);
+});
+
 describe('writeAssembly', () => {
   test('can write compressed assembly', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: true });
 
     expect(
@@ -58,7 +66,6 @@ describe('writeAssembly', () => {
   });
 
   test('can write uncompressed assembly', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
 
     expect(fs.existsSync(path.join(tmpdir, SPEC_FILE_NAME))).toBeTruthy();
@@ -67,22 +74,18 @@ describe('writeAssembly', () => {
 
 describe('getAssemblyFile', () => {
   test('finds SPEC_FILE_NAME file when there is no compression', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
 
     expect(getAssemblyFile(tmpdir)).toEqual(path.join(tmpdir, SPEC_FILE_NAME));
   });
 
   test('finds SPEC_FILE_NAME file even when there is compression', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: true });
 
     expect(getAssemblyFile(tmpdir)).toEqual(path.join(tmpdir, SPEC_FILE_NAME));
   });
 
   test('throws if SPEC_FILE_NAME file does not exist', () => {
-    const tmpdir = makeTempDir();
-
     expect(() => getAssemblyFile(tmpdir)).toThrow(
       `Expected to find ${SPEC_FILE_NAME} file in ${tmpdir}, but no such file found`,
     );
@@ -91,14 +94,12 @@ describe('getAssemblyFile', () => {
 
 describe('loadAssemblyFromPath', () => {
   test('loads compressed assembly', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: true });
 
     expect(loadAssemblyFromPath(tmpdir)).toEqual(TEST_ASSEMBLY);
   });
 
   test('loads uncompressed assembly', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
 
     expect(loadAssemblyFromPath(tmpdir)).toEqual(TEST_ASSEMBLY);
@@ -114,10 +115,12 @@ describe('loadAssemblyFromPath', () => {
     expect(loadAssemblyFromPath(compressedTmpDir)).toEqual(
       loadAssemblyFromPath(uncompressedTmpDir),
     );
+
+    fs.removeSync(compressedTmpDir);
+    fs.removeSync(uncompressedTmpDir);
   });
 
   test('throws if redirect schema is invalid', () => {
-    const tmpdir = makeTempDir();
     fs.writeJsonSync(path.join(tmpdir, SPEC_FILE_NAME), {
       schema: 'jsii/file-redirect',
       compression: '7zip',
@@ -133,7 +136,6 @@ describe('loadAssemblyFromPath', () => {
   });
 
   test('throws if assembly is invalid', () => {
-    const tmpdir = makeTempDir();
     fs.writeJsonSync(
       path.join(tmpdir, SPEC_FILE_NAME),
       {
@@ -151,7 +153,6 @@ describe('loadAssemblyFromPath', () => {
 
 describe('loadAssemblyFromTarball', () => {
   test('loads uncompressed assembly', () => {
-    const tmpdir = makeTempDir();
     writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
     const tarball = path.join(tmpdir, 'tar.tgz');
     create(

--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
-import * as os from 'os';
 import * as path from 'path';
+import { create } from 'tar';
 
 import {
   SPEC_FILE_NAME,
@@ -12,7 +12,9 @@ import {
   loadAssemblyFromPath,
   getAssemblyFile,
   writeAssembly,
+  loadAssemblyFromTarball,
 } from './assembly-utils';
+import { makeTempDir } from './utils';
 
 const TEST_ASSEMBLY: Assembly = {
   schema: SchemaVersion.LATEST,
@@ -147,6 +149,19 @@ describe('loadAssemblyFromPath', () => {
   });
 });
 
-function makeTempDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), path.basename(__filename)));
-}
+describe('loadAssemblyFromTarball', () => {
+  test('loads uncompressed assembly', () => {
+    const tmpdir = makeTempDir();
+    writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: false });
+    const tarball = path.join(tmpdir, 'tar.tgz');
+    create(
+      {
+        file: tarball,
+        sync: true,
+      },
+      [tmpdir],
+    );
+
+    expect(loadAssemblyFromTarball(tarball, tmpdir)).toEqual(TEST_ASSEMBLY);
+  });
+});

--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -165,4 +165,18 @@ describe('loadAssemblyFromTarball', () => {
 
     expect(loadAssemblyFromTarball(tarball, tmpdir)).toEqual(TEST_ASSEMBLY);
   });
+
+  test('loads compressed assembly', () => {
+    writeAssembly(tmpdir, TEST_ASSEMBLY, { compress: true });
+    const tarball = 'tar.tgz'; //path.join(tmpdir, 'tar.tgz');
+    create(
+      {
+        file: tarball,
+        sync: true,
+      },
+      [tmpdir],
+    );
+
+    expect(loadAssemblyFromTarball(tarball, tmpdir)).toEqual(TEST_ASSEMBLY);
+  });
 });

--- a/packages/@jsii/spec/src/assembly-utils.ts
+++ b/packages/@jsii/spec/src/assembly-utils.ts
@@ -85,16 +85,17 @@ export function loadAssemblyFromTarball(
 
   // Removes leading path.sep if present (i.e '/blah/.jsii' becomes 'blah/.jsii')
   const dotJsiiFile = path.join('.', directory, SPEC_FILE_NAME);
-  const extractedDotJsiiFile = extractFileFromTarball(tarball, dotJsiiFile);
+  const compDotJsiiFile = path.join('.', directory, SPEC_FILE_NAME_COMPRESSED);
+  const extDotJsiiFile = extractFileFromTarball(tarball, dotJsiiFile, tmpdir);
 
-  let contents = readAssembly(extractedDotJsiiFile);
+  let contents = readAssembly(extDotJsiiFile);
   if (isRedirect(contents)) {
-    extractFileFromTarball(
+    const extCompDotJsiiFile = extractFileFromTarball(
       tarball,
-      path.join(directory, SPEC_FILE_NAME_COMPRESSED),
+      compDotJsiiFile,
       tmpdir,
     );
-    contents = findRedirectAssembly(extractedDotJsiiFile, contents);
+    contents = findRedirectAssembly(extCompDotJsiiFile, contents);
   }
 
   fs.removeSync(tmpdir);

--- a/packages/@jsii/spec/src/utils.ts
+++ b/packages/@jsii/spec/src/utils.ts
@@ -1,0 +1,7 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+export function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), path.basename(__filename)));
+}


### PR DESCRIPTION
Usage is demonstrated here: https://github.com/cdklabs/construct-hub/pull/920

Two implementations were considered to fit the use case in construct hub, `loadAssemblyFromBuffer` and `loadAssemblyFromTarball`. I went with loading from a buffer because it allows us to utilize prior art in construct hub for parsing tarballs, does not need an added dependency on `tar`, and causes minimal impact when refactoring the ingestion lambda to use this function.

Also includes a small refactoring of the test suite. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
