### PR TITLE
chore(jsii-reflect): use `Map`s instead of `Record`s

### DIFF
--- a/packages/jsii-reflect/lib/class.ts
+++ b/packages/jsii-reflect/lib/class.ts
@@ -7,7 +7,6 @@ import { Method } from './method';
 import { Property } from './property';
 import { ReferenceType } from './reference-type';
 import { TypeSystem } from './type-system';
-import { indexBy } from './util';
 
 export class ClassType extends ReferenceType {
   public constructor(
@@ -76,7 +75,7 @@ export class ClassType extends ReferenceType {
    * @param inherited include all properties inherited from base classes (default: false)
    */
   public getProperties(inherited = false): { [name: string]: Property } {
-    return this._getProperties(inherited, this);
+    return Object.fromEntries(this._getProperties(inherited, this));
   }
 
   /**
@@ -84,7 +83,7 @@ export class ClassType extends ReferenceType {
    * @param inherited include all methods inherited from base classes (default: false)
    */
   public getMethods(inherited = false): { [name: string]: Method } {
-    return this._getMethods(inherited, this);
+    return Object.fromEntries(this._getMethods(inherited, this));
   }
 
   /**
@@ -118,39 +117,35 @@ export class ClassType extends ReferenceType {
   private _getProperties(
     inherited: boolean,
     parentType: ReferenceType,
-  ): { [name: string]: Property } {
-    const base =
+  ): Map<string, Property> {
+    const result =
       inherited && this.base
         ? this.base._getProperties(inherited, parentType)
-        : {};
-    return Object.assign(
-      base,
-      indexBy(
-        (this.spec.properties ?? []).map(
-          (p) => new Property(this.system, this.assembly, parentType, this, p),
-        ),
-        (p) => p.name,
-      ),
-    );
+        : new Map<string, Property>();
+    for (const p of this.spec.properties ?? []) {
+      result.set(
+        p.name,
+        new Property(this.system, this.assembly, parentType, this, p),
+      );
+    }
+    return result;
   }
 
   private _getMethods(
     inherited: boolean,
     parentType: ReferenceType,
-  ): { [name: string]: Method } {
-    const base =
+  ): Map<string, Method> {
+    const result =
       inherited && this.base
         ? this.base._getMethods(inherited, parentType)
-        : {};
-    return Object.assign(
-      base,
-      indexBy(
-        (this.spec.methods ?? []).map(
-          (m) => new Method(this.system, this.assembly, parentType, this, m),
-        ),
-        (m) => m.name,
-      ),
-    );
+        : new Map<string, Method>();
+    for (const m of this.spec.methods ?? []) {
+      result.set(
+        m.name,
+        new Method(this.system, this.assembly, parentType, this, m),
+      );
+    }
+    return result;
   }
 }
 

--- a/packages/jsii-reflect/lib/module-like.ts
+++ b/packages/jsii-reflect/lib/module-like.ts
@@ -17,10 +17,11 @@ export abstract class ModuleLike {
   public declare abstract readonly targets?: jsii.AssemblyTargets;
   public declare abstract readonly readme?: jsii.ReadMe;
 
-  protected declare abstract readonly submoduleMap: Readonly<
-    Record<string, Submodule>
+  protected declare abstract readonly submoduleMap: ReadonlyMap<
+    string,
+    Submodule
   >;
-  protected declare abstract readonly typeMap: Readonly<Record<string, Type>>;
+  protected declare abstract readonly typeMap: ReadonlyMap<string, Type>;
 
   /**
    * Cache for the results of `tryFindType`.
@@ -30,11 +31,11 @@ export abstract class ModuleLike {
   protected constructor(public readonly system: TypeSystem) {}
 
   public get submodules(): readonly Submodule[] {
-    return Object.values(this.submoduleMap);
+    return Array.from(this.submoduleMap.values());
   }
 
   public get types(): readonly Type[] {
-    return Object.values(this.typeMap);
+    return Array.from(this.typeMap.values());
   }
 
   public get classes(): readonly ClassType[] {
@@ -60,7 +61,7 @@ export abstract class ModuleLike {
       return this.typeLocatorCache.get(fqn);
     }
 
-    const ownType = this.typeMap[fqn];
+    const ownType = this.typeMap.get(fqn);
     if (ownType != null) {
       this.typeLocatorCache.set(fqn, ownType);
       return ownType;
@@ -76,7 +77,7 @@ export abstract class ModuleLike {
       .split('.')
       .slice(0, myFqnLength + 1)
       .join('.');
-    const sub = this.submoduleMap[subFqn];
+    const sub = this.submoduleMap.get(subFqn);
     const submoduleType = sub?.tryFindType(fqn);
     this.typeLocatorCache.set(fqn, submoduleType);
     return submoduleType;

--- a/packages/jsii-reflect/lib/submodule.ts
+++ b/packages/jsii-reflect/lib/submodule.ts
@@ -14,8 +14,8 @@ export class Submodule extends ModuleLike {
     system: TypeSystem,
     public readonly spec: jsii.Submodule,
     public readonly fqn: string,
-    protected readonly submoduleMap: Readonly<Record<string, Submodule>>,
-    protected readonly typeMap: Readonly<Record<string, Type>>,
+    protected readonly submoduleMap: ReadonlyMap<string, Submodule>,
+    protected readonly typeMap: ReadonlyMap<string, Type>,
   ) {
     super(system);
 

--- a/packages/jsii-reflect/lib/util.ts
+++ b/packages/jsii-reflect/lib/util.ts
@@ -1,14 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-export function indexBy<T>(xs: T[], f: (x: T) => string): { [key: string]: T } {
-  const ret: { [key: string]: T } = {};
-  for (const x of xs) {
-    ret[f(x)] = x;
-  }
-  return ret;
-}
-
 /**
  * Find the directory that contains a given dependency, identified by its 'package.json', from a starting search directory
  *


### PR DESCRIPTION
Instead of using objects as maps, use actual `Map` as this has better
performance characteristics (results in fewer shadow classes being
generated, and is friendlier with the optimizer).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
