### PR TITLE
revert: do not use node: protocol for imports

### DIFF
--- a/eslint-config.yaml
+++ b/eslint-config.yaml
@@ -8,7 +8,6 @@ plugins:
   - '@typescript-eslint'
   - import
   - prettier
-  - unicorn
 
 parser: '@typescript-eslint/parser'
 parserOptions:
@@ -42,9 +41,6 @@ rules:
   # Custom Configurations
 
   'prettier/prettier':
-    - error
-
-  'unicorn/prefer-node-protocol':
     - error
 
   '@typescript-eslint/array-type':

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint-import-resolver-typescript": "^3.2.4",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-unicorn": "^43.0.0",
     "jest": "^28.1.2",
     "jest-circus": "^28.1.2",
     "jest-config": "^28.1.2",

--- a/packages/@jsii/benchmarks/bin/benchmark.ts
+++ b/packages/@jsii/benchmarks/bin/benchmark.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as yargs from 'yargs';
 
 import { benchmarks } from '../lib';

--- a/packages/@jsii/benchmarks/lib/benchmark.ts
+++ b/packages/@jsii/benchmarks/lib/benchmark.ts
@@ -1,9 +1,9 @@
-import { Profiler, Session } from 'node:inspector';
+import { Profiler, Session } from 'inspector';
 import {
   performance,
   PerformanceObserver,
   PerformanceEntry,
-} from 'node:perf_hooks';
+} from 'perf_hooks';
 
 /**
  * Result of a single run of the subject

--- a/packages/@jsii/benchmarks/lib/benchmark.ts
+++ b/packages/@jsii/benchmarks/lib/benchmark.ts
@@ -1,9 +1,5 @@
 import { Profiler, Session } from 'inspector';
-import {
-  performance,
-  PerformanceObserver,
-  PerformanceEntry,
-} from 'perf_hooks';
+import { performance, PerformanceObserver, PerformanceEntry } from 'perf_hooks';
 
 /**
  * Result of a single run of the subject

--- a/packages/@jsii/benchmarks/lib/constants.ts
+++ b/packages/@jsii/benchmarks/lib/constants.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import * as path from 'path';
 
 export const fixturesDir = path.resolve(__dirname, '..', 'fixtures');
 

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-jsii.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-jsii.ts
@@ -1,7 +1,7 @@
 import { Compiler } from 'jsii/lib/compiler';
 import { loadProjectInfo } from 'jsii/lib/project-info';
-import * as path from 'node:path';
-import * as process from 'node:process';
+import * as path from 'path';
+import * as process from 'process';
 import * as ts from 'typescript';
 
 import type { Context } from '.';

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-tsc.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/build-with-tsc.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
-import * as process from 'node:process';
+import * as path from 'path';
+import * as process from 'process';
 import * as ts from 'typescript';
 
 import type { Context } from '.';

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs-extra';
 import * as cp from 'child_process';
+import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
+++ b/packages/@jsii/benchmarks/lib/suite/aws-cdk-lib/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
-import * as cp from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
 
 import { cdkTag, cdk } from '../../constants';
 import { inDirectory, streamUntar } from '../../util';

--- a/packages/@jsii/benchmarks/scripts/snapshot-package.ts
+++ b/packages/@jsii/benchmarks/scripts/snapshot-package.ts
@@ -1,6 +1,6 @@
+import * as cp from 'child_process';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
-import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';

--- a/packages/@jsii/benchmarks/scripts/snapshot-package.ts
+++ b/packages/@jsii/benchmarks/scripts/snapshot-package.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
-import * as cp from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
 import * as tar from 'tar';
 import * as ts from 'typescript';
 

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import * as process from 'process';
 import { Range, SemVer } from 'semver';
 
 const ONE_DAY_IN_MILLISECONDS = 86_400_000;

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -1,6 +1,6 @@
 import { Chalk, bgYellow, bgYellowBright, bgRed } from 'chalk';
-import { error } from 'node:console';
-import { version } from 'node:process';
+import { error } from 'console';
+import { version } from 'process';
 
 import { NodeRelease } from './constants';
 

--- a/packages/@jsii/integ-test/test/build-cdk.test.ts
+++ b/packages/@jsii/integ-test/test/build-cdk.test.ts
@@ -1,8 +1,8 @@
 import { Octokit } from '@octokit/rest';
 import * as dotenv from 'dotenv';
 import { mkdtemp, readdir, remove } from 'fs-extra';
-import { tmpdir } from 'node:os';
-import * as path from 'node:path';
+import { tmpdir } from 'os';
+import * as path from 'path';
 
 import {
   downloadReleaseAsset,

--- a/packages/@jsii/integ-test/utils/index.ts
+++ b/packages/@jsii/integ-test/utils/index.ts
@@ -1,7 +1,7 @@
-import * as cp from 'node:child_process';
-import { IncomingMessage } from 'node:http';
-import * as https from 'node:https';
-import { Readable } from 'node:stream';
+import * as cp from 'child_process';
+import { IncomingMessage } from 'http';
+import * as https from 'https';
+import { Readable } from 'stream';
 import { extract } from 'tar';
 
 /**

--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs-extra';
 import * as childProcess from 'child_process';
+import * as fs from 'fs-extra';
 import * as os from 'os';
 import { join } from 'path';
 import * as path from 'path';

--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs-extra';
-import * as childProcess from 'node:child_process';
-import * as os from 'node:os';
-import { join } from 'node:path';
-import * as path from 'node:path';
-import * as vm from 'node:vm';
+import * as childProcess from 'child_process';
+import * as os from 'os';
+import { join } from 'path';
+import * as path from 'path';
+import * as vm from 'vm';
 
 import * as api from './api';
 import {

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -1,10 +1,10 @@
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromPath } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as cp from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as vm from 'node:vm';
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import * as vm from 'vm';
 import * as tar from 'tar';
 
 import * as api from './api';
@@ -49,7 +49,7 @@ export class Kernel {
     // I wonder if webpack has some pragma that allows opting-out at certain points
     // in the code.
     // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-    const moduleLoad = require('node:module').Module._load;
+    const moduleLoad = require('module').Module._load;
     const nodeRequire = (p: string) => moduleLoad(p, module, false);
 
     this.sandbox = vm.createContext({

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -1,11 +1,11 @@
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromPath } from '@jsii/spec';
-import * as fs from 'fs-extra';
 import * as cp from 'child_process';
+import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as vm from 'vm';
 import * as tar from 'tar';
+import * as vm from 'vm';
 
 import * as api from './api';
 import { TOKEN_REF } from './api';

--- a/packages/@jsii/kernel/src/on-exit.ts
+++ b/packages/@jsii/kernel/src/on-exit.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as process from 'node:process';
+import * as process from 'process';
 
 const removeSyncPaths = new Array<string>();
 

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -27,8 +27,8 @@
  */
 
 import * as spec from '@jsii/spec';
-import * as assert from 'node:assert';
-import { inspect } from 'node:util';
+import * as assert from 'assert';
+import { inspect } from 'util';
 
 import {
   isObjRef,

--- a/packages/@jsii/runtime/bin/jsii-runtime.ts
+++ b/packages/@jsii/runtime/bin/jsii-runtime.ts
@@ -1,10 +1,10 @@
 import '@jsii/check-node/run';
 
-import { spawn } from 'node:child_process';
-import { error } from 'node:console';
-import { constants as os } from 'node:os';
-import { resolve } from 'node:path';
-import { Duplex } from 'node:stream';
+import { spawn } from 'child_process';
+import { error } from 'console';
+import { constants as os } from 'os';
+import { resolve } from 'path';
+import { Duplex } from 'stream';
 
 // Spawn another node process, with the following file descriptor setup:
 // - No STDIN will be provided

--- a/packages/@jsii/runtime/lib/host.ts
+++ b/packages/@jsii/runtime/lib/host.ts
@@ -1,5 +1,5 @@
 import { api, Kernel } from '@jsii/kernel';
-import { EventEmitter } from 'node:events';
+import { EventEmitter } from 'events';
 
 import { Input, IInputOutput } from './in-out';
 

--- a/packages/@jsii/runtime/lib/sync-stdio.ts
+++ b/packages/@jsii/runtime/lib/sync-stdio.ts
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs';
+import * as fs from 'fs';
 
 const INPUT_BUFFER_SIZE = 1_048_576; // 1MiB (aka: 1024 * 1024), not related to max line length
 

--- a/packages/@jsii/runtime/test/kernel-host.test.ts
+++ b/packages/@jsii/runtime/test/kernel-host.test.ts
@@ -1,9 +1,9 @@
 import { api } from '@jsii/kernel';
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromPath } from '@jsii/spec';
-import * as child from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import * as child from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { KernelHost, IInputOutput, Input, Output } from '../lib';
 

--- a/packages/@jsii/runtime/test/playback.test.ts
+++ b/packages/@jsii/runtime/test/playback.test.ts
@@ -1,7 +1,7 @@
-import * as child from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as child from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 import { IInputOutput, Input, KernelHost, Output } from '../lib';
 

--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as zlib from 'node:zlib';
+import * as os from 'os';
+import * as path from 'path';
+import * as zlib from 'zlib';
 
 import {
   SPEC_FILE_NAME,

--- a/packages/@jsii/spec/src/assembly-utils.ts
+++ b/packages/@jsii/spec/src/assembly-utils.ts
@@ -1,6 +1,6 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as zlib from 'node:zlib';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as zlib from 'zlib';
 
 import {
   Assembly,

--- a/packages/@jsii/spec/src/validate-assembly.test.ts
+++ b/packages/@jsii/spec/src/validate-assembly.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve } from 'path';
 
 import { validateAssembly } from './validate-assembly';
 

--- a/packages/codemaker/src/codemaker.test.ts
+++ b/packages/codemaker/src/codemaker.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import { CodeMaker } from './codemaker';
 

--- a/packages/codemaker/src/codemaker.ts
+++ b/packages/codemaker/src/codemaker.ts
@@ -1,4 +1,4 @@
-import * as util from 'node:util';
+import * as util from 'util';
 
 import * as caseutils from './case-utils';
 import FileBuffer from './filebuff';

--- a/packages/codemaker/src/filebuff.test.ts
+++ b/packages/codemaker/src/filebuff.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import FileBuffer from './filebuff';
 

--- a/packages/codemaker/src/filebuff.ts
+++ b/packages/codemaker/src/filebuff.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import * as path from 'path';
 
 /**
  * Buffers the text of a file for later saving.

--- a/packages/jsii-calc/lib/cdk16625/index.ts
+++ b/packages/jsii-calc/lib/cdk16625/index.ts
@@ -1,4 +1,4 @@
-import * as assert from 'node:assert';
+import * as assert from 'assert';
 
 import { IRandomNumberGenerator } from '../calculator';
 import { UnimportedSubmoduleType } from './donotimport';

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -8,11 +8,11 @@ import {
   StructWithOnlyOptionals,
   NumericValue,
 } from '@scope/jsii-calc-lib';
-import * as crypto from 'node:crypto';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import { promisify } from 'node:util';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
 
 import {
   IFriendlyRandomGenerator,

--- a/packages/jsii-calc/test/test.calc.ts
+++ b/packages/jsii-calc/test/test.calc.ts
@@ -1,5 +1,5 @@
 import * as calcLib from '@scope/jsii-calc-lib';
-import * as assert from 'node:assert';
+import * as assert from 'assert';
 
 import {
   Add,

--- a/packages/jsii-calc/test/test.transitive.ts
+++ b/packages/jsii-calc/test/test.transitive.ts
@@ -2,9 +2,9 @@
 // take a direct dependency on @scope/jsii-calc-base-of-base, which is intended
 // to only be used as a transitive dependency through @scope/jsii-calc-base.
 
-import * as assert from 'node:assert';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import * as assert from 'assert';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const pkgjsonPath = join(__dirname, '..', 'package.json');
 const pkgjson = JSON.parse(readFileSync(pkgjsonPath, 'utf-8'));

--- a/packages/jsii-config/bin/jsii-config.ts
+++ b/packages/jsii-config/bin/jsii-config.ts
@@ -1,7 +1,7 @@
 import '@jsii/check-node/run';
 
-import { writeFile } from 'node:fs';
-import { promisify } from 'node:util';
+import { writeFile } from 'fs';
+import { promisify } from 'util';
 import * as yargs from 'yargs';
 
 import jsiiConfig from '../lib';

--- a/packages/jsii-config/lib/util.ts
+++ b/packages/jsii-config/lib/util.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs';
+import { readFile } from 'fs';
 
 /*
  * Look for existing nested values in config, return undefined if not found

--- a/packages/jsii-config/test/index.test.ts
+++ b/packages/jsii-config/test/index.test.ts
@@ -1,5 +1,5 @@
-import * as inquirer from 'inquirer';
 import * as fs from 'fs';
+import * as inquirer from 'inquirer';
 
 import jsiiConfig from '../lib';
 import { packageJsonObject, findQuestions, findQuestion } from './util';

--- a/packages/jsii-config/test/index.test.ts
+++ b/packages/jsii-config/test/index.test.ts
@@ -1,5 +1,5 @@
 import * as inquirer from 'inquirer';
-import * as fs from 'node:fs';
+import * as fs from 'fs';
 
 import jsiiConfig from '../lib';
 import { packageJsonObject, findQuestions, findQuestion } from './util';

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -1,9 +1,9 @@
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as childProcess from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as util from 'node:util';
+import * as childProcess from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import * as util from 'util';
 
 const LOG = log4js.getLogger('jsii-diff');
 

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -1,6 +1,6 @@
+import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as childProcess from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';

--- a/packages/jsii-pacmak/lib/builder.ts
+++ b/packages/jsii-pacmak/lib/builder.ts
@@ -1,5 +1,5 @@
 import { Rosetta } from 'jsii-rosetta';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import * as logging from './logging';
 import { JsiiModule } from './packaging';

--- a/packages/jsii-pacmak/lib/dependency-graph.ts
+++ b/packages/jsii-pacmak/lib/dependency-graph.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { join } from 'node:path';
+import { join } from 'path';
 
 import * as util from './util';
 

--- a/packages/jsii-pacmak/lib/generator.ts
+++ b/packages/jsii-pacmak/lib/generator.ts
@@ -1,9 +1,9 @@
 import * as spec from '@jsii/spec';
 import * as clone from 'clone';
 import { CodeMaker } from 'codemaker';
+import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
-import * as crypto from 'crypto';
 import * as path from 'path';
 
 import { VERSION_DESC } from './version';

--- a/packages/jsii-pacmak/lib/generator.ts
+++ b/packages/jsii-pacmak/lib/generator.ts
@@ -3,8 +3,8 @@ import * as clone from 'clone';
 import { CodeMaker } from 'codemaker';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
-import * as crypto from 'node:crypto';
-import * as path from 'node:path';
+import * as crypto from 'crypto';
+import * as path from 'path';
 
 import { VERSION_DESC } from './version';
 

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -1,7 +1,7 @@
 import { TypeSystem } from 'jsii-reflect';
 import { Rosetta, UnknownSnippetMode } from 'jsii-rosetta';
-import { resolve } from 'node:path';
-import { cwd } from 'node:process';
+import { resolve } from 'path';
+import { cwd } from 'process';
 
 import * as logging from './logging';
 import { findJsiiModules, updateAllNpmIgnores } from './npm-modules';

--- a/packages/jsii-pacmak/lib/npm-modules.ts
+++ b/packages/jsii-pacmak/lib/npm-modules.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import * as logging from '../lib/logging';
 import { JsiiModule } from './packaging';

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -1,6 +1,6 @@
 import type { Assembly, TypeSystem } from 'jsii-reflect';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import * as logging from '../lib/logging';
 import { Scratch, shell } from './util';

--- a/packages/jsii-pacmak/lib/target.ts
+++ b/packages/jsii-pacmak/lib/target.ts
@@ -2,7 +2,7 @@ import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import { Rosetta } from 'jsii-rosetta';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as spdx from 'spdx-license-list/full';
 
 import { traverseDependencyGraph } from './dependency-graph';

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as xmlbuilder from 'xmlbuilder';
 
 import { TargetBuilder, BuildOptions } from '../builder';

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetgenerator.ts
@@ -3,7 +3,7 @@ import * as clone from 'clone';
 import * as fs from 'fs-extra';
 import * as reflect from 'jsii-reflect';
 import { Rosetta } from 'jsii-rosetta';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { Generator, Legalese } from '../../generator';
 import { MethodDefinition, PropertyDefinition } from '../_utils';

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -1,6 +1,6 @@
 import { Assembly } from '@jsii/spec';
 import { CodeMaker } from 'codemaker';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as xmlbuilder from 'xmlbuilder';
 
 import { TargetName } from '..';

--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -2,7 +2,7 @@ import { CodeMaker } from 'codemaker';
 import * as fs from 'fs-extra';
 import { Assembly } from 'jsii-reflect';
 import { Rosetta } from 'jsii-rosetta';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { IGenerator, Legalese } from '../generator';
 import * as logging from '../logging';

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -5,7 +5,7 @@ import {
   Type,
   Submodule as JsiiSubmodule,
 } from 'jsii-reflect';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join } from 'path';
 import * as semver from 'semver';
 
 import { VERSION } from '../../version';

--- a/packages/jsii-pacmak/lib/targets/go/types/struct.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/struct.ts
@@ -1,6 +1,6 @@
 import { CodeMaker } from 'codemaker';
 import { InterfaceType } from 'jsii-reflect';
-import * as assert from 'node:assert';
+import * as assert from 'assert';
 
 import { SpecialDependencies } from '../dependencies';
 import { EmitContext } from '../emit-context';

--- a/packages/jsii-pacmak/lib/targets/go/types/struct.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/struct.ts
@@ -1,6 +1,6 @@
+import * as assert from 'assert';
 import { CodeMaker } from 'codemaker';
 import { InterfaceType } from 'jsii-reflect';
-import * as assert from 'assert';
 
 import { SpecialDependencies } from '../dependencies';
 import { EmitContext } from '../emit-context';

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -10,7 +10,7 @@ import {
   markDownToJavaDoc,
   ApiLocation,
 } from 'jsii-rosetta';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as xmlbuilder from 'xmlbuilder';
 
 import { TargetBuilder, BuildOptions } from '../builder';

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1,4 +1,5 @@
 import * as spec from '@jsii/spec';
+import * as assert from 'assert';
 import { CodeMaker, toSnakeCase } from 'codemaker';
 import * as escapeStringRegexp from 'escape-string-regexp';
 import * as fs from 'fs-extra';
@@ -9,7 +10,6 @@ import {
   enforcesStrictMode,
   ApiLocation,
 } from 'jsii-rosetta';
-import * as assert from 'assert';
 import * as path from 'path';
 
 import { Generator, GeneratorOptions } from '../generator';

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -9,8 +9,8 @@ import {
   enforcesStrictMode,
   ApiLocation,
 } from 'jsii-rosetta';
-import * as assert from 'node:assert';
-import * as path from 'node:path';
+import * as assert from 'assert';
+import * as path from 'path';
 
 import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -12,7 +12,7 @@ import {
   Type,
 } from '@jsii/spec';
 import { toSnakeCase } from 'codemaker';
-import { createHash } from 'node:crypto';
+import { createHash } from 'crypto';
 
 import { die, toPythonIdentifier } from './util';
 

--- a/packages/jsii-pacmak/lib/targets/version-utils.ts
+++ b/packages/jsii-pacmak/lib/targets/version-utils.ts
@@ -1,5 +1,5 @@
-import { inspect } from 'util';
 import { Comparator, Range, parse } from 'semver';
+import { inspect } from 'util';
 
 import { TargetName } from '.';
 

--- a/packages/jsii-pacmak/lib/targets/version-utils.ts
+++ b/packages/jsii-pacmak/lib/targets/version-utils.ts
@@ -1,4 +1,4 @@
-import { inspect } from 'node:util';
+import { inspect } from 'util';
 import { Comparator, Range, parse } from 'semver';
 
 import { TargetName } from '.';

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
-import { spawn, SpawnOptions } from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import { spawn, SpawnOptions } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
 
 import * as logging from './logging';
 
@@ -45,7 +45,7 @@ export async function findDependencyDirectory(
  */
 export function isBuiltinModule(depName: string) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-  const { builtinModules } = require('node:module');
+  const { builtinModules } = require('module');
   return (builtinModules ?? []).includes(depName);
 }
 

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs-extra';
 import { spawn, SpawnOptions } from 'child_process';
+import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 

--- a/packages/jsii-pacmak/test/dependency-graph.test.ts
+++ b/packages/jsii-pacmak/test/dependency-graph.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { Callback, traverseDependencyGraph } from '../lib/dependency-graph';
 

--- a/packages/jsii-pacmak/test/generated-code/all-targets-tested.test.ts
+++ b/packages/jsii-pacmak/test/generated-code/all-targets-tested.test.ts
@@ -1,5 +1,5 @@
 import { pathExists, readFile } from 'fs-extra';
-import { join, relative, resolve } from 'node:path';
+import { join, relative, resolve } from 'path';
 
 import { TargetName } from '../../lib/targets';
 

--- a/packages/jsii-pacmak/test/generated-code/examples.test.ts
+++ b/packages/jsii-pacmak/test/generated-code/examples.test.ts
@@ -1,8 +1,8 @@
 import { AssemblyTargets, SPEC_FILE_NAME } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as jsii from 'jsii';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import * as pacmak from '../../lib';
 import { checkTree, TREE } from './harness';

--- a/packages/jsii-pacmak/test/generated-code/harness.ts
+++ b/packages/jsii-pacmak/test/generated-code/harness.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as process from 'node:process';
+import * as os from 'os';
+import * as path from 'path';
+import * as process from 'process';
 
 import { pacmak, TargetName } from '../../lib';
 import { shell } from '../../lib/util';

--- a/packages/jsii-pacmak/test/generated-code/prerelease-identifiers.test.ts
+++ b/packages/jsii-pacmak/test/generated-code/prerelease-identifiers.test.ts
@@ -1,8 +1,8 @@
 import { Assembly, SchemaVersion, SPEC_FILE_NAME } from '@jsii/spec';
 import { toPascalCase } from 'codemaker';
 import * as fs from 'fs-extra';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { pacmak } from '../../lib';
 import { checkTree, TREE } from './harness';

--- a/packages/jsii-pacmak/test/npm-modules.test.ts
+++ b/packages/jsii-pacmak/test/npm-modules.test.ts
@@ -1,6 +1,6 @@
 import { mkdirp, mkdtemp, remove, writeJson } from 'fs-extra';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { findJsiiModules } from '../lib/npm-modules';
 import { flatten } from '../lib/util';

--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -1,6 +1,6 @@
 import { findAssemblyFile, loadAssemblyFromFile } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { Assembly } from './assembly';
 import { ClassType } from './class';

--- a/packages/jsii-reflect/lib/util.ts
+++ b/packages/jsii-reflect/lib/util.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 export function indexBy<T>(xs: T[], f: (x: T) => string): { [key: string]: T } {
   const ret: { [key: string]: T } = {};
@@ -49,7 +49,7 @@ export async function findDependencyDirectory(
  */
 export function isBuiltinModule(depName: string) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-  const { builtinModules } = require('node:module');
+  const { builtinModules } = require('module');
   return (builtinModules ?? []).includes(depName);
 }
 

--- a/packages/jsii-reflect/test/jsii-tree.test.ts
+++ b/packages/jsii-reflect/test/jsii-tree.test.ts
@@ -1,6 +1,6 @@
-import * as childProcess from 'node:child_process';
-import * as path from 'node:path';
-import { promisify } from 'node:util';
+import * as childProcess from 'child_process';
+import * as path from 'path';
+import { promisify } from 'util';
 
 const exec = promisify(childProcess.exec);
 

--- a/packages/jsii-reflect/test/tree.test.ts
+++ b/packages/jsii-reflect/test/tree.test.ts
@@ -1,5 +1,5 @@
-import { dirname } from 'path';
 import { Printer } from 'oo-ascii-tree';
+import { dirname } from 'path';
 
 import { TypeSystemTree } from '../lib/tree';
 import { TypeSystem } from '../lib/type-system';

--- a/packages/jsii-reflect/test/tree.test.ts
+++ b/packages/jsii-reflect/test/tree.test.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname } from 'path';
 import { Printer } from 'oo-ascii-tree';
 
 import { TypeSystemTree } from '../lib/tree';

--- a/packages/jsii-reflect/test/type-system.test.ts
+++ b/packages/jsii-reflect/test/type-system.test.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import { Stability } from '@jsii/spec';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { TypeSystem } from '../lib';
 import { typeSystemFromSource, assemblyFromSource } from './util';

--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -1,7 +1,7 @@
 import '@jsii/check-node/run';
 
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as yargs from 'yargs';
 
 import { TranslateResult, translateTypeScript, RosettaDiagnostic } from '../lib';

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { loadAssemblies, allTypeScriptSnippets, loadAllDefaultTablets } from '../jsii/assemblies';
 import * as logging from '../logging';

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import {
   loadAssemblies,

--- a/packages/jsii-rosetta/lib/commands/transliterate.ts
+++ b/packages/jsii-rosetta/lib/commands/transliterate.ts
@@ -1,6 +1,6 @@
 import { Assembly, Docs, SPEC_FILE_NAME, Type, TypeKind, loadAssemblyFromPath } from '@jsii/spec';
 import { writeJson } from 'fs-extra';
-import { resolve } from 'node:path';
+import { resolve } from 'path';
 
 import { TargetLanguage } from '../languages';
 import { targetName } from '../languages/target-language';

--- a/packages/jsii-rosetta/lib/find-utils.ts
+++ b/packages/jsii-rosetta/lib/find-utils.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 /**
  * Find the directory that contains a given dependency, identified by its 'package.json', from a starting search directory
@@ -77,6 +77,6 @@ export function findUp(
  */
 export function isBuiltinModule(depName: string) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-  const { builtinModules } = require('node:module');
+  const { builtinModules } = require('module');
   return (builtinModules ?? []).includes(depName);
 }

--- a/packages/jsii-rosetta/lib/fixtures.ts
+++ b/packages/jsii-rosetta/lib/fixtures.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import { createSourceFile, ScriptKind, ScriptTarget, SyntaxKind } from 'typescript';
 
 import { TypeScriptSnippet, SnippetParameters, ApiLocation } from './snippet';

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -1,8 +1,8 @@
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromFile, loadAssemblyFromPath, findAssemblyFile, writeAssembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as crypto from 'node:crypto';
-import * as path from 'node:path';
+import * as crypto from 'crypto';
+import * as path from 'path';
 
 import { findDependencyDirectory, isBuiltinModule } from '../find-utils';
 import { fixturize } from '../fixtures';

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -1,7 +1,7 @@
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromFile, loadAssemblyFromPath, findAssemblyFile, writeAssembly } from '@jsii/spec';
-import * as fs from 'fs-extra';
 import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { findDependencyDirectory, isBuiltinModule } from '../find-utils';

--- a/packages/jsii-rosetta/lib/jsii/fingerprinting.ts
+++ b/packages/jsii-rosetta/lib/jsii/fingerprinting.ts
@@ -1,5 +1,5 @@
 import * as spec from '@jsii/spec';
-import * as crypto from 'node:crypto';
+import * as crypto from 'crypto';
 
 /**
  * Return a fingerprint for a type.

--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -1,6 +1,6 @@
 // import { JsiiSymbol, simpleName, namespaceName } from '../jsii/jsii-utils';
 // import { jsiiTargetParameter } from '../jsii/packages';
-import { AssertionError } from 'node:assert';
+import { AssertionError } from 'assert';
 import * as ts from 'typescript';
 
 import { analyzeObjectLiteral, determineJsiiType, JsiiType, ObjectLiteralStruct } from '../jsii/jsii-types';

--- a/packages/jsii-rosetta/lib/languages/target-language.ts
+++ b/packages/jsii-rosetta/lib/languages/target-language.ts
@@ -1,4 +1,4 @@
-import * as assert from 'node:assert';
+import * as assert from 'assert';
 
 export enum TargetLanguage {
   PYTHON = 'python',

--- a/packages/jsii-rosetta/lib/logging.ts
+++ b/packages/jsii-rosetta/lib/logging.ts
@@ -1,4 +1,4 @@
-import * as util from 'node:util';
+import * as util from 'util';
 
 export enum Level {
   ERROR = -2,

--- a/packages/jsii-rosetta/lib/rosetta-reader.ts
+++ b/packages/jsii-rosetta/lib/rosetta-reader.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { allTypeScriptSnippets } from './jsii/assemblies';
 import { TargetLanguage } from './languages';

--- a/packages/jsii-rosetta/lib/snippet-dependencies.ts
+++ b/packages/jsii-rosetta/lib/snippet-dependencies.ts
@@ -1,6 +1,6 @@
+import * as cp from 'child_process';
 import * as fastGlob from 'fast-glob';
 import * as fs from 'fs-extra';
-import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/packages/jsii-rosetta/lib/snippet-dependencies.ts
+++ b/packages/jsii-rosetta/lib/snippet-dependencies.ts
@@ -1,8 +1,8 @@
 import * as fastGlob from 'fast-glob';
 import * as fs from 'fs-extra';
-import * as cp from 'node:child_process';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as cp from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
 import * as semver from 'semver';
 import { intersect } from 'semver-intersect';
 

--- a/packages/jsii-rosetta/lib/tablets/key.ts
+++ b/packages/jsii-rosetta/lib/tablets/key.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'node:crypto';
+import * as crypto from 'crypto';
 
 import { RecordReferencesVisitor } from '../languages/record-references';
 import { TypeScriptSnippet, renderApiLocation } from '../snippet';

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { TargetLanguage } from '../languages';
 import * as logging from '../logging';

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -1,4 +1,4 @@
-import { inspect } from 'node:util';
+import { inspect } from 'util';
 import * as ts from 'typescript';
 
 import { TARGET_LANGUAGES, TargetLanguage } from './languages';

--- a/packages/jsii-rosetta/lib/translate.ts
+++ b/packages/jsii-rosetta/lib/translate.ts
@@ -1,5 +1,5 @@
-import { inspect } from 'util';
 import * as ts from 'typescript';
+import { inspect } from 'util';
 
 import { TARGET_LANGUAGES, TargetLanguage } from './languages';
 import { RecordReferencesVisitor } from './languages/record-references';

--- a/packages/jsii-rosetta/lib/translate_all.ts
+++ b/packages/jsii-rosetta/lib/translate_all.ts
@@ -1,5 +1,5 @@
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 import * as workerpool from 'workerpool';
 
 import * as logging from './logging';

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -1,7 +1,7 @@
 import { SPEC_FILE_NAME_COMPRESSED } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import { compileJsiiForTest } from 'jsii';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import {
   LanguageTablet,

--- a/packages/jsii-rosetta/test/commands/infuse.test.ts
+++ b/packages/jsii-rosetta/test/commands/infuse.test.ts
@@ -1,6 +1,6 @@
 import { loadAssemblyFromPath } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
 import { extractSnippets } from '../../lib/commands/extract';

--- a/packages/jsii-rosetta/test/commands/transliterate.test.ts
+++ b/packages/jsii-rosetta/test/commands/transliterate.test.ts
@@ -1,7 +1,7 @@
 import { Assembly, SPEC_FILE_NAME, writeAssembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as jsii from 'jsii';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { extractSnippets } from '../../lib/commands/extract';
 import { transliterateAssembly } from '../../lib/commands/transliterate';

--- a/packages/jsii-rosetta/test/commands/trim-cache.test.ts
+++ b/packages/jsii-rosetta/test/commands/trim-cache.test.ts
@@ -1,4 +1,4 @@
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { TranslatedSnippet, typeScriptSnippetFromVisibleSource, LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
 import { extractSnippets } from '../../lib/commands/extract';

--- a/packages/jsii-rosetta/test/jsii/assemblies.test.ts
+++ b/packages/jsii-rosetta/test/jsii/assemblies.test.ts
@@ -1,7 +1,7 @@
 import * as spec from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as mockfs from 'mock-fs';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { allTypeScriptSnippets } from '../../lib/jsii/assemblies';
 import { SnippetParameters } from '../../lib/snippet';

--- a/packages/jsii-rosetta/test/testutil.ts
+++ b/packages/jsii-rosetta/test/testutil.ts
@@ -1,8 +1,8 @@
 import { Assembly, writeAssembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import { PackageInfo, compileJsiiForTest, TestWorkspace } from 'jsii';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import {
   SnippetTranslator,

--- a/packages/jsii-rosetta/test/translations.test.ts
+++ b/packages/jsii-rosetta/test/translations.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 import { SnippetTranslator } from '../lib';
 import { TARGET_LANGUAGES, TargetLanguage, VisitorFactory } from '../lib/languages';

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -2,8 +2,8 @@ import '@jsii/check-node/run';
 
 import * as log4js from 'log4js';
 import * as path from 'path';
-import * as util from 'util';
 import { version as tsVersion } from 'typescript/package.json';
+import * as util from 'util';
 import * as yargs from 'yargs';
 
 import { Compiler } from '../lib/compiler';

--- a/packages/jsii/bin/jsii.ts
+++ b/packages/jsii/bin/jsii.ts
@@ -1,8 +1,8 @@
 import '@jsii/check-node/run';
 
 import * as log4js from 'log4js';
-import * as path from 'node:path';
-import * as util from 'node:util';
+import * as path from 'path';
+import * as util from 'util';
 import { version as tsVersion } from 'typescript/package.json';
 import * as yargs from 'yargs';
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -1,10 +1,10 @@
 import * as spec from '@jsii/spec';
 import { writeAssembly, SPEC_FILE_NAME, PackageJson } from '@jsii/spec';
 import * as chalk from 'chalk';
+import * as crypto from 'crypto';
 import * as deepEqual from 'fast-deep-equal/es6';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import * as ts from 'typescript';
 

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -4,8 +4,8 @@ import * as chalk from 'chalk';
 import * as deepEqual from 'fast-deep-equal/es6';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as crypto from 'node:crypto';
-import * as path from 'node:path';
+import * as crypto from 'crypto';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import * as Case from './case';

--- a/packages/jsii/lib/compiler.ts
+++ b/packages/jsii/lib/compiler.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { Assembler } from './assembler';
@@ -553,7 +553,7 @@ export class Compiler implements Emitter {
    */
   private findMonorepoPeerTsconfig(depName: string): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-    const { builtinModules } = require('node:module');
+    const { builtinModules } = require('module');
     if ((builtinModules ?? []).includes(depName)) {
       // Can happen for modules like 'punycode' which are declared as dependency for polyfill purposes
       return undefined;

--- a/packages/jsii/lib/helpers.ts
+++ b/packages/jsii/lib/helpers.ts
@@ -9,8 +9,8 @@
 import * as spec from '@jsii/spec';
 import { PackageJson, loadAssemblyFromPath, writeAssembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 import { DiagnosticCategory } from 'typescript';
 
 import { Compiler, CompilerOptions } from './compiler';

--- a/packages/jsii/lib/literate.ts
+++ b/packages/jsii/lib/literate.ts
@@ -57,7 +57,7 @@
  *     ```
  */
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 
 /**
  * Convert an annotated TypeScript source file to MarkDown

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -2,7 +2,7 @@ import * as spec from '@jsii/spec';
 import { findAssemblyFile, loadAssemblyFromFile } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as semver from 'semver';
 import * as ts from 'typescript';
 

--- a/packages/jsii/lib/symbol-id.ts
+++ b/packages/jsii/lib/symbol-id.ts
@@ -1,6 +1,6 @@
 import { Assembly } from '@jsii/spec';
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { findUp } from './utils';

--- a/packages/jsii/lib/transforms/deprecated-remover.ts
+++ b/packages/jsii/lib/transforms/deprecated-remover.ts
@@ -17,7 +17,7 @@ import {
   Stability,
   TypeReference,
 } from '@jsii/spec';
-import { basename, dirname, relative } from 'node:path';
+import { basename, dirname, relative } from 'path';
 import * as ts from 'typescript';
 
 import { JsiiDiagnostic } from '../jsii-diagnostic';

--- a/packages/jsii/lib/transforms/deprecation-warnings.ts
+++ b/packages/jsii/lib/transforms/deprecation-warnings.ts
@@ -1,7 +1,7 @@
 import * as spec from '@jsii/spec';
 import { Assembly } from '@jsii/spec';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { ProjectInfo } from '../project-info';

--- a/packages/jsii/lib/utils.ts
+++ b/packages/jsii/lib/utils.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as log4js from 'log4js';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { JsiiDiagnostic } from './jsii-diagnostic';

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as deepEqual from 'fast-deep-equal';
-import * as assert from 'node:assert';
+import * as assert from 'assert';
 import * as ts from 'typescript';
 
 import * as Case from './case';

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -1,6 +1,6 @@
 import * as spec from '@jsii/spec';
-import * as deepEqual from 'fast-deep-equal';
 import * as assert from 'assert';
+import * as deepEqual from 'fast-deep-equal';
 import * as ts from 'typescript';
 
 import * as Case from './case';

--- a/packages/jsii/test/compiler.test.ts
+++ b/packages/jsii/test/compiler.test.ts
@@ -12,8 +12,8 @@ import {
   readFileSync,
   readJsonSync,
 } from 'fs-extra';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 import { Compiler } from '../lib/compiler';
 import { ProjectInfo } from '../lib/project-info';

--- a/packages/jsii/test/deprecated-remover.test.ts
+++ b/packages/jsii/test/deprecated-remover.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 
 import { compileJsiiForTest, HelperCompilationResult } from '../lib';
 

--- a/packages/jsii/test/deprecation-warnings.test.ts
+++ b/packages/jsii/test/deprecation-warnings.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as vm from 'node:vm';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vm from 'vm';
 
 import { compileJsiiForTest, HelperCompilationResult } from '../lib';
 import { Compiler } from '../lib/compiler';

--- a/packages/jsii/test/negatives.test.ts
+++ b/packages/jsii/test/negatives.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import * as path from 'node:path';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { Compiler } from '../lib/compiler';

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -2,8 +2,8 @@ import * as spec from '@jsii/spec';
 import { writeAssembly } from '@jsii/spec';
 import * as clone from 'clone';
 import * as fs from 'fs-extra';
-import * as os from 'node:os';
-import * as path from 'node:path';
+import * as os from 'os';
+import * as path from 'path';
 import * as ts from 'typescript';
 
 import { loadProjectInfo } from '../lib/project-info';

--- a/packages/oo-ascii-tree/src/tree.test.ts
+++ b/packages/oo-ascii-tree/src/tree.test.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'node:fs';
-import * as path from 'node:path';
+import { promises as fs } from 'fs';
+import * as path from 'path';
 
 import { AsciiTree } from './ascii-tree';
 

--- a/tools/jsii-compliance/report.ts
+++ b/tools/jsii-compliance/report.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx ts-node
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import * as schema from './schema';
 import { suite } from './suite';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,11 +2595,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-builtin-modules@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
-  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
-
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
@@ -2754,7 +2749,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0, ci-info@^3.3.2:
+ci-info@^3.2.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
@@ -2770,13 +2765,6 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
-
-clean-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
-  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -3582,26 +3570,6 @@ eslint-plugin-prettier@^4.2.1:
   integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
-
-eslint-plugin-unicorn@^43.0.0:
-  version "43.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-43.0.0.tgz#c26fdfd146036b3f7951fa0f8c9af2b81bd87096"
-  integrity sha512-Z/6HX8yry+zAjo4jHHTAbe1rfniox7qgmCReGBfTc/CVgotfScaMCc4dtSSTHlJ+7Yix5o6LPXzwwpuGGFricg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
-    ci-info "^3.3.2"
-    clean-regexp "^1.0.0"
-    eslint-utils "^3.0.0"
-    esquery "^1.4.0"
-    indent-string "^4.0.0"
-    is-builtin-module "^3.1.0"
-    lodash "^4.17.21"
-    pluralize "^8.0.0"
-    read-pkg-up "^7.0.1"
-    regexp-tree "^0.1.24"
-    safe-regex "^2.1.1"
-    semver "^7.3.7"
-    strip-indent "^3.0.0"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -4472,13 +4440,6 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
-
-is-builtin-module@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.1.0.tgz#6fdb24313b1c03b75f8b9711c0feb8c30b903b00"
-  integrity sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==
-  dependencies:
-    builtin-modules "^3.0.0"
 
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
@@ -5444,7 +5405,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6494,11 +6455,6 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pluralize@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -6796,11 +6752,6 @@ regenerator-runtime@^0.13.4:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
-regexp-tree@^0.1.24, regexp-tree@~0.1.1:
-  version "0.1.24"
-  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
-  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
-
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -6926,13 +6877,6 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-regex@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-2.1.1.tgz#f7128f00d056e2fe5c11e81a1324dd974aadced2"
-  integrity sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==
-  dependencies:
-    regexp-tree "~0.1.1"
 
 safe-stable-stringify@^2.2.0:
   version "2.3.1"


### PR DESCRIPTION
It requires node 14.18.0 or greater, which is way more recent than
the earliest node engine we claim to support.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
