### PR TITLE
fix(pyhon): under-qualified types used by dynamic type checking

### DIFF
--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -1,6 +1,7 @@
 import pytest
 import re
 
+from scope.jsii_calc_lib.custom_submodule_name import NestingClass
 import jsii_calc
 
 
@@ -114,3 +115,7 @@ class TestRuntimeTypeChecking:
             ),
         ):
             subject.union_property = jsii_calc.StringEnum.B  # type:ignore
+
+    def test_nested_struct(self):
+        # None of these should throw...
+        NestingClass.NestedStruct(name="Queen B")

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -404,6 +404,20 @@ export function toPythonFqn(fqn: string, rootAssm: Assembly) {
 }
 
 /**
+ * Computes the nesting-qualified name of a type.
+ *
+ * @param fqn      the fully qualified jsii name of the type.
+ * @param rootAssm the root assembly for the project.
+ *
+ * @returns the nesting-qualified python type name (the name of the class,
+ *          qualified with all nesting parent classes).
+ */
+export function toPythonFullName(fqn: string, rootAssm: Assembly): string {
+  const { packageName, pythonFqn } = toPythonFqn(fqn, rootAssm);
+  return pythonFqn.slice(packageName.length + 1);
+}
+
+/**
  * Computes the python relative import path from `fromModule` to `toModule`.
  *
  * @param fromPkg the package where the relative import statement is located.

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -2570,7 +2570,7 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
             :param bar: -
             '''
             if __debug__:
-                type_hints = typing.get_type_hints(Foo.__init__)
+                type_hints = typing.get_type_hints(Namespace1.Foo.__init__)
                 check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             self._values: typing.Dict[str, typing.Any] = {
                 "bar": bar,

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -2021,7 +2021,7 @@ class NestingClass(
             :stability: deprecated
             '''
             if __debug__:
-                type_hints = typing.get_type_hints(NestedStruct.__init__)
+                type_hints = typing.get_type_hints(NestingClass.NestedStruct.__init__)
                 check_type(argname="argument name", value=name, expected_type=type_hints["name"])
             self._values: typing.Dict[str, typing.Any] = {
                 "name": name,
@@ -7840,7 +7840,7 @@ class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
             :param value: 
             '''
             if __debug__:
-                type_hints = typing.get_type_hints(PropBooleanValue.__init__)
+                type_hints = typing.get_type_hints(LevelOne.PropBooleanValue.__init__)
                 check_type(argname="argument value", value=value, expected_type=type_hints["value"])
             self._values: typing.Dict[str, typing.Any] = {
                 "value": value,
@@ -7880,7 +7880,7 @@ class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
             if isinstance(prop, dict):
                 prop = PropBooleanValue(**prop)
             if __debug__:
-                type_hints = typing.get_type_hints(PropProperty.__init__)
+                type_hints = typing.get_type_hints(LevelOne.PropProperty.__init__)
                 check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
             self._values: typing.Dict[str, typing.Any] = {
                 "prop": prop,

--- a/packages/jsii-rosetta/jest.config.mjs
+++ b/packages/jsii-rosetta/jest.config.mjs
@@ -1,6 +1,7 @@
 import { createRequire } from 'node:module';
-import { overriddenConfig } from '../../jest.config.mjs';
+import { default as defaultConfig, overriddenConfig } from '../../jest.config.mjs';
 
 export default overriddenConfig({
   setupFiles: [createRequire(import.meta.url).resolve('./jestsetup.js')],
+  testTimeout: process.env.CI ? 30_000 : defaultConfig.testTimeout,
 });


### PR DESCRIPTION
The types must be referenced from the current module's root, including
nesting class names, or the names will not be defined.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
