### PR TITLE
feat(jsii): allow specifying baseUrl and paths in tsconfig.json

### DIFF
--- a/gh-pages/content/user-guides/lib-author/configuration/index.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/index.md
@@ -197,6 +197,7 @@ are set in the `jsii.tsc` section of the `package.json` file, but use the same n
   default, all visible `@types/*` packages will be loaded, which can be undesirable (in particular in monorepos, where
   some type libraries are not compatible with the TypeScript compiler version that `jsii` uses). The value specified
   here will be forwarded as-is to the TypeScript compiler.
+- `baseUrl` and `paths` can be used to configure TypeScript path mappings, and are copied verbatim to `tsconfig.json`.
 
 Refer to the [TypeScript compiler options reference][ts-options] for more information about those options.
 

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -20,6 +20,9 @@ export type TSCompilerOptions = Partial<
     // Directory preferences
     | 'outDir'
     | 'rootDir'
+    // TypeScript path mapping
+    | 'baseUrl'
+    | 'paths'
     // Style preferences
     | 'forceConsistentCasingInFileNames'
     // Source map preferences
@@ -220,6 +223,8 @@ export function loadProjectInfo(projectRoot: string): ProjectInfoResult {
     tsc: {
       outDir: pkg.jsii?.tsc?.outDir,
       rootDir: pkg.jsii?.tsc?.rootDir,
+      baseUrl: pkg.jsii?.tsc?.baseUrl,
+      paths: pkg.jsii?.tsc?.paths,
       forceConsistentCasingInFileNames:
         pkg.jsii?.tsc?.forceConsistentCasingInFileNames,
       ..._sourceMapPreferences(pkg.jsii?.tsc),


### PR DESCRIPTION
Allow user control of the `baseUrl` and `paths` compiler options in
`tsconfig.json` via the `jsii.tsc` stanza in `package.json`.

Fixes #865



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
