### PR TITLE
fix(rosetta): tablet compression handled incorrectly in multiple places

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -231,7 +231,12 @@ function main() {
           .options('compress-tablet', {
             alias: 'z',
             type: 'boolean',
-            describe: 'Compress the resulting tablet file',
+            describe: 'Compress the implicit tablet file',
+            default: false,
+          })
+          .options('compress-cache', {
+            type: 'boolean',
+            describe: 'Compress the cache-to file',
             default: false,
           })
           .conflicts('loose', 'strict')
@@ -259,6 +264,7 @@ function main() {
           trimCache: args['trim-cache'],
           loose: args.loose,
           compressTablet: args['compress-tablet'],
+          compressCacheToFile: args['compress-cache'],
         };
 
         const result = args.infuse

--- a/packages/jsii-rosetta/lib/commands/infuse.ts
+++ b/packages/jsii-rosetta/lib/commands/infuse.ts
@@ -122,7 +122,10 @@ export async function infuse(assemblyLocations: string[], options?: InfuseOption
         if (insertedExamples > 0) {
           // Save the updated assembly and implicit tablets
           // eslint-disable-next-line no-await-in-loop
-          await Promise.all([replaceAssembly(assembly, directory), implicitTablet.save(implicitTabletFile)]);
+          await Promise.all([
+            replaceAssembly(assembly, directory),
+            implicitTablet.save(implicitTabletFile, implicitTablet.compressedSource),
+          ]);
         }
 
         return [

--- a/packages/jsii-rosetta/lib/commands/trim-cache.ts
+++ b/packages/jsii-rosetta/lib/commands/trim-cache.ts
@@ -25,7 +25,8 @@ export async function trimCache(options: TrimCacheOptions): Promise<void> {
   const original = await LanguageTablet.fromFile(options.cacheFile);
   const updated = new LanguageTablet();
   updated.addSnippets(...snippets.map((snip) => original.tryGetSnippet(snippetKey(snip))).filter(isDefined));
-  await updated.save(options.cacheFile);
+  // if the original file was compressed, then compress the updated file too
+  await updated.save(options.cacheFile, original.compressedSource);
 
   // eslint-disable-next-line prettier/prettier
   logging.info(`${options.cacheFile}: ${updated.count} snippets remaining (${original.count} - ${updated.count} trimmed)`);

--- a/packages/jsii-rosetta/lib/jsii/assemblies.ts
+++ b/packages/jsii-rosetta/lib/jsii/assemblies.ts
@@ -18,7 +18,7 @@ import {
   INITIALIZER_METHOD_NAME,
 } from '../snippet';
 import { enforcesStrictMode } from '../strict';
-import { LanguageTablet, DEFAULT_TABLET_NAME } from '../tablets/tablets';
+import { LanguageTablet, DEFAULT_TABLET_NAME, DEFAULT_TABLET_NAME_COMPRESSED } from '../tablets/tablets';
 import { fmap, mkDict, sortBy } from '../util';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
@@ -86,12 +86,15 @@ export function loadAssemblies(
 export async function loadAllDefaultTablets(asms: readonly LoadedAssembly[]): Promise<Record<string, LanguageTablet>> {
   return mkDict(
     await Promise.all(
-      asms.map(
-        async (a) =>
-          [a.directory, await LanguageTablet.fromOptionalFile(path.join(a.directory, DEFAULT_TABLET_NAME))] as const,
-      ),
+      asms.map(async (a) => [a.directory, await LanguageTablet.fromOptionalFile(guessTabletLocation(a))] as const),
     ),
   );
+
+  function guessTabletLocation(a: LoadedAssembly): string {
+    const defaultTablet = path.join(a.directory, DEFAULT_TABLET_NAME);
+    const compDefaultTablet = path.join(a.directory, DEFAULT_TABLET_NAME_COMPRESSED);
+    return fs.existsSync(defaultTablet) ? defaultTablet : compDefaultTablet;
+  }
 }
 
 export type AssemblySnippetSource =

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -54,6 +54,10 @@ export class LanguageTablet {
     return ret;
   }
 
+  /**
+   * Whether or not the LanguageTablet was loaded with a compressed source.
+   * This gets used to determine if it should be compressed when saved.
+   */
   public compressedSource = false;
 
   private readonly snippets: Record<string, TranslatedSnippet> = {};
@@ -171,16 +175,14 @@ export class LanguageTablet {
   }
 
   /**
-   * Saves the tablet schema to a file. The file will be gzipped if one of the following happens:
-   *
-   * - the compress option is explicitly passed
-   * - the LanguageTablet was originally loaded from a compressed file
+   * Saves the tablet schema to a file. The file will be gzipped if the
+   * compress option is passed.
    */
   public async save(filename: string, compress = false) {
     await fs.mkdirp(path.dirname(filename));
 
     let schema = Buffer.from(JSON.stringify(this.toSchema(), null, 2));
-    if (compress || this.compressedSource) {
+    if (compress) {
       schema = zlib.gzipSync(schema);
     }
 

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -175,8 +175,8 @@ export class LanguageTablet {
   }
 
   /**
-   * Saves the tablet schema to a file. The file will be gzipped if the
-   * compress option is passed.
+   * Saves the tablet schema to a file. If the compress option is passed, then
+   * the schema will be gzipped before writing to the file.
    */
   public async save(filename: string, compress = false) {
     await fs.mkdirp(path.dirname(filename));

--- a/packages/jsii-rosetta/test/commands/extract.test.ts
+++ b/packages/jsii-rosetta/test/commands/extract.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_TABLET_NAME,
   TranslatedSnippet,
   typeScriptSnippetFromVisibleSource,
+  DEFAULT_TABLET_NAME_COMPRESSED,
 } from '../../lib';
 import * as extract from '../../lib/commands/extract';
 import { loadAssemblies } from '../../lib/jsii/assemblies';
@@ -71,18 +72,36 @@ test('extract samples from test assembly', async () => {
   await tablet.load(cacheToFile);
 
   expect(tablet.snippetKeys.length).toEqual(1);
+  expect(tablet.compressedSource).toBeFalsy();
 });
 
-test('extract can save/load compressed tablets', async () => {
+test('extract can compress cached tablet file', async () => {
   const compressedCacheFile = path.join(assembly.moduleDirectory, 'test.tabl.gz');
   await extract.extractSnippets([assembly.moduleDirectory], {
     cacheToFile: compressedCacheFile,
+    compressCacheToFile: true,
     ...defaultExtractOptions,
   });
 
   const tablet = new LanguageTablet();
   await tablet.load(compressedCacheFile);
 
+  expect(tablet.snippetKeys.length).toEqual(1);
+  expect(tablet.compressedSource).toBeTruthy();
+});
+
+test('extract can compress implicit tablet file', async () => {
+  await extract.extractSnippets([assembly.moduleDirectory], {
+    ...defaultExtractOptions,
+    compressTablet: true,
+  });
+
+  const compImplicitTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME_COMPRESSED);
+  expect(fs.existsSync(compImplicitTablet)).toBeTruthy();
+  expect(fs.existsSync(path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME))).toBeFalsy();
+
+  const tablet = new LanguageTablet();
+  await tablet.load(compImplicitTablet);
   expect(tablet.snippetKeys.length).toEqual(1);
 });
 

--- a/packages/jsii-rosetta/test/commands/infuse.test.ts
+++ b/packages/jsii-rosetta/test/commands/infuse.test.ts
@@ -108,7 +108,7 @@ test('can log to output file', async () => {
   expect(stats.size).toBeGreaterThan(0);
 });
 
-test('default tablets can be compressed', async () => {
+test('can infuse with compressed default tablets', async () => {
   // remove any tablets that may currently exist
   const implicitTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME);
   const compImplicitTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME_COMPRESSED);
@@ -134,7 +134,7 @@ test('default tablets can be compressed', async () => {
   expect(types!['my_assembly.ClassA'].docs?.example).toBeDefined();
 });
 
-test('cacheToFile can be compressed', async () => {
+test('can compress cacheToFile', async () => {
   const compressedTabletFile = path.join(assembly.moduleDirectory, 'tabl.json.gz');
 
   await infuse([assembly.moduleDirectory], {

--- a/packages/jsii-rosetta/test/commands/infuse.test.ts
+++ b/packages/jsii-rosetta/test/commands/infuse.test.ts
@@ -2,7 +2,7 @@ import { loadAssemblyFromPath } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
+import { LanguageTablet, DEFAULT_TABLET_NAME, DEFAULT_TABLET_NAME_COMPRESSED } from '../../lib';
 import { extractSnippets } from '../../lib/commands/extract';
 import { infuse, DEFAULT_INFUSION_RESULTS_NAME } from '../../lib/commands/infuse';
 import { loadAssemblies } from '../../lib/jsii/assemblies';
@@ -106,4 +106,42 @@ test('can log to output file', async () => {
 
   expect(stats.isFile()).toBeTruthy();
   expect(stats.size).toBeGreaterThan(0);
+});
+
+test('default tablets can be compressed', async () => {
+  // remove any tablets that may currently exist
+  const implicitTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME);
+  const compImplicitTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME_COMPRESSED);
+  await fs.remove(implicitTablet);
+  await fs.remove(compImplicitTablet);
+
+  // create a compressed implicit tablet file via extract
+  await extractSnippets([assembly.moduleDirectory], {
+    includeCompilerDiagnostics: false,
+    validateAssemblies: false,
+    compressTablet: true,
+  });
+
+  expect(fs.existsSync(compImplicitTablet)).toBeTruthy();
+  expect(fs.existsSync(implicitTablet)).toBeFalsy();
+
+  // infuse can use compressed implicit tablets
+  await infuse([assembly.moduleDirectory]);
+
+  const assemblies = loadAssemblies([assembly.moduleDirectory], false);
+  const types = assemblies[0].assembly.types;
+  expect(types).toBeDefined();
+  expect(types!['my_assembly.ClassA'].docs?.example).toBeDefined();
+});
+
+test('cacheToFile preserves compression', async () => {
+  const compressedTabletFile = path.join(assembly.moduleDirectory, 'tabl.json.gz');
+
+  await infuse([assembly.moduleDirectory], {
+    cacheToFile: compressedTabletFile,
+    compressCacheToFile: true,
+  });
+
+  const tablet = await LanguageTablet.fromFile(compressedTabletFile);
+  expect(tablet.compressedSource).toBeTruthy();
 });

--- a/packages/jsii-rosetta/test/commands/infuse.test.ts
+++ b/packages/jsii-rosetta/test/commands/infuse.test.ts
@@ -134,7 +134,7 @@ test('default tablets can be compressed', async () => {
   expect(types!['my_assembly.ClassA'].docs?.example).toBeDefined();
 });
 
-test('cacheToFile preserves compression', async () => {
+test('cacheToFile can be compressed', async () => {
   const compressedTabletFile = path.join(assembly.moduleDirectory, 'tabl.json.gz');
 
   await infuse([assembly.moduleDirectory], {

--- a/packages/jsii-rosetta/test/commands/trim-cache.test.ts
+++ b/packages/jsii-rosetta/test/commands/trim-cache.test.ts
@@ -1,6 +1,12 @@
 import * as path from 'path';
 
-import { TranslatedSnippet, typeScriptSnippetFromVisibleSource, LanguageTablet, DEFAULT_TABLET_NAME } from '../../lib';
+import {
+  TranslatedSnippet,
+  typeScriptSnippetFromVisibleSource,
+  LanguageTablet,
+  DEFAULT_TABLET_NAME,
+  DEFAULT_TABLET_NAME_COMPRESSED,
+} from '../../lib';
 import { extractSnippets } from '../../lib/commands/extract';
 import { trimCache } from '../../lib/commands/trim-cache';
 import { TestJsiiModule, DUMMY_JSII_CONFIG, testSnippetLocation } from '../testutil';
@@ -75,6 +81,26 @@ test('trim-cache leaves used snippets', async () => {
   // THEN
   const updated = await LanguageTablet.fromFile(defaultTablet);
   expect(updated.count).toEqual(1);
+});
+
+test('trim-cache preserves tablet compression', async () => {
+  const compDefaultTablet = path.join(assembly.moduleDirectory, DEFAULT_TABLET_NAME_COMPRESSED);
+
+  // GIVEN
+  const tbl = new LanguageTablet();
+  tbl.addSnippets(bogusTranslatedSnippet());
+  // explicitly compress the tablet file
+  await tbl.save(compDefaultTablet, true);
+
+  // WHEN
+  await trimCache({
+    assemblyLocations: [assembly.moduleDirectory],
+    cacheFile: compDefaultTablet,
+  });
+
+  // THEN
+  const updated = await LanguageTablet.fromFile(compDefaultTablet);
+  expect(updated.compressedSource).toBeTruthy();
 });
 
 function bogusTranslatedSnippet() {


### PR DESCRIPTION
Unfortunately, #3652 was half-baked and this PR serves to finish handling tablet compression. It introduces the following:

- `compress-cache` cli option so that you can use a compressed cache file
- update  to all usages of `languageTablet.save()` to explicitly pass the compress flag
- `languageTablet.compressedSource`, which is set when we load from a compressed source, so that we can remember to save as a compressed source.
- `loadAllDefaultTablets` now handles compressed default tablets.
- a far more encompassing set of unit tests for the above features
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
