### PR TITLE
chore: stop testing .NET 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       # Set up all of our standard runtimes
-      - name: Set up .NET 5
+      - name: Set up .NET 6
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Set up Go 1.16
         uses: actions/setup-go@v3
         with:
@@ -122,10 +122,10 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
       # Set up all of our standard runtimes
-      - name: Set up .NET 5
+      - name: Set up .NET 6
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Set up Go 1.16
         uses: actions/setup-go@v3
         with:
@@ -240,12 +240,6 @@ jobs:
             node: '14'
             python: '3.7'
           # Test alternate .NETs
-          - java: '8'
-            dotnet: '5.0.x'
-            go: '1.16'
-            node: '14'
-            os: ubuntu-latest
-            python: '3.7'
           - java: '8'
             dotnet: '6.0.x'
             go: '1.16'

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -14,7 +14,7 @@ queue_rules:
       - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
-      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
+      - status-success~=^Test \(.* dotnet 6\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
@@ -64,7 +64,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
-      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
+      - status-success~=^Test \(.* dotnet 6\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
@@ -114,7 +114,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
-      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
+      - status-success~=^Test \(.* dotnet 6\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$
@@ -164,7 +164,7 @@ pull_request_rules:
       - status-success~=^Test \(.* node 18 .*$
       # One test for each supported dotnet version
       - status-success~=^Test \(.* dotnet 3\.1\.x .*$
-      - status-success~=^Test \(.* dotnet 5\.0\.x .*$
+      - status-success~=^Test \(.* dotnet 6\.0\.x .*$
       # One test for Java 8 and 11
       - status-success~=^Test \(.* java 8 .*$
       - status-success~=^Test \(.* java 11 .*$


### PR DESCRIPTION
.NET 5 has been out of support since May 10, 2022. It no longer receives
updates, and it is hence no longer useful to continue testing against
it. It has been superceded by .NET 6.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
