### PR TITLE
feat(rosetta): tablets can be compressed

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -228,6 +228,12 @@ function main() {
             describe: 'Ignore missing fixtures and literate markdown files instead of failing',
             type: 'boolean',
           })
+          .options('compress-tablet', {
+            alias: 'z',
+            type: 'boolean',
+            describe: 'Compress the resulting tablet file',
+            default: false,
+          })
           .conflicts('loose', 'strict')
           .conflicts('loose', 'fail'),
       wrapHandler(async (args) => {
@@ -252,6 +258,7 @@ function main() {
           cacheToFile: absCacheTo,
           trimCache: args['trim-cache'],
           loose: args.loose,
+          compressTablet: args['compress-tablet'],
         };
 
         const result = args.infuse

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -170,7 +170,7 @@ export async function extractSnippets(
 
         const asmTablet = new LanguageTablet();
         asmTablet.addSnippets(...translations);
-        await asmTablet.save(asmTabletFile);
+        await asmTablet.save(asmTabletFile, options.compressTablet);
       }),
     );
   }

--- a/packages/jsii-rosetta/lib/commands/extract.ts
+++ b/packages/jsii-rosetta/lib/commands/extract.ts
@@ -5,7 +5,7 @@ import * as logging from '../logging';
 import { RosettaTranslator, RosettaTranslatorOptions } from '../rosetta-translator';
 import { TypeScriptSnippet, SnippetParameters } from '../snippet';
 import { snippetKey } from '../tablets/key';
-import { LanguageTablet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
+import { LanguageTablet, DEFAULT_TABLET_NAME, DEFAULT_TABLET_NAME_COMPRESSED } from '../tablets/tablets';
 import { RosettaDiagnostic } from '../translate';
 import { groupBy, isDefined } from '../util';
 import { infuse } from './infuse';
@@ -73,6 +73,13 @@ export interface ExtractOptions {
    * @default false
    */
   readonly allowDirtyTranslations?: boolean;
+
+  /**
+   * Compress the resulting tablet file
+   *
+   * @default false
+   */
+  readonly compressTablet?: boolean;
 }
 
 export async function extractAndInfuse(assemblyLocations: string[], options: ExtractOptions): Promise<ExtractResult> {
@@ -154,7 +161,10 @@ export async function extractSnippets(
   if (options.writeToImplicitTablets ?? true) {
     await Promise.all(
       Object.entries(snippetsPerAssembly).map(async ([location, snips]) => {
-        const asmTabletFile = path.join(location, DEFAULT_TABLET_NAME);
+        const asmTabletFile = path.join(
+          location,
+          options.compressTablet ? DEFAULT_TABLET_NAME_COMPRESSED : DEFAULT_TABLET_NAME,
+        );
         logging.debug(`Writing ${snips.length} translations to ${asmTabletFile}`);
         const translations = snips.map(({ key }) => translator.tablet.tryGetSnippet(key)).filter(isDefined);
 

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -12,7 +12,14 @@ import { TabletSchema, TranslatedSnippetSchema, ORIGINAL_SNIPPET_KEY } from './s
 // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
 const TOOL_VERSION = require('../../package.json').version;
 
+/**
+ * The default name of the tablet file
+ */
 export const DEFAULT_TABLET_NAME = '.jsii.tabl.json';
+
+/**
+ * The default name of the compressed tablet file
+ */
 export const DEFAULT_TABLET_NAME_COMPRESSED = '.jsii.tabl.json.gz';
 
 export const CURRENT_SCHEMA_VERSION = '2';

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -174,7 +174,7 @@ export class LanguageTablet {
   public async save(filename: string, compress = false) {
     await fs.mkdirp(path.dirname(filename));
 
-    let schema = Buffer.from(JSON.stringify(this.toSchema()));
+    let schema = Buffer.from(JSON.stringify(this.toSchema(), null, 2));
     if (compress) {
       schema = zlib.gzipSync(schema);
     }

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -73,6 +73,19 @@ test('extract samples from test assembly', async () => {
   expect(tablet.snippetKeys.length).toEqual(1);
 });
 
+test('extract can save/load compressed tablets', async () => {
+  const compressedCacheFile = path.join(assembly.moduleDirectory, 'test.tabl.gz');
+  await extract.extractSnippets([assembly.moduleDirectory], {
+    cacheToFile: compressedCacheFile,
+    ...defaultExtractOptions,
+  });
+
+  const tablet = new LanguageTablet();
+  await tablet.load(compressedCacheFile);
+
+  expect(tablet.snippetKeys.length).toEqual(1);
+});
+
 test('extract works from compressed test assembly', async () => {
   const compressedAssembly = TestJsiiModule.fromSource(
     {


### PR DESCRIPTION
Usage: `yarn rosetta extract --compress-tablet`

This should reduce the `.jsii.tabl.json` size by about 90%.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
