### PR TITLE
chore(kernel): remove unnecessary v8 sandbox

### DIFF
--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as tar from 'tar';
-import * as vm from 'vm';
 
 import * as api from './api';
 import { TOKEN_REF } from './api';
@@ -28,8 +27,6 @@ export class Kernel {
   private syncInProgress?: string; // forbids async calls (begin) while processing sync calls (get/set/invoke)
   private installDir?: string;
 
-  private readonly sandbox: vm.Context;
-
   /**
    * Creates a jsii kernel object.
    *
@@ -37,27 +34,7 @@ export class Kernel {
    *                        It's responsibility is to execute the callback and return it's
    *                        result (or throw an error).
    */
-  public constructor(public callbackHandler: (callback: api.Callback) => any) {
-    // `setImmediate` is required for tests to pass (it is otherwise
-    // impossible to wait for in-VM promises to complete)
-
-    // `Buffer` is required when using simple-resource-bundler.
-
-    // HACK: when we webpack @jsii/runtime, all "require" statements get transpiled,
-    // so modules can be resolved within the pack. However, here we actually want to
-    // let loaded modules to use the native node "require" method.
-    // I wonder if webpack has some pragma that allows opting-out at certain points
-    // in the code.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
-    const moduleLoad = require('module').Module._load;
-    const nodeRequire = (p: string) => moduleLoad(p, module, false);
-
-    this.sandbox = vm.createContext({
-      Buffer, // to use simple-resource-bundler
-      setImmediate, // async tests
-      require: nodeRequire, // modules need to "require"
-    });
-  }
+  public constructor(public callbackHandler: (callback: api.Callback) => any) {}
 
   public load(req: api.LoadRequest): api.LoadResponse {
     this._debug('load', req);
@@ -123,10 +100,8 @@ export class Kernel {
     }
 
     // load the module and capture it's closure
-    const closure = this._execute(
-      `require(String.raw\`${packageDir}\`)`,
-      packageDir,
-    );
+    // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
+    const closure = require(packageDir);
     const assm = new Assembly(assmSpec, closure);
     this._addAssembly(assm);
 
@@ -205,8 +180,9 @@ export class Kernel {
 
     const prototype = this._findSymbol(fqn);
 
-    const value = this._ensureSync(`property ${property}`, () =>
-      this._wrapSandboxCode(() => prototype[property]),
+    const value = this._ensureSync(
+      `property ${property}`,
+      () => prototype[property],
     );
 
     this._debug('value:', value);
@@ -231,15 +207,14 @@ export class Kernel {
 
     const prototype = this._findSymbol(fqn);
 
-    this._ensureSync(`property ${property}`, () =>
-      this._wrapSandboxCode(
-        () =>
-          (prototype[property] = this._toSandbox(
-            value,
-            ti,
-            `assigned to static property ${symbol}`,
-          )),
-      ),
+    this._ensureSync(
+      `property ${property}`,
+      () =>
+        (prototype[property] = this._toSandbox(
+          value,
+          ti,
+          `assigned to static property ${symbol}`,
+        )),
     );
 
     return {};
@@ -262,7 +237,7 @@ export class Kernel {
     // by jsii overrides.
     const value = this._ensureSync(
       `property '${objref[TOKEN_REF]}.${propertyToGet}'`,
-      () => this._wrapSandboxCode(() => instance[propertyToGet]),
+      () => instance[propertyToGet],
     );
     this._debug('value:', value);
     const ret = this._fromSandbox(value, ti, `of property ${fqn}.${property}`);
@@ -285,15 +260,14 @@ export class Kernel {
 
     const propertyToSet = this._findPropertyTarget(instance, property);
 
-    this._ensureSync(`property '${objref[TOKEN_REF]}.${propertyToSet}'`, () =>
-      this._wrapSandboxCode(
-        () =>
-          (instance[propertyToSet] = this._toSandbox(
-            value,
-            propInfo,
-            `assigned to property ${fqn}.${property}`,
-          )),
-      ),
+    this._ensureSync(
+      `property '${objref[TOKEN_REF]}.${propertyToSet}'`,
+      () =>
+        (instance[propertyToSet] = this._toSandbox(
+          value,
+          propInfo,
+          `assigned to property ${fqn}.${property}`,
+        )),
     );
 
     return {};
@@ -315,14 +289,12 @@ export class Kernel {
     const ret = this._ensureSync(
       `method '${objref[TOKEN_REF]}.${method}'`,
       () => {
-        return this._wrapSandboxCode(() =>
-          fn.apply(
-            obj,
-            this._toSandboxValues(
-              args,
-              `method ${fqn ? `${fqn}#` : ''}${method}`,
-              ti.parameters,
-            ),
+        return fn.apply(
+          obj,
+          this._toSandboxValues(
+            args,
+            `method ${fqn ? `${fqn}#` : ''}${method}`,
+            ti.parameters,
           ),
         );
       },
@@ -359,14 +331,16 @@ export class Kernel {
     const fn = prototype[method] as (...params: any[]) => any;
 
     const ret = this._ensureSync(`method '${fqn}.${method}'`, () => {
-      return this._wrapSandboxCode(() =>
-        fn.apply(
-          prototype,
-          this._toSandboxValues(
-            args,
-            `static method ${fqn}.${method}`,
-            ti.parameters,
-          ),
+      if (method === 'toS3') {
+        debugger;
+      }
+
+      return fn.apply(
+        prototype,
+        this._toSandboxValues(
+          args,
+          `static method ${fqn}.${method}`,
+          ti.parameters,
         ),
       );
     });
@@ -402,14 +376,12 @@ export class Kernel {
 
     const fqn = jsiiTypeFqn(obj);
 
-    const promise = this._wrapSandboxCode(() =>
-      fn.apply(
-        obj,
-        this._toSandboxValues(
-          args,
-          `async method ${fqn ? `${fqn}#` : ''}${method}`,
-          ti.parameters,
-        ),
+    const promise = fn.apply(
+      obj,
+      this._toSandboxValues(
+        args,
+        `async method ${fqn ? `${fqn}#` : ''}${method}`,
+        ti.parameters,
       ),
     ) as Promise<any>;
 
@@ -597,15 +569,12 @@ export class Kernel {
 
     const ctorResult = this._findCtor(fqn, requestArgs);
     const ctor = ctorResult.ctor;
-    const obj = this._wrapSandboxCode(
-      () =>
-        new ctor(
-          ...this._toSandboxValues(
-            requestArgs,
-            `new ${fqn}`,
-            ctorResult.parameters,
-          ),
-        ),
+    const obj = new ctor(
+      ...this._toSandboxValues(
+        requestArgs,
+        `new ${fqn}`,
+        ctorResult.parameters,
+      ),
     );
     const objref = this.objects.registerObject(obj, fqn, req.interfaces ?? []);
 
@@ -1275,23 +1244,6 @@ export class Kernel {
 
   private _makeprid() {
     return `jsii::promise::${this.nextid++}`;
-  }
-
-  private _wrapSandboxCode<T>(fn: () => T): T {
-    return fn();
-  }
-
-  /**
-   * Executes arbitrary code in a VM sandbox.
-   *
-   * @param code       JavaScript code to be executed in the VM
-   * @param filename   the file name to use for the executed code
-   *
-   * @returns the result of evaluating the code
-   */
-  private _execute(code: string, filename: string) {
-    const script = new vm.Script(code, { filename });
-    return script.runInContext(this.sandbox, { displayErrors: true });
   }
 }
 

--- a/packages/@jsii/runtime/bin/jsii-runtime.ts
+++ b/packages/@jsii/runtime/bin/jsii-runtime.ts
@@ -13,7 +13,7 @@ import { Duplex } from 'stream';
 // - FD#4 is the communication pipe to write jsii API responses
 const child = spawn(
   process.execPath,
-  [...process.execArgv, resolve(__dirname, '..', 'lib', 'program.js')],
+  [...process.execArgv, '--inspect-brk', resolve(__dirname, '..', 'lib', 'program.js')],
   { stdio: ['ignore', 'pipe', 'pipe', 'pipe'] },
 );
 


### PR DESCRIPTION
Use of the v8 sandbox had already been reduced to the point of being
entirely unnecessary. Finish removing what is left of it, as it also
turns out to make inline debugging a lot easier to perform.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
