### PR TITLE
chore: federate into AWS to authenticate to ECR Public

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -45,8 +45,13 @@ jobs:
               echo '⏯ Dockerfile changed'
               echo "::set-output name=result::true"
             else
-              echo '⏭ Dockerfile not changed'
-              echo "::set-output name=result::false"
+              if grep '.github/workflows/docker-images.yml' <<< "${changed}" ; then
+                echo '⏯ docker-images workflow changed'
+                echo "::set-output name=result::true"
+              else
+                echo '⏭ Dockerfile not changed'
+                echo "::set-output name=result::false"
+              fi
             fi
           fi
 
@@ -55,6 +60,7 @@ jobs:
       # See: https://github.com/actions/runner/issues/520
       - name: Check AWS federation configuration
         id: federate_to_aws
+        if: steps.should-run.outputs.result == 'true'
         run: |-
           if [[ "${{ secrets.AWS_ROLE_TO_ASSUME }}" != "" ]]; then
             echo "🔑 Federation into AWS is possible (AWS_ROLE_TO_ASSUME is available)"
@@ -66,7 +72,7 @@ jobs:
 
       # Federate into the PR Validation AWS Account
       - name: Federate into AWS
-        if: ${{ steps.federate_to_aws.outputs.enabled }} == true
+        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -74,7 +80,7 @@ jobs:
 
       # Login to ECR Public registry, so we don't get throttled at 1 TPS
       - name: Login to ECR Public
-        if: ${{ steps.federate_to_aws.outputs.enabled }} == true
+        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} == 'true'
         run: |-
           aws ecr-public get-login-password --region=us-east-1                  \
           | docker login --username AWS --password-stdin public.ecr.aws

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -57,8 +57,10 @@ jobs:
         id: federate_to_aws
         run: |-
           if [[ "${{ secrets.AWS_ROLE_TO_ASSUME }}" != "" ]]; then
+            echo "🔑 Federation into AWS is possible (AWS_ROLE_TO_ASSUME is available)"
             echo "::set-output name=enabled::true"
           else
+            echo "❌ Federation into AWS is disabled (no AWS_ROLE_TO_ASSUME secret found)"
             echo "::set-output name=enabled::false"
           fi
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -50,8 +50,35 @@ jobs:
             fi
           fi
 
+      # Check if federation into AWS is configured. This is necessary because
+      # GitHub does not interpret ${{ secret.FOO }} within `if:` conditions...
+      # See: https://github.com/actions/runner/issues/520
+      - name: Check AWS federation configuration
+        id: federate_to_aws
+        run: |-
+          if [[ "${{ secrets.AWS_ROLE_TO_ASSUME }}" != "" ]]; then
+            echo "::set-output name=enabled::true"
+          else
+            echo "::set-output name=enabled::false"
+          fi
+
+      # Federate into the PR Validation AWS Account
+      - name: Federate into AWS
+        if: ${{ steps.federate_to_aws.outputs.enabled }} == true
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      # Login to ECR Public registry, so we don't get throttled at 1 TPS
+      - name: Login to ECR Public
+        if: ${{ steps.federate_to_aws.outputs.enabled }} == true
+        run: |-
+          aws ecr-public get-login-password --region=us-east-1                  \
+          | docker login --username AWS --password-stdin public.ecr.aws
+
       # We only authenticate to Docker on the 'aws/jsii' repo, as forks will not have the secret
-      - name: Login to Docker
+      - name: Login to Docker Hub
         if: steps.should-run.outputs.result == 'true' && github.repository == 'aws/jsii'
         # The DOCKER_CREDENTIALS secret is expected to contain a username:token pair
         run: |-
@@ -70,6 +97,12 @@ jobs:
         id: buildx
         if: steps.should-run.outputs.result == 'true'
         uses: docker/setup-buildx-action@v2
+        with:
+          # Disable parallelism because IO contention makes it too slow on GitHub
+          # workers...
+          config-inline: |-
+            [worker.oci]
+              max-parallelism = 1
 
       # We only restore GH cache if we are not going to publish the result (i.e: PR validation)
       - name: Set up layer cache
@@ -85,7 +118,7 @@ jobs:
       # 1 pull per second from ECR Public
       - name: Jitter the start time to avoid ECR Public throttling
         id: sleep-start
-        if: steps.should-run.outputs.result == 'true'
+        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} != true
         run: |-
           sleep $((RANDOM % 60))
 
@@ -111,27 +144,12 @@ jobs:
             -f superchain/Dockerfile                                            \
             .
 
-      # Testing sequentially, because in parallel it's too slow due to IO contention
-      - name: Test Image (AMD64)
+      - name: Test Image
         if: steps.should-run.outputs.result == 'true'
         run: |-
           docker buildx build                                                   \
             --builder ${{ steps.buildx.outputs.name }}                          \
-            --platform linux/amd64                                              \
-            --target superchain                                                 \
-            --cache-from type=local,src=/tmp/.buildx-cache                      \
-            --cache-to type=local,dest=/tmp/.buildx-cache                       \
-            --build-arg BUILD_TIMESTAMP="${{ steps.build-time.outputs.value }}" \
-            --build-arg COMMIT_ID='${{ github.sha }}'                           \
-            --build-arg NODE_MAJOR_VERSION=${{ matrix.node }}                   \
-            -f superchain/Dockerfile                                            \
-            .
-      - name: Test Image (ARM64)
-        if: steps.should-run.outputs.result == 'true'
-        run: |-
-          docker buildx build                                                   \
-            --builder ${{ steps.buildx.outputs.name }}                          \
-            --platform linux/arm64                                              \
+            --platform linux/amd64,linux/arm64                                  \
             --target superchain                                                 \
             --cache-from type=local,src=/tmp/.buildx-cache                      \
             --cache-to type=local,dest=/tmp/.buildx-cache                       \

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Federate into the PR Validation AWS Account
       - name: Federate into AWS
-        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} == 'true'
+        if: steps.should-run.outputs.result == 'true' && steps.federate_to_aws.outputs.enabled == 'true'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -80,7 +80,7 @@ jobs:
 
       # Login to ECR Public registry, so we don't get throttled at 1 TPS
       - name: Login to ECR Public
-        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} == 'true'
+        if: steps.should-run.outputs.result == 'true' && steps.federate_to_aws.outputs.enabled == 'true'
         run: |-
           aws ecr-public get-login-password --region=us-east-1                  \
           | docker login --username AWS --password-stdin public.ecr.aws
@@ -126,7 +126,7 @@ jobs:
       # 1 pull per second from ECR Public
       - name: Jitter the start time to avoid ECR Public throttling
         id: sleep-start
-        if: steps.should-run.outputs.result == 'true' && ${{ steps.federate_to_aws.outputs.enabled }} != true
+        if: steps.should-run.outputs.result == 'true' && steps.federate_to_aws.outputs.enabled != true
         run: |-
           sleep $((RANDOM % 60))
 


### PR DESCRIPTION
In order to reduce throttlin events, federate into AWS using the
GitHub OpenID Connect provider, and authenticate to ECR Public.
When no `AWS_ROLE_TO_ASSUME` secret is configured, federation is
skipped and the jitter is applied instead.

Also reduces parallelism of the `buildx` OCI provider so that
we can more reliably re-use layer caches across all platforms
without choking the runner's IO.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
