### PR TITLE
fix(rosetta): infuse incorrectly handles compressed assemblies

### DIFF
--- a/packages/@jsii/spec/src/assembly-utils.ts
+++ b/packages/@jsii/spec/src/assembly-utils.ts
@@ -15,6 +15,13 @@ import {
 import { validateAssembly } from './validate-assembly';
 
 /**
+ * Returns true if the SPEC_FILE_NAME_COMPRESSED file exists in the directory.
+ */
+export function compressedAssemblyExists(directory: string): boolean {
+  return fs.existsSync(path.join(directory, SPEC_FILE_NAME_COMPRESSED));
+}
+
+/**
  * Finds the path to the SPEC_FILE_NAME file, which will either
  * be the assembly or hold instructions to find the assembly.
  *

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -1,5 +1,11 @@
 import * as spec from '@jsii/spec';
-import { loadAssemblyFromFile, loadAssemblyFromPath, findAssemblyFile, writeAssembly } from '@jsii/spec';
+import {
+  compressedAssemblyExists,
+  loadAssemblyFromFile,
+  loadAssemblyFromPath,
+  findAssemblyFile,
+  writeAssembly,
+} from '@jsii/spec';
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -228,14 +234,11 @@ export async function allTypeScriptSnippets(
 
 /**
  * Replaces the file where the original assembly file *should* be found with a new assembly file.
+ * Detects whether or not there is a compressed assembly, and if there is, compresses the new assembly also.
  * Recalculates the fingerprint of the assembly to avoid tampering detection.
  */
-export function replaceAssembly(
-  assembly: spec.Assembly,
-  directory: string,
-  { compress = false }: { compress?: boolean } = {},
-) {
-  writeAssembly(directory, _fingerprint(assembly), { compress });
+export function replaceAssembly(assembly: spec.Assembly, directory: string) {
+  writeAssembly(directory, _fingerprint(assembly), { compress: compressedAssemblyExists(directory) });
 }
 
 /**


### PR DESCRIPTION
The behavior of `rosetta infuse` was incorrectly handled before. `infuse` would always overwrite the `.jsii` file with the uncompressed assembly. This PR fixes that behavior by detecting whether or not there is a compressed file in the directory, and compressing if that is the case.

There are two alternative solutions I considered, primarily because I'm concerned that looking up the location of the compressed assembly can be considered a leaky abstraction:
- loading and looking into the contents of `.jsii` again to determine whether or not it is a file redirect. I did not choose this option as it involves additional loading, which will slow things down.
- We can expand the `LoadedAssembly` type to include information on whether or not the assembly was originally compressed. Then pass that into the `replaceAssembly()` function. I ultimately decided against this because it would involve changing the function signature of all `loadAssemblyFromXxx` functions. It's both a breaking change, and unnecessary clutter for a single use case.

Based on the reasoning above, I think what is included in this PR makes the most sense: expose an independent function, `compressedAssemblyExists`, that returns whether or not there is a file located at `SPEC_FILE_NAME_COMPRESSED`. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
