### PR TITLE
fix: jitter Docker build startup

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -82,6 +82,13 @@ jobs:
             ${{ runner.os }}-buildx-${{ hashFiles('superchain/*') }}-
             ${{ runner.os }}-buildx-
 
+      # 1 pull per second from ECR Public
+      - name: Jitter the start time to avoid ECR Public throttling
+        id: sleep-start
+        if: steps.should-run.outputs.result == 'true'
+        run: |-
+          sleep $((RANDOM % 60))
+
       - name: Determine build time
         id: build-time
         if: steps.should-run.outputs.result == 'true'


### PR DESCRIPTION
ECR Public will throttle to 1 image pull/second.

Since we start multiple workflows in parallel, make sure they don't all pull from ECR Public at the exact same time by jittering their start times.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
