### PR TITLE
chore: upgrade benchmark to aws-cdk-lib v2.31.0

### DIFF
--- a/packages/@jsii/benchmarks/lib/constants.ts
+++ b/packages/@jsii/benchmarks/lib/constants.ts
@@ -2,8 +2,8 @@ import * as path from 'node:path';
 
 export const fixturesDir = path.resolve(__dirname, '..', 'fixtures');
 
-export const cdkTagv2_21_1 = 'v2.21.1';
-export const cdkv2_21_1 = path.resolve(
+export const cdkTag = 'v2.31.0';
+export const cdk = path.resolve(
   fixturesDir,
-  `aws-cdk-lib@${cdkTagv2_21_1.replace(/\./g, '-')}.tgz`,
+  `aws-cdk-lib@${cdkTag.replace(/\./g, '-')}.tgz`,
 );

--- a/packages/@jsii/benchmarks/lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/index.ts
@@ -1,17 +1,17 @@
 import { Benchmark } from './benchmark';
-import { cdkTagv2_21_1 } from './constants';
+import { cdkTag } from './constants';
 import * as awsCdkLib from './suite/aws-cdk-lib';
 
 export const benchmarks = [
   // Reference comparison using the TypeScript compiler
-  new Benchmark(`Compile aws-cdk-lib@${cdkTagv2_21_1} (tsc)`)
+  new Benchmark(`Compile aws-cdk-lib@${cdkTag} (tsc)`)
     .setup(awsCdkLib.setup)
     .beforeEach(awsCdkLib.beforeEach)
     .teardown(awsCdkLib.teardown)
     .subject(awsCdkLib.buildWithTsc),
 
   // Always run against the same version of CDK source
-  new Benchmark(`Compile aws-cdk-lib@${cdkTagv2_21_1}`)
+  new Benchmark(`Compile aws-cdk-lib@${cdkTag}`)
     .setup(awsCdkLib.setup)
     .beforeEach(awsCdkLib.beforeEach)
     .teardown(awsCdkLib.teardown)

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
@@ -3,7 +3,7 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { cdkTagv2_21_1, cdkv2_21_1 } from '../../constants';
+import { cdkTag, cdk } from '../../constants';
 import { inDirectory, streamUntar } from '../../util';
 
 // Using the local `npm` package (from dependencies)
@@ -26,12 +26,12 @@ export async function setup(): Promise<Context> {
   const sourceDir = await fs.mkdtemp(
     path.join(os.tmpdir(), 'jsii-cdk-bench-snapshot'),
   );
-  await streamUntar(cdkv2_21_1, { cwd: sourceDir });
+  await streamUntar(cdk, { cwd: sourceDir });
   cp.execSync(`${npm} ci`, { cwd: sourceDir });
 
   // Working directory for benchmark
   const workingDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), `tsc-cdk-bench@${cdkTagv2_21_1}`),
+    path.join(os.tmpdir(), `tsc-cdk-bench@${cdkTag}`),
   );
 
   return {

--- a/packages/@jsii/benchmarks/scripts/snapshot-package.ts
+++ b/packages/@jsii/benchmarks/scripts/snapshot-package.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import * as tar from 'tar';
 import * as ts from 'typescript';
 
-import { cdkTagv2_21_1, cdkv2_21_1 } from '../lib/constants';
+import { cdkTag, cdk, fixturesDir } from '../lib/constants';
 
 // Using the local `npm` package (from dependencies)
 const npm = path.resolve(__dirname, '..', 'node_modules', '.bin', 'npm');
@@ -109,7 +109,8 @@ function snapshotAwsCdk(tag: string, file: string) {
 }
 
 function main() {
-  snapshotAwsCdk(cdkTagv2_21_1, cdkv2_21_1);
+  fs.mkdirpSync(fixturesDir);
+  snapshotAwsCdk(cdkTag, cdk);
 }
 
 main();


### PR DESCRIPTION
This is necessary as the previous benchark target had multiple occurrences
of enums with several constants having the same value, which is now illegal
in jsii code (#3207).

The fix for this (https://github.com/aws/aws-cdk/commit/7f4f150b97b5f58b936e6ed221a1b9bf67dad107) was released in CDK 2.31.0.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
