### PR TITLE
chore(go): emit one file per type

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -239,7 +239,9 @@ export abstract class Package {
       });
     }
 
-    for (const goModuleName of new Set(type.dependencies.map(({goModuleName}) => goModuleName))) {
+    for (const goModuleName of new Set(
+      type.dependencies.map(({ goModuleName }) => goModuleName),
+    )) {
       // If the module is the same as the current one being written, don't emit an import statement
       if (goModuleName !== this.goModuleName) {
         toImport.push({ module: goModuleName });

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -58,7 +58,7 @@ export abstract class Package {
     root?: Package,
   ) {
     this.directory = filePath;
-    this.file = `${this.directory}/${packageName}.go`;
+    this.file = join(this.directory, `${packageName}.go`);
     this.root = root ?? this;
     this.submodules = this.jsiiModule.submodules.map(
       (sm) => new InternalPackage(this.root, this, sm),
@@ -198,7 +198,7 @@ export abstract class Package {
     // form. It also saves us from "imported but unused" errors that would arise
     // as a consequence.
     if (this.types.length > 0) {
-      const initFile = `${this.directory}/${this.packageName}.go`;
+      const initFile = join(this.directory, `${this.packageName}.go`);
       code.openFile(initFile);
       code.line(`package ${this.packageName}`);
       code.line();
@@ -254,7 +254,10 @@ export abstract class Package {
 
   private emitTypes(context: EmitContext) {
     for (const type of this.types) {
-      const filePath = `${this.directory}/${this.packageName}_${type.name}.go`;
+      const filePath = join(
+        this.directory,
+        `${this.packageName}_${type.name}.go`,
+      );
       context.code.openFile(filePath);
 
       this.emitHeader(context.code);

--- a/packages/jsii-pacmak/lib/targets/go/types/interface.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/interface.ts
@@ -145,9 +145,10 @@ export class GoInterface extends GoType<InterfaceType> {
   public get specialDependencies(): SpecialDependencies {
     return [
       ...this.properties.map((p) => p.specialDependencies),
-      ...this.reimplementedProperties?.map((p) => p.specialDependencies) ?? [],
+      ...(this.reimplementedProperties?.map((p) => p.specialDependencies) ??
+        []),
       ...this.methods.map((m) => m.specialDependencies),
-      ...this.reimplementedMethods?.map((m) => m.specialDependencies) ?? [],
+      ...(this.reimplementedMethods?.map((m) => m.specialDependencies) ?? []),
     ].reduce(
       (acc, elt) => ({
         runtime: acc.runtime || elt.runtime,

--- a/packages/jsii-pacmak/lib/targets/go/types/interface.ts
+++ b/packages/jsii-pacmak/lib/targets/go/types/interface.ts
@@ -145,7 +145,9 @@ export class GoInterface extends GoType<InterfaceType> {
   public get specialDependencies(): SpecialDependencies {
     return [
       ...this.properties.map((p) => p.specialDependencies),
+      ...this.reimplementedProperties?.map((p) => p.specialDependencies) ?? [],
       ...this.methods.map((m) => m.specialDependencies),
+      ...this.reimplementedMethods?.map((m) => m.specialDependencies) ?? [],
     ].reduce(
       (acc, elt) => ({
         runtime: acc.runtime || elt.runtime,

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -24,8 +24,11 @@ exports[`diamond-struct-parameter.ts: <outDir>/ 1`] = `
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┗━ 📄 jsii.go
- ┃     ┣━ 📄 testpkg.go
- ┃     ┗━ 📄 testpkg.init.go
+ ┃     ┣━ 📄 testpkg_Baz.go
+ ┃     ┣━ 📄 testpkg_Consumer.go
+ ┃     ┣━ 📄 testpkg_Foo.go
+ ┃     ┣━ 📄 testpkg_FooBar.go
+ ┃     ┗━ 📄 testpkg.go
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -412,51 +415,6 @@ func Initialize() {
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg.go 1`] = `
-// testpkg
-package testpkg
-
-import (
-	_init_ "example.test/demo/testpkg/jsii"
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-type Baz struct {
-	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
-	Bar *string \`field:"optional" json:"bar" yaml:"bar"\`
-	Baz *bool \`field:"required" json:"baz" yaml:"baz"\`
-}
-
-type Consumer interface {
-}
-
-// The jsii proxy struct for Consumer
-type jsiiProxy_Consumer struct {
-	_ byte // padding
-}
-
-func Consumer_ConsumeBaz(baz *Baz) {
-	_init_.Initialize()
-
-	_jsii_.StaticInvokeVoid(
-		"testpkg.Consumer",
-		"consumeBaz",
-		[]interface{}{baz},
-	)
-}
-
-type Foo struct {
-	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
-}
-
-type FooBar struct {
-	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
-	Bar *string \`field:"optional" json:"bar" yaml:"bar"\`
-}
-
-
-`;
-
-exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg.init.go 1`] = `
 package testpkg
 
 import (
@@ -487,6 +445,75 @@ func init() {
 		reflect.TypeOf((*FooBar)(nil)).Elem(),
 	)
 }
+
+`;
+
+exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg_Baz.go 1`] = `
+// testpkg
+package testpkg
+
+
+type Baz struct {
+	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
+	Bar *string \`field:"optional" json:"bar" yaml:"bar"\`
+	Baz *bool \`field:"required" json:"baz" yaml:"baz"\`
+}
+
+
+`;
+
+exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg_Consumer.go 1`] = `
+// testpkg
+package testpkg
+
+import (
+	_init_ "example.test/demo/testpkg/jsii"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type Consumer interface {
+}
+
+// The jsii proxy struct for Consumer
+type jsiiProxy_Consumer struct {
+	_ byte // padding
+}
+
+func Consumer_ConsumeBaz(baz *Baz) {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"testpkg.Consumer",
+		"consumeBaz",
+		[]interface{}{baz},
+	)
+}
+
+
+`;
+
+exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg_Foo.go 1`] = `
+// testpkg
+package testpkg
+
+
+type Foo struct {
+	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
+}
+
+
+`;
+
+exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/testpkg_FooBar.go 1`] = `
+// testpkg
+package testpkg
+
+
+type FooBar struct {
+	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
+	Bar *string \`field:"optional" json:"bar" yaml:"bar"\`
+}
+
 
 `;
 
@@ -1457,8 +1484,13 @@ exports[`nested-types.ts: <outDir>/ 1`] = `
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┗━ 📄 jsii.go
- ┃     ┣━ 📄 testpkg.go
- ┃     ┗━ 📄 testpkg.init.go
+ ┃     ┣━ 📄 testpkg_Namespace1_Foo.go
+ ┃     ┣━ 📄 testpkg_Namespace1_IBar.go
+ ┃     ┣━ 📄 testpkg_Namespace1.go
+ ┃     ┣━ 📄 testpkg_Namespace2_Foo_Final.go
+ ┃     ┣━ 📄 testpkg_Namespace2_Foo.go
+ ┃     ┣━ 📄 testpkg_Namespace2.go
+ ┃     ┗━ 📄 testpkg.go
  ┣━ 📁 java
  ┃  ┣━ 📄 pom.xml
  ┃  ┗━ 📁 src
@@ -1763,183 +1795,6 @@ func Initialize() {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/testpkg.go 1`] = `
-// testpkg
-package testpkg
-
-import (
-	_init_ "example.test/demo/testpkg/jsii"
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-type Namespace1 interface {
-	Foo()
-}
-
-// The jsii proxy struct for Namespace1
-type jsiiProxy_Namespace1 struct {
-	_ byte // padding
-}
-
-func NewNamespace1() Namespace1 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Namespace1{}
-
-	_jsii_.Create(
-		"testpkg.Namespace1",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewNamespace1_Override(n Namespace1) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"testpkg.Namespace1",
-		nil, // no parameters
-		n,
-	)
-}
-
-func (n *jsiiProxy_Namespace1) Foo() {
-	_jsii_.InvokeVoid(
-		n,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-type Namespace1_Foo struct {
-	Bar *string \`field:"required" json:"bar" yaml:"bar"\`
-}
-
-type Namespace1_IBar interface {
-	Method()
-	Bar() *string
-}
-
-// The jsii proxy for Namespace1_IBar
-type jsiiProxy_Namespace1_IBar struct {
-	_ byte // padding
-}
-
-func (n *jsiiProxy_Namespace1_IBar) Method() {
-	_jsii_.InvokeVoid(
-		n,
-		"method",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_Namespace1_IBar) Bar() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"bar",
-		&returns,
-	)
-	return returns
-}
-
-type Namespace2 interface {
-	Foo()
-}
-
-// The jsii proxy struct for Namespace2
-type jsiiProxy_Namespace2 struct {
-	_ byte // padding
-}
-
-func NewNamespace2() Namespace2 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Namespace2{}
-
-	_jsii_.Create(
-		"testpkg.Namespace2",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewNamespace2_Override(n Namespace2) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"testpkg.Namespace2",
-		nil, // no parameters
-		n,
-	)
-}
-
-func (n *jsiiProxy_Namespace2) Foo() {
-	_jsii_.InvokeVoid(
-		n,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-type Namespace2_Foo string
-
-const (
-	Namespace2_Foo_BAR Namespace2_Foo = "BAR"
-	Namespace2_Foo_BAZ Namespace2_Foo = "BAZ"
-)
-
-type Namespace2_Foo_Final interface {
-	Done() *bool
-}
-
-// The jsii proxy struct for Namespace2_Foo_Final
-type jsiiProxy_Namespace2_Foo_Final struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_Namespace2_Foo_Final) Done() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"done",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewNamespace2_Foo_Final() Namespace2_Foo_Final {
-	_init_.Initialize()
-
-	j := jsiiProxy_Namespace2_Foo_Final{}
-
-	_jsii_.Create(
-		"testpkg.Namespace2.Foo.Final",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewNamespace2_Foo_Final_Override(n Namespace2_Foo_Final) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"testpkg.Namespace2.Foo.Final",
-		nil, // no parameters
-		n,
-	)
-}
-
-
-`;
-
-exports[`nested-types.ts: <outDir>/go/testpkg/testpkg.init.go 1`] = `
 package testpkg
 
 import (
@@ -2003,6 +1858,234 @@ func init() {
 		},
 	)
 }
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace1.go 1`] = `
+// testpkg
+package testpkg
+
+import (
+	_init_ "example.test/demo/testpkg/jsii"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type Namespace1 interface {
+	Foo()
+}
+
+// The jsii proxy struct for Namespace1
+type jsiiProxy_Namespace1 struct {
+	_ byte // padding
+}
+
+func NewNamespace1() Namespace1 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Namespace1{}
+
+	_jsii_.Create(
+		"testpkg.Namespace1",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewNamespace1_Override(n Namespace1) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"testpkg.Namespace1",
+		nil, // no parameters
+		n,
+	)
+}
+
+func (n *jsiiProxy_Namespace1) Foo() {
+	_jsii_.InvokeVoid(
+		n,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace1_Foo.go 1`] = `
+// testpkg
+package testpkg
+
+
+type Namespace1_Foo struct {
+	Bar *string \`field:"required" json:"bar" yaml:"bar"\`
+}
+
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace1_IBar.go 1`] = `
+// testpkg
+package testpkg
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type Namespace1_IBar interface {
+	Method()
+	Bar() *string
+}
+
+// The jsii proxy for Namespace1_IBar
+type jsiiProxy_Namespace1_IBar struct {
+	_ byte // padding
+}
+
+func (n *jsiiProxy_Namespace1_IBar) Method() {
+	_jsii_.InvokeVoid(
+		n,
+		"method",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_Namespace1_IBar) Bar() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"bar",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace2.go 1`] = `
+// testpkg
+package testpkg
+
+import (
+	_init_ "example.test/demo/testpkg/jsii"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type Namespace2 interface {
+	Foo()
+}
+
+// The jsii proxy struct for Namespace2
+type jsiiProxy_Namespace2 struct {
+	_ byte // padding
+}
+
+func NewNamespace2() Namespace2 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Namespace2{}
+
+	_jsii_.Create(
+		"testpkg.Namespace2",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewNamespace2_Override(n Namespace2) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"testpkg.Namespace2",
+		nil, // no parameters
+		n,
+	)
+}
+
+func (n *jsiiProxy_Namespace2) Foo() {
+	_jsii_.InvokeVoid(
+		n,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace2_Foo.go 1`] = `
+// testpkg
+package testpkg
+
+
+type Namespace2_Foo string
+
+const (
+	Namespace2_Foo_BAR Namespace2_Foo = "BAR"
+	Namespace2_Foo_BAZ Namespace2_Foo = "BAZ"
+)
+
+
+`;
+
+exports[`nested-types.ts: <outDir>/go/testpkg/testpkg_Namespace2_Foo_Final.go 1`] = `
+// testpkg
+package testpkg
+
+import (
+	_init_ "example.test/demo/testpkg/jsii"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type Namespace2_Foo_Final interface {
+	Done() *bool
+}
+
+// The jsii proxy struct for Namespace2_Foo_Final
+type jsiiProxy_Namespace2_Foo_Final struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_Namespace2_Foo_Final) Done() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"done",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewNamespace2_Foo_Final() Namespace2_Foo_Final {
+	_init_.Initialize()
+
+	j := jsiiProxy_Namespace2_Foo_Final{}
+
+	_jsii_.Create(
+		"testpkg.Namespace2.Foo.Final",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewNamespace2_Foo_Final_Override(n Namespace2_Foo_Final) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"testpkg.Namespace2.Foo.Final",
+		nil, // no parameters
+		n,
+	)
+}
+
 
 `;
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -15,7 +15,6 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/ 1`] = `
  ┃     ┗━ 📄 foo-1.2.3.tgz
  ┣━ 📁 go
  ┃  ┗━ 📁 foo
- ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┣━ 📄 foo-1.2.3.tgz
@@ -115,14 +114,6 @@ namespace Com.Acme.Foo.Internal.DependencyResolution
 `;
 
 exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/foo-1.2.3.tgz 1`] = `dotnet/Com.Acme.Foo/foo-1.2.3.tgz is a tarball`;
-
-exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/go/foo/foo.go 1`] = `
-// Test assembly: foo
-package foo
-
-
-
-`;
 
 exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/go/foo/go.mod 1`] = `
 module foo
@@ -527,7 +518,6 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/ 1`] = `
  ┃     ┗━ 📄 foo-1.2.3.tgz
  ┣━ 📁 go
  ┃  ┗━ 📁 foo
- ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┣━ 📄 foo-1.2.3.tgz
@@ -627,14 +617,6 @@ namespace Com.Acme.Foo.Internal.DependencyResolution
 `;
 
 exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/foo-1.2.3.tgz 1`] = `dotnet/Com.Acme.Foo/foo-1.2.3.tgz is a tarball`;
-
-exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/go/foo/foo.go 1`] = `
-// Test assembly: foo
-package foo
-
-
-
-`;
 
 exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/go/foo/go.mod 1`] = `
 module foo
@@ -1039,7 +1021,6 @@ exports[`foo@2.0.0-rc.42: <outDir>/ 1`] = `
  ┃     ┗━ 📄 foo-2.0.0-rc.42.tgz
  ┣━ 📁 go
  ┃  ┗━ 📁 foo
- ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┣━ 📄 foo-2.0.0-rc.42.tgz
@@ -1137,14 +1118,6 @@ namespace Com.Acme.Foo.Internal.DependencyResolution
 `;
 
 exports[`foo@2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/foo-2.0.0-rc.42.tgz 1`] = `dotnet/Com.Acme.Foo/foo-2.0.0-rc.42.tgz is a tarball`;
-
-exports[`foo@2.0.0-rc.42: <outDir>/go/foo/foo.go 1`] = `
-// Test assembly: foo
-package foo
-
-
-
-`;
 
 exports[`foo@2.0.0-rc.42: <outDir>/go/foo/go.mod 1`] = `
 module foo/v2
@@ -1528,7 +1501,6 @@ exports[`foo@4.5.6-pre.1337: <outDir>/ 1`] = `
  ┃     ┗━ 📄 foo-4.5.6-pre.1337.tgz
  ┣━ 📁 go
  ┃  ┗━ 📁 foo
- ┃     ┣━ 📄 foo.go
  ┃     ┣━ 📄 go.mod
  ┃     ┣━ 📁 jsii
  ┃     ┃  ┣━ 📄 foo-4.5.6-pre.1337.tgz
@@ -1626,14 +1598,6 @@ namespace Com.Acme.Foo.Internal.DependencyResolution
 `;
 
 exports[`foo@4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/foo-4.5.6-pre.1337.tgz 1`] = `dotnet/Com.Acme.Foo/foo-4.5.6-pre.1337.tgz is a tarball`;
-
-exports[`foo@4.5.6-pre.1337: <outDir>/go/foo/foo.go 1`] = `
-// Test assembly: foo
-package foo
-
-
-
-`;
 
 exports[`foo@4.5.6-pre.1337: <outDir>/go/foo/go.mod 1`] = `
 module foo/v4

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -7,8 +7,11 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/ 1`] = `
        ┣━ 📄 go.mod
        ┣━ 📁 internal
        ┃  ┗━ 📄 types.go
+       ┣━ 📄 jcb_Base.go
+       ┣━ 📄 jcb_BaseProps.go
+       ┣━ 📄 jcb_IBaseInterface.go
+       ┣━ 📄 jcb_StaticConsumer.go
        ┣━ 📄 jcb.go
-       ┣━ 📄 jcb.init.go
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii.go
        ┃  ┗━ 📄 scope-jsii-calc-base-0.0.0.tgz
@@ -250,15 +253,61 @@ type Type__scopejsiicalcbaseofbaseIVeryBaseInterface = scopejsiicalcbaseofbase.I
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb.go 1`] = `
+package jcb
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-base.Base",
+		reflect.TypeOf((*Base)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "typeName", GoMethod: "TypeName"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Base{}
+		},
+	)
+	_jsii_.RegisterStruct(
+		"@scope/jsii-calc-base.BaseProps",
+		reflect.TypeOf((*BaseProps)(nil)).Elem(),
+	)
+	_jsii_.RegisterInterface(
+		"@scope/jsii-calc-base.IBaseInterface",
+		reflect.TypeOf((*IBaseInterface)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+		},
+		func() interface{} {
+			j := jsiiProxy_IBaseInterface{}
+			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalcbaseofbaseIVeryBaseInterface)
+			return &j
+		},
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-base.StaticConsumer",
+		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_StaticConsumer{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb_Base.go 1`] = `
 // An example direct dependency for jsii-calc.
 package jcb
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jcb/jsii"
-
-	"github.com/aws/jsii/jsii-calc/go/jcb/internal"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
 )
 
 // A base class.
@@ -295,10 +344,35 @@ func (b *jsiiProxy_Base) TypeName() interface{} {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb_BaseProps.go 1`] = `
+// An example direct dependency for jsii-calc.
+package jcb
+
+import (
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
+)
+
 type BaseProps struct {
 	Foo scopejsiicalcbaseofbase.Very \`field:"required" json:"foo" yaml:"foo"\`
 	Bar *string \`field:"required" json:"bar" yaml:"bar"\`
 }
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb_IBaseInterface.go 1`] = `
+// An example direct dependency for jsii-calc.
+package jcb
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
+)
 
 type IBaseInterface interface {
 	scopejsiicalcbaseofbase.IVeryBaseInterface
@@ -317,6 +391,18 @@ func (i *jsiiProxy_IBaseInterface) Bar() {
 		nil, // no parameters
 	)
 }
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb_StaticConsumer.go 1`] = `
+// An example direct dependency for jsii-calc.
+package jcb
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jcb/jsii"
+)
 
 // Hides the transitive dependency of base-of-base.
 type StaticConsumer interface {
@@ -369,55 +455,6 @@ func StaticConsumer_Consume(args ...interface{}) {
 
 `;
 
-exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jcb.init.go 1`] = `
-package jcb
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-base.Base",
-		reflect.TypeOf((*Base)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "typeName", GoMethod: "TypeName"},
-		},
-		func() interface{} {
-			return &jsiiProxy_Base{}
-		},
-	)
-	_jsii_.RegisterStruct(
-		"@scope/jsii-calc-base.BaseProps",
-		reflect.TypeOf((*BaseProps)(nil)).Elem(),
-	)
-	_jsii_.RegisterInterface(
-		"@scope/jsii-calc-base.IBaseInterface",
-		reflect.TypeOf((*IBaseInterface)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
-		},
-		func() interface{} {
-			j := jsiiProxy_IBaseInterface{}
-			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalcbaseofbaseIVeryBaseInterface)
-			return &j
-		},
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-base.StaticConsumer",
-		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
-		nil, // no members
-		func() interface{} {
-			return &jsiiProxy_StaticConsumer{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jsii/jsii.go 1`] = `
 // Package jsii contains the functionaility needed for jsii packages to
 // initialize their dependencies and themselves. Users should never need to use this package
@@ -465,8 +502,11 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
        ┃  ┗━ 📄 scope-jsii-calc-base-of-base-2.1.1.tgz
        ┣━ 📄 LICENSE
        ┣━ 📄 NOTICE
+       ┣━ 📄 scopejsiicalcbaseofbase_IVeryBaseInterface.go
+       ┣━ 📄 scopejsiicalcbaseofbase_StaticConsumer.go
+       ┣━ 📄 scopejsiicalcbaseofbase_Very.go
+       ┣━ 📄 scopejsiicalcbaseofbase_VeryBaseProps.go
        ┣━ 📄 scopejsiicalcbaseofbase.go
-       ┣━ 📄 scopejsiicalcbaseofbase.init.go
        ┗━ 📄 version
 `;
 
@@ -720,12 +760,57 @@ func Initialize() {
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/jsii/scope-jsii-calc-base-of-base-2.1.1.tgz 1`] = `go/scopejsiicalcbaseofbase/jsii/scope-jsii-calc-base-of-base-2.1.1.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase.go 1`] = `
+package scopejsiicalcbaseofbase
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterInterface(
+		"@scope/jsii-calc-base-of-base.IVeryBaseInterface",
+		reflect.TypeOf((*IVeryBaseInterface)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+		},
+		func() interface{} {
+			return &jsiiProxy_IVeryBaseInterface{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-base-of-base.StaticConsumer",
+		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_StaticConsumer{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"@scope/jsii-calc-base-of-base.Very",
+		reflect.TypeOf((*Very)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "hey", GoMethod: "Hey"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Very{}
+		},
+	)
+	_jsii_.RegisterStruct(
+		"@scope/jsii-calc-base-of-base.VeryBaseProps",
+		reflect.TypeOf((*VeryBaseProps)(nil)).Elem(),
+	)
+}
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_IVeryBaseInterface.go 1`] = `
 // An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
 )
 
 type IVeryBaseInterface interface {
@@ -744,6 +829,18 @@ func (i *jsiiProxy_IVeryBaseInterface) Foo() {
 		nil, // no parameters
 	)
 }
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer.go 1`] = `
+// An example transitive dependency for jsii-calc.
+package scopejsiicalcbaseofbase
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
+)
 
 type StaticConsumer interface {
 }
@@ -767,6 +864,18 @@ func StaticConsumer_Consume(_args ...interface{}) {
 		args,
 	)
 }
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_Very.go 1`] = `
+// An example transitive dependency for jsii-calc.
+package scopejsiicalcbaseofbase
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2/jsii"
+)
 
 // Something here.
 // Experimental.
@@ -819,56 +928,18 @@ func (v *jsiiProxy_Very) Hey() *float64 {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_VeryBaseProps.go 1`] = `
+// An example transitive dependency for jsii-calc.
+package scopejsiicalcbaseofbase
+
+
 type VeryBaseProps struct {
 	Foo Very \`field:"required" json:"foo" yaml:"foo"\`
 }
 
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase.init.go 1`] = `
-package scopejsiicalcbaseofbase
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterInterface(
-		"@scope/jsii-calc-base-of-base.IVeryBaseInterface",
-		reflect.TypeOf((*IVeryBaseInterface)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
-		},
-		func() interface{} {
-			return &jsiiProxy_IVeryBaseInterface{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-base-of-base.StaticConsumer",
-		reflect.TypeOf((*StaticConsumer)(nil)).Elem(),
-		nil, // no members
-		func() interface{} {
-			return &jsiiProxy_StaticConsumer{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"@scope/jsii-calc-base-of-base.Very",
-		reflect.TypeOf((*Very)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "hey", GoMethod: "Hey"},
-		},
-		func() interface{} {
-			return &jsiiProxy_Very{}
-		},
-	)
-	_jsii_.RegisterStruct(
-		"@scope/jsii-calc-base-of-base.VeryBaseProps",
-		reflect.TypeOf((*VeryBaseProps)(nil)).Elem(),
-	)
-}
 
 `;
 
@@ -882,8 +953,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
  ┗━ 📁 go
     ┗━ 📁 scopejsiicalclib
        ┣━ 📁 customsubmodulename
+       ┃  ┣━ 📄 customsubmodulename_IReflectable.go
+       ┃  ┣━ 📄 customsubmodulename_NestingClass_NestedClass.go
+       ┃  ┣━ 📄 customsubmodulename_NestingClass_NestedStruct.go
+       ┃  ┣━ 📄 customsubmodulename_NestingClass.go
+       ┃  ┣━ 📄 customsubmodulename_ReflectableEntry.go
+       ┃  ┣━ 📄 customsubmodulename_Reflector.go
        ┃  ┣━ 📄 customsubmodulename.go
-       ┃  ┣━ 📄 customsubmodulename.init.go
        ┃  ┗━ 📄 README.md
        ┣━ 📄 go.mod
        ┣━ 📁 internal
@@ -893,8 +969,19 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
        ┃  ┗━ 📄 scope-jsii-calc-lib-0.0.0.tgz
        ┣━ 📄 LICENSE
        ┣━ 📄 NOTICE
+       ┣━ 📄 scopejsiicalclib_BaseFor2647.go
+       ┣━ 📄 scopejsiicalclib_DiamondLeft.go
+       ┣━ 📄 scopejsiicalclib_DiamondRight.go
+       ┣━ 📄 scopejsiicalclib_EnumFromScopedModule.go
+       ┣━ 📄 scopejsiicalclib_IDoublable.go
+       ┣━ 📄 scopejsiicalclib_IFriendly.go
+       ┣━ 📄 scopejsiicalclib_IThreeLevelsInterface.go
+       ┣━ 📄 scopejsiicalclib_MyFirstStruct.go
+       ┣━ 📄 scopejsiicalclib_Number.go
+       ┣━ 📄 scopejsiicalclib_NumericValue.go
+       ┣━ 📄 scopejsiicalclib_Operation.go
+       ┣━ 📄 scopejsiicalclib_StructWithOnlyOptionals.go
        ┣━ 📄 scopejsiicalclib.go
-       ┣━ 📄 scopejsiicalclib.init.go
        ┗━ 📄 version
 `;
 
@@ -1120,164 +1207,6 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 package customsubmodulename
 
 import (
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
-)
-
-// Deprecated.
-type IReflectable interface {
-	// Deprecated.
-	Entries() *[]*ReflectableEntry
-}
-
-// The jsii proxy for IReflectable
-type jsiiProxy_IReflectable struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IReflectable) Entries() *[]*ReflectableEntry {
-	var returns *[]*ReflectableEntry
-	_jsii_.Get(
-		j,
-		"entries",
-		&returns,
-	)
-	return returns
-}
-
-// This class is here to show we can use nested classes across module boundaries.
-// Deprecated.
-type NestingClass interface {
-}
-
-// The jsii proxy struct for NestingClass
-type jsiiProxy_NestingClass struct {
-	_ byte // padding
-}
-
-// This class is here to show we can use nested classes across module boundaries.
-// Deprecated.
-type NestingClass_NestedClass interface {
-	// Deprecated.
-	Property() *string
-}
-
-// The jsii proxy struct for NestingClass_NestedClass
-type jsiiProxy_NestingClass_NestedClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_NestingClass_NestedClass) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-// Deprecated.
-func NewNestingClass_NestedClass() NestingClass_NestedClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_NestingClass_NestedClass{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated.
-func NewNestingClass_NestedClass_Override(n NestingClass_NestedClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
-		nil, // no parameters
-		n,
-	)
-}
-
-// This is a struct, nested within a class.
-//
-// Normal.
-// Deprecated.
-type NestingClass_NestedStruct struct {
-	// Deprecated.
-	Name *string \`field:"required" json:"name" yaml:"name"\`
-}
-
-// Deprecated.
-type ReflectableEntry struct {
-	// Deprecated.
-	Key *string \`field:"required" json:"key" yaml:"key"\`
-	// Deprecated.
-	Value interface{} \`field:"required" json:"value" yaml:"value"\`
-}
-
-// Deprecated.
-type Reflector interface {
-	// Deprecated.
-	AsMap(reflectable IReflectable) *map[string]interface{}
-}
-
-// The jsii proxy struct for Reflector
-type jsiiProxy_Reflector struct {
-	_ byte // padding
-}
-
-// Deprecated.
-func NewReflector() Reflector {
-	_init_.Initialize()
-
-	j := jsiiProxy_Reflector{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.Reflector",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated.
-func NewReflector_Override(r Reflector) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.submodule.Reflector",
-		nil, // no parameters
-		r,
-	)
-}
-
-func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) *map[string]interface{} {
-	var returns *map[string]interface{}
-
-	_jsii_.Invoke(
-		r,
-		"asMap",
-		[]interface{}{reflectable},
-		&returns,
-	)
-
-	return returns
-}
-
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename.init.go 1`] = `
-package customsubmodulename
-
-import (
 	"reflect"
 
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
@@ -1331,6 +1260,206 @@ func init() {
 		},
 	)
 }
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_IReflectable.go 1`] = `
+package customsubmodulename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Deprecated.
+type IReflectable interface {
+	// Deprecated.
+	Entries() *[]*ReflectableEntry
+}
+
+// The jsii proxy for IReflectable
+type jsiiProxy_IReflectable struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IReflectable) Entries() *[]*ReflectableEntry {
+	var returns *[]*ReflectableEntry
+	_jsii_.Get(
+		j,
+		"entries",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_NestingClass.go 1`] = `
+package customsubmodulename
+
+
+// This class is here to show we can use nested classes across module boundaries.
+// Deprecated.
+type NestingClass interface {
+}
+
+// The jsii proxy struct for NestingClass
+type jsiiProxy_NestingClass struct {
+	_ byte // padding
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_NestingClass_NestedClass.go 1`] = `
+package customsubmodulename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+)
+
+// This class is here to show we can use nested classes across module boundaries.
+// Deprecated.
+type NestingClass_NestedClass interface {
+	// Deprecated.
+	Property() *string
+}
+
+// The jsii proxy struct for NestingClass_NestedClass
+type jsiiProxy_NestingClass_NestedClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_NestingClass_NestedClass) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+// Deprecated.
+func NewNestingClass_NestedClass() NestingClass_NestedClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_NestingClass_NestedClass{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated.
+func NewNestingClass_NestedClass_Override(n NestingClass_NestedClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.NestingClass.NestedClass",
+		nil, // no parameters
+		n,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_NestingClass_NestedStruct.go 1`] = `
+package customsubmodulename
+
+
+// This is a struct, nested within a class.
+//
+// Normal.
+// Deprecated.
+type NestingClass_NestedStruct struct {
+	// Deprecated.
+	Name *string \`field:"required" json:"name" yaml:"name"\`
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_ReflectableEntry.go 1`] = `
+package customsubmodulename
+
+
+// Deprecated.
+type ReflectableEntry struct {
+	// Deprecated.
+	Key *string \`field:"required" json:"key" yaml:"key"\`
+	// Deprecated.
+	Value interface{} \`field:"required" json:"value" yaml:"value"\`
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/customsubmodulename_Reflector.go 1`] = `
+package customsubmodulename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+)
+
+// Deprecated.
+type Reflector interface {
+	// Deprecated.
+	AsMap(reflectable IReflectable) *map[string]interface{}
+}
+
+// The jsii proxy struct for Reflector
+type jsiiProxy_Reflector struct {
+	_ byte // padding
+}
+
+// Deprecated.
+func NewReflector() Reflector {
+	_init_.Initialize()
+
+	j := jsiiProxy_Reflector{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.Reflector",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated.
+func NewReflector_Override(r Reflector) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.submodule.Reflector",
+		nil, // no parameters
+		r,
+	)
+}
+
+func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) *map[string]interface{} {
+	var returns *map[string]interface{}
+
+	_jsii_.Invoke(
+		r,
+		"asMap",
+		[]interface{}{reflectable},
+		&returns,
+	)
+
+	return returns
+}
+
 
 `;
 
@@ -1392,439 +1521,6 @@ func Initialize() {
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/jsii/scope-jsii-calc-lib-0.0.0.tgz 1`] = `go/scopejsiicalclib/jsii/scope-jsii-calc-lib-0.0.0.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib.go 1`] = `
-// A simple calcuator library built on JSII.
-package scopejsiicalclib
-
-import (
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
-
-	"github.com/aws/jsii/jsii-calc/go/jcb"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/internal"
-)
-
-// A base class for testing #2647.
-//
-// The method \`foo\` has a parameter that uses a type
-// from a dependent module. Since Go "reimplments" this method, it will also need
-// to include an "import" statement for the calc-base module.
-// See: https://github.com/aws/jsii/issues/2647
-//
-// Deprecated.
-type BaseFor2647 interface {
-	// Deprecated.
-	Foo(obj jcb.IBaseInterface)
-}
-
-// The jsii proxy struct for BaseFor2647
-type jsiiProxy_BaseFor2647 struct {
-	_ byte // padding
-}
-
-// Deprecated.
-func NewBaseFor2647(very scopejsiicalcbaseofbase.Very) BaseFor2647 {
-	_init_.Initialize()
-
-	j := jsiiProxy_BaseFor2647{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.BaseFor2647",
-		[]interface{}{very},
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated.
-func NewBaseFor2647_Override(b BaseFor2647, very scopejsiicalcbaseofbase.Very) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.BaseFor2647",
-		[]interface{}{very},
-		b,
-	)
-}
-
-func (b *jsiiProxy_BaseFor2647) Foo(obj jcb.IBaseInterface) {
-	_jsii_.InvokeVoid(
-		b,
-		"foo",
-		[]interface{}{obj},
-	)
-}
-
-// Deprecated.
-type DiamondLeft struct {
-	// Deprecated.
-	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
-	// Deprecated.
-	Left *float64 \`field:"optional" json:"left" yaml:"left"\`
-}
-
-// Deprecated.
-type DiamondRight struct {
-	// Deprecated.
-	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
-	// Deprecated.
-	Right *bool \`field:"optional" json:"right" yaml:"right"\`
-}
-
-// Check that enums from \\@scoped packages can be references.
-//
-// See awslabs/jsii#138.
-// Deprecated.
-type EnumFromScopedModule string
-
-const (
-	// Deprecated.
-	EnumFromScopedModule_VALUE1 EnumFromScopedModule = "VALUE1"
-	// Deprecated.
-	EnumFromScopedModule_VALUE2 EnumFromScopedModule = "VALUE2"
-)
-
-// The general contract for a concrete number.
-// Deprecated.
-type IDoublable interface {
-	// Deprecated.
-	DoubleValue() *float64
-}
-
-// The jsii proxy for IDoublable
-type jsiiProxy_IDoublable struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IDoublable) DoubleValue() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"doubleValue",
-		&returns,
-	)
-	return returns
-}
-
-// Applies to classes that are considered friendly.
-//
-// These classes can be greeted with
-// a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
-// Deprecated.
-type IFriendly interface {
-	// Say hello!
-	// Deprecated.
-	Hello() *string
-}
-
-// The jsii proxy for IFriendly
-type jsiiProxy_IFriendly struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IFriendly) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Interface that inherits from packages 2 levels up the tree.
-//
-// Their presence validates that .NET/Java/jsii-reflect can track all fields
-// far enough up the tree.
-// Deprecated.
-type IThreeLevelsInterface interface {
-	jcb.IBaseInterface
-	// Deprecated.
-	Baz()
-}
-
-// The jsii proxy for IThreeLevelsInterface
-type jsiiProxy_IThreeLevelsInterface struct {
-	internal.Type__jcbIBaseInterface
-}
-
-func (i *jsiiProxy_IThreeLevelsInterface) Baz() {
-	_jsii_.InvokeVoid(
-		i,
-		"baz",
-		nil, // no parameters
-	)
-}
-
-// This is the first struct we have created in jsii.
-// Deprecated.
-type MyFirstStruct struct {
-	// An awesome number value.
-	// Deprecated.
-	Anumber *float64 \`field:"required" json:"anumber" yaml:"anumber"\`
-	// A string value.
-	// Deprecated.
-	Astring *string \`field:"required" json:"astring" yaml:"astring"\`
-	// Deprecated.
-	FirstOptional *[]*string \`field:"optional" json:"firstOptional" yaml:"firstOptional"\`
-}
-
-// Represents a concrete number.
-// Deprecated.
-type Number interface {
-	NumericValue
-	IDoublable
-	// The number multiplied by 2.
-	// Deprecated.
-	DoubleValue() *float64
-	// The number.
-	// Deprecated.
-	Value() *float64
-	// String representation of the value.
-	// Deprecated.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	// Deprecated.
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Number
-type jsiiProxy_Number struct {
-	jsiiProxy_NumericValue
-	jsiiProxy_IDoublable
-}
-
-func (j *jsiiProxy_Number) DoubleValue() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"doubleValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Number) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a Number object.
-// Deprecated.
-func NewNumber(value *float64) Number {
-	_init_.Initialize()
-
-	j := jsiiProxy_Number{}
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.Number",
-		[]interface{}{value},
-		&j,
-	)
-
-	return &j
-}
-
-// Creates a Number object.
-// Deprecated.
-func NewNumber_Override(n Number, value *float64) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.Number",
-		[]interface{}{value},
-		n,
-	)
-}
-
-func (n *jsiiProxy_Number) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_Number) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Abstract class which represents a numeric value.
-// Deprecated.
-type NumericValue interface {
-	jcb.Base
-	// The value.
-	// Deprecated.
-	Value() *float64
-	// String representation of the value.
-	// Deprecated.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	// Deprecated.
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for NumericValue
-type jsiiProxy_NumericValue struct {
-	internal.Type__jcbBase
-}
-
-func (j *jsiiProxy_NumericValue) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Deprecated.
-func NewNumericValue_Override(n NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.NumericValue",
-		nil, // no parameters
-		n,
-	)
-}
-
-func (n *jsiiProxy_NumericValue) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_NumericValue) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Represents an operation on values.
-// Deprecated.
-type Operation interface {
-	NumericValue
-	// The value.
-	// Deprecated.
-	Value() *float64
-	// String representation of the value.
-	// Deprecated.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	// Deprecated.
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Operation
-type jsiiProxy_Operation struct {
-	jsiiProxy_NumericValue
-}
-
-func (j *jsiiProxy_Operation) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Deprecated.
-func NewOperation_Override(o Operation) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"@scope/jsii-calc-lib.Operation",
-		nil, // no parameters
-		o,
-	)
-}
-
-func (o *jsiiProxy_Operation) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		o,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (o *jsiiProxy_Operation) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		o,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// This is a struct with only optional properties.
-// Deprecated.
-type StructWithOnlyOptionals struct {
-	// The first optional!
-	// Deprecated.
-	Optional1 *string \`field:"optional" json:"optional1" yaml:"optional1"\`
-	// Deprecated.
-	Optional2 *float64 \`field:"optional" json:"optional2" yaml:"optional2"\`
-	// Deprecated.
-	Optional3 *bool \`field:"optional" json:"optional3" yaml:"optional3"\`
-}
-
-
-`;
-
-exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib.init.go 1`] = `
 package scopejsiicalclib
 
 import (
@@ -1950,6 +1646,553 @@ func init() {
 
 `;
 
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_BaseFor2647.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
+)
+
+// A base class for testing #2647.
+//
+// The method \`foo\` has a parameter that uses a type
+// from a dependent module. Since Go "reimplments" this method, it will also need
+// to include an "import" statement for the calc-base module.
+// See: https://github.com/aws/jsii/issues/2647
+//
+// Deprecated.
+type BaseFor2647 interface {
+	// Deprecated.
+	Foo(obj jcb.IBaseInterface)
+}
+
+// The jsii proxy struct for BaseFor2647
+type jsiiProxy_BaseFor2647 struct {
+	_ byte // padding
+}
+
+// Deprecated.
+func NewBaseFor2647(very scopejsiicalcbaseofbase.Very) BaseFor2647 {
+	_init_.Initialize()
+
+	j := jsiiProxy_BaseFor2647{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.BaseFor2647",
+		[]interface{}{very},
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated.
+func NewBaseFor2647_Override(b BaseFor2647, very scopejsiicalcbaseofbase.Very) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.BaseFor2647",
+		[]interface{}{very},
+		b,
+	)
+}
+
+func (b *jsiiProxy_BaseFor2647) Foo(obj jcb.IBaseInterface) {
+	_jsii_.InvokeVoid(
+		b,
+		"foo",
+		[]interface{}{obj},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_DiamondLeft.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+
+// Deprecated.
+type DiamondLeft struct {
+	// Deprecated.
+	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
+	// Deprecated.
+	Left *float64 \`field:"optional" json:"left" yaml:"left"\`
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_DiamondRight.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+
+// Deprecated.
+type DiamondRight struct {
+	// Deprecated.
+	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
+	// Deprecated.
+	Right *bool \`field:"optional" json:"right" yaml:"right"\`
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_EnumFromScopedModule.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+
+// Check that enums from \\@scoped packages can be references.
+//
+// See awslabs/jsii#138.
+// Deprecated.
+type EnumFromScopedModule string
+
+const (
+	// Deprecated.
+	EnumFromScopedModule_VALUE1 EnumFromScopedModule = "VALUE1"
+	// Deprecated.
+	EnumFromScopedModule_VALUE2 EnumFromScopedModule = "VALUE2"
+)
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_IDoublable.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// The general contract for a concrete number.
+// Deprecated.
+type IDoublable interface {
+	// Deprecated.
+	DoubleValue() *float64
+}
+
+// The jsii proxy for IDoublable
+type jsiiProxy_IDoublable struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IDoublable) DoubleValue() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"doubleValue",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_IFriendly.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Applies to classes that are considered friendly.
+//
+// These classes can be greeted with
+// a "hello" or "goodbye" blessing and they will respond back in a fun and friendly manner.
+// Deprecated.
+type IFriendly interface {
+	// Say hello!
+	// Deprecated.
+	Hello() *string
+}
+
+// The jsii proxy for IFriendly
+type jsiiProxy_IFriendly struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IFriendly) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_IThreeLevelsInterface.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/internal"
+)
+
+// Interface that inherits from packages 2 levels up the tree.
+//
+// Their presence validates that .NET/Java/jsii-reflect can track all fields
+// far enough up the tree.
+// Deprecated.
+type IThreeLevelsInterface interface {
+	jcb.IBaseInterface
+	// Deprecated.
+	Baz()
+}
+
+// The jsii proxy for IThreeLevelsInterface
+type jsiiProxy_IThreeLevelsInterface struct {
+	internal.Type__jcbIBaseInterface
+}
+
+func (i *jsiiProxy_IThreeLevelsInterface) Baz() {
+	_jsii_.InvokeVoid(
+		i,
+		"baz",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_MyFirstStruct.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+
+// This is the first struct we have created in jsii.
+// Deprecated.
+type MyFirstStruct struct {
+	// An awesome number value.
+	// Deprecated.
+	Anumber *float64 \`field:"required" json:"anumber" yaml:"anumber"\`
+	// A string value.
+	// Deprecated.
+	Astring *string \`field:"required" json:"astring" yaml:"astring"\`
+	// Deprecated.
+	FirstOptional *[]*string \`field:"optional" json:"firstOptional" yaml:"firstOptional"\`
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_Number.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+)
+
+// Represents a concrete number.
+// Deprecated.
+type Number interface {
+	NumericValue
+	IDoublable
+	// The number multiplied by 2.
+	// Deprecated.
+	DoubleValue() *float64
+	// The number.
+	// Deprecated.
+	Value() *float64
+	// String representation of the value.
+	// Deprecated.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	// Deprecated.
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Number
+type jsiiProxy_Number struct {
+	jsiiProxy_NumericValue
+	jsiiProxy_IDoublable
+}
+
+func (j *jsiiProxy_Number) DoubleValue() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"doubleValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Number) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a Number object.
+// Deprecated.
+func NewNumber(value *float64) Number {
+	_init_.Initialize()
+
+	j := jsiiProxy_Number{}
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.Number",
+		[]interface{}{value},
+		&j,
+	)
+
+	return &j
+}
+
+// Creates a Number object.
+// Deprecated.
+func NewNumber_Override(n Number, value *float64) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.Number",
+		[]interface{}{value},
+		n,
+	)
+}
+
+func (n *jsiiProxy_Number) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_Number) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_NumericValue.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/internal"
+)
+
+// Abstract class which represents a numeric value.
+// Deprecated.
+type NumericValue interface {
+	jcb.Base
+	// The value.
+	// Deprecated.
+	Value() *float64
+	// String representation of the value.
+	// Deprecated.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	// Deprecated.
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for NumericValue
+type jsiiProxy_NumericValue struct {
+	internal.Type__jcbBase
+}
+
+func (j *jsiiProxy_NumericValue) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Deprecated.
+func NewNumericValue_Override(n NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.NumericValue",
+		nil, // no parameters
+		n,
+	)
+}
+
+func (n *jsiiProxy_NumericValue) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_NumericValue) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_Operation.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/jsii"
+)
+
+// Represents an operation on values.
+// Deprecated.
+type Operation interface {
+	NumericValue
+	// The value.
+	// Deprecated.
+	Value() *float64
+	// String representation of the value.
+	// Deprecated.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	// Deprecated.
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Operation
+type jsiiProxy_Operation struct {
+	jsiiProxy_NumericValue
+}
+
+func (j *jsiiProxy_Operation) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Deprecated.
+func NewOperation_Override(o Operation) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"@scope/jsii-calc-lib.Operation",
+		nil, // no parameters
+		o,
+	)
+}
+
+func (o *jsiiProxy_Operation) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		o,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (o *jsiiProxy_Operation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		o,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/scopejsiicalclib_StructWithOnlyOptionals.go 1`] = `
+// A simple calcuator library built on JSII.
+package scopejsiicalclib
+
+
+// This is a struct with only optional properties.
+// Deprecated.
+type StructWithOnlyOptionals struct {
+	// The first optional!
+	// Deprecated.
+	Optional1 *string \`field:"optional" json:"optional1" yaml:"optional1"\`
+	// Deprecated.
+	Optional2 *float64 \`field:"optional" json:"optional2" yaml:"optional2"\`
+	// Deprecated.
+	Optional3 *bool \`field:"optional" json:"optional3" yaml:"optional3"\`
+}
+
+
+`;
+
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/version 1`] = `
 0.0.0-devpreview
 
@@ -1960,126 +2203,366 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
  ┗━ 📁 go
     ┗━ 📁 jsiicalc
        ┣━ 📁 cdk16625
+       ┃  ┣━ 📄 cdk16625_Cdk16625.go
        ┃  ┣━ 📄 cdk16625.go
-       ┃  ┣━ 📄 cdk16625.init.go
        ┃  ┗━ 📁 donotimport
+       ┃     ┣━ 📄 donotimport_UnimportedSubmoduleType.go
        ┃     ┣━ 📄 donotimport.go
-       ┃     ┣━ 📄 donotimport.init.go
        ┃     ┗━ 📁 internal
        ┃        ┗━ 📄 types.go
        ┣━ 📁 composition
+       ┃  ┣━ 📄 composition_CompositeOperation_CompositionStringStyle.go
+       ┃  ┣━ 📄 composition_CompositeOperation.go
        ┃  ┣━ 📄 composition.go
-       ┃  ┣━ 📄 composition.init.go
        ┃  ┗━ 📁 internal
        ┃     ┗━ 📄 types.go
        ┣━ 📁 derivedclasshasnoproperties
-       ┃  ┣━ 📄 derivedclasshasnoproperties.go
-       ┃  ┗━ 📄 derivedclasshasnoproperties.init.go
+       ┃  ┣━ 📄 derivedclasshasnoproperties_Base.go
+       ┃  ┣━ 📄 derivedclasshasnoproperties_Derived.go
+       ┃  ┗━ 📄 derivedclasshasnoproperties.go
        ┣━ 📄 go.mod
        ┣━ 📁 interfaceinnamespaceincludesclasses
-       ┃  ┣━ 📄 interfaceinnamespaceincludesclasses.go
-       ┃  ┗━ 📄 interfaceinnamespaceincludesclasses.init.go
+       ┃  ┣━ 📄 interfaceinnamespaceincludesclasses_Foo.go
+       ┃  ┣━ 📄 interfaceinnamespaceincludesclasses_Hello.go
+       ┃  ┗━ 📄 interfaceinnamespaceincludesclasses.go
        ┣━ 📁 interfaceinnamespaceonlyinterface
-       ┃  ┣━ 📄 interfaceinnamespaceonlyinterface.go
-       ┃  ┗━ 📄 interfaceinnamespaceonlyinterface.init.go
+       ┃  ┣━ 📄 interfaceinnamespaceonlyinterface_Hello.go
+       ┃  ┗━ 📄 interfaceinnamespaceonlyinterface.go
        ┣━ 📁 internal
        ┃  ┗━ 📄 types.go
        ┣━ 📁 jsii
        ┃  ┣━ 📄 jsii-calc-3.20.120.tgz
        ┃  ┗━ 📄 jsii.go
        ┣━ 📁 jsii3656
-       ┃  ┣━ 📄 jsii3656.go
-       ┃  ┗━ 📄 jsii3656.init.go
+       ┃  ┣━ 📄 jsii3656_ImplementMeOpts.go
+       ┃  ┣━ 📄 jsii3656_OverrideMe.go
+       ┃  ┗━ 📄 jsii3656.go
+       ┣━ 📄 jsiicalc_AbstractClass.go
+       ┣━ 📄 jsiicalc_AbstractClassBase.go
+       ┣━ 📄 jsiicalc_AbstractClassReturner.go
+       ┣━ 📄 jsiicalc_AbstractSuite.go
+       ┣━ 📄 jsiicalc_Add.go
+       ┣━ 📄 jsiicalc_AllowedMethodNames.go
+       ┣━ 📄 jsiicalc_AllTypes.go
+       ┣━ 📄 jsiicalc_AllTypesEnum.go
+       ┣━ 📄 jsiicalc_AmbiguousParameters.go
+       ┣━ 📄 jsiicalc_AnonymousImplementationProvider.go
+       ┣━ 📄 jsiicalc_AsyncVirtualMethods.go
+       ┣━ 📄 jsiicalc_AugmentableClass.go
+       ┣━ 📄 jsiicalc_BaseClass.go
+       ┣━ 📄 jsiicalc_BaseJsii976.go
+       ┣━ 📄 jsiicalc_Bell.go
+       ┣━ 📄 jsiicalc_BinaryOperation.go
+       ┣━ 📄 jsiicalc_BurriedAnonymousObject.go
+       ┣━ 📄 jsiicalc_Calculator.go
+       ┣━ 📄 jsiicalc_CalculatorProps.go
+       ┣━ 📄 jsiicalc_ChildStruct982.go
+       ┣━ 📄 jsiicalc_ClassThatImplementsTheInternalInterface.go
+       ┣━ 📄 jsiicalc_ClassThatImplementsThePrivateInterface.go
+       ┣━ 📄 jsiicalc_ClassWithCollections.go
+       ┣━ 📄 jsiicalc_ClassWithContainerTypes.go
+       ┣━ 📄 jsiicalc_ClassWithDocs.go
+       ┣━ 📄 jsiicalc_ClassWithJavaReservedWords.go
+       ┣━ 📄 jsiicalc_ClassWithMutableObjectLiteralProperty.go
+       ┣━ 📄 jsiicalc_ClassWithPrivateConstructorAndAutomaticProperties.go
+       ┣━ 📄 jsiicalc_ConfusingToJackson.go
+       ┣━ 📄 jsiicalc_ConfusingToJacksonStruct.go
+       ┣━ 📄 jsiicalc_ConstructorPassesThisOut.go
+       ┣━ 📄 jsiicalc_Constructors.go
+       ┣━ 📄 jsiicalc_ConsumePureInterface.go
+       ┣━ 📄 jsiicalc_ConsumerCanRingBell.go
+       ┣━ 📄 jsiicalc_ConsumersOfThisCrazyTypeSystem.go
+       ┣━ 📄 jsiicalc_ContainerProps.go
+       ┣━ 📄 jsiicalc_DataRenderer.go
+       ┣━ 📄 jsiicalc_Default.go
+       ┣━ 📄 jsiicalc_DefaultedConstructorArgument.go
+       ┣━ 📄 jsiicalc_Demonstrate982.go
+       ┣━ 📄 jsiicalc_DeprecatedClass.go
+       ┣━ 📄 jsiicalc_DeprecatedEnum.go
+       ┣━ 📄 jsiicalc_DeprecatedStruct.go
+       ┣━ 📄 jsiicalc_DerivedStruct.go
+       ┣━ 📄 jsiicalc_DiamondBottom.go
+       ┣━ 📄 jsiicalc_DiamondInheritanceBaseLevelStruct.go
+       ┣━ 📄 jsiicalc_DiamondInheritanceFirstMidLevelStruct.go
+       ┣━ 📄 jsiicalc_DiamondInheritanceSecondMidLevelStruct.go
+       ┣━ 📄 jsiicalc_DiamondInheritanceTopLevelStruct.go
+       ┣━ 📄 jsiicalc_DisappointingCollectionSource.go
+       ┣━ 📄 jsiicalc_DocumentedClass.go
+       ┣━ 📄 jsiicalc_DoNotOverridePrivates.go
+       ┣━ 📄 jsiicalc_DoNotRecognizeAnyAsOptional.go
+       ┣━ 📄 jsiicalc_DontComplainAboutVariadicAfterOptional.go
+       ┣━ 📄 jsiicalc_DoubleTrouble.go
+       ┣━ 📄 jsiicalc_DummyObj.go
+       ┣━ 📄 jsiicalc_DynamicPropertyBearer.go
+       ┣━ 📄 jsiicalc_DynamicPropertyBearerChild.go
+       ┣━ 📄 jsiicalc_Entropy.go
+       ┣━ 📄 jsiicalc_EnumDispenser.go
+       ┣━ 📄 jsiicalc_EraseUndefinedHashValues.go
+       ┣━ 📄 jsiicalc_EraseUndefinedHashValuesOptions.go
+       ┣━ 📄 jsiicalc_ExperimentalClass.go
+       ┣━ 📄 jsiicalc_ExperimentalEnum.go
+       ┣━ 📄 jsiicalc_ExperimentalStruct.go
+       ┣━ 📄 jsiicalc_ExportedBaseClass.go
+       ┣━ 📄 jsiicalc_ExtendsInternalInterface.go
+       ┣━ 📄 jsiicalc_ExternalClass.go
+       ┣━ 📄 jsiicalc_ExternalEnum.go
+       ┣━ 📄 jsiicalc_ExternalStruct.go
+       ┣━ 📄 jsiicalc_FullCombo.go
+       ┣━ 📄 jsiicalc_GiveMeStructs.go
+       ┣━ 📄 jsiicalc_Greetee.go
+       ┣━ 📄 jsiicalc_GreetingAugmenter.go
+       ┣━ 📄 jsiicalc_IAnonymousImplementationProvider.go
+       ┣━ 📄 jsiicalc_IAnonymouslyImplementMe.go
+       ┣━ 📄 jsiicalc_IAnotherPublicInterface.go
+       ┣━ 📄 jsiicalc_IBell.go
+       ┣━ 📄 jsiicalc_IBellRinger.go
+       ┣━ 📄 jsiicalc_IConcreteBellRinger.go
+       ┣━ 📄 jsiicalc_IDeprecatedInterface.go
+       ┣━ 📄 jsiicalc_IExperimentalInterface.go
+       ┣━ 📄 jsiicalc_IExtendsPrivateInterface.go
+       ┣━ 📄 jsiicalc_IExternalInterface.go
+       ┣━ 📄 jsiicalc_IFriendlier.go
+       ┣━ 📄 jsiicalc_IFriendlyRandomGenerator.go
+       ┣━ 📄 jsiicalc_IIndirectlyImplemented.go
+       ┣━ 📄 jsiicalc_IInterfaceImplementedByAbstractClass.go
+       ┣━ 📄 jsiicalc_IInterfaceThatShouldNotBeADataType.go
+       ┣━ 📄 jsiicalc_IInterfaceWithInternal.go
+       ┣━ 📄 jsiicalc_IInterfaceWithMethods.go
+       ┣━ 📄 jsiicalc_IInterfaceWithOptionalMethodArguments.go
+       ┣━ 📄 jsiicalc_IInterfaceWithProperties.go
+       ┣━ 📄 jsiicalc_IInterfaceWithPropertiesExtension.go
+       ┣━ 📄 jsiicalc_IJavaReservedWordsInAnInterface.go
+       ┣━ 📄 jsiicalc_IJSII417Derived.go
+       ┣━ 📄 jsiicalc_IJSII417PublicBaseOfBase.go
+       ┣━ 📄 jsiicalc_IJsii487External.go
+       ┣━ 📄 jsiicalc_IJsii487External2.go
+       ┣━ 📄 jsiicalc_IJsii496.go
+       ┣━ 📄 jsiicalc_Implementation.go
+       ┣━ 📄 jsiicalc_ImplementInternalInterface.go
+       ┣━ 📄 jsiicalc_ImplementsInterfaceWithInternal.go
+       ┣━ 📄 jsiicalc_ImplementsInterfaceWithInternalSubclass.go
+       ┣━ 📄 jsiicalc_ImplementsPrivateInterface.go
+       ┣━ 📄 jsiicalc_ImplictBaseOfBase.go
+       ┣━ 📄 jsiicalc_IMutableObjectLiteral.go
+       ┣━ 📄 jsiicalc_InbetweenClass.go
+       ┣━ 📄 jsiicalc_INonInternalInterface.go
+       ┣━ 📄 jsiicalc_InterfaceCollections.go
+       ┣━ 📄 jsiicalc_InterfacesMaker.go
+       ┣━ 📄 jsiicalc_IObjectWithProperty.go
+       ┣━ 📄 jsiicalc_IOptionalMethod.go
+       ┣━ 📄 jsiicalc_IPrivatelyImplemented.go
+       ┣━ 📄 jsiicalc_IPublicInterface.go
+       ┣━ 📄 jsiicalc_IPublicInterface2.go
+       ┣━ 📄 jsiicalc_IRandomNumberGenerator.go
+       ┣━ 📄 jsiicalc_IReturnJsii976.go
+       ┣━ 📄 jsiicalc_IReturnsNumber.go
+       ┣━ 📄 jsiicalc_Isomorphism.go
+       ┣━ 📄 jsiicalc_Issue2638.go
+       ┣━ 📄 jsiicalc_Issue2638B.go
+       ┣━ 📄 jsiicalc_IStableInterface.go
+       ┣━ 📄 jsiicalc_IStructReturningDelegate.go
+       ┣━ 📄 jsiicalc_IWallClock.go
+       ┣━ 📄 jsiicalc_JavaReservedWords.go
+       ┣━ 📄 jsiicalc_JSII417Derived.go
+       ┣━ 📄 jsiicalc_JSII417PublicBaseOfBase.go
+       ┣━ 📄 jsiicalc_Jsii487Derived.go
+       ┣━ 📄 jsiicalc_Jsii496Derived.go
+       ┣━ 📄 jsiicalc_JsiiAgent.go
+       ┣━ 📄 jsiicalc_JSObjectLiteralForInterface.go
+       ┣━ 📄 jsiicalc_JSObjectLiteralToNative.go
+       ┣━ 📄 jsiicalc_JSObjectLiteralToNativeClass.go
+       ┣━ 📄 jsiicalc_JsonFormatter.go
+       ┣━ 📄 jsiicalc_LevelOne_PropBooleanValue.go
+       ┣━ 📄 jsiicalc_LevelOne_PropProperty.go
+       ┣━ 📄 jsiicalc_LevelOne.go
+       ┣━ 📄 jsiicalc_LevelOneProps.go
+       ┣━ 📄 jsiicalc_LoadBalancedFargateServiceProps.go
+       ┣━ 📄 jsiicalc_MethodNamedProperty.go
+       ┣━ 📄 jsiicalc_Multiply.go
+       ┣━ 📄 jsiicalc_Negate.go
+       ┣━ 📄 jsiicalc_NestedClassInstance.go
+       ┣━ 📄 jsiicalc_NestedStruct.go
+       ┣━ 📄 jsiicalc_NodeStandardLibrary.go
+       ┣━ 📄 jsiicalc_NullShouldBeTreatedAsUndefined.go
+       ┣━ 📄 jsiicalc_NullShouldBeTreatedAsUndefinedData.go
+       ┣━ 📄 jsiicalc_NumberGenerator.go
+       ┣━ 📄 jsiicalc_ObjectRefsInCollections.go
+       ┣━ 📄 jsiicalc_ObjectWithPropertyProvider.go
+       ┣━ 📄 jsiicalc_Old.go
+       ┣━ 📄 jsiicalc_OptionalArgumentInvoker.go
+       ┣━ 📄 jsiicalc_OptionalConstructorArgument.go
+       ┣━ 📄 jsiicalc_OptionalStruct.go
+       ┣━ 📄 jsiicalc_OptionalStructConsumer.go
+       ┣━ 📄 jsiicalc_OverridableProtectedMember.go
+       ┣━ 📄 jsiicalc_OverrideReturnsObject.go
+       ┣━ 📄 jsiicalc_ParentStruct982.go
+       ┣━ 📄 jsiicalc_PartiallyInitializedThisConsumer.go
+       ┣━ 📄 jsiicalc_Polymorphism.go
+       ┣━ 📄 jsiicalc_Power.go
+       ┣━ 📄 jsiicalc_PropertyNamedProperty.go
+       ┣━ 📄 jsiicalc_PublicClass.go
+       ┣━ 📄 jsiicalc_PythonReservedWords.go
+       ┣━ 📄 jsiicalc_ReferenceEnumFromScopedPackage.go
+       ┣━ 📄 jsiicalc_ReturnsPrivateImplementationOfInterface.go
+       ┣━ 📄 jsiicalc_RootStruct.go
+       ┣━ 📄 jsiicalc_RootStructValidator.go
+       ┣━ 📄 jsiicalc_RuntimeTypeChecking.go
+       ┣━ 📄 jsiicalc_SecondLevelStruct.go
+       ┣━ 📄 jsiicalc_SingleInstanceTwoTypes.go
+       ┣━ 📄 jsiicalc_SingletonInt.go
+       ┣━ 📄 jsiicalc_SingletonIntEnum.go
+       ┣━ 📄 jsiicalc_SingletonString.go
+       ┣━ 📄 jsiicalc_SingletonStringEnum.go
+       ┣━ 📄 jsiicalc_SmellyStruct.go
+       ┣━ 📄 jsiicalc_SomeTypeJsii976.go
+       ┣━ 📄 jsiicalc_StableClass.go
+       ┣━ 📄 jsiicalc_StableEnum.go
+       ┣━ 📄 jsiicalc_StableStruct.go
+       ┣━ 📄 jsiicalc_StaticContext.go
+       ┣━ 📄 jsiicalc_StaticHelloChild.go
+       ┣━ 📄 jsiicalc_StaticHelloParent.go
+       ┣━ 📄 jsiicalc_Statics.go
+       ┣━ 📄 jsiicalc_StringEnum.go
+       ┣━ 📄 jsiicalc_StripInternal.go
+       ┣━ 📄 jsiicalc_StructA.go
+       ┣━ 📄 jsiicalc_StructB.go
+       ┣━ 📄 jsiicalc_StructParameterType.go
+       ┣━ 📄 jsiicalc_StructPassing.go
+       ┣━ 📄 jsiicalc_StructUnionConsumer.go
+       ┣━ 📄 jsiicalc_StructWithEnum.go
+       ┣━ 📄 jsiicalc_StructWithJavaReservedWords.go
+       ┣━ 📄 jsiicalc_Sum.go
+       ┣━ 📄 jsiicalc_SupportsNiceJavaBuilder.go
+       ┣━ 📄 jsiicalc_SupportsNiceJavaBuilderProps.go
+       ┣━ 📄 jsiicalc_SupportsNiceJavaBuilderWithRequiredProps.go
+       ┣━ 📄 jsiicalc_SyncVirtualMethods.go
+       ┣━ 📄 jsiicalc_TestStructWithEnum.go
+       ┣━ 📄 jsiicalc_Thrower.go
+       ┣━ 📄 jsiicalc_TopLevelStruct.go
+       ┣━ 📄 jsiicalc_TwoMethodsWithSimilarCapitalization.go
+       ┣━ 📄 jsiicalc_UmaskCheck.go
+       ┣━ 📄 jsiicalc_UnaryOperation.go
+       ┣━ 📄 jsiicalc_UnionProperties.go
+       ┣━ 📄 jsiicalc_UpcasingReflectable.go
+       ┣━ 📄 jsiicalc_UseBundledDependency.go
+       ┣━ 📄 jsiicalc_UseCalcBase.go
+       ┣━ 📄 jsiicalc_UsesInterfaceWithProperties.go
+       ┣━ 📄 jsiicalc_VariadicInvoker.go
+       ┣━ 📄 jsiicalc_VariadicMethod.go
+       ┣━ 📄 jsiicalc_VirtualMethodPlayground.go
+       ┣━ 📄 jsiicalc_VoidCallback.go
+       ┣━ 📄 jsiicalc_WithPrivatePropertyInConstructor.go
        ┣━ 📄 jsiicalc.go
-       ┣━ 📄 jsiicalc.init.go
        ┣━ 📄 LICENSE
        ┣━ 📁 module2530
-       ┃  ┣━ 📄 module2530.go
-       ┃  ┗━ 📄 module2530.init.go
+       ┃  ┣━ 📄 module2530_MyClass.go
+       ┃  ┗━ 📄 module2530.go
        ┣━ 📁 module2617
-       ┃  ┣━ 📄 module2617.go
-       ┃  ┗━ 📄 module2617.init.go
+       ┃  ┣━ 📄 module2617_OnlyStatics.go
+       ┃  ┗━ 📄 module2617.go
        ┣━ 📁 module2647
        ┃  ┣━ 📁 internal
        ┃  ┃  ┗━ 📄 types.go
-       ┃  ┣━ 📄 module2647.go
-       ┃  ┗━ 📄 module2647.init.go
+       ┃  ┣━ 📄 module2647_ExtendAndImplement.go
+       ┃  ┗━ 📄 module2647.go
        ┣━ 📁 module2689
        ┃  ┣━ 📁 methods
-       ┃  ┃  ┣━ 📄 methods.go
-       ┃  ┃  ┗━ 📄 methods.init.go
-       ┃  ┣━ 📄 module2689.go
+       ┃  ┃  ┣━ 📄 methods_MyClass.go
+       ┃  ┃  ┗━ 📄 methods.go
        ┃  ┣━ 📁 props
-       ┃  ┃  ┣━ 📄 props.go
-       ┃  ┃  ┗━ 📄 props.init.go
+       ┃  ┃  ┣━ 📄 props_MyClass.go
+       ┃  ┃  ┗━ 📄 props.go
        ┃  ┣━ 📁 retval
-       ┃  ┃  ┣━ 📄 retval.go
-       ┃  ┃  ┗━ 📄 retval.init.go
+       ┃  ┃  ┣━ 📄 retval_MyClass.go
+       ┃  ┃  ┗━ 📄 retval.go
        ┃  ┗━ 📁 structs
-       ┃     ┣━ 📄 structs.go
-       ┃     ┗━ 📄 structs.init.go
+       ┃     ┣━ 📄 structs_MyStruct.go
+       ┃     ┗━ 📄 structs.go
        ┣━ 📁 module2692
-       ┃  ┣━ 📄 module2692.go
        ┃  ┣━ 📁 submodule1
-       ┃  ┃  ┣━ 📄 submodule1.go
-       ┃  ┃  ┗━ 📄 submodule1.init.go
+       ┃  ┃  ┣━ 📄 submodule1_Bar.go
+       ┃  ┃  ┗━ 📄 submodule1.go
        ┃  ┗━ 📁 submodule2
-       ┃     ┣━ 📄 submodule2.go
-       ┃     ┗━ 📄 submodule2.init.go
+       ┃     ┣━ 📄 submodule2_Bar.go
+       ┃     ┣━ 📄 submodule2_Foo.go
+       ┃     ┗━ 📄 submodule2.go
        ┣━ 📁 module2700
-       ┃  ┣━ 📄 module2700.go
-       ┃  ┗━ 📄 module2700.init.go
+       ┃  ┣━ 📄 module2700_Base.go
+       ┃  ┣━ 📄 module2700_Derived.go
+       ┃  ┣━ 📄 module2700_IFoo.go
+       ┃  ┗━ 📄 module2700.go
        ┣━ 📁 module2702
        ┃  ┣━ 📁 internal
        ┃  ┃  ┗━ 📄 types.go
-       ┃  ┣━ 📄 module2702.go
-       ┃  ┗━ 📄 module2702.init.go
+       ┃  ┣━ 📄 module2702_Baz.go
+       ┃  ┣━ 📄 module2702_Class1.go
+       ┃  ┣━ 📄 module2702_Class2.go
+       ┃  ┣━ 📄 module2702_Class3.go
+       ┃  ┣━ 📄 module2702_Construct.go
+       ┃  ┣━ 📄 module2702_IBaz.go
+       ┃  ┣━ 📄 module2702_IConstruct.go
+       ┃  ┣━ 📄 module2702_IFoo.go
+       ┃  ┣━ 📄 module2702_IResource.go
+       ┃  ┣━ 📄 module2702_IVpc.go
+       ┃  ┣━ 📄 module2702_Resource.go
+       ┃  ┣━ 📄 module2702_Vpc.go
+       ┃  ┗━ 📄 module2702.go
        ┣━ 📁 nodirect
-       ┃  ┣━ 📄 nodirect.go
        ┃  ┣━ 📁 sub1
-       ┃  ┃  ┣━ 📄 sub1.go
-       ┃  ┃  ┗━ 📄 sub1.init.go
+       ┃  ┃  ┣━ 📄 sub1_TypeFromSub1.go
+       ┃  ┃  ┗━ 📄 sub1.go
        ┃  ┗━ 📁 sub2
-       ┃     ┣━ 📄 sub2.go
-       ┃     ┗━ 📄 sub2.init.go
+       ┃     ┣━ 📄 sub2_TypeFromSub2.go
+       ┃     ┗━ 📄 sub2.go
        ┣━ 📄 NOTICE
        ┣━ 📁 onlystatic
-       ┃  ┣━ 📄 onlystatic.go
-       ┃  ┗━ 📄 onlystatic.init.go
+       ┃  ┣━ 📄 onlystatic_OnlyStaticMethods.go
+       ┃  ┗━ 📄 onlystatic.go
        ┣━ 📁 pythonself
-       ┃  ┣━ 📄 pythonself.go
-       ┃  ┗━ 📄 pythonself.init.go
+       ┃  ┣━ 📄 pythonself_ClassWithSelf.go
+       ┃  ┣━ 📄 pythonself_ClassWithSelfKwarg.go
+       ┃  ┣━ 📄 pythonself_IInterfaceWithSelf.go
+       ┃  ┣━ 📄 pythonself_StructWithSelf.go
+       ┃  ┗━ 📄 pythonself.go
        ┣━ 📄 README.md
        ┣━ 📁 submodule
        ┃  ┣━ 📁 backreferences
-       ┃  ┃  ┣━ 📄 backreferences.go
-       ┃  ┃  ┗━ 📄 backreferences.init.go
+       ┃  ┃  ┣━ 📄 backreferences_MyClassReference.go
+       ┃  ┃  ┗━ 📄 backreferences.go
        ┃  ┣━ 📁 child
-       ┃  ┃  ┣━ 📄 child.go
-       ┃  ┃  ┗━ 📄 child.init.go
+       ┃  ┃  ┣━ 📄 child_Awesomeness.go
+       ┃  ┃  ┣━ 📄 child_Goodness.go
+       ┃  ┃  ┣━ 📄 child_InnerClass.go
+       ┃  ┃  ┣━ 📄 child_KwargsProps.go
+       ┃  ┃  ┣━ 📄 child_OuterClass.go
+       ┃  ┃  ┣━ 📄 child_SomeEnum.go
+       ┃  ┃  ┣━ 📄 child_SomeStruct.go
+       ┃  ┃  ┣━ 📄 child_Structure.go
+       ┃  ┃  ┗━ 📄 child.go
        ┃  ┣━ 📁 internal
        ┃  ┃  ┗━ 📄 types.go
        ┃  ┣━ 📁 isolated
+       ┃  ┃  ┣━ 📄 isolated_Kwargs.go
        ┃  ┃  ┣━ 📄 isolated.go
-       ┃  ┃  ┣━ 📄 isolated.init.go
        ┃  ┃  ┗━ 📄 README.md
        ┃  ┣━ 📁 nestedsubmodule
        ┃  ┃  ┣━ 📁 deeplynested
-       ┃  ┃  ┃  ┣━ 📄 deeplynested.go
-       ┃  ┃  ┃  ┗━ 📄 deeplynested.init.go
+       ┃  ┃  ┃  ┣━ 📄 deeplynested_INamespaced.go
+       ┃  ┃  ┃  ┗━ 📄 deeplynested.go
        ┃  ┃  ┣━ 📁 internal
        ┃  ┃  ┃  ┗━ 📄 types.go
-       ┃  ┃  ┣━ 📄 nestedsubmodule.go
-       ┃  ┃  ┗━ 📄 nestedsubmodule.init.go
+       ┃  ┃  ┣━ 📄 nestedsubmodule_Namespaced.go
+       ┃  ┃  ┗━ 📄 nestedsubmodule.go
        ┃  ┣━ 📁 param
-       ┃  ┃  ┣━ 📄 param.go
-       ┃  ┃  ┗━ 📄 param.init.go
+       ┃  ┃  ┣━ 📄 param_SpecialParameter.go
+       ┃  ┃  ┗━ 📄 param.go
        ┃  ┣━ 📄 README.md
        ┃  ┣━ 📁 returnsparam
-       ┃  ┃  ┣━ 📄 returnsparam.go
-       ┃  ┃  ┗━ 📄 returnsparam.init.go
-       ┃  ┣━ 📄 submodule.go
-       ┃  ┗━ 📄 submodule.init.go
+       ┃  ┃  ┣━ 📄 returnsparam_ReturnsSpecialParameter.go
+       ┃  ┃  ┗━ 📄 returnsparam.go
+       ┃  ┣━ 📄 submodule_Default.go
+       ┃  ┣━ 📄 submodule_MyClass.go
+       ┃  ┗━ 📄 submodule.go
        ┗━ 📄 version
 `;
 
@@ -2326,6 +2809,31 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/cdk16625.
 package cdk16625
 
 import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.cdk16625.Cdk16625",
+		reflect.TypeOf((*Cdk16625)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "test", GoMethod: "Test"},
+			_jsii_.MemberMethod{JsiiMethod: "unwrap", GoMethod: "Unwrap"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Cdk16625{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/cdk16625_Cdk16625.go 1`] = `
+package cdk16625
+
+import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 
@@ -2378,8 +2886,8 @@ func (c *jsiiProxy_Cdk16625) Unwrap(gen jsiicalc.IRandomNumberGenerator) *float6
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/cdk16625.init.go 1`] = `
-package cdk16625
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/donotimport.go 1`] = `
+package donotimport
 
 import (
 	"reflect"
@@ -2389,21 +2897,22 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.cdk16625.Cdk16625",
-		reflect.TypeOf((*Cdk16625)(nil)).Elem(),
+		"jsii-calc.cdk16625.donotimport.UnimportedSubmoduleType",
+		reflect.TypeOf((*UnimportedSubmoduleType)(nil)).Elem(),
 		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "test", GoMethod: "Test"},
-			_jsii_.MemberMethod{JsiiMethod: "unwrap", GoMethod: "Unwrap"},
+			_jsii_.MemberMethod{JsiiMethod: "next", GoMethod: "Next"},
 		},
 		func() interface{} {
-			return &jsiiProxy_Cdk16625{}
+			j := jsiiProxy_UnimportedSubmoduleType{}
+			_jsii_.InitJsiiProxy(&j.Type__jsiicalcIRandomNumberGenerator)
+			return &j
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/donotimport.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/donotimport_UnimportedSubmoduleType.go 1`] = `
 package donotimport
 
 import (
@@ -2474,32 +2983,6 @@ func (u *jsiiProxy_UnimportedSubmoduleType) Next() *float64 {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/donotimport.init.go 1`] = `
-package donotimport
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.cdk16625.donotimport.UnimportedSubmoduleType",
-		reflect.TypeOf((*UnimportedSubmoduleType)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "next", GoMethod: "Next"},
-		},
-		func() interface{} {
-			j := jsiiProxy_UnimportedSubmoduleType{}
-			_jsii_.InitJsiiProxy(&j.Type__jsiicalcIRandomNumberGenerator)
-			return &j
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/internal/types.go 1`] = `
 package internal
 import (
@@ -2510,6 +2993,46 @@ type Type__jsiicalcIRandomNumberGenerator = jsiicalc.IRandomNumberGenerator
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/composition.go 1`] = `
+package composition
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.composition.CompositeOperation",
+		reflect.TypeOf((*CompositeOperation)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "decorationPostfixes", GoGetter: "DecorationPostfixes"},
+			_jsii_.MemberProperty{JsiiProperty: "decorationPrefixes", GoGetter: "DecorationPrefixes"},
+			_jsii_.MemberProperty{JsiiProperty: "expression", GoGetter: "Expression"},
+			_jsii_.MemberProperty{JsiiProperty: "stringStyle", GoGetter: "StringStyle"},
+			_jsii_.MemberMethod{JsiiMethod: "toString", GoMethod: "ToString"},
+			_jsii_.MemberMethod{JsiiMethod: "typeName", GoMethod: "TypeName"},
+			_jsii_.MemberProperty{JsiiProperty: "value", GoGetter: "Value"},
+		},
+		func() interface{} {
+			j := jsiiProxy_CompositeOperation{}
+			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibOperation)
+			return &j
+		},
+	)
+	_jsii_.RegisterEnum(
+		"jsii-calc.composition.CompositeOperation.CompositionStringStyle",
+		reflect.TypeOf((*CompositeOperation_CompositionStringStyle)(nil)).Elem(),
+		map[string]interface{}{
+			"NORMAL": CompositeOperation_CompositionStringStyle_NORMAL,
+			"DECORATED": CompositeOperation_CompositionStringStyle_DECORATED,
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/composition_CompositeOperation.go 1`] = `
 package composition
 
 import (
@@ -2660,6 +3183,13 @@ func (c *jsiiProxy_CompositeOperation) TypeName() interface{} {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/composition_CompositeOperation_CompositionStringStyle.go 1`] = `
+package composition
+
+
 // Style of .toString() output for CompositeOperation.
 type CompositeOperation_CompositionStringStyle string
 
@@ -2673,46 +3203,6 @@ const (
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/composition.init.go 1`] = `
-package composition
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.composition.CompositeOperation",
-		reflect.TypeOf((*CompositeOperation)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "decorationPostfixes", GoGetter: "DecorationPostfixes"},
-			_jsii_.MemberProperty{JsiiProperty: "decorationPrefixes", GoGetter: "DecorationPrefixes"},
-			_jsii_.MemberProperty{JsiiProperty: "expression", GoGetter: "Expression"},
-			_jsii_.MemberProperty{JsiiProperty: "stringStyle", GoGetter: "StringStyle"},
-			_jsii_.MemberMethod{JsiiMethod: "toString", GoMethod: "ToString"},
-			_jsii_.MemberMethod{JsiiMethod: "typeName", GoMethod: "TypeName"},
-			_jsii_.MemberProperty{JsiiProperty: "value", GoGetter: "Value"},
-		},
-		func() interface{} {
-			j := jsiiProxy_CompositeOperation{}
-			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibOperation)
-			return &j
-		},
-	)
-	_jsii_.RegisterEnum(
-		"jsii-calc.composition.CompositeOperation.CompositionStringStyle",
-		reflect.TypeOf((*CompositeOperation_CompositionStringStyle)(nil)).Elem(),
-		map[string]interface{}{
-			"NORMAL": CompositeOperation_CompositionStringStyle_NORMAL,
-			"DECORATED": CompositeOperation_CompositionStringStyle_DECORATED,
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/internal/types.go 1`] = `
 package internal
 import (
@@ -2723,6 +3213,42 @@ type Type__scopejsiicalclibOperation = scopejsiicalclib.Operation
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/derivedclasshasnoproperties.go 1`] = `
+package derivedclasshasnoproperties
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.DerivedClassHasNoProperties.Base",
+		reflect.TypeOf((*Base)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "prop", GoGetter: "Prop"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Base{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.DerivedClassHasNoProperties.Derived",
+		reflect.TypeOf((*Derived)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "prop", GoGetter: "Prop"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Derived{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_Base)
+			return &j
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/derivedclasshasnoproperties_Base.go 1`] = `
 package derivedclasshasnoproperties
 
 import (
@@ -2783,6 +3309,17 @@ func (j *jsiiProxy_Base) SetProp(val *string) {
 	)
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/derivedclasshasnoproperties_Derived.go 1`] = `
+package derivedclasshasnoproperties
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
 type Derived interface {
 	Base
 	Prop() *string
@@ -2840,42 +3377,6 @@ func (j *jsiiProxy_Derived) SetProp(val *string) {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/derivedclasshasnoproperties.init.go 1`] = `
-package derivedclasshasnoproperties
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.DerivedClassHasNoProperties.Base",
-		reflect.TypeOf((*Base)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "prop", GoGetter: "Prop"},
-		},
-		func() interface{} {
-			return &jsiiProxy_Base{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"jsii-calc.DerivedClassHasNoProperties.Derived",
-		reflect.TypeOf((*Derived)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "prop", GoGetter: "Prop"},
-		},
-		func() interface{} {
-			j := jsiiProxy_Derived{}
-			_jsii_.InitJsiiProxy(&j.jsiiProxy_Base)
-			return &j
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/go.mod 1`] = `
 module github.com/aws/jsii/jsii-calc/go/jsiicalc/v3
 
@@ -2891,6 +3392,34 @@ require (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/interfaceinnamespaceincludesclasses.go 1`] = `
+package interfaceinnamespaceincludesclasses
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
+		reflect.TypeOf((*Foo)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "bar", GoGetter: "Bar"},
+		},
+		func() interface{} {
+			return &jsiiProxy_Foo{}
+		},
+	)
+	_jsii_.RegisterStruct(
+		"jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
+		reflect.TypeOf((*Hello)(nil)).Elem(),
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/interfaceinnamespaceincludesclasses_Foo.go 1`] = `
 package interfaceinnamespaceincludesclasses
 
 import (
@@ -2951,53 +3480,21 @@ func (j *jsiiProxy_Foo) SetBar(val *string) {
 	)
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/interfaceinnamespaceincludesclasses_Hello.go 1`] = `
+package interfaceinnamespaceincludesclasses
+
+
 type Hello struct {
 	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
 }
 
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/interfaceinnamespaceincludesclasses.init.go 1`] = `
-package interfaceinnamespaceincludesclasses
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.InterfaceInNamespaceIncludesClasses.Foo",
-		reflect.TypeOf((*Foo)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "bar", GoGetter: "Bar"},
-		},
-		func() interface{} {
-			return &jsiiProxy_Foo{}
-		},
-	)
-	_jsii_.RegisterStruct(
-		"jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
-		reflect.TypeOf((*Hello)(nil)).Elem(),
-	)
-}
 
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceonlyinterface/interfaceinnamespaceonlyinterface.go 1`] = `
-package interfaceinnamespaceonlyinterface
-
-
-type Hello struct {
-	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceonlyinterface/interfaceinnamespaceonlyinterface.init.go 1`] = `
 package interfaceinnamespaceonlyinterface
 
 import (
@@ -3012,6 +3509,17 @@ func init() {
 		reflect.TypeOf((*Hello)(nil)).Elem(),
 	)
 }
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceonlyinterface/interfaceinnamespaceonlyinterface_Hello.go 1`] = `
+package interfaceinnamespaceonlyinterface
+
+
+type Hello struct {
+	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
+}
+
 
 `;
 
@@ -3067,14 +3575,49 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/jsii3656.
 package jsii3656
 
 import (
+	"reflect"
+
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
 )
+
+func init() {
+	_jsii_.RegisterStruct(
+		"jsii-calc.jsii3656.ImplementMeOpts",
+		reflect.TypeOf((*ImplementMeOpts)(nil)).Elem(),
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.jsii3656.OverrideMe",
+		reflect.TypeOf((*OverrideMe)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "implementMe", GoMethod: "ImplementMe"},
+		},
+		func() interface{} {
+			return &jsiiProxy_OverrideMe{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/jsii3656_ImplementMeOpts.go 1`] = `
+package jsii3656
+
 
 type ImplementMeOpts struct {
 	Name *string \`field:"required" json:"name" yaml:"name"\`
 	Count *float64 \`field:"optional" json:"count" yaml:"count"\`
 }
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/jsii3656_OverrideMe.go 1`] = `
+package jsii3656
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
 
 type OverrideMe interface {
 	ImplementMe(opts *ImplementMeOpts) *bool
@@ -3126,12166 +3669,7 @@ func (o *jsiiProxy_OverrideMe) ImplementMe(opts *ImplementMeOpts) *bool {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/jsii3656.init.go 1`] = `
-package jsii3656
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterStruct(
-		"jsii-calc.jsii3656.ImplementMeOpts",
-		reflect.TypeOf((*ImplementMeOpts)(nil)).Elem(),
-	)
-	_jsii_.RegisterClass(
-		"jsii-calc.jsii3656.OverrideMe",
-		reflect.TypeOf((*OverrideMe)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "implementMe", GoMethod: "ImplementMe"},
-		},
-		func() interface{} {
-			return &jsiiProxy_OverrideMe{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc.go 1`] = `
-// A simple calcuator built on JSII.
-package jsiicalc
-
-import (
-	"time"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
-
-	"github.com/aws/jsii/jsii-calc/go/jcb"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
-)
-
-type AbstractClass interface {
-	AbstractClassBase
-	IInterfaceImplementedByAbstractClass
-	AbstractProperty() *string
-	PropFromInterface() *string
-	AbstractMethod(name *string) *string
-	NonAbstractMethod() *float64
-}
-
-// The jsii proxy struct for AbstractClass
-type jsiiProxy_AbstractClass struct {
-	jsiiProxy_AbstractClassBase
-	jsiiProxy_IInterfaceImplementedByAbstractClass
-}
-
-func (j *jsiiProxy_AbstractClass) AbstractProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"abstractProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AbstractClass) PropFromInterface() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"propFromInterface",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAbstractClass_Override(a AbstractClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AbstractClass",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AbstractClass) AbstractMethod(name *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"abstractMethod",
-		[]interface{}{name},
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AbstractClass) NonAbstractMethod() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"nonAbstractMethod",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type AbstractClassBase interface {
-	AbstractProperty() *string
-}
-
-// The jsii proxy struct for AbstractClassBase
-type jsiiProxy_AbstractClassBase struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_AbstractClassBase) AbstractProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"abstractProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAbstractClassBase_Override(a AbstractClassBase) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AbstractClassBase",
-		nil, // no parameters
-		a,
-	)
-}
-
-type AbstractClassReturner interface {
-	ReturnAbstractFromProperty() AbstractClassBase
-	GiveMeAbstract() AbstractClass
-	GiveMeInterface() IInterfaceImplementedByAbstractClass
-}
-
-// The jsii proxy struct for AbstractClassReturner
-type jsiiProxy_AbstractClassReturner struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_AbstractClassReturner) ReturnAbstractFromProperty() AbstractClassBase {
-	var returns AbstractClassBase
-	_jsii_.Get(
-		j,
-		"returnAbstractFromProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAbstractClassReturner() AbstractClassReturner {
-	_init_.Initialize()
-
-	j := jsiiProxy_AbstractClassReturner{}
-
-	_jsii_.Create(
-		"jsii-calc.AbstractClassReturner",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAbstractClassReturner_Override(a AbstractClassReturner) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AbstractClassReturner",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AbstractClassReturner) GiveMeAbstract() AbstractClass {
-	var returns AbstractClass
-
-	_jsii_.Invoke(
-		a,
-		"giveMeAbstract",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstractClass {
-	var returns IInterfaceImplementedByAbstractClass
-
-	_jsii_.Invoke(
-		a,
-		"giveMeInterface",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Ensures abstract members implementations correctly register overrides in various languages.
-type AbstractSuite interface {
-	Property() *string
-	SetProperty(val *string)
-	SomeMethod(str *string) *string
-	// Sets \`seed\` to \`this.property\`, then calls \`someMethod\` with \`this.property\` and returns the result.
-	WorkItAll(seed *string) *string
-}
-
-// The jsii proxy struct for AbstractSuite
-type jsiiProxy_AbstractSuite struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_AbstractSuite) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAbstractSuite_Override(a AbstractSuite) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AbstractSuite",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (j *jsiiProxy_AbstractSuite) SetProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"property",
-		val,
-	)
-}
-
-func (a *jsiiProxy_AbstractSuite) SomeMethod(str *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"someMethod",
-		[]interface{}{str},
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AbstractSuite) WorkItAll(seed *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"workItAll",
-		[]interface{}{seed},
-		&returns,
-	)
-
-	return returns
-}
-
-// The "+" binary operation.
-type Add interface {
-	BinaryOperation
-	// Left-hand side operand.
-	Lhs() scopejsiicalclib.NumericValue
-	// Right-hand side operand.
-	Rhs() scopejsiicalclib.NumericValue
-	// The value.
-	Value() *float64
-	// Say hello!
-	Hello() *string
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Add
-type jsiiProxy_Add struct {
-	jsiiProxy_BinaryOperation
-}
-
-func (j *jsiiProxy_Add) Lhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"lhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Add) Rhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"rhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Add) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a BinaryOperation.
-func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Add {
-	_init_.Initialize()
-
-	j := jsiiProxy_Add{}
-
-	_jsii_.Create(
-		"jsii-calc.Add",
-		[]interface{}{lhs, rhs},
-		&j,
-	)
-
-	return &j
-}
-
-// Creates a BinaryOperation.
-func NewAdd_Override(a Add, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Add",
-		[]interface{}{lhs, rhs},
-		a,
-	)
-}
-
-func (a *jsiiProxy_Add) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_Add) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_Add) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		a,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// This class includes property for all types supported by jsii.
-//
-// The setters will validate
-// that the value set is of the expected type and throw otherwise.
-type AllTypes interface {
-	AnyArrayProperty() *[]interface{}
-	SetAnyArrayProperty(val *[]interface{})
-	AnyMapProperty() *map[string]interface{}
-	SetAnyMapProperty(val *map[string]interface{})
-	AnyProperty() interface{}
-	SetAnyProperty(val interface{})
-	ArrayProperty() *[]*string
-	SetArrayProperty(val *[]*string)
-	BooleanProperty() *bool
-	SetBooleanProperty(val *bool)
-	DateProperty() *time.Time
-	SetDateProperty(val *time.Time)
-	EnumProperty() AllTypesEnum
-	SetEnumProperty(val AllTypesEnum)
-	EnumPropertyValue() *float64
-	JsonProperty() *map[string]interface{}
-	SetJsonProperty(val *map[string]interface{})
-	MapProperty() *map[string]scopejsiicalclib.Number
-	SetMapProperty(val *map[string]scopejsiicalclib.Number)
-	NumberProperty() *float64
-	SetNumberProperty(val *float64)
-	OptionalEnumValue() StringEnum
-	SetOptionalEnumValue(val StringEnum)
-	StringProperty() *string
-	SetStringProperty(val *string)
-	UnionArrayProperty() *[]interface{}
-	SetUnionArrayProperty(val *[]interface{})
-	UnionMapProperty() *map[string]interface{}
-	SetUnionMapProperty(val *map[string]interface{})
-	UnionProperty() interface{}
-	SetUnionProperty(val interface{})
-	UnknownArrayProperty() *[]interface{}
-	SetUnknownArrayProperty(val *[]interface{})
-	UnknownMapProperty() *map[string]interface{}
-	SetUnknownMapProperty(val *map[string]interface{})
-	UnknownProperty() interface{}
-	SetUnknownProperty(val interface{})
-	AnyIn(inp interface{})
-	AnyOut() interface{}
-	EnumMethod(value StringEnum) StringEnum
-}
-
-// The jsii proxy struct for AllTypes
-type jsiiProxy_AllTypes struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_AllTypes) AnyArrayProperty() *[]interface{} {
-	var returns *[]interface{}
-	_jsii_.Get(
-		j,
-		"anyArrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) AnyMapProperty() *map[string]interface{} {
-	var returns *map[string]interface{}
-	_jsii_.Get(
-		j,
-		"anyMapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) AnyProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		j,
-		"anyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) ArrayProperty() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"arrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) BooleanProperty() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"booleanProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) DateProperty() *time.Time {
-	var returns *time.Time
-	_jsii_.Get(
-		j,
-		"dateProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) EnumProperty() AllTypesEnum {
-	var returns AllTypesEnum
-	_jsii_.Get(
-		j,
-		"enumProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) EnumPropertyValue() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"enumPropertyValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) JsonProperty() *map[string]interface{} {
-	var returns *map[string]interface{}
-	_jsii_.Get(
-		j,
-		"jsonProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) MapProperty() *map[string]scopejsiicalclib.Number {
-	var returns *map[string]scopejsiicalclib.Number
-	_jsii_.Get(
-		j,
-		"mapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) NumberProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"numberProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) OptionalEnumValue() StringEnum {
-	var returns StringEnum
-	_jsii_.Get(
-		j,
-		"optionalEnumValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) StringProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"stringProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnionArrayProperty() *[]interface{} {
-	var returns *[]interface{}
-	_jsii_.Get(
-		j,
-		"unionArrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnionMapProperty() *map[string]interface{} {
-	var returns *map[string]interface{}
-	_jsii_.Get(
-		j,
-		"unionMapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnionProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		j,
-		"unionProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnknownArrayProperty() *[]interface{} {
-	var returns *[]interface{}
-	_jsii_.Get(
-		j,
-		"unknownArrayProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnknownMapProperty() *map[string]interface{} {
-	var returns *map[string]interface{}
-	_jsii_.Get(
-		j,
-		"unknownMapProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AllTypes) UnknownProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		j,
-		"unknownProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAllTypes() AllTypes {
-	_init_.Initialize()
-
-	j := jsiiProxy_AllTypes{}
-
-	_jsii_.Create(
-		"jsii-calc.AllTypes",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAllTypes_Override(a AllTypes) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AllTypes",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetAnyArrayProperty(val *[]interface{}) {
-	_jsii_.Set(
-		j,
-		"anyArrayProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetAnyMapProperty(val *map[string]interface{}) {
-	_jsii_.Set(
-		j,
-		"anyMapProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetAnyProperty(val interface{}) {
-	_jsii_.Set(
-		j,
-		"anyProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetArrayProperty(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"arrayProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetBooleanProperty(val *bool) {
-	_jsii_.Set(
-		j,
-		"booleanProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetDateProperty(val *time.Time) {
-	_jsii_.Set(
-		j,
-		"dateProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetEnumProperty(val AllTypesEnum) {
-	_jsii_.Set(
-		j,
-		"enumProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetJsonProperty(val *map[string]interface{}) {
-	_jsii_.Set(
-		j,
-		"jsonProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetMapProperty(val *map[string]scopejsiicalclib.Number) {
-	_jsii_.Set(
-		j,
-		"mapProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetNumberProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"numberProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetOptionalEnumValue(val StringEnum) {
-	_jsii_.Set(
-		j,
-		"optionalEnumValue",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetStringProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"stringProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnionArrayProperty(val *[]interface{}) {
-	_jsii_.Set(
-		j,
-		"unionArrayProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnionMapProperty(val *map[string]interface{}) {
-	_jsii_.Set(
-		j,
-		"unionMapProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnionProperty(val interface{}) {
-	_jsii_.Set(
-		j,
-		"unionProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnknownArrayProperty(val *[]interface{}) {
-	_jsii_.Set(
-		j,
-		"unknownArrayProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnknownMapProperty(val *map[string]interface{}) {
-	_jsii_.Set(
-		j,
-		"unknownMapProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_AllTypes) SetUnknownProperty(val interface{}) {
-	_jsii_.Set(
-		j,
-		"unknownProperty",
-		val,
-	)
-}
-
-func (a *jsiiProxy_AllTypes) AnyIn(inp interface{}) {
-	_jsii_.InvokeVoid(
-		a,
-		"anyIn",
-		[]interface{}{inp},
-	)
-}
-
-func (a *jsiiProxy_AllTypes) AnyOut() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		a,
-		"anyOut",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AllTypes) EnumMethod(value StringEnum) StringEnum {
-	var returns StringEnum
-
-	_jsii_.Invoke(
-		a,
-		"enumMethod",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-type AllTypesEnum string
-
-const (
-	AllTypesEnum_MY_ENUM_VALUE AllTypesEnum = "MY_ENUM_VALUE"
-	AllTypesEnum_YOUR_ENUM_VALUE AllTypesEnum = "YOUR_ENUM_VALUE"
-	AllTypesEnum_THIS_IS_GREAT AllTypesEnum = "THIS_IS_GREAT"
-)
-
-type AllowedMethodNames interface {
-	GetBar(_p1 *string, _p2 *float64)
-	// getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
-	GetFoo(withParam *string) *string
-	SetBar(_x *string, _y *float64, _z *bool)
-	// setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
-	SetFoo(_x *string, _y *float64)
-}
-
-// The jsii proxy struct for AllowedMethodNames
-type jsiiProxy_AllowedMethodNames struct {
-	_ byte // padding
-}
-
-func NewAllowedMethodNames() AllowedMethodNames {
-	_init_.Initialize()
-
-	j := jsiiProxy_AllowedMethodNames{}
-
-	_jsii_.Create(
-		"jsii-calc.AllowedMethodNames",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAllowedMethodNames_Override(a AllowedMethodNames) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AllowedMethodNames",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AllowedMethodNames) GetBar(_p1 *string, _p2 *float64) {
-	_jsii_.InvokeVoid(
-		a,
-		"getBar",
-		[]interface{}{_p1, _p2},
-	)
-}
-
-func (a *jsiiProxy_AllowedMethodNames) GetFoo(withParam *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		a,
-		"getFoo",
-		[]interface{}{withParam},
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AllowedMethodNames) SetBar(_x *string, _y *float64, _z *bool) {
-	_jsii_.InvokeVoid(
-		a,
-		"setBar",
-		[]interface{}{_x, _y, _z},
-	)
-}
-
-func (a *jsiiProxy_AllowedMethodNames) SetFoo(_x *string, _y *float64) {
-	_jsii_.InvokeVoid(
-		a,
-		"setFoo",
-		[]interface{}{_x, _y},
-	)
-}
-
-type AmbiguousParameters interface {
-	Props() *StructParameterType
-	Scope() Bell
-}
-
-// The jsii proxy struct for AmbiguousParameters
-type jsiiProxy_AmbiguousParameters struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_AmbiguousParameters) Props() *StructParameterType {
-	var returns *StructParameterType
-	_jsii_.Get(
-		j,
-		"props",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_AmbiguousParameters) Scope() Bell {
-	var returns Bell
-	_jsii_.Get(
-		j,
-		"scope",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewAmbiguousParameters(scope Bell, props *StructParameterType) AmbiguousParameters {
-	_init_.Initialize()
-
-	j := jsiiProxy_AmbiguousParameters{}
-
-	_jsii_.Create(
-		"jsii-calc.AmbiguousParameters",
-		[]interface{}{scope, props},
-		&j,
-	)
-
-	return &j
-}
-
-func NewAmbiguousParameters_Override(a AmbiguousParameters, scope Bell, props *StructParameterType) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AmbiguousParameters",
-		[]interface{}{scope, props},
-		a,
-	)
-}
-
-type AnonymousImplementationProvider interface {
-	IAnonymousImplementationProvider
-	ProvideAsClass() Implementation
-	ProvideAsInterface() IAnonymouslyImplementMe
-}
-
-// The jsii proxy struct for AnonymousImplementationProvider
-type jsiiProxy_AnonymousImplementationProvider struct {
-	jsiiProxy_IAnonymousImplementationProvider
-}
-
-func NewAnonymousImplementationProvider() AnonymousImplementationProvider {
-	_init_.Initialize()
-
-	j := jsiiProxy_AnonymousImplementationProvider{}
-
-	_jsii_.Create(
-		"jsii-calc.AnonymousImplementationProvider",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAnonymousImplementationProvider_Override(a AnonymousImplementationProvider) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AnonymousImplementationProvider",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsClass() Implementation {
-	var returns Implementation
-
-	_jsii_.Invoke(
-		a,
-		"provideAsClass",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
-	var returns IAnonymouslyImplementMe
-
-	_jsii_.Invoke(
-		a,
-		"provideAsInterface",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type AsyncVirtualMethods interface {
-	CallMe() *float64
-	// Just calls "overrideMeToo".
-	CallMe2() *float64
-	// This method calls the "callMe" async method indirectly, which will then invoke a virtual method.
-	//
-	// This is a "double promise" situation, which
-	// means that callbacks are not going to be available immediate, but only
-	// after an "immediates" cycle.
-	CallMeDoublePromise() *float64
-	DontOverrideMe() *float64
-	OverrideMe(mult *float64) *float64
-	OverrideMeToo() *float64
-}
-
-// The jsii proxy struct for AsyncVirtualMethods
-type jsiiProxy_AsyncVirtualMethods struct {
-	_ byte // padding
-}
-
-func NewAsyncVirtualMethods() AsyncVirtualMethods {
-	_init_.Initialize()
-
-	j := jsiiProxy_AsyncVirtualMethods{}
-
-	_jsii_.Create(
-		"jsii-calc.AsyncVirtualMethods",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAsyncVirtualMethods_Override(a AsyncVirtualMethods) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AsyncVirtualMethods",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) CallMe() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"callMe",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) CallMe2() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"callMe2",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) CallMeDoublePromise() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"callMeDoublePromise",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) DontOverrideMe() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"dontOverrideMe",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) OverrideMe(mult *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"overrideMe",
-		[]interface{}{mult},
-		&returns,
-	)
-
-	return returns
-}
-
-func (a *jsiiProxy_AsyncVirtualMethods) OverrideMeToo() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		a,
-		"overrideMeToo",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type AugmentableClass interface {
-	MethodOne()
-	MethodTwo()
-}
-
-// The jsii proxy struct for AugmentableClass
-type jsiiProxy_AugmentableClass struct {
-	_ byte // padding
-}
-
-func NewAugmentableClass() AugmentableClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_AugmentableClass{}
-
-	_jsii_.Create(
-		"jsii-calc.AugmentableClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewAugmentableClass_Override(a AugmentableClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.AugmentableClass",
-		nil, // no parameters
-		a,
-	)
-}
-
-func (a *jsiiProxy_AugmentableClass) MethodOne() {
-	_jsii_.InvokeVoid(
-		a,
-		"methodOne",
-		nil, // no parameters
-	)
-}
-
-func (a *jsiiProxy_AugmentableClass) MethodTwo() {
-	_jsii_.InvokeVoid(
-		a,
-		"methodTwo",
-		nil, // no parameters
-	)
-}
-
-type BaseClass interface {
-	Property() *string
-	Method() *float64
-}
-
-// The jsii proxy struct for BaseClass
-type jsiiProxy_BaseClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_BaseClass) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewBaseClass_Override(b BaseClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.BaseClass",
-		nil, // no parameters
-		b,
-	)
-}
-
-func (b *jsiiProxy_BaseClass) Method() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		b,
-		"method",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type BaseJsii976 interface {
-}
-
-// The jsii proxy struct for BaseJsii976
-type jsiiProxy_BaseJsii976 struct {
-	_ byte // padding
-}
-
-func NewBaseJsii976() BaseJsii976 {
-	_init_.Initialize()
-
-	j := jsiiProxy_BaseJsii976{}
-
-	_jsii_.Create(
-		"jsii-calc.BaseJsii976",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewBaseJsii976_Override(b BaseJsii976) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.BaseJsii976",
-		nil, // no parameters
-		b,
-	)
-}
-
-type Bell interface {
-	IBell
-	Rung() *bool
-	SetRung(val *bool)
-	Ring()
-}
-
-// The jsii proxy struct for Bell
-type jsiiProxy_Bell struct {
-	jsiiProxy_IBell
-}
-
-func (j *jsiiProxy_Bell) Rung() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"rung",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewBell() Bell {
-	_init_.Initialize()
-
-	j := jsiiProxy_Bell{}
-
-	_jsii_.Create(
-		"jsii-calc.Bell",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewBell_Override(b Bell) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Bell",
-		nil, // no parameters
-		b,
-	)
-}
-
-func (j *jsiiProxy_Bell) SetRung(val *bool) {
-	_jsii_.Set(
-		j,
-		"rung",
-		val,
-	)
-}
-
-func (b *jsiiProxy_Bell) Ring() {
-	_jsii_.InvokeVoid(
-		b,
-		"ring",
-		nil, // no parameters
-	)
-}
-
-// Represents an operation with two operands.
-type BinaryOperation interface {
-	scopejsiicalclib.Operation
-	scopejsiicalclib.IFriendly
-	// Left-hand side operand.
-	Lhs() scopejsiicalclib.NumericValue
-	// Right-hand side operand.
-	Rhs() scopejsiicalclib.NumericValue
-	// The value.
-	// Deprecated.
-	Value() *float64
-	// Say hello!
-	Hello() *string
-	// String representation of the value.
-	// Deprecated.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for BinaryOperation
-type jsiiProxy_BinaryOperation struct {
-	internal.Type__scopejsiicalclibOperation
-	internal.Type__scopejsiicalclibIFriendly
-}
-
-func (j *jsiiProxy_BinaryOperation) Lhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"lhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_BinaryOperation) Rhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"rhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_BinaryOperation) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a BinaryOperation.
-func NewBinaryOperation_Override(b BinaryOperation, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.BinaryOperation",
-		[]interface{}{lhs, rhs},
-		b,
-	)
-}
-
-func (b *jsiiProxy_BinaryOperation) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		b,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (b *jsiiProxy_BinaryOperation) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		b,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (b *jsiiProxy_BinaryOperation) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		b,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// See https://github.com/aws/aws-cdk/issues/7977.
-type BurriedAnonymousObject interface {
-	Check() *bool
-	// Implement this method and have it return it's parameter.
-	//
-	// Returns: \`value\`.
-	GiveItBack(value interface{}) interface{}
-}
-
-// The jsii proxy struct for BurriedAnonymousObject
-type jsiiProxy_BurriedAnonymousObject struct {
-	_ byte // padding
-}
-
-func NewBurriedAnonymousObject_Override(b BurriedAnonymousObject) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.BurriedAnonymousObject",
-		nil, // no parameters
-		b,
-	)
-}
-
-func (b *jsiiProxy_BurriedAnonymousObject) Check() *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		b,
-		"check",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (b *jsiiProxy_BurriedAnonymousObject) GiveItBack(value interface{}) interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		b,
-		"giveItBack",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-// A calculator which maintains a current value and allows adding operations.
-//
-// Here's how you use it:
-//
-// \`\`\`ts
-// const calculator = new calc.Calculator();
-// calculator.add(5);
-// calculator.mul(3);
-// console.log(calculator.expression.value);
-// \`\`\`
-//
-// I will repeat this example again, but in an @example tag.
-//
-// Example:
-//   calculator := calc.NewCalculator()
-//   calculator.add(jsii.Number(5))
-//   calculator.mul(jsii.Number(3))
-//   fmt.Println(calculator.expression.value)
-//
-type Calculator interface {
-	composition.CompositeOperation
-	// The current value.
-	Curr() scopejsiicalclib.NumericValue
-	SetCurr(val scopejsiicalclib.NumericValue)
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes() *[]*string
-	SetDecorationPostfixes(val *[]*string)
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes() *[]*string
-	SetDecorationPrefixes(val *[]*string)
-	// Returns the expression.
-	Expression() scopejsiicalclib.NumericValue
-	// The maximum value allows in this calculator.
-	MaxValue() *float64
-	SetMaxValue(val *float64)
-	// A log of all operations.
-	OperationsLog() *[]scopejsiicalclib.NumericValue
-	// A map of per operation name of all operations performed.
-	OperationsMap() *map[string]*[]scopejsiicalclib.NumericValue
-	// The .toString() style.
-	StringStyle() composition.CompositeOperation_CompositionStringStyle
-	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
-	// Example of a property that accepts a union of types.
-	UnionProperty() interface{}
-	SetUnionProperty(val interface{})
-	// The value.
-	Value() *float64
-	// Adds a number to the current value.
-	Add(value *float64)
-	// Multiplies the current value by a number.
-	Mul(value *float64)
-	// Negates the current value.
-	Neg()
-	// Raises the current value by a power.
-	Pow(value *float64)
-	// Returns teh value of the union property (if defined).
-	ReadUnionValue() *float64
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Calculator
-type jsiiProxy_Calculator struct {
-	internal.Type__compositionCompositeOperation
-}
-
-func (j *jsiiProxy_Calculator) Curr() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"curr",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) DecorationPostfixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) DecorationPrefixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) Expression() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) MaxValue() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"maxValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) OperationsLog() *[]scopejsiicalclib.NumericValue {
-	var returns *[]scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"operationsLog",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) OperationsMap() *map[string]*[]scopejsiicalclib.NumericValue {
-	var returns *map[string]*[]scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"operationsMap",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) StringStyle() composition.CompositeOperation_CompositionStringStyle {
-	var returns composition.CompositeOperation_CompositionStringStyle
-	_jsii_.Get(
-		j,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) UnionProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		j,
-		"unionProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Calculator) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a Calculator object.
-func NewCalculator(props *CalculatorProps) Calculator {
-	_init_.Initialize()
-
-	j := jsiiProxy_Calculator{}
-
-	_jsii_.Create(
-		"jsii-calc.Calculator",
-		[]interface{}{props},
-		&j,
-	)
-
-	return &j
-}
-
-// Creates a Calculator object.
-func NewCalculator_Override(c Calculator, props *CalculatorProps) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Calculator",
-		[]interface{}{props},
-		c,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetCurr(val scopejsiicalclib.NumericValue) {
-	_jsii_.Set(
-		j,
-		"curr",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetDecorationPostfixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetDecorationPrefixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetMaxValue(val *float64) {
-	_jsii_.Set(
-		j,
-		"maxValue",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
-	_jsii_.Set(
-		j,
-		"stringStyle",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Calculator) SetUnionProperty(val interface{}) {
-	_jsii_.Set(
-		j,
-		"unionProperty",
-		val,
-	)
-}
-
-func (c *jsiiProxy_Calculator) Add(value *float64) {
-	_jsii_.InvokeVoid(
-		c,
-		"add",
-		[]interface{}{value},
-	)
-}
-
-func (c *jsiiProxy_Calculator) Mul(value *float64) {
-	_jsii_.InvokeVoid(
-		c,
-		"mul",
-		[]interface{}{value},
-	)
-}
-
-func (c *jsiiProxy_Calculator) Neg() {
-	_jsii_.InvokeVoid(
-		c,
-		"neg",
-		nil, // no parameters
-	)
-}
-
-func (c *jsiiProxy_Calculator) Pow(value *float64) {
-	_jsii_.InvokeVoid(
-		c,
-		"pow",
-		[]interface{}{value},
-	)
-}
-
-func (c *jsiiProxy_Calculator) ReadUnionValue() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		c,
-		"readUnionValue",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_Calculator) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		c,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_Calculator) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		c,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Properties for Calculator.
-type CalculatorProps struct {
-	// The initial value of the calculator.
-	//
-	// NOTE: Any number works here, it's fine.
-	InitialValue *float64 \`field:"optional" json:"initialValue" yaml:"initialValue"\`
-	// The maximum value the calculator can store.
-	MaximumValue *float64 \`field:"optional" json:"maximumValue" yaml:"maximumValue"\`
-}
-
-type ChildStruct982 struct {
-	Foo *string \`field:"required" json:"foo" yaml:"foo"\`
-	Bar *float64 \`field:"required" json:"bar" yaml:"bar"\`
-}
-
-type ClassThatImplementsTheInternalInterface interface {
-	INonInternalInterface
-	A() *string
-	SetA(val *string)
-	B() *string
-	SetB(val *string)
-	C() *string
-	SetC(val *string)
-	D() *string
-	SetD(val *string)
-}
-
-// The jsii proxy struct for ClassThatImplementsTheInternalInterface
-type jsiiProxy_ClassThatImplementsTheInternalInterface struct {
-	jsiiProxy_INonInternalInterface
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) A() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"a",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) B() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"b",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) C() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"c",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) D() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"d",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassThatImplementsTheInternalInterface() ClassThatImplementsTheInternalInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassThatImplementsTheInternalInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassThatImplementsTheInternalInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassThatImplementsTheInternalInterface_Override(c ClassThatImplementsTheInternalInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassThatImplementsTheInternalInterface",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetA(val *string) {
-	_jsii_.Set(
-		j,
-		"a",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetB(val *string) {
-	_jsii_.Set(
-		j,
-		"b",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetC(val *string) {
-	_jsii_.Set(
-		j,
-		"c",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetD(val *string) {
-	_jsii_.Set(
-		j,
-		"d",
-		val,
-	)
-}
-
-type ClassThatImplementsThePrivateInterface interface {
-	INonInternalInterface
-	A() *string
-	SetA(val *string)
-	B() *string
-	SetB(val *string)
-	C() *string
-	SetC(val *string)
-	E() *string
-	SetE(val *string)
-}
-
-// The jsii proxy struct for ClassThatImplementsThePrivateInterface
-type jsiiProxy_ClassThatImplementsThePrivateInterface struct {
-	jsiiProxy_INonInternalInterface
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) A() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"a",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) B() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"b",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) C() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"c",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) E() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"e",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassThatImplementsThePrivateInterface() ClassThatImplementsThePrivateInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassThatImplementsThePrivateInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassThatImplementsThePrivateInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassThatImplementsThePrivateInterface_Override(c ClassThatImplementsThePrivateInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassThatImplementsThePrivateInterface",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetA(val *string) {
-	_jsii_.Set(
-		j,
-		"a",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetB(val *string) {
-	_jsii_.Set(
-		j,
-		"b",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetC(val *string) {
-	_jsii_.Set(
-		j,
-		"c",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetE(val *string) {
-	_jsii_.Set(
-		j,
-		"e",
-		val,
-	)
-}
-
-type ClassWithCollections interface {
-	Array() *[]*string
-	SetArray(val *[]*string)
-	Map() *map[string]*string
-	SetMap(val *map[string]*string)
-}
-
-// The jsii proxy struct for ClassWithCollections
-type jsiiProxy_ClassWithCollections struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ClassWithCollections) Array() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"array",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassWithCollections) Map() *map[string]*string {
-	var returns *map[string]*string
-	_jsii_.Get(
-		j,
-		"map",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassWithCollections(map_ *map[string]*string, array *[]*string) ClassWithCollections {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassWithCollections{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithCollections",
-		[]interface{}{map_, array},
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassWithCollections_Override(c ClassWithCollections, map_ *map[string]*string, array *[]*string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithCollections",
-		[]interface{}{map_, array},
-		c,
-	)
-}
-
-func (j *jsiiProxy_ClassWithCollections) SetArray(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"array",
-		val,
-	)
-}
-
-func (j *jsiiProxy_ClassWithCollections) SetMap(val *map[string]*string) {
-	_jsii_.Set(
-		j,
-		"map",
-		val,
-	)
-}
-
-func ClassWithCollections_CreateAList() *[]*string {
-	_init_.Initialize()
-
-	var returns *[]*string
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ClassWithCollections",
-		"createAList",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func ClassWithCollections_CreateAMap() *map[string]*string {
-	_init_.Initialize()
-
-	var returns *map[string]*string
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ClassWithCollections",
-		"createAMap",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func ClassWithCollections_StaticArray() *[]*string {
-	_init_.Initialize()
-	var returns *[]*string
-	_jsii_.StaticGet(
-		"jsii-calc.ClassWithCollections",
-		"staticArray",
-		&returns,
-	)
-	return returns
-}
-
-func ClassWithCollections_SetStaticArray(val *[]*string) {
-	_init_.Initialize()
-	_jsii_.StaticSet(
-		"jsii-calc.ClassWithCollections",
-		"staticArray",
-		val,
-	)
-}
-
-func ClassWithCollections_StaticMap() *map[string]*string {
-	_init_.Initialize()
-	var returns *map[string]*string
-	_jsii_.StaticGet(
-		"jsii-calc.ClassWithCollections",
-		"staticMap",
-		&returns,
-	)
-	return returns
-}
-
-func ClassWithCollections_SetStaticMap(val *map[string]*string) {
-	_init_.Initialize()
-	_jsii_.StaticSet(
-		"jsii-calc.ClassWithCollections",
-		"staticMap",
-		val,
-	)
-}
-
-type ClassWithContainerTypes interface {
-	Array() *[]*DummyObj
-	Obj() *map[string]*DummyObj
-	Props() *ContainerProps
-	Record() *map[string]*DummyObj
-}
-
-// The jsii proxy struct for ClassWithContainerTypes
-type jsiiProxy_ClassWithContainerTypes struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ClassWithContainerTypes) Array() *[]*DummyObj {
-	var returns *[]*DummyObj
-	_jsii_.Get(
-		j,
-		"array",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassWithContainerTypes) Obj() *map[string]*DummyObj {
-	var returns *map[string]*DummyObj
-	_jsii_.Get(
-		j,
-		"obj",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassWithContainerTypes) Props() *ContainerProps {
-	var returns *ContainerProps
-	_jsii_.Get(
-		j,
-		"props",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassWithContainerTypes) Record() *map[string]*DummyObj {
-	var returns *map[string]*DummyObj
-	_jsii_.Get(
-		j,
-		"record",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassWithContainerTypes(array *[]*DummyObj, record *map[string]*DummyObj, obj *map[string]*DummyObj, props *ContainerProps) ClassWithContainerTypes {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassWithContainerTypes{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithContainerTypes",
-		[]interface{}{array, record, obj, props},
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassWithContainerTypes_Override(c ClassWithContainerTypes, array *[]*DummyObj, record *map[string]*DummyObj, obj *map[string]*DummyObj, props *ContainerProps) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithContainerTypes",
-		[]interface{}{array, record, obj, props},
-		c,
-	)
-}
-
-// This class has docs.
-//
-// The docs are great. They're a bunch of tags.
-//
-// Example:
-//   func anExample() {
-//   }
-//
-// See: https://aws.amazon.com/
-//
-type ClassWithDocs interface {
-}
-
-// The jsii proxy struct for ClassWithDocs
-type jsiiProxy_ClassWithDocs struct {
-	_ byte // padding
-}
-
-func NewClassWithDocs() ClassWithDocs {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassWithDocs{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithDocs",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassWithDocs_Override(c ClassWithDocs) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithDocs",
-		nil, // no parameters
-		c,
-	)
-}
-
-type ClassWithJavaReservedWords interface {
-	Int() *string
-	Import(assert *string) *string
-}
-
-// The jsii proxy struct for ClassWithJavaReservedWords
-type jsiiProxy_ClassWithJavaReservedWords struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ClassWithJavaReservedWords) Int() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"int",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassWithJavaReservedWords(int *string) ClassWithJavaReservedWords {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassWithJavaReservedWords{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithJavaReservedWords",
-		[]interface{}{int},
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassWithJavaReservedWords_Override(c ClassWithJavaReservedWords, int *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithJavaReservedWords",
-		[]interface{}{int},
-		c,
-	)
-}
-
-func (c *jsiiProxy_ClassWithJavaReservedWords) Import(assert *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		c,
-		"import",
-		[]interface{}{assert},
-		&returns,
-	)
-
-	return returns
-}
-
-type ClassWithMutableObjectLiteralProperty interface {
-	MutableObject() IMutableObjectLiteral
-	SetMutableObject(val IMutableObjectLiteral)
-}
-
-// The jsii proxy struct for ClassWithMutableObjectLiteralProperty
-type jsiiProxy_ClassWithMutableObjectLiteralProperty struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ClassWithMutableObjectLiteralProperty) MutableObject() IMutableObjectLiteral {
-	var returns IMutableObjectLiteral
-	_jsii_.Get(
-		j,
-		"mutableObject",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClassWithMutableObjectLiteralProperty() ClassWithMutableObjectLiteralProperty {
-	_init_.Initialize()
-
-	j := jsiiProxy_ClassWithMutableObjectLiteralProperty{}
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithMutableObjectLiteralProperty",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClassWithMutableObjectLiteralProperty_Override(c ClassWithMutableObjectLiteralProperty) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ClassWithMutableObjectLiteralProperty",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (j *jsiiProxy_ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObjectLiteral) {
-	_jsii_.Set(
-		j,
-		"mutableObject",
-		val,
-	)
-}
-
-// Class that implements interface properties automatically, but using a private constructor.
-type ClassWithPrivateConstructorAndAutomaticProperties interface {
-	IInterfaceWithProperties
-	ReadOnlyString() *string
-	ReadWriteString() *string
-	SetReadWriteString(val *string)
-}
-
-// The jsii proxy struct for ClassWithPrivateConstructorAndAutomaticProperties
-type jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties struct {
-	jsiiProxy_IInterfaceWithProperties
-}
-
-func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) ReadOnlyString() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readOnlyString",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) ReadWriteString() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readWriteString",
-		&returns,
-	)
-	return returns
-}
-
-
-func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(val *string) {
-	_jsii_.Set(
-		j,
-		"readWriteString",
-		val,
-	)
-}
-
-func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString *string, readWriteString *string) ClassWithPrivateConstructorAndAutomaticProperties {
-	_init_.Initialize()
-
-	var returns ClassWithPrivateConstructorAndAutomaticProperties
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
-		"create",
-		[]interface{}{readOnlyString, readWriteString},
-		&returns,
-	)
-
-	return returns
-}
-
-// This tries to confuse Jackson by having overloaded property setters.
-// See: https://github.com/aws/aws-cdk/issues/4080
-//
-type ConfusingToJackson interface {
-	UnionProperty() interface{}
-	SetUnionProperty(val interface{})
-}
-
-// The jsii proxy struct for ConfusingToJackson
-type jsiiProxy_ConfusingToJackson struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ConfusingToJackson) UnionProperty() interface{} {
-	var returns interface{}
-	_jsii_.Get(
-		j,
-		"unionProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func (j *jsiiProxy_ConfusingToJackson) SetUnionProperty(val interface{}) {
-	_jsii_.Set(
-		j,
-		"unionProperty",
-		val,
-	)
-}
-
-func ConfusingToJackson_MakeInstance() ConfusingToJackson {
-	_init_.Initialize()
-
-	var returns ConfusingToJackson
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConfusingToJackson",
-		"makeInstance",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func ConfusingToJackson_MakeStructInstance() *ConfusingToJacksonStruct {
-	_init_.Initialize()
-
-	var returns *ConfusingToJacksonStruct
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConfusingToJackson",
-		"makeStructInstance",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type ConfusingToJacksonStruct struct {
-	UnionProperty interface{} \`field:"optional" json:"unionProperty" yaml:"unionProperty"\`
-}
-
-type ConstructorPassesThisOut interface {
-}
-
-// The jsii proxy struct for ConstructorPassesThisOut
-type jsiiProxy_ConstructorPassesThisOut struct {
-	_ byte // padding
-}
-
-func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumer) ConstructorPassesThisOut {
-	_init_.Initialize()
-
-	j := jsiiProxy_ConstructorPassesThisOut{}
-
-	_jsii_.Create(
-		"jsii-calc.ConstructorPassesThisOut",
-		[]interface{}{consumer},
-		&j,
-	)
-
-	return &j
-}
-
-func NewConstructorPassesThisOut_Override(c ConstructorPassesThisOut, consumer PartiallyInitializedThisConsumer) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ConstructorPassesThisOut",
-		[]interface{}{consumer},
-		c,
-	)
-}
-
-type Constructors interface {
-}
-
-// The jsii proxy struct for Constructors
-type jsiiProxy_Constructors struct {
-	_ byte // padding
-}
-
-func NewConstructors() Constructors {
-	_init_.Initialize()
-
-	j := jsiiProxy_Constructors{}
-
-	_jsii_.Create(
-		"jsii-calc.Constructors",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewConstructors_Override(c Constructors) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Constructors",
-		nil, // no parameters
-		c,
-	)
-}
-
-func Constructors_HiddenInterface() IPublicInterface {
-	_init_.Initialize()
-
-	var returns IPublicInterface
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"hiddenInterface",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_HiddenInterfaces() *[]IPublicInterface {
-	_init_.Initialize()
-
-	var returns *[]IPublicInterface
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"hiddenInterfaces",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_HiddenSubInterfaces() *[]IPublicInterface {
-	_init_.Initialize()
-
-	var returns *[]IPublicInterface
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"hiddenSubInterfaces",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_MakeClass() PublicClass {
-	_init_.Initialize()
-
-	var returns PublicClass
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"makeClass",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_MakeInterface() IPublicInterface {
-	_init_.Initialize()
-
-	var returns IPublicInterface
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"makeInterface",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_MakeInterface2() IPublicInterface2 {
-	_init_.Initialize()
-
-	var returns IPublicInterface2
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"makeInterface2",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func Constructors_MakeInterfaces() *[]IPublicInterface {
-	_init_.Initialize()
-
-	var returns *[]IPublicInterface
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Constructors",
-		"makeInterfaces",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type ConsumePureInterface interface {
-	WorkItBaby() *StructB
-}
-
-// The jsii proxy struct for ConsumePureInterface
-type jsiiProxy_ConsumePureInterface struct {
-	_ byte // padding
-}
-
-func NewConsumePureInterface(delegate IStructReturningDelegate) ConsumePureInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ConsumePureInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ConsumePureInterface",
-		[]interface{}{delegate},
-		&j,
-	)
-
-	return &j
-}
-
-func NewConsumePureInterface_Override(c ConsumePureInterface, delegate IStructReturningDelegate) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ConsumePureInterface",
-		[]interface{}{delegate},
-		c,
-	)
-}
-
-func (c *jsiiProxy_ConsumePureInterface) WorkItBaby() *StructB {
-	var returns *StructB
-
-	_jsii_.Invoke(
-		c,
-		"workItBaby",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Test calling back to consumers that implement interfaces.
-//
-// Check that if a JSII consumer implements IConsumerWithInterfaceParam, they can call
-// the method on the argument that they're passed...
-type ConsumerCanRingBell interface {
-	// ...if the interface is implemented using an object literal.
-	//
-	// Returns whether the bell was rung.
-	ImplementedByObjectLiteral(ringer IBellRinger) *bool
-	// ...if the interface is implemented using a private class.
-	//
-	// Return whether the bell was rung.
-	ImplementedByPrivateClass(ringer IBellRinger) *bool
-	// ...if the interface is implemented using a public class.
-	//
-	// Return whether the bell was rung.
-	ImplementedByPublicClass(ringer IBellRinger) *bool
-	// If the parameter is a concrete class instead of an interface.
-	//
-	// Return whether the bell was rung.
-	WhenTypedAsClass(ringer IConcreteBellRinger) *bool
-}
-
-// The jsii proxy struct for ConsumerCanRingBell
-type jsiiProxy_ConsumerCanRingBell struct {
-	_ byte // padding
-}
-
-func NewConsumerCanRingBell() ConsumerCanRingBell {
-	_init_.Initialize()
-
-	j := jsiiProxy_ConsumerCanRingBell{}
-
-	_jsii_.Create(
-		"jsii-calc.ConsumerCanRingBell",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewConsumerCanRingBell_Override(c ConsumerCanRingBell) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ConsumerCanRingBell",
-		nil, // no parameters
-		c,
-	)
-}
-
-// ...if the interface is implemented using an object literal.
-//
-// Returns whether the bell was rung.
-func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRinger) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConsumerCanRingBell",
-		"staticImplementedByObjectLiteral",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-// ...if the interface is implemented using a private class.
-//
-// Return whether the bell was rung.
-func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRinger) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConsumerCanRingBell",
-		"staticImplementedByPrivateClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-// ...if the interface is implemented using a public class.
-//
-// Return whether the bell was rung.
-func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRinger) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConsumerCanRingBell",
-		"staticImplementedByPublicClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-// If the parameter is a concrete class instead of an interface.
-//
-// Return whether the bell was rung.
-func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRinger) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ConsumerCanRingBell",
-		"staticWhenTypedAsClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRinger) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		c,
-		"implementedByObjectLiteral",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByPrivateClass(ringer IBellRinger) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		c,
-		"implementedByPrivateClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByPublicClass(ringer IBellRinger) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		c,
-		"implementedByPublicClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRinger) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		c,
-		"whenTypedAsClass",
-		[]interface{}{ringer},
-		&returns,
-	)
-
-	return returns
-}
-
-type ConsumersOfThisCrazyTypeSystem interface {
-	ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) *string
-	ConsumeNonInternalInterface(obj INonInternalInterface) interface{}
-}
-
-// The jsii proxy struct for ConsumersOfThisCrazyTypeSystem
-type jsiiProxy_ConsumersOfThisCrazyTypeSystem struct {
-	_ byte // padding
-}
-
-func NewConsumersOfThisCrazyTypeSystem() ConsumersOfThisCrazyTypeSystem {
-	_init_.Initialize()
-
-	j := jsiiProxy_ConsumersOfThisCrazyTypeSystem{}
-
-	_jsii_.Create(
-		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewConsumersOfThisCrazyTypeSystem_Override(c ConsumersOfThisCrazyTypeSystem) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (c *jsiiProxy_ConsumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		c,
-		"consumeAnotherPublicInterface",
-		[]interface{}{obj},
-		&returns,
-	)
-
-	return returns
-}
-
-func (c *jsiiProxy_ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInternalInterface) interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		c,
-		"consumeNonInternalInterface",
-		[]interface{}{obj},
-		&returns,
-	)
-
-	return returns
-}
-
-type ContainerProps struct {
-	ArrayProp *[]*DummyObj \`field:"required" json:"arrayProp" yaml:"arrayProp"\`
-	ObjProp *map[string]*DummyObj \`field:"required" json:"objProp" yaml:"objProp"\`
-	RecordProp *map[string]*DummyObj \`field:"required" json:"recordProp" yaml:"recordProp"\`
-}
-
-// Verifies proper type handling through dynamic overrides.
-type DataRenderer interface {
-	Render(data *scopejsiicalclib.MyFirstStruct) *string
-	RenderArbitrary(data *map[string]interface{}) *string
-	RenderMap(map_ *map[string]interface{}) *string
-}
-
-// The jsii proxy struct for DataRenderer
-type jsiiProxy_DataRenderer struct {
-	_ byte // padding
-}
-
-func NewDataRenderer() DataRenderer {
-	_init_.Initialize()
-
-	j := jsiiProxy_DataRenderer{}
-
-	_jsii_.Create(
-		"jsii-calc.DataRenderer",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDataRenderer_Override(d DataRenderer) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DataRenderer",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DataRenderer) Render(data *scopejsiicalclib.MyFirstStruct) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"render",
-		[]interface{}{data},
-		&returns,
-	)
-
-	return returns
-}
-
-func (d *jsiiProxy_DataRenderer) RenderArbitrary(data *map[string]interface{}) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"renderArbitrary",
-		[]interface{}{data},
-		&returns,
-	)
-
-	return returns
-}
-
-func (d *jsiiProxy_DataRenderer) RenderMap(map_ *map[string]interface{}) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"renderMap",
-		[]interface{}{map_},
-		&returns,
-	)
-
-	return returns
-}
-
-// A class named "Default".
-// See: https://github.com/aws/jsii/issues/2637
-//
-type Default interface {
-	PleaseCompile()
-}
-
-// The jsii proxy struct for Default
-type jsiiProxy_Default struct {
-	_ byte // padding
-}
-
-func NewDefault() Default {
-	_init_.Initialize()
-
-	j := jsiiProxy_Default{}
-
-	_jsii_.Create(
-		"jsii-calc.Default",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDefault_Override(d Default) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Default",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_Default) PleaseCompile() {
-	_jsii_.InvokeVoid(
-		d,
-		"pleaseCompile",
-		nil, // no parameters
-	)
-}
-
-type DefaultedConstructorArgument interface {
-	Arg1() *float64
-	Arg2() *string
-	Arg3() *time.Time
-}
-
-// The jsii proxy struct for DefaultedConstructorArgument
-type jsiiProxy_DefaultedConstructorArgument struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_DefaultedConstructorArgument) Arg1() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"arg1",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DefaultedConstructorArgument) Arg2() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"arg2",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DefaultedConstructorArgument) Arg3() *time.Time {
-	var returns *time.Time
-	_jsii_.Get(
-		j,
-		"arg3",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewDefaultedConstructorArgument(arg1 *float64, arg2 *string, arg3 *time.Time) DefaultedConstructorArgument {
-	_init_.Initialize()
-
-	j := jsiiProxy_DefaultedConstructorArgument{}
-
-	_jsii_.Create(
-		"jsii-calc.DefaultedConstructorArgument",
-		[]interface{}{arg1, arg2, arg3},
-		&j,
-	)
-
-	return &j
-}
-
-func NewDefaultedConstructorArgument_Override(d DefaultedConstructorArgument, arg1 *float64, arg2 *string, arg3 *time.Time) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DefaultedConstructorArgument",
-		[]interface{}{arg1, arg2, arg3},
-		d,
-	)
-}
-
-// 1.
-//
-// call #takeThis() -> An ObjectRef will be provisioned for the value (it'll be re-used!)
-// 2. call #takeThisToo() -> The ObjectRef from before will need to be down-cased to the ParentStruct982 type
-type Demonstrate982 interface {
-}
-
-// The jsii proxy struct for Demonstrate982
-type jsiiProxy_Demonstrate982 struct {
-	_ byte // padding
-}
-
-func NewDemonstrate982() Demonstrate982 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Demonstrate982{}
-
-	_jsii_.Create(
-		"jsii-calc.Demonstrate982",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDemonstrate982_Override(d Demonstrate982) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Demonstrate982",
-		nil, // no parameters
-		d,
-	)
-}
-
-// It's dangerous to go alone!
-func Demonstrate982_TakeThis() *ChildStruct982 {
-	_init_.Initialize()
-
-	var returns *ChildStruct982
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Demonstrate982",
-		"takeThis",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// It's dangerous to go alone!
-func Demonstrate982_TakeThisToo() *ParentStruct982 {
-	_init_.Initialize()
-
-	var returns *ParentStruct982
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Demonstrate982",
-		"takeThisToo",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Deprecated: a pretty boring class.
-type DeprecatedClass interface {
-	// Deprecated: shouldn't have been mutable.
-	MutableProperty() *float64
-	// Deprecated: shouldn't have been mutable.
-	SetMutableProperty(val *float64)
-	// Deprecated: this is not always "wazoo", be ready to be disappointed.
-	ReadonlyProperty() *string
-	// Deprecated: it was a bad idea.
-	Method()
-}
-
-// The jsii proxy struct for DeprecatedClass
-type jsiiProxy_DeprecatedClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_DeprecatedClass) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DeprecatedClass) ReadonlyProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-// Deprecated: this constructor is "just" okay.
-func NewDeprecatedClass(readonlyString *string, mutableNumber *float64) DeprecatedClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_DeprecatedClass{}
-
-	_jsii_.Create(
-		"jsii-calc.DeprecatedClass",
-		[]interface{}{readonlyString, mutableNumber},
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated: this constructor is "just" okay.
-func NewDeprecatedClass_Override(d DeprecatedClass, readonlyString *string, mutableNumber *float64) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DeprecatedClass",
-		[]interface{}{readonlyString, mutableNumber},
-		d,
-	)
-}
-
-func (j *jsiiProxy_DeprecatedClass) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-func (d *jsiiProxy_DeprecatedClass) Method() {
-	_jsii_.InvokeVoid(
-		d,
-		"method",
-		nil, // no parameters
-	)
-}
-
-// Deprecated: your deprecated selection of bad options.
-type DeprecatedEnum string
-
-const (
-	// Deprecated: option A is not great.
-	DeprecatedEnum_OPTION_A DeprecatedEnum = "OPTION_A"
-	// Deprecated: option B is kinda bad, too.
-	DeprecatedEnum_OPTION_B DeprecatedEnum = "OPTION_B"
-)
-
-// Deprecated: it just wraps a string.
-type DeprecatedStruct struct {
-	// Deprecated: well, yeah.
-	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
-}
-
-// A struct which derives from another struct.
-type DerivedStruct struct {
-	// An awesome number value.
-	// Deprecated.
-	Anumber *float64 \`field:"required" json:"anumber" yaml:"anumber"\`
-	// A string value.
-	// Deprecated.
-	Astring *string \`field:"required" json:"astring" yaml:"astring"\`
-	// Deprecated.
-	FirstOptional *[]*string \`field:"optional" json:"firstOptional" yaml:"firstOptional"\`
-	AnotherRequired *time.Time \`field:"required" json:"anotherRequired" yaml:"anotherRequired"\`
-	Bool *bool \`field:"required" json:"bool" yaml:"bool"\`
-	// An example of a non primitive property.
-	NonPrimitive DoubleTrouble \`field:"required" json:"nonPrimitive" yaml:"nonPrimitive"\`
-	// This is optional.
-	AnotherOptional *map[string]scopejsiicalclib.NumericValue \`field:"optional" json:"anotherOptional" yaml:"anotherOptional"\`
-	OptionalAny interface{} \`field:"optional" json:"optionalAny" yaml:"optionalAny"\`
-	OptionalArray *[]*string \`field:"optional" json:"optionalArray" yaml:"optionalArray"\`
-}
-
-type DiamondBottom struct {
-	// Deprecated.
-	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
-	// Deprecated.
-	Left *float64 \`field:"optional" json:"left" yaml:"left"\`
-	// Deprecated.
-	Right *bool \`field:"optional" json:"right" yaml:"right"\`
-	Bottom *time.Time \`field:"optional" json:"bottom" yaml:"bottom"\`
-}
-
-type DiamondInheritanceBaseLevelStruct struct {
-	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
-}
-
-type DiamondInheritanceFirstMidLevelStruct struct {
-	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
-	FirstMidLevelProperty *string \`field:"required" json:"firstMidLevelProperty" yaml:"firstMidLevelProperty"\`
-}
-
-type DiamondInheritanceSecondMidLevelStruct struct {
-	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
-	SecondMidLevelProperty *string \`field:"required" json:"secondMidLevelProperty" yaml:"secondMidLevelProperty"\`
-}
-
-type DiamondInheritanceTopLevelStruct struct {
-	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
-	FirstMidLevelProperty *string \`field:"required" json:"firstMidLevelProperty" yaml:"firstMidLevelProperty"\`
-	SecondMidLevelProperty *string \`field:"required" json:"secondMidLevelProperty" yaml:"secondMidLevelProperty"\`
-	TopLevelProperty *string \`field:"required" json:"topLevelProperty" yaml:"topLevelProperty"\`
-}
-
-// Verifies that null/undefined can be returned for optional collections.
-//
-// This source of collections is disappointing - it'll always give you nothing :(.
-type DisappointingCollectionSource interface {
-}
-
-// The jsii proxy struct for DisappointingCollectionSource
-type jsiiProxy_DisappointingCollectionSource struct {
-	_ byte // padding
-}
-
-func DisappointingCollectionSource_MaybeList() *[]*string {
-	_init_.Initialize()
-	var returns *[]*string
-	_jsii_.StaticGet(
-		"jsii-calc.DisappointingCollectionSource",
-		"maybeList",
-		&returns,
-	)
-	return returns
-}
-
-func DisappointingCollectionSource_MaybeMap() *map[string]*float64 {
-	_init_.Initialize()
-	var returns *map[string]*float64
-	_jsii_.StaticGet(
-		"jsii-calc.DisappointingCollectionSource",
-		"maybeMap",
-		&returns,
-	)
-	return returns
-}
-
-type DoNotOverridePrivates interface {
-	ChangePrivatePropertyValue(newValue *string)
-	PrivateMethodValue() *string
-	PrivatePropertyValue() *string
-}
-
-// The jsii proxy struct for DoNotOverridePrivates
-type jsiiProxy_DoNotOverridePrivates struct {
-	_ byte // padding
-}
-
-func NewDoNotOverridePrivates() DoNotOverridePrivates {
-	_init_.Initialize()
-
-	j := jsiiProxy_DoNotOverridePrivates{}
-
-	_jsii_.Create(
-		"jsii-calc.DoNotOverridePrivates",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDoNotOverridePrivates_Override(d DoNotOverridePrivates) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DoNotOverridePrivates",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DoNotOverridePrivates) ChangePrivatePropertyValue(newValue *string) {
-	_jsii_.InvokeVoid(
-		d,
-		"changePrivatePropertyValue",
-		[]interface{}{newValue},
-	)
-}
-
-func (d *jsiiProxy_DoNotOverridePrivates) PrivateMethodValue() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"privateMethodValue",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (d *jsiiProxy_DoNotOverridePrivates) PrivatePropertyValue() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"privatePropertyValue",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// jsii#284: do not recognize "any" as an optional argument.
-type DoNotRecognizeAnyAsOptional interface {
-	Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString *string)
-}
-
-// The jsii proxy struct for DoNotRecognizeAnyAsOptional
-type jsiiProxy_DoNotRecognizeAnyAsOptional struct {
-	_ byte // padding
-}
-
-func NewDoNotRecognizeAnyAsOptional() DoNotRecognizeAnyAsOptional {
-	_init_.Initialize()
-
-	j := jsiiProxy_DoNotRecognizeAnyAsOptional{}
-
-	_jsii_.Create(
-		"jsii-calc.DoNotRecognizeAnyAsOptional",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDoNotRecognizeAnyAsOptional_Override(d DoNotRecognizeAnyAsOptional) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DoNotRecognizeAnyAsOptional",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DoNotRecognizeAnyAsOptional) Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString *string) {
-	_jsii_.InvokeVoid(
-		d,
-		"method",
-		[]interface{}{_requiredAny, _optionalAny, _optionalString},
-	)
-}
-
-// Here's the first line of the TSDoc comment.
-//
-// This is the meat of the TSDoc comment. It may contain
-// multiple lines and multiple paragraphs.
-//
-// Multiple paragraphs are separated by an empty line.
-//
-// Example:
-//   x := 12 + 44
-//   s1 := "string"
-//   s2 := "string \\nwith new newlines" // see https://github.com/aws/jsii/issues/2569
-//   s3 := "string\\n            with\\n            new lines"
-//
-type DocumentedClass interface {
-	// Greet the indicated person.
-	//
-	// This will print out a friendly greeting intended for the indicated person.
-	//
-	// Returns: A number that everyone knows very well and represents the answer
-	// to the ultimate question.
-	Greet(greetee *Greetee) *float64
-	// Say ¡Hola!
-	// Experimental.
-	Hola()
-}
-
-// The jsii proxy struct for DocumentedClass
-type jsiiProxy_DocumentedClass struct {
-	_ byte // padding
-}
-
-func NewDocumentedClass() DocumentedClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_DocumentedClass{}
-
-	_jsii_.Create(
-		"jsii-calc.DocumentedClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDocumentedClass_Override(d DocumentedClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DocumentedClass",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DocumentedClass) Greet(greetee *Greetee) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		d,
-		"greet",
-		[]interface{}{greetee},
-		&returns,
-	)
-
-	return returns
-}
-
-func (d *jsiiProxy_DocumentedClass) Hola() {
-	_jsii_.InvokeVoid(
-		d,
-		"hola",
-		nil, // no parameters
-	)
-}
-
-type DontComplainAboutVariadicAfterOptional interface {
-	OptionalAndVariadic(optional *string, things ...*string) *string
-}
-
-// The jsii proxy struct for DontComplainAboutVariadicAfterOptional
-type jsiiProxy_DontComplainAboutVariadicAfterOptional struct {
-	_ byte // padding
-}
-
-func NewDontComplainAboutVariadicAfterOptional() DontComplainAboutVariadicAfterOptional {
-	_init_.Initialize()
-
-	j := jsiiProxy_DontComplainAboutVariadicAfterOptional{}
-
-	_jsii_.Create(
-		"jsii-calc.DontComplainAboutVariadicAfterOptional",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDontComplainAboutVariadicAfterOptional_Override(d DontComplainAboutVariadicAfterOptional) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DontComplainAboutVariadicAfterOptional",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional *string, things ...*string) *string {
-	args := []interface{}{optional}
-	for _, a := range things {
-		args = append(args, a)
-	}
-
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"optionalAndVariadic",
-		args,
-		&returns,
-	)
-
-	return returns
-}
-
-type DoubleTrouble interface {
-	IFriendlyRandomGenerator
-	// Say hello!
-	Hello() *string
-	// Returns another random number.
-	Next() *float64
-}
-
-// The jsii proxy struct for DoubleTrouble
-type jsiiProxy_DoubleTrouble struct {
-	jsiiProxy_IFriendlyRandomGenerator
-}
-
-func NewDoubleTrouble() DoubleTrouble {
-	_init_.Initialize()
-
-	j := jsiiProxy_DoubleTrouble{}
-
-	_jsii_.Create(
-		"jsii-calc.DoubleTrouble",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewDoubleTrouble_Override(d DoubleTrouble) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DoubleTrouble",
-		nil, // no parameters
-		d,
-	)
-}
-
-func (d *jsiiProxy_DoubleTrouble) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (d *jsiiProxy_DoubleTrouble) Next() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		d,
-		"next",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type DummyObj struct {
-	Example *string \`field:"required" json:"example" yaml:"example"\`
-}
-
-// Ensures we can override a dynamic property that was inherited.
-type DynamicPropertyBearer interface {
-	DynamicProperty() *string
-	SetDynamicProperty(val *string)
-	ValueStore() *string
-	SetValueStore(val *string)
-}
-
-// The jsii proxy struct for DynamicPropertyBearer
-type jsiiProxy_DynamicPropertyBearer struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_DynamicPropertyBearer) DynamicProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"dynamicProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DynamicPropertyBearer) ValueStore() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"valueStore",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewDynamicPropertyBearer(valueStore *string) DynamicPropertyBearer {
-	_init_.Initialize()
-
-	j := jsiiProxy_DynamicPropertyBearer{}
-
-	_jsii_.Create(
-		"jsii-calc.DynamicPropertyBearer",
-		[]interface{}{valueStore},
-		&j,
-	)
-
-	return &j
-}
-
-func NewDynamicPropertyBearer_Override(d DynamicPropertyBearer, valueStore *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DynamicPropertyBearer",
-		[]interface{}{valueStore},
-		d,
-	)
-}
-
-func (j *jsiiProxy_DynamicPropertyBearer) SetDynamicProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"dynamicProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_DynamicPropertyBearer) SetValueStore(val *string) {
-	_jsii_.Set(
-		j,
-		"valueStore",
-		val,
-	)
-}
-
-type DynamicPropertyBearerChild interface {
-	DynamicPropertyBearer
-	DynamicProperty() *string
-	SetDynamicProperty(val *string)
-	OriginalValue() *string
-	ValueStore() *string
-	SetValueStore(val *string)
-	// Sets \`this.dynamicProperty\` to the new value, and returns the old value.
-	//
-	// Returns: the old value that was set.
-	OverrideValue(newValue *string) *string
-}
-
-// The jsii proxy struct for DynamicPropertyBearerChild
-type jsiiProxy_DynamicPropertyBearerChild struct {
-	jsiiProxy_DynamicPropertyBearer
-}
-
-func (j *jsiiProxy_DynamicPropertyBearerChild) DynamicProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"dynamicProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DynamicPropertyBearerChild) OriginalValue() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"originalValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_DynamicPropertyBearerChild) ValueStore() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"valueStore",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewDynamicPropertyBearerChild(originalValue *string) DynamicPropertyBearerChild {
-	_init_.Initialize()
-
-	j := jsiiProxy_DynamicPropertyBearerChild{}
-
-	_jsii_.Create(
-		"jsii-calc.DynamicPropertyBearerChild",
-		[]interface{}{originalValue},
-		&j,
-	)
-
-	return &j
-}
-
-func NewDynamicPropertyBearerChild_Override(d DynamicPropertyBearerChild, originalValue *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.DynamicPropertyBearerChild",
-		[]interface{}{originalValue},
-		d,
-	)
-}
-
-func (j *jsiiProxy_DynamicPropertyBearerChild) SetDynamicProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"dynamicProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_DynamicPropertyBearerChild) SetValueStore(val *string) {
-	_jsii_.Set(
-		j,
-		"valueStore",
-		val,
-	)
-}
-
-func (d *jsiiProxy_DynamicPropertyBearerChild) OverrideValue(newValue *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		d,
-		"overrideValue",
-		[]interface{}{newValue},
-		&returns,
-	)
-
-	return returns
-}
-
-// This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
-type Entropy interface {
-	// Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-	//
-	// Returns: the time from the \`WallClock\`.
-	Increase() *string
-	// Implement this method such that it returns \`word\`.
-	//
-	// Returns: \`word\`.
-	Repeat(word *string) *string
-}
-
-// The jsii proxy struct for Entropy
-type jsiiProxy_Entropy struct {
-	_ byte // padding
-}
-
-// Creates a new instance of Entropy.
-func NewEntropy_Override(e Entropy, clock IWallClock) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Entropy",
-		[]interface{}{clock},
-		e,
-	)
-}
-
-func (e *jsiiProxy_Entropy) Increase() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		e,
-		"increase",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (e *jsiiProxy_Entropy) Repeat(word *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		e,
-		"repeat",
-		[]interface{}{word},
-		&returns,
-	)
-
-	return returns
-}
-
-type EnumDispenser interface {
-}
-
-// The jsii proxy struct for EnumDispenser
-type jsiiProxy_EnumDispenser struct {
-	_ byte // padding
-}
-
-func EnumDispenser_RandomIntegerLikeEnum() AllTypesEnum {
-	_init_.Initialize()
-
-	var returns AllTypesEnum
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.EnumDispenser",
-		"randomIntegerLikeEnum",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func EnumDispenser_RandomStringLikeEnum() StringEnum {
-	_init_.Initialize()
-
-	var returns StringEnum
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.EnumDispenser",
-		"randomStringLikeEnum",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type EraseUndefinedHashValues interface {
-}
-
-// The jsii proxy struct for EraseUndefinedHashValues
-type jsiiProxy_EraseUndefinedHashValues struct {
-	_ byte // padding
-}
-
-func NewEraseUndefinedHashValues() EraseUndefinedHashValues {
-	_init_.Initialize()
-
-	j := jsiiProxy_EraseUndefinedHashValues{}
-
-	_jsii_.Create(
-		"jsii-calc.EraseUndefinedHashValues",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewEraseUndefinedHashValues_Override(e EraseUndefinedHashValues) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.EraseUndefinedHashValues",
-		nil, // no parameters
-		e,
-	)
-}
-
-// Returns \`true\` if \`key\` is defined in \`opts\`.
-//
-// Used to check that undefined/null hash values
-// are being erased when sending values from native code to JS.
-func EraseUndefinedHashValues_DoesKeyExist(opts *EraseUndefinedHashValuesOptions, key *string) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.EraseUndefinedHashValues",
-		"doesKeyExist",
-		[]interface{}{opts, key},
-		&returns,
-	)
-
-	return returns
-}
-
-// We expect "prop1" to be erased.
-func EraseUndefinedHashValues_Prop1IsNull() *map[string]interface{} {
-	_init_.Initialize()
-
-	var returns *map[string]interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.EraseUndefinedHashValues",
-		"prop1IsNull",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// We expect "prop2" to be erased.
-func EraseUndefinedHashValues_Prop2IsUndefined() *map[string]interface{} {
-	_init_.Initialize()
-
-	var returns *map[string]interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.EraseUndefinedHashValues",
-		"prop2IsUndefined",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type EraseUndefinedHashValuesOptions struct {
-	Option1 *string \`field:"optional" json:"option1" yaml:"option1"\`
-	Option2 *string \`field:"optional" json:"option2" yaml:"option2"\`
-}
-
-// Experimental.
-type ExperimentalClass interface {
-	// Experimental.
-	MutableProperty() *float64
-	// Experimental.
-	SetMutableProperty(val *float64)
-	// Experimental.
-	ReadonlyProperty() *string
-	// Experimental.
-	Method()
-}
-
-// The jsii proxy struct for ExperimentalClass
-type jsiiProxy_ExperimentalClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ExperimentalClass) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ExperimentalClass) ReadonlyProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-// Experimental.
-func NewExperimentalClass(readonlyString *string, mutableNumber *float64) ExperimentalClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_ExperimentalClass{}
-
-	_jsii_.Create(
-		"jsii-calc.ExperimentalClass",
-		[]interface{}{readonlyString, mutableNumber},
-		&j,
-	)
-
-	return &j
-}
-
-// Experimental.
-func NewExperimentalClass_Override(e ExperimentalClass, readonlyString *string, mutableNumber *float64) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ExperimentalClass",
-		[]interface{}{readonlyString, mutableNumber},
-		e,
-	)
-}
-
-func (j *jsiiProxy_ExperimentalClass) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-func (e *jsiiProxy_ExperimentalClass) Method() {
-	_jsii_.InvokeVoid(
-		e,
-		"method",
-		nil, // no parameters
-	)
-}
-
-// Experimental.
-type ExperimentalEnum string
-
-const (
-	// Experimental.
-	ExperimentalEnum_OPTION_A ExperimentalEnum = "OPTION_A"
-	// Experimental.
-	ExperimentalEnum_OPTION_B ExperimentalEnum = "OPTION_B"
-)
-
-// Experimental.
-type ExperimentalStruct struct {
-	// Experimental.
-	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
-}
-
-type ExportedBaseClass interface {
-	Success() *bool
-}
-
-// The jsii proxy struct for ExportedBaseClass
-type jsiiProxy_ExportedBaseClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ExportedBaseClass) Success() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"success",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewExportedBaseClass(success *bool) ExportedBaseClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_ExportedBaseClass{}
-
-	_jsii_.Create(
-		"jsii-calc.ExportedBaseClass",
-		[]interface{}{success},
-		&j,
-	)
-
-	return &j
-}
-
-func NewExportedBaseClass_Override(e ExportedBaseClass, success *bool) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ExportedBaseClass",
-		[]interface{}{success},
-		e,
-	)
-}
-
-type ExtendsInternalInterface struct {
-	Boom *bool \`field:"required" json:"boom" yaml:"boom"\`
-	Prop *string \`field:"required" json:"prop" yaml:"prop"\`
-}
-
-type ExternalClass interface {
-	MutableProperty() *float64
-	SetMutableProperty(val *float64)
-	ReadonlyProperty() *string
-	Method()
-}
-
-// The jsii proxy struct for ExternalClass
-type jsiiProxy_ExternalClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ExternalClass) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_ExternalClass) ReadonlyProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewExternalClass(readonlyString *string, mutableNumber *float64) ExternalClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_ExternalClass{}
-
-	_jsii_.Create(
-		"jsii-calc.ExternalClass",
-		[]interface{}{readonlyString, mutableNumber},
-		&j,
-	)
-
-	return &j
-}
-
-func NewExternalClass_Override(e ExternalClass, readonlyString *string, mutableNumber *float64) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ExternalClass",
-		[]interface{}{readonlyString, mutableNumber},
-		e,
-	)
-}
-
-func (j *jsiiProxy_ExternalClass) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-func (e *jsiiProxy_ExternalClass) Method() {
-	_jsii_.InvokeVoid(
-		e,
-		"method",
-		nil, // no parameters
-	)
-}
-
-type ExternalEnum string
-
-const (
-	ExternalEnum_OPTION_A ExternalEnum = "OPTION_A"
-	ExternalEnum_OPTION_B ExternalEnum = "OPTION_B"
-)
-
-type ExternalStruct struct {
-	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
-}
-
-type FullCombo interface {
-	BaseClass
-	IIndirectlyImplemented
-	Property() *string
-	Method() *float64
-}
-
-// The jsii proxy struct for FullCombo
-type jsiiProxy_FullCombo struct {
-	jsiiProxy_BaseClass
-	jsiiProxy_IIndirectlyImplemented
-}
-
-func (j *jsiiProxy_FullCombo) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-func (f *jsiiProxy_FullCombo) Method() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		f,
-		"method",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type GiveMeStructs interface {
-	StructLiteral() *scopejsiicalclib.StructWithOnlyOptionals
-	// Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
-	DerivedToFirst(derived *DerivedStruct) *scopejsiicalclib.MyFirstStruct
-	// Returns the boolean from a DerivedStruct struct.
-	ReadDerivedNonPrimitive(derived *DerivedStruct) DoubleTrouble
-	// Returns the "anumber" from a MyFirstStruct struct;.
-	ReadFirstNumber(first *scopejsiicalclib.MyFirstStruct) *float64
-}
-
-// The jsii proxy struct for GiveMeStructs
-type jsiiProxy_GiveMeStructs struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_GiveMeStructs) StructLiteral() *scopejsiicalclib.StructWithOnlyOptionals {
-	var returns *scopejsiicalclib.StructWithOnlyOptionals
-	_jsii_.Get(
-		j,
-		"structLiteral",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewGiveMeStructs() GiveMeStructs {
-	_init_.Initialize()
-
-	j := jsiiProxy_GiveMeStructs{}
-
-	_jsii_.Create(
-		"jsii-calc.GiveMeStructs",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewGiveMeStructs_Override(g GiveMeStructs) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.GiveMeStructs",
-		nil, // no parameters
-		g,
-	)
-}
-
-func (g *jsiiProxy_GiveMeStructs) DerivedToFirst(derived *DerivedStruct) *scopejsiicalclib.MyFirstStruct {
-	var returns *scopejsiicalclib.MyFirstStruct
-
-	_jsii_.Invoke(
-		g,
-		"derivedToFirst",
-		[]interface{}{derived},
-		&returns,
-	)
-
-	return returns
-}
-
-func (g *jsiiProxy_GiveMeStructs) ReadDerivedNonPrimitive(derived *DerivedStruct) DoubleTrouble {
-	var returns DoubleTrouble
-
-	_jsii_.Invoke(
-		g,
-		"readDerivedNonPrimitive",
-		[]interface{}{derived},
-		&returns,
-	)
-
-	return returns
-}
-
-func (g *jsiiProxy_GiveMeStructs) ReadFirstNumber(first *scopejsiicalclib.MyFirstStruct) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		g,
-		"readFirstNumber",
-		[]interface{}{first},
-		&returns,
-	)
-
-	return returns
-}
-
-// These are some arguments you can pass to a method.
-type Greetee struct {
-	// The name of the greetee.
-	Name *string \`field:"optional" json:"name" yaml:"name"\`
-}
-
-type GreetingAugmenter interface {
-	BetterGreeting(friendly scopejsiicalclib.IFriendly) *string
-}
-
-// The jsii proxy struct for GreetingAugmenter
-type jsiiProxy_GreetingAugmenter struct {
-	_ byte // padding
-}
-
-func NewGreetingAugmenter() GreetingAugmenter {
-	_init_.Initialize()
-
-	j := jsiiProxy_GreetingAugmenter{}
-
-	_jsii_.Create(
-		"jsii-calc.GreetingAugmenter",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewGreetingAugmenter_Override(g GreetingAugmenter) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.GreetingAugmenter",
-		nil, // no parameters
-		g,
-	)
-}
-
-func (g *jsiiProxy_GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendly) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		g,
-		"betterGreeting",
-		[]interface{}{friendly},
-		&returns,
-	)
-
-	return returns
-}
-
-// We can return an anonymous interface implementation from an override without losing the interface declarations.
-type IAnonymousImplementationProvider interface {
-	ProvideAsClass() Implementation
-	ProvideAsInterface() IAnonymouslyImplementMe
-}
-
-// The jsii proxy for IAnonymousImplementationProvider
-type jsiiProxy_IAnonymousImplementationProvider struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IAnonymousImplementationProvider) ProvideAsClass() Implementation {
-	var returns Implementation
-
-	_jsii_.Invoke(
-		i,
-		"provideAsClass",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (i *jsiiProxy_IAnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
-	var returns IAnonymouslyImplementMe
-
-	_jsii_.Invoke(
-		i,
-		"provideAsInterface",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type IAnonymouslyImplementMe interface {
-	Verb() *string
-	Value() *float64
-}
-
-// The jsii proxy for IAnonymouslyImplementMe
-type jsiiProxy_IAnonymouslyImplementMe struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IAnonymouslyImplementMe) Verb() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"verb",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_IAnonymouslyImplementMe) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-type IAnotherPublicInterface interface {
-	A() *string
-	SetA(a *string)
-}
-
-// The jsii proxy for IAnotherPublicInterface
-type jsiiProxy_IAnotherPublicInterface struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IAnotherPublicInterface) A() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"a",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IAnotherPublicInterface) SetA(val *string) {
-	_jsii_.Set(
-		j,
-		"a",
-		val,
-	)
-}
-
-type IBell interface {
-	Ring()
-}
-
-// The jsii proxy for IBell
-type jsiiProxy_IBell struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IBell) Ring() {
-	_jsii_.InvokeVoid(
-		i,
-		"ring",
-		nil, // no parameters
-	)
-}
-
-// Takes the object parameter as an interface.
-type IBellRinger interface {
-	YourTurn(bell IBell)
-}
-
-// The jsii proxy for IBellRinger
-type jsiiProxy_IBellRinger struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IBellRinger) YourTurn(bell IBell) {
-	_jsii_.InvokeVoid(
-		i,
-		"yourTurn",
-		[]interface{}{bell},
-	)
-}
-
-// Takes the object parameter as a calss.
-type IConcreteBellRinger interface {
-	YourTurn(bell Bell)
-}
-
-// The jsii proxy for IConcreteBellRinger
-type jsiiProxy_IConcreteBellRinger struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IConcreteBellRinger) YourTurn(bell Bell) {
-	_jsii_.InvokeVoid(
-		i,
-		"yourTurn",
-		[]interface{}{bell},
-	)
-}
-
-// Deprecated: useless interface.
-type IDeprecatedInterface interface {
-	// Deprecated: services no purpose.
-	Method()
-	// Deprecated: could be better.
-	MutableProperty() *float64
-	// Deprecated: could be better.
-	SetMutableProperty(m *float64)
-}
-
-// The jsii proxy for IDeprecatedInterface
-type jsiiProxy_IDeprecatedInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IDeprecatedInterface) Method() {
-	_jsii_.InvokeVoid(
-		i,
-		"method",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IDeprecatedInterface) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IDeprecatedInterface) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-// Experimental.
-type IExperimentalInterface interface {
-	// Experimental.
-	Method()
-	// Experimental.
-	MutableProperty() *float64
-	// Experimental.
-	SetMutableProperty(m *float64)
-}
-
-// The jsii proxy for IExperimentalInterface
-type jsiiProxy_IExperimentalInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IExperimentalInterface) Method() {
-	_jsii_.InvokeVoid(
-		i,
-		"method",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IExperimentalInterface) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IExperimentalInterface) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-type IExtendsPrivateInterface interface {
-	MoreThings() *[]*string
-	Private() *string
-	SetPrivate(p *string)
-}
-
-// The jsii proxy for IExtendsPrivateInterface
-type jsiiProxy_IExtendsPrivateInterface struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IExtendsPrivateInterface) MoreThings() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"moreThings",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IExtendsPrivateInterface) Private() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"private",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IExtendsPrivateInterface) SetPrivate(val *string) {
-	_jsii_.Set(
-		j,
-		"private",
-		val,
-	)
-}
-
-type IExternalInterface interface {
-	Method()
-	MutableProperty() *float64
-	SetMutableProperty(m *float64)
-}
-
-// The jsii proxy for IExternalInterface
-type jsiiProxy_IExternalInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IExternalInterface) Method() {
-	_jsii_.InvokeVoid(
-		i,
-		"method",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IExternalInterface) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IExternalInterface) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-// Even friendlier classes can implement this interface.
-type IFriendlier interface {
-	scopejsiicalclib.IFriendly
-	// Say farewell.
-	Farewell() *string
-	// Say goodbye.
-	//
-	// Returns: A goodbye blessing.
-	Goodbye() *string
-}
-
-// The jsii proxy for IFriendlier
-type jsiiProxy_IFriendlier struct {
-	internal.Type__scopejsiicalclibIFriendly
-}
-
-func (i *jsiiProxy_IFriendlier) Farewell() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"farewell",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (i *jsiiProxy_IFriendlier) Goodbye() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"goodbye",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type IFriendlyRandomGenerator interface {
-	scopejsiicalclib.IFriendly
-	IRandomNumberGenerator
-}
-
-// The jsii proxy for IFriendlyRandomGenerator
-type jsiiProxy_IFriendlyRandomGenerator struct {
-	internal.Type__scopejsiicalclibIFriendly
-	jsiiProxy_IRandomNumberGenerator
-}
-
-func (i *jsiiProxy_IFriendlyRandomGenerator) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (i *jsiiProxy_IFriendlyRandomGenerator) Next() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		i,
-		"next",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type IIndirectlyImplemented interface {
-	Method() *float64
-	Property() *string
-}
-
-// The jsii proxy for IIndirectlyImplemented
-type jsiiProxy_IIndirectlyImplemented struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IIndirectlyImplemented) Method() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		i,
-		"method",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_IIndirectlyImplemented) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-// awslabs/jsii#220 Abstract return type.
-type IInterfaceImplementedByAbstractClass interface {
-	PropFromInterface() *string
-}
-
-// The jsii proxy for IInterfaceImplementedByAbstractClass
-type jsiiProxy_IInterfaceImplementedByAbstractClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IInterfaceImplementedByAbstractClass) PropFromInterface() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"propFromInterface",
-		&returns,
-	)
-	return returns
-}
-
-// Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
-type IInterfaceThatShouldNotBeADataType interface {
-	IInterfaceWithMethods
-	OtherValue() *string
-}
-
-// The jsii proxy for IInterfaceThatShouldNotBeADataType
-type jsiiProxy_IInterfaceThatShouldNotBeADataType struct {
-	jsiiProxy_IInterfaceWithMethods
-}
-
-func (j *jsiiProxy_IInterfaceThatShouldNotBeADataType) OtherValue() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"otherValue",
-		&returns,
-	)
-	return returns
-}
-
-type IInterfaceWithInternal interface {
-	Visible()
-}
-
-// The jsii proxy for IInterfaceWithInternal
-type jsiiProxy_IInterfaceWithInternal struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IInterfaceWithInternal) Visible() {
-	_jsii_.InvokeVoid(
-		i,
-		"visible",
-		nil, // no parameters
-	)
-}
-
-type IInterfaceWithMethods interface {
-	DoThings()
-	Value() *string
-}
-
-// The jsii proxy for IInterfaceWithMethods
-type jsiiProxy_IInterfaceWithMethods struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IInterfaceWithMethods) DoThings() {
-	_jsii_.InvokeVoid(
-		i,
-		"doThings",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IInterfaceWithMethods) Value() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-// awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
-type IInterfaceWithOptionalMethodArguments interface {
-	Hello(arg1 *string, arg2 *float64)
-}
-
-// The jsii proxy for IInterfaceWithOptionalMethodArguments
-type jsiiProxy_IInterfaceWithOptionalMethodArguments struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IInterfaceWithOptionalMethodArguments) Hello(arg1 *string, arg2 *float64) {
-	_jsii_.InvokeVoid(
-		i,
-		"hello",
-		[]interface{}{arg1, arg2},
-	)
-}
-
-type IInterfaceWithProperties interface {
-	ReadOnlyString() *string
-	ReadWriteString() *string
-	SetReadWriteString(r *string)
-}
-
-// The jsii proxy for IInterfaceWithProperties
-type jsiiProxy_IInterfaceWithProperties struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IInterfaceWithProperties) ReadOnlyString() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readOnlyString",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IInterfaceWithProperties) ReadWriteString() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readWriteString",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IInterfaceWithProperties) SetReadWriteString(val *string) {
-	_jsii_.Set(
-		j,
-		"readWriteString",
-		val,
-	)
-}
-
-type IInterfaceWithPropertiesExtension interface {
-	IInterfaceWithProperties
-	Foo() *float64
-	SetFoo(f *float64)
-}
-
-// The jsii proxy for IInterfaceWithPropertiesExtension
-type jsiiProxy_IInterfaceWithPropertiesExtension struct {
-	jsiiProxy_IInterfaceWithProperties
-}
-
-func (j *jsiiProxy_IInterfaceWithPropertiesExtension) Foo() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"foo",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IInterfaceWithPropertiesExtension) SetFoo(val *float64) {
-	_jsii_.Set(
-		j,
-		"foo",
-		val,
-	)
-}
-
-type IJSII417Derived interface {
-	IJSII417PublicBaseOfBase
-	Bar()
-	Baz()
-	Property() *string
-}
-
-// The jsii proxy for IJSII417Derived
-type jsiiProxy_IJSII417Derived struct {
-	jsiiProxy_IJSII417PublicBaseOfBase
-}
-
-func (i *jsiiProxy_IJSII417Derived) Bar() {
-	_jsii_.InvokeVoid(
-		i,
-		"bar",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJSII417Derived) Baz() {
-	_jsii_.InvokeVoid(
-		i,
-		"baz",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IJSII417Derived) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-type IJSII417PublicBaseOfBase interface {
-	Foo()
-	HasRoot() *bool
-}
-
-// The jsii proxy for IJSII417PublicBaseOfBase
-type jsiiProxy_IJSII417PublicBaseOfBase struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IJSII417PublicBaseOfBase) Foo() {
-	_jsii_.InvokeVoid(
-		i,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IJSII417PublicBaseOfBase) HasRoot() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"hasRoot",
-		&returns,
-	)
-	return returns
-}
-
-type IJavaReservedWordsInAnInterface interface {
-	Abstract()
-	Assert()
-	Boolean()
-	Break()
-	Byte()
-	Case()
-	Catch()
-	Char()
-	Class()
-	Const()
-	Continue()
-	Default()
-	Do()
-	Double()
-	Else()
-	Enum()
-	Extends()
-	False()
-	Final()
-	Finally()
-	Float()
-	For()
-	Goto()
-	If()
-	Implements()
-	Import()
-	Instanceof()
-	Int()
-	Interface()
-	Long()
-	Native()
-	Null()
-	Package()
-	Private()
-	Protected()
-	Public()
-	Return()
-	Short()
-	Static()
-	Strictfp()
-	Super()
-	Switch()
-	Synchronized()
-	This()
-	Throw()
-	Throws()
-	Transient()
-	True()
-	Try()
-	Void()
-	Volatile()
-	While() *string
-}
-
-// The jsii proxy for IJavaReservedWordsInAnInterface
-type jsiiProxy_IJavaReservedWordsInAnInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Abstract() {
-	_jsii_.InvokeVoid(
-		i,
-		"abstract",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Assert() {
-	_jsii_.InvokeVoid(
-		i,
-		"assert",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Boolean() {
-	_jsii_.InvokeVoid(
-		i,
-		"boolean",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Break() {
-	_jsii_.InvokeVoid(
-		i,
-		"break",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Byte() {
-	_jsii_.InvokeVoid(
-		i,
-		"byte",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Case() {
-	_jsii_.InvokeVoid(
-		i,
-		"case",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Catch() {
-	_jsii_.InvokeVoid(
-		i,
-		"catch",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Char() {
-	_jsii_.InvokeVoid(
-		i,
-		"char",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Class() {
-	_jsii_.InvokeVoid(
-		i,
-		"class",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Const() {
-	_jsii_.InvokeVoid(
-		i,
-		"const",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Continue() {
-	_jsii_.InvokeVoid(
-		i,
-		"continue",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Default() {
-	_jsii_.InvokeVoid(
-		i,
-		"default",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Do() {
-	_jsii_.InvokeVoid(
-		i,
-		"do",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Double() {
-	_jsii_.InvokeVoid(
-		i,
-		"double",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Else() {
-	_jsii_.InvokeVoid(
-		i,
-		"else",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Enum() {
-	_jsii_.InvokeVoid(
-		i,
-		"enum",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Extends() {
-	_jsii_.InvokeVoid(
-		i,
-		"extends",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) False() {
-	_jsii_.InvokeVoid(
-		i,
-		"false",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Final() {
-	_jsii_.InvokeVoid(
-		i,
-		"final",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Finally() {
-	_jsii_.InvokeVoid(
-		i,
-		"finally",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Float() {
-	_jsii_.InvokeVoid(
-		i,
-		"float",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) For() {
-	_jsii_.InvokeVoid(
-		i,
-		"for",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Goto() {
-	_jsii_.InvokeVoid(
-		i,
-		"goto",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) If() {
-	_jsii_.InvokeVoid(
-		i,
-		"if",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Implements() {
-	_jsii_.InvokeVoid(
-		i,
-		"implements",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Import() {
-	_jsii_.InvokeVoid(
-		i,
-		"import",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Instanceof() {
-	_jsii_.InvokeVoid(
-		i,
-		"instanceof",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Int() {
-	_jsii_.InvokeVoid(
-		i,
-		"int",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Interface() {
-	_jsii_.InvokeVoid(
-		i,
-		"interface",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Long() {
-	_jsii_.InvokeVoid(
-		i,
-		"long",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Native() {
-	_jsii_.InvokeVoid(
-		i,
-		"native",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Null() {
-	_jsii_.InvokeVoid(
-		i,
-		"null",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Package() {
-	_jsii_.InvokeVoid(
-		i,
-		"package",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Private() {
-	_jsii_.InvokeVoid(
-		i,
-		"private",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Protected() {
-	_jsii_.InvokeVoid(
-		i,
-		"protected",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Public() {
-	_jsii_.InvokeVoid(
-		i,
-		"public",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Return() {
-	_jsii_.InvokeVoid(
-		i,
-		"return",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Short() {
-	_jsii_.InvokeVoid(
-		i,
-		"short",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Static() {
-	_jsii_.InvokeVoid(
-		i,
-		"static",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Strictfp() {
-	_jsii_.InvokeVoid(
-		i,
-		"strictfp",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Super() {
-	_jsii_.InvokeVoid(
-		i,
-		"super",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Switch() {
-	_jsii_.InvokeVoid(
-		i,
-		"switch",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Synchronized() {
-	_jsii_.InvokeVoid(
-		i,
-		"synchronized",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) This() {
-	_jsii_.InvokeVoid(
-		i,
-		"this",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Throw() {
-	_jsii_.InvokeVoid(
-		i,
-		"throw",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Throws() {
-	_jsii_.InvokeVoid(
-		i,
-		"throws",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Transient() {
-	_jsii_.InvokeVoid(
-		i,
-		"transient",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) True() {
-	_jsii_.InvokeVoid(
-		i,
-		"true",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Try() {
-	_jsii_.InvokeVoid(
-		i,
-		"try",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Void() {
-	_jsii_.InvokeVoid(
-		i,
-		"void",
-		nil, // no parameters
-	)
-}
-
-func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Volatile() {
-	_jsii_.InvokeVoid(
-		i,
-		"volatile",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IJavaReservedWordsInAnInterface) While() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"while",
-		&returns,
-	)
-	return returns
-}
-
-type IJsii487External interface {
-}
-
-// The jsii proxy for IJsii487External
-type jsiiProxy_IJsii487External struct {
-	_ byte // padding
-}
-
-type IJsii487External2 interface {
-}
-
-// The jsii proxy for IJsii487External2
-type jsiiProxy_IJsii487External2 struct {
-	_ byte // padding
-}
-
-type IJsii496 interface {
-}
-
-// The jsii proxy for IJsii496
-type jsiiProxy_IJsii496 struct {
-	_ byte // padding
-}
-
-type IMutableObjectLiteral interface {
-	Value() *string
-	SetValue(v *string)
-}
-
-// The jsii proxy for IMutableObjectLiteral
-type jsiiProxy_IMutableObjectLiteral struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IMutableObjectLiteral) Value() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IMutableObjectLiteral) SetValue(val *string) {
-	_jsii_.Set(
-		j,
-		"value",
-		val,
-	)
-}
-
-type INonInternalInterface interface {
-	IAnotherPublicInterface
-	B() *string
-	SetB(b *string)
-	C() *string
-	SetC(c *string)
-}
-
-// The jsii proxy for INonInternalInterface
-type jsiiProxy_INonInternalInterface struct {
-	jsiiProxy_IAnotherPublicInterface
-}
-
-func (j *jsiiProxy_INonInternalInterface) B() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"b",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_INonInternalInterface) SetB(val *string) {
-	_jsii_.Set(
-		j,
-		"b",
-		val,
-	)
-}
-
-func (j *jsiiProxy_INonInternalInterface) C() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"c",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_INonInternalInterface) SetC(val *string) {
-	_jsii_.Set(
-		j,
-		"c",
-		val,
-	)
-}
-
-// Make sure that setters are properly called on objects with interfaces.
-type IObjectWithProperty interface {
-	WasSet() *bool
-	Property() *string
-	SetProperty(p *string)
-}
-
-// The jsii proxy for IObjectWithProperty
-type jsiiProxy_IObjectWithProperty struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IObjectWithProperty) WasSet() *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		i,
-		"wasSet",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_IObjectWithProperty) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IObjectWithProperty) SetProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"property",
-		val,
-	)
-}
-
-// Checks that optional result from interface method code generates correctly.
-type IOptionalMethod interface {
-	Optional() *string
-}
-
-// The jsii proxy for IOptionalMethod
-type jsiiProxy_IOptionalMethod struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IOptionalMethod) Optional() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"optional",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type IPrivatelyImplemented interface {
-	Success() *bool
-}
-
-// The jsii proxy for IPrivatelyImplemented
-type jsiiProxy_IPrivatelyImplemented struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IPrivatelyImplemented) Success() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"success",
-		&returns,
-	)
-	return returns
-}
-
-type IPublicInterface interface {
-	Bye() *string
-}
-
-// The jsii proxy for IPublicInterface
-type jsiiProxy_IPublicInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IPublicInterface) Bye() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"bye",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type IPublicInterface2 interface {
-	Ciao() *string
-}
-
-// The jsii proxy for IPublicInterface2
-type jsiiProxy_IPublicInterface2 struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IPublicInterface2) Ciao() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"ciao",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Generates random numbers.
-type IRandomNumberGenerator interface {
-	// Returns another random number.
-	//
-	// Returns: A random number.
-	Next() *float64
-}
-
-// The jsii proxy for IRandomNumberGenerator
-type jsiiProxy_IRandomNumberGenerator struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IRandomNumberGenerator) Next() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		i,
-		"next",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Returns a subclass of a known class which implements an interface.
-type IReturnJsii976 interface {
-	Foo() *float64
-}
-
-// The jsii proxy for IReturnJsii976
-type jsiiProxy_IReturnJsii976 struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_IReturnJsii976) Foo() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"foo",
-		&returns,
-	)
-	return returns
-}
-
-type IReturnsNumber interface {
-	ObtainNumber() scopejsiicalclib.IDoublable
-	NumberProp() scopejsiicalclib.Number
-}
-
-// The jsii proxy for IReturnsNumber
-type jsiiProxy_IReturnsNumber struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IReturnsNumber) ObtainNumber() scopejsiicalclib.IDoublable {
-	var returns scopejsiicalclib.IDoublable
-
-	_jsii_.Invoke(
-		i,
-		"obtainNumber",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_IReturnsNumber) NumberProp() scopejsiicalclib.Number {
-	var returns scopejsiicalclib.Number
-	_jsii_.Get(
-		j,
-		"numberProp",
-		&returns,
-	)
-	return returns
-}
-
-type IStableInterface interface {
-	Method()
-	MutableProperty() *float64
-	SetMutableProperty(m *float64)
-}
-
-// The jsii proxy for IStableInterface
-type jsiiProxy_IStableInterface struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IStableInterface) Method() {
-	_jsii_.InvokeVoid(
-		i,
-		"method",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_IStableInterface) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_IStableInterface) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-// Verifies that a "pure" implementation of an interface works correctly.
-type IStructReturningDelegate interface {
-	ReturnStruct() *StructB
-}
-
-// The jsii proxy for IStructReturningDelegate
-type jsiiProxy_IStructReturningDelegate struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IStructReturningDelegate) ReturnStruct() *StructB {
-	var returns *StructB
-
-	_jsii_.Invoke(
-		i,
-		"returnStruct",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Implement this interface.
-type IWallClock interface {
-	// Returns the current time, formatted as an ISO-8601 string.
-	Iso8601Now() *string
-}
-
-// The jsii proxy for IWallClock
-type jsiiProxy_IWallClock struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IWallClock) Iso8601Now() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"iso8601Now",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type ImplementInternalInterface interface {
-	Prop() *string
-	SetProp(val *string)
-}
-
-// The jsii proxy struct for ImplementInternalInterface
-type jsiiProxy_ImplementInternalInterface struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ImplementInternalInterface) Prop() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"prop",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewImplementInternalInterface() ImplementInternalInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ImplementInternalInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ImplementInternalInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewImplementInternalInterface_Override(i ImplementInternalInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ImplementInternalInterface",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (j *jsiiProxy_ImplementInternalInterface) SetProp(val *string) {
-	_jsii_.Set(
-		j,
-		"prop",
-		val,
-	)
-}
-
-type Implementation interface {
-	Value() *float64
-}
-
-// The jsii proxy struct for Implementation
-type jsiiProxy_Implementation struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_Implementation) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewImplementation() Implementation {
-	_init_.Initialize()
-
-	j := jsiiProxy_Implementation{}
-
-	_jsii_.Create(
-		"jsii-calc.Implementation",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewImplementation_Override(i Implementation) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Implementation",
-		nil, // no parameters
-		i,
-	)
-}
-
-type ImplementsInterfaceWithInternal interface {
-	IInterfaceWithInternal
-	Visible()
-}
-
-// The jsii proxy struct for ImplementsInterfaceWithInternal
-type jsiiProxy_ImplementsInterfaceWithInternal struct {
-	jsiiProxy_IInterfaceWithInternal
-}
-
-func NewImplementsInterfaceWithInternal() ImplementsInterfaceWithInternal {
-	_init_.Initialize()
-
-	j := jsiiProxy_ImplementsInterfaceWithInternal{}
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsInterfaceWithInternal",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewImplementsInterfaceWithInternal_Override(i ImplementsInterfaceWithInternal) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsInterfaceWithInternal",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (i *jsiiProxy_ImplementsInterfaceWithInternal) Visible() {
-	_jsii_.InvokeVoid(
-		i,
-		"visible",
-		nil, // no parameters
-	)
-}
-
-type ImplementsInterfaceWithInternalSubclass interface {
-	ImplementsInterfaceWithInternal
-	Visible()
-}
-
-// The jsii proxy struct for ImplementsInterfaceWithInternalSubclass
-type jsiiProxy_ImplementsInterfaceWithInternalSubclass struct {
-	jsiiProxy_ImplementsInterfaceWithInternal
-}
-
-func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInternalSubclass {
-	_init_.Initialize()
-
-	j := jsiiProxy_ImplementsInterfaceWithInternalSubclass{}
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewImplementsInterfaceWithInternalSubclass_Override(i ImplementsInterfaceWithInternalSubclass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (i *jsiiProxy_ImplementsInterfaceWithInternalSubclass) Visible() {
-	_jsii_.InvokeVoid(
-		i,
-		"visible",
-		nil, // no parameters
-	)
-}
-
-type ImplementsPrivateInterface interface {
-	Private() *string
-	SetPrivate(val *string)
-}
-
-// The jsii proxy struct for ImplementsPrivateInterface
-type jsiiProxy_ImplementsPrivateInterface struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ImplementsPrivateInterface) Private() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"private",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewImplementsPrivateInterface() ImplementsPrivateInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ImplementsPrivateInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsPrivateInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewImplementsPrivateInterface_Override(i ImplementsPrivateInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ImplementsPrivateInterface",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (j *jsiiProxy_ImplementsPrivateInterface) SetPrivate(val *string) {
-	_jsii_.Set(
-		j,
-		"private",
-		val,
-	)
-}
-
-type ImplictBaseOfBase struct {
-	Foo scopejsiicalcbaseofbase.Very \`field:"required" json:"foo" yaml:"foo"\`
-	Bar *string \`field:"required" json:"bar" yaml:"bar"\`
-	Goo *time.Time \`field:"required" json:"goo" yaml:"goo"\`
-}
-
-type InbetweenClass interface {
-	PublicClass
-	IPublicInterface2
-	Ciao() *string
-	Hello()
-}
-
-// The jsii proxy struct for InbetweenClass
-type jsiiProxy_InbetweenClass struct {
-	jsiiProxy_PublicClass
-	jsiiProxy_IPublicInterface2
-}
-
-func NewInbetweenClass() InbetweenClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_InbetweenClass{}
-
-	_jsii_.Create(
-		"jsii-calc.InbetweenClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewInbetweenClass_Override(i InbetweenClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.InbetweenClass",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (i *jsiiProxy_InbetweenClass) Ciao() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		i,
-		"ciao",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (i *jsiiProxy_InbetweenClass) Hello() {
-	_jsii_.InvokeVoid(
-		i,
-		"hello",
-		nil, // no parameters
-	)
-}
-
-// Verifies that collections of interfaces or structs are correctly handled.
-//
-// See: https://github.com/aws/jsii/issues/1196
-type InterfaceCollections interface {
-}
-
-// The jsii proxy struct for InterfaceCollections
-type jsiiProxy_InterfaceCollections struct {
-	_ byte // padding
-}
-
-func InterfaceCollections_ListOfInterfaces() *[]IBell {
-	_init_.Initialize()
-
-	var returns *[]IBell
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.InterfaceCollections",
-		"listOfInterfaces",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func InterfaceCollections_ListOfStructs() *[]*StructA {
-	_init_.Initialize()
-
-	var returns *[]*StructA
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.InterfaceCollections",
-		"listOfStructs",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func InterfaceCollections_MapOfInterfaces() *map[string]IBell {
-	_init_.Initialize()
-
-	var returns *map[string]IBell
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.InterfaceCollections",
-		"mapOfInterfaces",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func InterfaceCollections_MapOfStructs() *map[string]*StructA {
-	_init_.Initialize()
-
-	var returns *map[string]*StructA
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.InterfaceCollections",
-		"mapOfStructs",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// We can return arrays of interfaces See aws/aws-cdk#2362.
-type InterfacesMaker interface {
-}
-
-// The jsii proxy struct for InterfacesMaker
-type jsiiProxy_InterfacesMaker struct {
-	_ byte // padding
-}
-
-func InterfacesMaker_MakeInterfaces(count *float64) *[]scopejsiicalclib.IDoublable {
-	_init_.Initialize()
-
-	var returns *[]scopejsiicalclib.IDoublable
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.InterfacesMaker",
-		"makeInterfaces",
-		[]interface{}{count},
-		&returns,
-	)
-
-	return returns
-}
-
-// Checks the "same instance" isomorphism is preserved within the constructor.
-//
-// Create a subclass of this, and assert that \`this.myself()\` actually returns
-// \`this\` from within the constructor.
-type Isomorphism interface {
-	Myself() Isomorphism
-}
-
-// The jsii proxy struct for Isomorphism
-type jsiiProxy_Isomorphism struct {
-	_ byte // padding
-}
-
-func NewIsomorphism_Override(i Isomorphism) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Isomorphism",
-		nil, // no parameters
-		i,
-	)
-}
-
-func (i *jsiiProxy_Isomorphism) Myself() Isomorphism {
-	var returns Isomorphism
-
-	_jsii_.Invoke(
-		i,
-		"myself",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Docstrings with period.
-// See: https://github.com/aws/jsii/issues/2638
-//
-type Issue2638 interface {
-}
-
-// The jsii proxy struct for Issue2638
-type jsiiProxy_Issue2638 struct {
-	_ byte // padding
-}
-
-// First sentence.
-//
-// Second sentence. Third sentence.
-func NewIssue2638() Issue2638 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Issue2638{}
-
-	_jsii_.Create(
-		"jsii-calc.Issue2638",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-// First sentence.
-//
-// Second sentence. Third sentence.
-func NewIssue2638_Override(i Issue2638) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Issue2638",
-		nil, // no parameters
-		i,
-	)
-}
-
-type Issue2638B interface {
-}
-
-// The jsii proxy struct for Issue2638B
-type jsiiProxy_Issue2638B struct {
-	_ byte // padding
-}
-
-func NewIssue2638B() Issue2638B {
-	_init_.Initialize()
-
-	j := jsiiProxy_Issue2638B{}
-
-	_jsii_.Create(
-		"jsii-calc.Issue2638B",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewIssue2638B_Override(i Issue2638B) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Issue2638B",
-		nil, // no parameters
-		i,
-	)
-}
-
-type JSII417Derived interface {
-	JSII417PublicBaseOfBase
-	HasRoot() *bool
-	Property() *string
-	Bar()
-	Baz()
-	Foo()
-}
-
-// The jsii proxy struct for JSII417Derived
-type jsiiProxy_JSII417Derived struct {
-	jsiiProxy_JSII417PublicBaseOfBase
-}
-
-func (j *jsiiProxy_JSII417Derived) HasRoot() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"hasRoot",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_JSII417Derived) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewJSII417Derived(property *string) JSII417Derived {
-	_init_.Initialize()
-
-	j := jsiiProxy_JSII417Derived{}
-
-	_jsii_.Create(
-		"jsii-calc.JSII417Derived",
-		[]interface{}{property},
-		&j,
-	)
-
-	return &j
-}
-
-func NewJSII417Derived_Override(j JSII417Derived, property *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JSII417Derived",
-		[]interface{}{property},
-		j,
-	)
-}
-
-func JSII417Derived_MakeInstance() JSII417PublicBaseOfBase {
-	_init_.Initialize()
-
-	var returns JSII417PublicBaseOfBase
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JSII417Derived",
-		"makeInstance",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_JSII417Derived) Bar() {
-	_jsii_.InvokeVoid(
-		j,
-		"bar",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JSII417Derived) Baz() {
-	_jsii_.InvokeVoid(
-		j,
-		"baz",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JSII417Derived) Foo() {
-	_jsii_.InvokeVoid(
-		j,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-type JSII417PublicBaseOfBase interface {
-	HasRoot() *bool
-	Foo()
-}
-
-// The jsii proxy struct for JSII417PublicBaseOfBase
-type jsiiProxy_JSII417PublicBaseOfBase struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_JSII417PublicBaseOfBase) HasRoot() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"hasRoot",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewJSII417PublicBaseOfBase() JSII417PublicBaseOfBase {
-	_init_.Initialize()
-
-	j := jsiiProxy_JSII417PublicBaseOfBase{}
-
-	_jsii_.Create(
-		"jsii-calc.JSII417PublicBaseOfBase",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJSII417PublicBaseOfBase_Override(j JSII417PublicBaseOfBase) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JSII417PublicBaseOfBase",
-		nil, // no parameters
-		j,
-	)
-}
-
-func JSII417PublicBaseOfBase_MakeInstance() JSII417PublicBaseOfBase {
-	_init_.Initialize()
-
-	var returns JSII417PublicBaseOfBase
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JSII417PublicBaseOfBase",
-		"makeInstance",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_JSII417PublicBaseOfBase) Foo() {
-	_jsii_.InvokeVoid(
-		j,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-type JSObjectLiteralForInterface interface {
-	GiveMeFriendly() scopejsiicalclib.IFriendly
-	GiveMeFriendlyGenerator() IFriendlyRandomGenerator
-}
-
-// The jsii proxy struct for JSObjectLiteralForInterface
-type jsiiProxy_JSObjectLiteralForInterface struct {
-	_ byte // padding
-}
-
-func NewJSObjectLiteralForInterface() JSObjectLiteralForInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_JSObjectLiteralForInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralForInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJSObjectLiteralForInterface_Override(j JSObjectLiteralForInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralForInterface",
-		nil, // no parameters
-		j,
-	)
-}
-
-func (j *jsiiProxy_JSObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendly {
-	var returns scopejsiicalclib.IFriendly
-
-	_jsii_.Invoke(
-		j,
-		"giveMeFriendly",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (j *jsiiProxy_JSObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomGenerator {
-	var returns IFriendlyRandomGenerator
-
-	_jsii_.Invoke(
-		j,
-		"giveMeFriendlyGenerator",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type JSObjectLiteralToNative interface {
-	ReturnLiteral() JSObjectLiteralToNativeClass
-}
-
-// The jsii proxy struct for JSObjectLiteralToNative
-type jsiiProxy_JSObjectLiteralToNative struct {
-	_ byte // padding
-}
-
-func NewJSObjectLiteralToNative() JSObjectLiteralToNative {
-	_init_.Initialize()
-
-	j := jsiiProxy_JSObjectLiteralToNative{}
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralToNative",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJSObjectLiteralToNative_Override(j JSObjectLiteralToNative) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralToNative",
-		nil, // no parameters
-		j,
-	)
-}
-
-func (j *jsiiProxy_JSObjectLiteralToNative) ReturnLiteral() JSObjectLiteralToNativeClass {
-	var returns JSObjectLiteralToNativeClass
-
-	_jsii_.Invoke(
-		j,
-		"returnLiteral",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type JSObjectLiteralToNativeClass interface {
-	PropA() *string
-	SetPropA(val *string)
-	PropB() *float64
-	SetPropB(val *float64)
-}
-
-// The jsii proxy struct for JSObjectLiteralToNativeClass
-type jsiiProxy_JSObjectLiteralToNativeClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_JSObjectLiteralToNativeClass) PropA() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"propA",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_JSObjectLiteralToNativeClass) PropB() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"propB",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewJSObjectLiteralToNativeClass() JSObjectLiteralToNativeClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_JSObjectLiteralToNativeClass{}
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralToNativeClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJSObjectLiteralToNativeClass_Override(j JSObjectLiteralToNativeClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JSObjectLiteralToNativeClass",
-		nil, // no parameters
-		j,
-	)
-}
-
-func (j *jsiiProxy_JSObjectLiteralToNativeClass) SetPropA(val *string) {
-	_jsii_.Set(
-		j,
-		"propA",
-		val,
-	)
-}
-
-func (j *jsiiProxy_JSObjectLiteralToNativeClass) SetPropB(val *float64) {
-	_jsii_.Set(
-		j,
-		"propB",
-		val,
-	)
-}
-
-type JavaReservedWords interface {
-	While() *string
-	SetWhile(val *string)
-	Abstract()
-	Assert()
-	Boolean()
-	Break()
-	Byte()
-	Case()
-	Catch()
-	Char()
-	Class()
-	Const()
-	Continue()
-	Default()
-	Do()
-	Double()
-	Else()
-	Enum()
-	Extends()
-	False()
-	Final()
-	Finally()
-	Float()
-	For()
-	Goto()
-	If()
-	Implements()
-	Import()
-	Instanceof()
-	Int()
-	Interface()
-	Long()
-	Native()
-	New()
-	Null()
-	Package()
-	Private()
-	Protected()
-	Public()
-	Return()
-	Short()
-	Static()
-	Strictfp()
-	Super()
-	Switch()
-	Synchronized()
-	This()
-	Throw()
-	Throws()
-	Transient()
-	True()
-	Try()
-	Void()
-	Volatile()
-}
-
-// The jsii proxy struct for JavaReservedWords
-type jsiiProxy_JavaReservedWords struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_JavaReservedWords) While() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"while",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewJavaReservedWords() JavaReservedWords {
-	_init_.Initialize()
-
-	j := jsiiProxy_JavaReservedWords{}
-
-	_jsii_.Create(
-		"jsii-calc.JavaReservedWords",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJavaReservedWords_Override(j JavaReservedWords) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JavaReservedWords",
-		nil, // no parameters
-		j,
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) SetWhile(val *string) {
-	_jsii_.Set(
-		j,
-		"while",
-		val,
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Abstract() {
-	_jsii_.InvokeVoid(
-		j,
-		"abstract",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Assert() {
-	_jsii_.InvokeVoid(
-		j,
-		"assert",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Boolean() {
-	_jsii_.InvokeVoid(
-		j,
-		"boolean",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Break() {
-	_jsii_.InvokeVoid(
-		j,
-		"break",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Byte() {
-	_jsii_.InvokeVoid(
-		j,
-		"byte",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Case() {
-	_jsii_.InvokeVoid(
-		j,
-		"case",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Catch() {
-	_jsii_.InvokeVoid(
-		j,
-		"catch",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Char() {
-	_jsii_.InvokeVoid(
-		j,
-		"char",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Class() {
-	_jsii_.InvokeVoid(
-		j,
-		"class",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Const() {
-	_jsii_.InvokeVoid(
-		j,
-		"const",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Continue() {
-	_jsii_.InvokeVoid(
-		j,
-		"continue",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Default() {
-	_jsii_.InvokeVoid(
-		j,
-		"default",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Do() {
-	_jsii_.InvokeVoid(
-		j,
-		"do",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Double() {
-	_jsii_.InvokeVoid(
-		j,
-		"double",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Else() {
-	_jsii_.InvokeVoid(
-		j,
-		"else",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Enum() {
-	_jsii_.InvokeVoid(
-		j,
-		"enum",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Extends() {
-	_jsii_.InvokeVoid(
-		j,
-		"extends",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) False() {
-	_jsii_.InvokeVoid(
-		j,
-		"false",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Final() {
-	_jsii_.InvokeVoid(
-		j,
-		"final",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Finally() {
-	_jsii_.InvokeVoid(
-		j,
-		"finally",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Float() {
-	_jsii_.InvokeVoid(
-		j,
-		"float",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) For() {
-	_jsii_.InvokeVoid(
-		j,
-		"for",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Goto() {
-	_jsii_.InvokeVoid(
-		j,
-		"goto",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) If() {
-	_jsii_.InvokeVoid(
-		j,
-		"if",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Implements() {
-	_jsii_.InvokeVoid(
-		j,
-		"implements",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Import() {
-	_jsii_.InvokeVoid(
-		j,
-		"import",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Instanceof() {
-	_jsii_.InvokeVoid(
-		j,
-		"instanceof",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Int() {
-	_jsii_.InvokeVoid(
-		j,
-		"int",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Interface() {
-	_jsii_.InvokeVoid(
-		j,
-		"interface",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Long() {
-	_jsii_.InvokeVoid(
-		j,
-		"long",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Native() {
-	_jsii_.InvokeVoid(
-		j,
-		"native",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) New() {
-	_jsii_.InvokeVoid(
-		j,
-		"new",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Null() {
-	_jsii_.InvokeVoid(
-		j,
-		"null",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Package() {
-	_jsii_.InvokeVoid(
-		j,
-		"package",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Private() {
-	_jsii_.InvokeVoid(
-		j,
-		"private",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Protected() {
-	_jsii_.InvokeVoid(
-		j,
-		"protected",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Public() {
-	_jsii_.InvokeVoid(
-		j,
-		"public",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Return() {
-	_jsii_.InvokeVoid(
-		j,
-		"return",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Short() {
-	_jsii_.InvokeVoid(
-		j,
-		"short",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Static() {
-	_jsii_.InvokeVoid(
-		j,
-		"static",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Strictfp() {
-	_jsii_.InvokeVoid(
-		j,
-		"strictfp",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Super() {
-	_jsii_.InvokeVoid(
-		j,
-		"super",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Switch() {
-	_jsii_.InvokeVoid(
-		j,
-		"switch",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Synchronized() {
-	_jsii_.InvokeVoid(
-		j,
-		"synchronized",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) This() {
-	_jsii_.InvokeVoid(
-		j,
-		"this",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Throw() {
-	_jsii_.InvokeVoid(
-		j,
-		"throw",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Throws() {
-	_jsii_.InvokeVoid(
-		j,
-		"throws",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Transient() {
-	_jsii_.InvokeVoid(
-		j,
-		"transient",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) True() {
-	_jsii_.InvokeVoid(
-		j,
-		"true",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Try() {
-	_jsii_.InvokeVoid(
-		j,
-		"try",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Void() {
-	_jsii_.InvokeVoid(
-		j,
-		"void",
-		nil, // no parameters
-	)
-}
-
-func (j *jsiiProxy_JavaReservedWords) Volatile() {
-	_jsii_.InvokeVoid(
-		j,
-		"volatile",
-		nil, // no parameters
-	)
-}
-
-type Jsii487Derived interface {
-	IJsii487External
-	IJsii487External2
-}
-
-// The jsii proxy struct for Jsii487Derived
-type jsiiProxy_Jsii487Derived struct {
-	jsiiProxy_IJsii487External
-	jsiiProxy_IJsii487External2
-}
-
-func NewJsii487Derived() Jsii487Derived {
-	_init_.Initialize()
-
-	j := jsiiProxy_Jsii487Derived{}
-
-	_jsii_.Create(
-		"jsii-calc.Jsii487Derived",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJsii487Derived_Override(j Jsii487Derived) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Jsii487Derived",
-		nil, // no parameters
-		j,
-	)
-}
-
-type Jsii496Derived interface {
-	IJsii496
-}
-
-// The jsii proxy struct for Jsii496Derived
-type jsiiProxy_Jsii496Derived struct {
-	jsiiProxy_IJsii496
-}
-
-func NewJsii496Derived() Jsii496Derived {
-	_init_.Initialize()
-
-	j := jsiiProxy_Jsii496Derived{}
-
-	_jsii_.Create(
-		"jsii-calc.Jsii496Derived",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJsii496Derived_Override(j Jsii496Derived) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Jsii496Derived",
-		nil, // no parameters
-		j,
-	)
-}
-
-// Host runtime version should be set via JSII_AGENT.
-type JsiiAgent interface {
-}
-
-// The jsii proxy struct for JsiiAgent
-type jsiiProxy_JsiiAgent struct {
-	_ byte // padding
-}
-
-func NewJsiiAgent() JsiiAgent {
-	_init_.Initialize()
-
-	j := jsiiProxy_JsiiAgent{}
-
-	_jsii_.Create(
-		"jsii-calc.JsiiAgent",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewJsiiAgent_Override(j JsiiAgent) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.JsiiAgent",
-		nil, // no parameters
-		j,
-	)
-}
-
-func JsiiAgent_Value() *string {
-	_init_.Initialize()
-	var returns *string
-	_jsii_.StaticGet(
-		"jsii-calc.JsiiAgent",
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-// Make sure structs are un-decorated on the way in.
-// See: https://github.com/aws/aws-cdk/issues/5066
-//
-type JsonFormatter interface {
-}
-
-// The jsii proxy struct for JsonFormatter
-type jsiiProxy_JsonFormatter struct {
-	_ byte // padding
-}
-
-func JsonFormatter_AnyArray() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyArray",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyBooleanFalse() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyBooleanFalse",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyBooleanTrue() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyBooleanTrue",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyDate() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyDate",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyEmptyString() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyEmptyString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyFunction() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyFunction",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyHash() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyHash",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyNull() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyNull",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyNumber() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyNumber",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyRef() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyRef",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyString() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyUndefined() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyUndefined",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_AnyZero() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"anyZero",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func JsonFormatter_Stringify(value interface{}) *string {
-	_init_.Initialize()
-
-	var returns *string
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.JsonFormatter",
-		"stringify",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-// Validates that nested classes get correct code generation for the occasional forward reference.
-type LevelOne interface {
-	Props() *LevelOneProps
-}
-
-// The jsii proxy struct for LevelOne
-type jsiiProxy_LevelOne struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_LevelOne) Props() *LevelOneProps {
-	var returns *LevelOneProps
-	_jsii_.Get(
-		j,
-		"props",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewLevelOne(props *LevelOneProps) LevelOne {
-	_init_.Initialize()
-
-	j := jsiiProxy_LevelOne{}
-
-	_jsii_.Create(
-		"jsii-calc.LevelOne",
-		[]interface{}{props},
-		&j,
-	)
-
-	return &j
-}
-
-func NewLevelOne_Override(l LevelOne, props *LevelOneProps) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.LevelOne",
-		[]interface{}{props},
-		l,
-	)
-}
-
-type LevelOne_PropBooleanValue struct {
-	Value *bool \`field:"required" json:"value" yaml:"value"\`
-}
-
-type LevelOne_PropProperty struct {
-	Prop *LevelOne_PropBooleanValue \`field:"required" json:"prop" yaml:"prop"\`
-}
-
-type LevelOneProps struct {
-	Prop *LevelOne_PropProperty \`field:"required" json:"prop" yaml:"prop"\`
-}
-
-// jsii#298: show default values in sphinx documentation, and respect newlines.
-type LoadBalancedFargateServiceProps struct {
-	// The container port of the application load balancer attached to your Fargate service.
-	//
-	// Corresponds to container port mapping.
-	ContainerPort *float64 \`field:"optional" json:"containerPort" yaml:"containerPort"\`
-	// The number of cpu units used by the task.
-	//
-	// Valid values, which determines your range of valid values for the memory parameter:
-	// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
-	// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
-	// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
-	// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
-	// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
-	//
-	// This default is set in the underlying FargateTaskDefinition construct.
-	Cpu *string \`field:"optional" json:"cpu" yaml:"cpu"\`
-	// The amount (in MiB) of memory used by the task.
-	//
-	// This field is required and you must use one of the following values, which determines your range of valid values
-	// for the cpu parameter:
-	//
-	// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
-	//
-	// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
-	//
-	// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
-	//
-	// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
-	//
-	// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
-	//
-	// This default is set in the underlying FargateTaskDefinition construct.
-	MemoryMiB *string \`field:"optional" json:"memoryMiB" yaml:"memoryMiB"\`
-	// Determines whether the Application Load Balancer will be internet-facing.
-	PublicLoadBalancer *bool \`field:"optional" json:"publicLoadBalancer" yaml:"publicLoadBalancer"\`
-	// Determines whether your Fargate Service will be assigned a public IP address.
-	PublicTasks *bool \`field:"optional" json:"publicTasks" yaml:"publicTasks"\`
-}
-
-type MethodNamedProperty interface {
-	Elite() *float64
-	Property() *string
-}
-
-// The jsii proxy struct for MethodNamedProperty
-type jsiiProxy_MethodNamedProperty struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_MethodNamedProperty) Elite() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"elite",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewMethodNamedProperty() MethodNamedProperty {
-	_init_.Initialize()
-
-	j := jsiiProxy_MethodNamedProperty{}
-
-	_jsii_.Create(
-		"jsii-calc.MethodNamedProperty",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewMethodNamedProperty_Override(m MethodNamedProperty) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.MethodNamedProperty",
-		nil, // no parameters
-		m,
-	)
-}
-
-func (m *jsiiProxy_MethodNamedProperty) Property() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		m,
-		"property",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// The "*" binary operation.
-type Multiply interface {
-	BinaryOperation
-	IFriendlier
-	IRandomNumberGenerator
-	// Left-hand side operand.
-	Lhs() scopejsiicalclib.NumericValue
-	// Right-hand side operand.
-	Rhs() scopejsiicalclib.NumericValue
-	// The value.
-	Value() *float64
-	// Say farewell.
-	Farewell() *string
-	// Say goodbye.
-	Goodbye() *string
-	// Say hello!
-	Hello() *string
-	// Returns another random number.
-	Next() *float64
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Multiply
-type jsiiProxy_Multiply struct {
-	jsiiProxy_BinaryOperation
-	jsiiProxy_IFriendlier
-	jsiiProxy_IRandomNumberGenerator
-}
-
-func (j *jsiiProxy_Multiply) Lhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"lhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Multiply) Rhs() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"rhs",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Multiply) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a BinaryOperation.
-func NewMultiply(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Multiply {
-	_init_.Initialize()
-
-	j := jsiiProxy_Multiply{}
-
-	_jsii_.Create(
-		"jsii-calc.Multiply",
-		[]interface{}{lhs, rhs},
-		&j,
-	)
-
-	return &j
-}
-
-// Creates a BinaryOperation.
-func NewMultiply_Override(m Multiply, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Multiply",
-		[]interface{}{lhs, rhs},
-		m,
-	)
-}
-
-func (m *jsiiProxy_Multiply) Farewell() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		m,
-		"farewell",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (m *jsiiProxy_Multiply) Goodbye() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		m,
-		"goodbye",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (m *jsiiProxy_Multiply) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		m,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (m *jsiiProxy_Multiply) Next() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		m,
-		"next",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (m *jsiiProxy_Multiply) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		m,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (m *jsiiProxy_Multiply) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		m,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// The negation operation ("-value").
-type Negate interface {
-	UnaryOperation
-	IFriendlier
-	Operand() scopejsiicalclib.NumericValue
-	// The value.
-	Value() *float64
-	// Say farewell.
-	Farewell() *string
-	// Say goodbye.
-	Goodbye() *string
-	// Say hello!
-	Hello() *string
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Negate
-type jsiiProxy_Negate struct {
-	jsiiProxy_UnaryOperation
-	jsiiProxy_IFriendlier
-}
-
-func (j *jsiiProxy_Negate) Operand() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"operand",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Negate) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewNegate(operand scopejsiicalclib.NumericValue) Negate {
-	_init_.Initialize()
-
-	j := jsiiProxy_Negate{}
-
-	_jsii_.Create(
-		"jsii-calc.Negate",
-		[]interface{}{operand},
-		&j,
-	)
-
-	return &j
-}
-
-func NewNegate_Override(n Negate, operand scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Negate",
-		[]interface{}{operand},
-		n,
-	)
-}
-
-func (n *jsiiProxy_Negate) Farewell() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"farewell",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_Negate) Goodbye() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"goodbye",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_Negate) Hello() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_Negate) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_Negate) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		n,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type NestedClassInstance interface {
-}
-
-// The jsii proxy struct for NestedClassInstance
-type jsiiProxy_NestedClassInstance struct {
-	_ byte // padding
-}
-
-func NestedClassInstance_MakeInstance() customsubmodulename.NestingClass_NestedClass {
-	_init_.Initialize()
-
-	var returns customsubmodulename.NestingClass_NestedClass
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.NestedClassInstance",
-		"makeInstance",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type NestedStruct struct {
-	// When provided, must be > 0.
-	NumberProp *float64 \`field:"required" json:"numberProp" yaml:"numberProp"\`
-}
-
-// Test fixture to verify that jsii modules can use the node standard library.
-type NodeStandardLibrary interface {
-	// Returns the current os.platform() from the "os" node module.
-	OsPlatform() *string
-	// Uses node.js "crypto" module to calculate sha256 of a string.
-	//
-	// Returns: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50".
-	CryptoSha256() *string
-	// Reads a local resource file (resource.txt) asynchronously.
-	//
-	// Returns: "Hello, resource!"
-	FsReadFile() *string
-	// Sync version of fsReadFile.
-	//
-	// Returns: "Hello, resource! SYNC!"
-	FsReadFileSync() *string
-}
-
-// The jsii proxy struct for NodeStandardLibrary
-type jsiiProxy_NodeStandardLibrary struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_NodeStandardLibrary) OsPlatform() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"osPlatform",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewNodeStandardLibrary() NodeStandardLibrary {
-	_init_.Initialize()
-
-	j := jsiiProxy_NodeStandardLibrary{}
-
-	_jsii_.Create(
-		"jsii-calc.NodeStandardLibrary",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewNodeStandardLibrary_Override(n NodeStandardLibrary) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.NodeStandardLibrary",
-		nil, // no parameters
-		n,
-	)
-}
-
-func (n *jsiiProxy_NodeStandardLibrary) CryptoSha256() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"cryptoSha256",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_NodeStandardLibrary) FsReadFile() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"fsReadFile",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_NodeStandardLibrary) FsReadFileSync() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		n,
-		"fsReadFileSync",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// jsii#282, aws-cdk#157: null should be treated as "undefined".
-type NullShouldBeTreatedAsUndefined interface {
-	ChangeMeToUndefined() *string
-	SetChangeMeToUndefined(val *string)
-	GiveMeUndefined(value interface{})
-	GiveMeUndefinedInsideAnObject(input *NullShouldBeTreatedAsUndefinedData)
-	VerifyPropertyIsUndefined()
-}
-
-// The jsii proxy struct for NullShouldBeTreatedAsUndefined
-type jsiiProxy_NullShouldBeTreatedAsUndefined struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_NullShouldBeTreatedAsUndefined) ChangeMeToUndefined() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"changeMeToUndefined",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewNullShouldBeTreatedAsUndefined(_param1 *string, optional interface{}) NullShouldBeTreatedAsUndefined {
-	_init_.Initialize()
-
-	j := jsiiProxy_NullShouldBeTreatedAsUndefined{}
-
-	_jsii_.Create(
-		"jsii-calc.NullShouldBeTreatedAsUndefined",
-		[]interface{}{_param1, optional},
-		&j,
-	)
-
-	return &j
-}
-
-func NewNullShouldBeTreatedAsUndefined_Override(n NullShouldBeTreatedAsUndefined, _param1 *string, optional interface{}) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.NullShouldBeTreatedAsUndefined",
-		[]interface{}{_param1, optional},
-		n,
-	)
-}
-
-func (j *jsiiProxy_NullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val *string) {
-	_jsii_.Set(
-		j,
-		"changeMeToUndefined",
-		val,
-	)
-}
-
-func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) GiveMeUndefined(value interface{}) {
-	_jsii_.InvokeVoid(
-		n,
-		"giveMeUndefined",
-		[]interface{}{value},
-	)
-}
-
-func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input *NullShouldBeTreatedAsUndefinedData) {
-	_jsii_.InvokeVoid(
-		n,
-		"giveMeUndefinedInsideAnObject",
-		[]interface{}{input},
-	)
-}
-
-func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
-	_jsii_.InvokeVoid(
-		n,
-		"verifyPropertyIsUndefined",
-		nil, // no parameters
-	)
-}
-
-type NullShouldBeTreatedAsUndefinedData struct {
-	ArrayWithThreeElementsAndUndefinedAsSecondArgument *[]interface{} \`field:"required" json:"arrayWithThreeElementsAndUndefinedAsSecondArgument" yaml:"arrayWithThreeElementsAndUndefinedAsSecondArgument"\`
-	ThisShouldBeUndefined interface{} \`field:"optional" json:"thisShouldBeUndefined" yaml:"thisShouldBeUndefined"\`
-}
-
-// This allows us to test that a reference can be stored for objects that implement interfaces.
-type NumberGenerator interface {
-	Generator() IRandomNumberGenerator
-	SetGenerator(val IRandomNumberGenerator)
-	IsSameGenerator(gen IRandomNumberGenerator) *bool
-	NextTimes100() *float64
-}
-
-// The jsii proxy struct for NumberGenerator
-type jsiiProxy_NumberGenerator struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_NumberGenerator) Generator() IRandomNumberGenerator {
-	var returns IRandomNumberGenerator
-	_jsii_.Get(
-		j,
-		"generator",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewNumberGenerator(generator IRandomNumberGenerator) NumberGenerator {
-	_init_.Initialize()
-
-	j := jsiiProxy_NumberGenerator{}
-
-	_jsii_.Create(
-		"jsii-calc.NumberGenerator",
-		[]interface{}{generator},
-		&j,
-	)
-
-	return &j
-}
-
-func NewNumberGenerator_Override(n NumberGenerator, generator IRandomNumberGenerator) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.NumberGenerator",
-		[]interface{}{generator},
-		n,
-	)
-}
-
-func (j *jsiiProxy_NumberGenerator) SetGenerator(val IRandomNumberGenerator) {
-	_jsii_.Set(
-		j,
-		"generator",
-		val,
-	)
-}
-
-func (n *jsiiProxy_NumberGenerator) IsSameGenerator(gen IRandomNumberGenerator) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		n,
-		"isSameGenerator",
-		[]interface{}{gen},
-		&returns,
-	)
-
-	return returns
-}
-
-func (n *jsiiProxy_NumberGenerator) NextTimes100() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		n,
-		"nextTimes100",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Verify that object references can be passed inside collections.
-type ObjectRefsInCollections interface {
-	// Returns the sum of all values.
-	SumFromArray(values *[]scopejsiicalclib.NumericValue) *float64
-	// Returns the sum of all values in a map.
-	SumFromMap(values *map[string]scopejsiicalclib.NumericValue) *float64
-}
-
-// The jsii proxy struct for ObjectRefsInCollections
-type jsiiProxy_ObjectRefsInCollections struct {
-	_ byte // padding
-}
-
-func NewObjectRefsInCollections() ObjectRefsInCollections {
-	_init_.Initialize()
-
-	j := jsiiProxy_ObjectRefsInCollections{}
-
-	_jsii_.Create(
-		"jsii-calc.ObjectRefsInCollections",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewObjectRefsInCollections_Override(o ObjectRefsInCollections) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ObjectRefsInCollections",
-		nil, // no parameters
-		o,
-	)
-}
-
-func (o *jsiiProxy_ObjectRefsInCollections) SumFromArray(values *[]scopejsiicalclib.NumericValue) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		o,
-		"sumFromArray",
-		[]interface{}{values},
-		&returns,
-	)
-
-	return returns
-}
-
-func (o *jsiiProxy_ObjectRefsInCollections) SumFromMap(values *map[string]scopejsiicalclib.NumericValue) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		o,
-		"sumFromMap",
-		[]interface{}{values},
-		&returns,
-	)
-
-	return returns
-}
-
-type ObjectWithPropertyProvider interface {
-}
-
-// The jsii proxy struct for ObjectWithPropertyProvider
-type jsiiProxy_ObjectWithPropertyProvider struct {
-	_ byte // padding
-}
-
-func ObjectWithPropertyProvider_Provide() IObjectWithProperty {
-	_init_.Initialize()
-
-	var returns IObjectWithProperty
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.ObjectWithPropertyProvider",
-		"provide",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Old class.
-// Deprecated: Use the new class or the old class whatever you want because
-// whatever you like is always the best.
-type Old interface {
-	// Doo wop that thing.
-	// Deprecated: Use the new class or the old class whatever you want because
-	// whatever you like is always the best.
-	DoAThing()
-}
-
-// The jsii proxy struct for Old
-type jsiiProxy_Old struct {
-	_ byte // padding
-}
-
-// Deprecated: Use the new class or the old class whatever you want because
-// whatever you like is always the best.
-func NewOld() Old {
-	_init_.Initialize()
-
-	j := jsiiProxy_Old{}
-
-	_jsii_.Create(
-		"jsii-calc.Old",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-// Deprecated: Use the new class or the old class whatever you want because
-// whatever you like is always the best.
-func NewOld_Override(o Old) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Old",
-		nil, // no parameters
-		o,
-	)
-}
-
-func (o *jsiiProxy_Old) DoAThing() {
-	_jsii_.InvokeVoid(
-		o,
-		"doAThing",
-		nil, // no parameters
-	)
-}
-
-type OptionalArgumentInvoker interface {
-	InvokeWithOptional()
-	InvokeWithoutOptional()
-}
-
-// The jsii proxy struct for OptionalArgumentInvoker
-type jsiiProxy_OptionalArgumentInvoker struct {
-	_ byte // padding
-}
-
-func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArguments) OptionalArgumentInvoker {
-	_init_.Initialize()
-
-	j := jsiiProxy_OptionalArgumentInvoker{}
-
-	_jsii_.Create(
-		"jsii-calc.OptionalArgumentInvoker",
-		[]interface{}{delegate},
-		&j,
-	)
-
-	return &j
-}
-
-func NewOptionalArgumentInvoker_Override(o OptionalArgumentInvoker, delegate IInterfaceWithOptionalMethodArguments) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.OptionalArgumentInvoker",
-		[]interface{}{delegate},
-		o,
-	)
-}
-
-func (o *jsiiProxy_OptionalArgumentInvoker) InvokeWithOptional() {
-	_jsii_.InvokeVoid(
-		o,
-		"invokeWithOptional",
-		nil, // no parameters
-	)
-}
-
-func (o *jsiiProxy_OptionalArgumentInvoker) InvokeWithoutOptional() {
-	_jsii_.InvokeVoid(
-		o,
-		"invokeWithoutOptional",
-		nil, // no parameters
-	)
-}
-
-type OptionalConstructorArgument interface {
-	Arg1() *float64
-	Arg2() *string
-	Arg3() *time.Time
-}
-
-// The jsii proxy struct for OptionalConstructorArgument
-type jsiiProxy_OptionalConstructorArgument struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_OptionalConstructorArgument) Arg1() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"arg1",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_OptionalConstructorArgument) Arg2() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"arg2",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_OptionalConstructorArgument) Arg3() *time.Time {
-	var returns *time.Time
-	_jsii_.Get(
-		j,
-		"arg3",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewOptionalConstructorArgument(arg1 *float64, arg2 *string, arg3 *time.Time) OptionalConstructorArgument {
-	_init_.Initialize()
-
-	j := jsiiProxy_OptionalConstructorArgument{}
-
-	_jsii_.Create(
-		"jsii-calc.OptionalConstructorArgument",
-		[]interface{}{arg1, arg2, arg3},
-		&j,
-	)
-
-	return &j
-}
-
-func NewOptionalConstructorArgument_Override(o OptionalConstructorArgument, arg1 *float64, arg2 *string, arg3 *time.Time) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.OptionalConstructorArgument",
-		[]interface{}{arg1, arg2, arg3},
-		o,
-	)
-}
-
-type OptionalStruct struct {
-	Field *string \`field:"optional" json:"field" yaml:"field"\`
-}
-
-type OptionalStructConsumer interface {
-	FieldValue() *string
-	ParameterWasUndefined() *bool
-}
-
-// The jsii proxy struct for OptionalStructConsumer
-type jsiiProxy_OptionalStructConsumer struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_OptionalStructConsumer) FieldValue() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"fieldValue",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_OptionalStructConsumer) ParameterWasUndefined() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"parameterWasUndefined",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewOptionalStructConsumer(optionalStruct *OptionalStruct) OptionalStructConsumer {
-	_init_.Initialize()
-
-	j := jsiiProxy_OptionalStructConsumer{}
-
-	_jsii_.Create(
-		"jsii-calc.OptionalStructConsumer",
-		[]interface{}{optionalStruct},
-		&j,
-	)
-
-	return &j
-}
-
-func NewOptionalStructConsumer_Override(o OptionalStructConsumer, optionalStruct *OptionalStruct) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.OptionalStructConsumer",
-		[]interface{}{optionalStruct},
-		o,
-	)
-}
-
-// See: https://github.com/aws/jsii/issues/903
-//
-type OverridableProtectedMember interface {
-	OverrideReadOnly() *string
-	OverrideReadWrite() *string
-	SetOverrideReadWrite(val *string)
-	OverrideMe() *string
-	SwitchModes()
-	ValueFromProtected() *string
-}
-
-// The jsii proxy struct for OverridableProtectedMember
-type jsiiProxy_OverridableProtectedMember struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_OverridableProtectedMember) OverrideReadOnly() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"overrideReadOnly",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_OverridableProtectedMember) OverrideReadWrite() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"overrideReadWrite",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewOverridableProtectedMember() OverridableProtectedMember {
-	_init_.Initialize()
-
-	j := jsiiProxy_OverridableProtectedMember{}
-
-	_jsii_.Create(
-		"jsii-calc.OverridableProtectedMember",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewOverridableProtectedMember_Override(o OverridableProtectedMember) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.OverridableProtectedMember",
-		nil, // no parameters
-		o,
-	)
-}
-
-func (j *jsiiProxy_OverridableProtectedMember) SetOverrideReadWrite(val *string) {
-	_jsii_.Set(
-		j,
-		"overrideReadWrite",
-		val,
-	)
-}
-
-func (o *jsiiProxy_OverridableProtectedMember) OverrideMe() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		o,
-		"overrideMe",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (o *jsiiProxy_OverridableProtectedMember) SwitchModes() {
-	_jsii_.InvokeVoid(
-		o,
-		"switchModes",
-		nil, // no parameters
-	)
-}
-
-func (o *jsiiProxy_OverridableProtectedMember) ValueFromProtected() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		o,
-		"valueFromProtected",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type OverrideReturnsObject interface {
-	Test(obj IReturnsNumber) *float64
-}
-
-// The jsii proxy struct for OverrideReturnsObject
-type jsiiProxy_OverrideReturnsObject struct {
-	_ byte // padding
-}
-
-func NewOverrideReturnsObject() OverrideReturnsObject {
-	_init_.Initialize()
-
-	j := jsiiProxy_OverrideReturnsObject{}
-
-	_jsii_.Create(
-		"jsii-calc.OverrideReturnsObject",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewOverrideReturnsObject_Override(o OverrideReturnsObject) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.OverrideReturnsObject",
-		nil, // no parameters
-		o,
-	)
-}
-
-func (o *jsiiProxy_OverrideReturnsObject) Test(obj IReturnsNumber) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		o,
-		"test",
-		[]interface{}{obj},
-		&returns,
-	)
-
-	return returns
-}
-
-// https://github.com/aws/jsii/issues/982.
-type ParentStruct982 struct {
-	Foo *string \`field:"required" json:"foo" yaml:"foo"\`
-}
-
-type PartiallyInitializedThisConsumer interface {
-	ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt *time.Time, ev AllTypesEnum) *string
-}
-
-// The jsii proxy struct for PartiallyInitializedThisConsumer
-type jsiiProxy_PartiallyInitializedThisConsumer struct {
-	_ byte // padding
-}
-
-func NewPartiallyInitializedThisConsumer_Override(p PartiallyInitializedThisConsumer) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.PartiallyInitializedThisConsumer",
-		nil, // no parameters
-		p,
-	)
-}
-
-func (p *jsiiProxy_PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt *time.Time, ev AllTypesEnum) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		p,
-		"consumePartiallyInitializedThis",
-		[]interface{}{obj, dt, ev},
-		&returns,
-	)
-
-	return returns
-}
-
-type Polymorphism interface {
-	SayHello(friendly scopejsiicalclib.IFriendly) *string
-}
-
-// The jsii proxy struct for Polymorphism
-type jsiiProxy_Polymorphism struct {
-	_ byte // padding
-}
-
-func NewPolymorphism() Polymorphism {
-	_init_.Initialize()
-
-	j := jsiiProxy_Polymorphism{}
-
-	_jsii_.Create(
-		"jsii-calc.Polymorphism",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewPolymorphism_Override(p Polymorphism) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Polymorphism",
-		nil, // no parameters
-		p,
-	)
-}
-
-func (p *jsiiProxy_Polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		p,
-		"sayHello",
-		[]interface{}{friendly},
-		&returns,
-	)
-
-	return returns
-}
-
-// The power operation.
-type Power interface {
-	composition.CompositeOperation
-	// The base of the power.
-	Base() scopejsiicalclib.NumericValue
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes() *[]*string
-	SetDecorationPostfixes(val *[]*string)
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes() *[]*string
-	SetDecorationPrefixes(val *[]*string)
-	// The expression that this operation consists of.
-	//
-	// Must be implemented by derived classes.
-	Expression() scopejsiicalclib.NumericValue
-	// The number of times to multiply.
-	Pow() scopejsiicalclib.NumericValue
-	// The .toString() style.
-	StringStyle() composition.CompositeOperation_CompositionStringStyle
-	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
-	// The value.
-	Value() *float64
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Power
-type jsiiProxy_Power struct {
-	internal.Type__compositionCompositeOperation
-}
-
-func (j *jsiiProxy_Power) Base() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"base",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) DecorationPostfixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) DecorationPrefixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) Expression() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) Pow() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"pow",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) StringStyle() composition.CompositeOperation_CompositionStringStyle {
-	var returns composition.CompositeOperation_CompositionStringStyle
-	_jsii_.Get(
-		j,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Power) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-// Creates a Power operation.
-func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) Power {
-	_init_.Initialize()
-
-	j := jsiiProxy_Power{}
-
-	_jsii_.Create(
-		"jsii-calc.Power",
-		[]interface{}{base, pow},
-		&j,
-	)
-
-	return &j
-}
-
-// Creates a Power operation.
-func NewPower_Override(p Power, base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Power",
-		[]interface{}{base, pow},
-		p,
-	)
-}
-
-func (j *jsiiProxy_Power) SetDecorationPostfixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Power) SetDecorationPrefixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Power) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
-	_jsii_.Set(
-		j,
-		"stringStyle",
-		val,
-	)
-}
-
-func (p *jsiiProxy_Power) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		p,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (p *jsiiProxy_Power) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		p,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.
-type PropertyNamedProperty interface {
-	Property() *string
-	YetAnoterOne() *bool
-}
-
-// The jsii proxy struct for PropertyNamedProperty
-type jsiiProxy_PropertyNamedProperty struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_PropertyNamedProperty) Property() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_PropertyNamedProperty) YetAnoterOne() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"yetAnoterOne",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewPropertyNamedProperty() PropertyNamedProperty {
-	_init_.Initialize()
-
-	j := jsiiProxy_PropertyNamedProperty{}
-
-	_jsii_.Create(
-		"jsii-calc.PropertyNamedProperty",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewPropertyNamedProperty_Override(p PropertyNamedProperty) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.PropertyNamedProperty",
-		nil, // no parameters
-		p,
-	)
-}
-
-type PublicClass interface {
-	Hello()
-}
-
-// The jsii proxy struct for PublicClass
-type jsiiProxy_PublicClass struct {
-	_ byte // padding
-}
-
-func NewPublicClass() PublicClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_PublicClass{}
-
-	_jsii_.Create(
-		"jsii-calc.PublicClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewPublicClass_Override(p PublicClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.PublicClass",
-		nil, // no parameters
-		p,
-	)
-}
-
-func (p *jsiiProxy_PublicClass) Hello() {
-	_jsii_.InvokeVoid(
-		p,
-		"hello",
-		nil, // no parameters
-	)
-}
-
-type PythonReservedWords interface {
-	And()
-	As()
-	Assert()
-	Async()
-	Await()
-	Break()
-	Class()
-	Continue()
-	Def()
-	Del()
-	Elif()
-	Else()
-	Except()
-	Finally()
-	For()
-	From()
-	Global()
-	If()
-	Import()
-	In()
-	Is()
-	Lambda()
-	Nonlocal()
-	Not()
-	Or()
-	Pass()
-	Raise()
-	Return()
-	Try()
-	While()
-	With()
-	Yield()
-}
-
-// The jsii proxy struct for PythonReservedWords
-type jsiiProxy_PythonReservedWords struct {
-	_ byte // padding
-}
-
-func NewPythonReservedWords() PythonReservedWords {
-	_init_.Initialize()
-
-	j := jsiiProxy_PythonReservedWords{}
-
-	_jsii_.Create(
-		"jsii-calc.PythonReservedWords",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewPythonReservedWords_Override(p PythonReservedWords) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.PythonReservedWords",
-		nil, // no parameters
-		p,
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) And() {
-	_jsii_.InvokeVoid(
-		p,
-		"and",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) As() {
-	_jsii_.InvokeVoid(
-		p,
-		"as",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Assert() {
-	_jsii_.InvokeVoid(
-		p,
-		"assert",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Async() {
-	_jsii_.InvokeVoid(
-		p,
-		"async",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Await() {
-	_jsii_.InvokeVoid(
-		p,
-		"await",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Break() {
-	_jsii_.InvokeVoid(
-		p,
-		"break",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Class() {
-	_jsii_.InvokeVoid(
-		p,
-		"class",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Continue() {
-	_jsii_.InvokeVoid(
-		p,
-		"continue",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Def() {
-	_jsii_.InvokeVoid(
-		p,
-		"def",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Del() {
-	_jsii_.InvokeVoid(
-		p,
-		"del",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Elif() {
-	_jsii_.InvokeVoid(
-		p,
-		"elif",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Else() {
-	_jsii_.InvokeVoid(
-		p,
-		"else",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Except() {
-	_jsii_.InvokeVoid(
-		p,
-		"except",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Finally() {
-	_jsii_.InvokeVoid(
-		p,
-		"finally",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) For() {
-	_jsii_.InvokeVoid(
-		p,
-		"for",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) From() {
-	_jsii_.InvokeVoid(
-		p,
-		"from",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Global() {
-	_jsii_.InvokeVoid(
-		p,
-		"global",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) If() {
-	_jsii_.InvokeVoid(
-		p,
-		"if",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Import() {
-	_jsii_.InvokeVoid(
-		p,
-		"import",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) In() {
-	_jsii_.InvokeVoid(
-		p,
-		"in",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Is() {
-	_jsii_.InvokeVoid(
-		p,
-		"is",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Lambda() {
-	_jsii_.InvokeVoid(
-		p,
-		"lambda",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Nonlocal() {
-	_jsii_.InvokeVoid(
-		p,
-		"nonlocal",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Not() {
-	_jsii_.InvokeVoid(
-		p,
-		"not",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Or() {
-	_jsii_.InvokeVoid(
-		p,
-		"or",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Pass() {
-	_jsii_.InvokeVoid(
-		p,
-		"pass",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Raise() {
-	_jsii_.InvokeVoid(
-		p,
-		"raise",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Return() {
-	_jsii_.InvokeVoid(
-		p,
-		"return",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Try() {
-	_jsii_.InvokeVoid(
-		p,
-		"try",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) While() {
-	_jsii_.InvokeVoid(
-		p,
-		"while",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) With() {
-	_jsii_.InvokeVoid(
-		p,
-		"with",
-		nil, // no parameters
-	)
-}
-
-func (p *jsiiProxy_PythonReservedWords) Yield() {
-	_jsii_.InvokeVoid(
-		p,
-		"yield",
-		nil, // no parameters
-	)
-}
-
-// See awslabs/jsii#138.
-type ReferenceEnumFromScopedPackage interface {
-	Foo() scopejsiicalclib.EnumFromScopedModule
-	SetFoo(val scopejsiicalclib.EnumFromScopedModule)
-	LoadFoo() scopejsiicalclib.EnumFromScopedModule
-	SaveFoo(value scopejsiicalclib.EnumFromScopedModule)
-}
-
-// The jsii proxy struct for ReferenceEnumFromScopedPackage
-type jsiiProxy_ReferenceEnumFromScopedPackage struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ReferenceEnumFromScopedPackage) Foo() scopejsiicalclib.EnumFromScopedModule {
-	var returns scopejsiicalclib.EnumFromScopedModule
-	_jsii_.Get(
-		j,
-		"foo",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewReferenceEnumFromScopedPackage() ReferenceEnumFromScopedPackage {
-	_init_.Initialize()
-
-	j := jsiiProxy_ReferenceEnumFromScopedPackage{}
-
-	_jsii_.Create(
-		"jsii-calc.ReferenceEnumFromScopedPackage",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewReferenceEnumFromScopedPackage_Override(r ReferenceEnumFromScopedPackage) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ReferenceEnumFromScopedPackage",
-		nil, // no parameters
-		r,
-	)
-}
-
-func (j *jsiiProxy_ReferenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromScopedModule) {
-	_jsii_.Set(
-		j,
-		"foo",
-		val,
-	)
-}
-
-func (r *jsiiProxy_ReferenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScopedModule {
-	var returns scopejsiicalclib.EnumFromScopedModule
-
-	_jsii_.Invoke(
-		r,
-		"loadFoo",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (r *jsiiProxy_ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFromScopedModule) {
-	_jsii_.InvokeVoid(
-		r,
-		"saveFoo",
-		[]interface{}{value},
-	)
-}
-
-// Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
-//
-// Returns: an instance of an un-exported class that extends \`ExportedBaseClass\`, declared as \`IPrivatelyImplemented\`.
-// See: https://github.com/aws/jsii/issues/320
-//
-type ReturnsPrivateImplementationOfInterface interface {
-	PrivateImplementation() IPrivatelyImplemented
-}
-
-// The jsii proxy struct for ReturnsPrivateImplementationOfInterface
-type jsiiProxy_ReturnsPrivateImplementationOfInterface struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_ReturnsPrivateImplementationOfInterface) PrivateImplementation() IPrivatelyImplemented {
-	var returns IPrivatelyImplemented
-	_jsii_.Get(
-		j,
-		"privateImplementation",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewReturnsPrivateImplementationOfInterface() ReturnsPrivateImplementationOfInterface {
-	_init_.Initialize()
-
-	j := jsiiProxy_ReturnsPrivateImplementationOfInterface{}
-
-	_jsii_.Create(
-		"jsii-calc.ReturnsPrivateImplementationOfInterface",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewReturnsPrivateImplementationOfInterface_Override(r ReturnsPrivateImplementationOfInterface) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.ReturnsPrivateImplementationOfInterface",
-		nil, // no parameters
-		r,
-	)
-}
-
-// This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
-//
-// This is cheating with the (current) declared types, but this is the "more
-// idiomatic" way for Pythonists.
-type RootStruct struct {
-	// May not be empty.
-	StringProp *string \`field:"required" json:"stringProp" yaml:"stringProp"\`
-	NestedStruct *NestedStruct \`field:"optional" json:"nestedStruct" yaml:"nestedStruct"\`
-}
-
-type RootStructValidator interface {
-}
-
-// The jsii proxy struct for RootStructValidator
-type jsiiProxy_RootStructValidator struct {
-	_ byte // padding
-}
-
-func RootStructValidator_Validate(struct_ *RootStruct) {
-	_init_.Initialize()
-
-	_jsii_.StaticInvokeVoid(
-		"jsii-calc.RootStructValidator",
-		"validate",
-		[]interface{}{struct_},
-	)
-}
-
-type RuntimeTypeChecking interface {
-	MethodWithDefaultedArguments(arg1 *float64, arg2 *string, arg3 *time.Time)
-	MethodWithOptionalAnyArgument(arg interface{})
-	// Used to verify verification of number of method arguments.
-	MethodWithOptionalArguments(arg1 *float64, arg2 *string, arg3 *time.Time)
-}
-
-// The jsii proxy struct for RuntimeTypeChecking
-type jsiiProxy_RuntimeTypeChecking struct {
-	_ byte // padding
-}
-
-func NewRuntimeTypeChecking() RuntimeTypeChecking {
-	_init_.Initialize()
-
-	j := jsiiProxy_RuntimeTypeChecking{}
-
-	_jsii_.Create(
-		"jsii-calc.RuntimeTypeChecking",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewRuntimeTypeChecking_Override(r RuntimeTypeChecking) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.RuntimeTypeChecking",
-		nil, // no parameters
-		r,
-	)
-}
-
-func (r *jsiiProxy_RuntimeTypeChecking) MethodWithDefaultedArguments(arg1 *float64, arg2 *string, arg3 *time.Time) {
-	_jsii_.InvokeVoid(
-		r,
-		"methodWithDefaultedArguments",
-		[]interface{}{arg1, arg2, arg3},
-	)
-}
-
-func (r *jsiiProxy_RuntimeTypeChecking) MethodWithOptionalAnyArgument(arg interface{}) {
-	_jsii_.InvokeVoid(
-		r,
-		"methodWithOptionalAnyArgument",
-		[]interface{}{arg},
-	)
-}
-
-func (r *jsiiProxy_RuntimeTypeChecking) MethodWithOptionalArguments(arg1 *float64, arg2 *string, arg3 *time.Time) {
-	_jsii_.InvokeVoid(
-		r,
-		"methodWithOptionalArguments",
-		[]interface{}{arg1, arg2, arg3},
-	)
-}
-
-type SecondLevelStruct struct {
-	// It's long and required.
-	DeeperRequiredProp *string \`field:"required" json:"deeperRequiredProp" yaml:"deeperRequiredProp"\`
-	// It's long, but you'll almost never pass it.
-	DeeperOptionalProp *string \`field:"optional" json:"deeperOptionalProp" yaml:"deeperOptionalProp"\`
-}
-
-// Test that a single instance can be returned under two different FQNs.
-//
-// JSII clients can instantiate 2 different strongly-typed wrappers for the same
-// object. Unfortunately, this will break object equality, but if we didn't do
-// this it would break runtime type checks in the JVM or CLR.
-type SingleInstanceTwoTypes interface {
-	Interface1() InbetweenClass
-	Interface2() IPublicInterface
-}
-
-// The jsii proxy struct for SingleInstanceTwoTypes
-type jsiiProxy_SingleInstanceTwoTypes struct {
-	_ byte // padding
-}
-
-func NewSingleInstanceTwoTypes() SingleInstanceTwoTypes {
-	_init_.Initialize()
-
-	j := jsiiProxy_SingleInstanceTwoTypes{}
-
-	_jsii_.Create(
-		"jsii-calc.SingleInstanceTwoTypes",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewSingleInstanceTwoTypes_Override(s SingleInstanceTwoTypes) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.SingleInstanceTwoTypes",
-		nil, // no parameters
-		s,
-	)
-}
-
-func (s *jsiiProxy_SingleInstanceTwoTypes) Interface1() InbetweenClass {
-	var returns InbetweenClass
-
-	_jsii_.Invoke(
-		s,
-		"interface1",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SingleInstanceTwoTypes) Interface2() IPublicInterface {
-	var returns IPublicInterface
-
-	_jsii_.Invoke(
-		s,
-		"interface2",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Verifies that singleton enums are handled correctly.
-//
-// https://github.com/aws/jsii/issues/231
-type SingletonInt interface {
-	IsSingletonInt(value *float64) *bool
-}
-
-// The jsii proxy struct for SingletonInt
-type jsiiProxy_SingletonInt struct {
-	_ byte // padding
-}
-
-func (s *jsiiProxy_SingletonInt) IsSingletonInt(value *float64) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		s,
-		"isSingletonInt",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-// A singleton integer.
-type SingletonIntEnum string
-
-const (
-	// Elite!
-	SingletonIntEnum_SINGLETON_INT SingletonIntEnum = "SINGLETON_INT"
-)
-
-// Verifies that singleton enums are handled correctly.
-//
-// https://github.com/aws/jsii/issues/231
-type SingletonString interface {
-	IsSingletonString(value *string) *bool
-}
-
-// The jsii proxy struct for SingletonString
-type jsiiProxy_SingletonString struct {
-	_ byte // padding
-}
-
-func (s *jsiiProxy_SingletonString) IsSingletonString(value *string) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		s,
-		"isSingletonString",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-// A singleton string.
-type SingletonStringEnum string
-
-const (
-	// 1337.
-	SingletonStringEnum_SINGLETON_STRING SingletonStringEnum = "SINGLETON_STRING"
-)
-
-type SmellyStruct struct {
-	Property *string \`field:"required" json:"property" yaml:"property"\`
-	YetAnoterOne *bool \`field:"required" json:"yetAnoterOne" yaml:"yetAnoterOne"\`
-}
-
-type SomeTypeJsii976 interface {
-}
-
-// The jsii proxy struct for SomeTypeJsii976
-type jsiiProxy_SomeTypeJsii976 struct {
-	_ byte // padding
-}
-
-func NewSomeTypeJsii976() SomeTypeJsii976 {
-	_init_.Initialize()
-
-	j := jsiiProxy_SomeTypeJsii976{}
-
-	_jsii_.Create(
-		"jsii-calc.SomeTypeJsii976",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewSomeTypeJsii976_Override(s SomeTypeJsii976) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.SomeTypeJsii976",
-		nil, // no parameters
-		s,
-	)
-}
-
-func SomeTypeJsii976_ReturnAnonymous() interface{} {
-	_init_.Initialize()
-
-	var returns interface{}
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.SomeTypeJsii976",
-		"returnAnonymous",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func SomeTypeJsii976_ReturnReturn() IReturnJsii976 {
-	_init_.Initialize()
-
-	var returns IReturnJsii976
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.SomeTypeJsii976",
-		"returnReturn",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type StableClass interface {
-	MutableProperty() *float64
-	SetMutableProperty(val *float64)
-	ReadonlyProperty() *string
-	Method()
-}
-
-// The jsii proxy struct for StableClass
-type jsiiProxy_StableClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_StableClass) MutableProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"mutableProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_StableClass) ReadonlyProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewStableClass(readonlyString *string, mutableNumber *float64) StableClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_StableClass{}
-
-	_jsii_.Create(
-		"jsii-calc.StableClass",
-		[]interface{}{readonlyString, mutableNumber},
-		&j,
-	)
-
-	return &j
-}
-
-func NewStableClass_Override(s StableClass, readonlyString *string, mutableNumber *float64) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.StableClass",
-		[]interface{}{readonlyString, mutableNumber},
-		s,
-	)
-}
-
-func (j *jsiiProxy_StableClass) SetMutableProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"mutableProperty",
-		val,
-	)
-}
-
-func (s *jsiiProxy_StableClass) Method() {
-	_jsii_.InvokeVoid(
-		s,
-		"method",
-		nil, // no parameters
-	)
-}
-
-type StableEnum string
-
-const (
-	StableEnum_OPTION_A StableEnum = "OPTION_A"
-	StableEnum_OPTION_B StableEnum = "OPTION_B"
-)
-
-type StableStruct struct {
-	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
-}
-
-// This is used to validate the ability to use \`this\` from within a static context.
-//
-// https://github.com/awslabs/aws-cdk/issues/2304
-type StaticContext interface {
-}
-
-// The jsii proxy struct for StaticContext
-type jsiiProxy_StaticContext struct {
-	_ byte // padding
-}
-
-func StaticContext_CanAccessStaticContext() *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.StaticContext",
-		"canAccessStaticContext",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func StaticContext_StaticVariable() *bool {
-	_init_.Initialize()
-	var returns *bool
-	_jsii_.StaticGet(
-		"jsii-calc.StaticContext",
-		"staticVariable",
-		&returns,
-	)
-	return returns
-}
-
-func StaticContext_SetStaticVariable(val *bool) {
-	_init_.Initialize()
-	_jsii_.StaticSet(
-		"jsii-calc.StaticContext",
-		"staticVariable",
-		val,
-	)
-}
-
-type StaticHelloChild interface {
-	StaticHelloParent
-}
-
-// The jsii proxy struct for StaticHelloChild
-type jsiiProxy_StaticHelloChild struct {
-	jsiiProxy_StaticHelloParent
-}
-
-func StaticHelloChild_Method() {
-	_init_.Initialize()
-
-	_jsii_.StaticInvokeVoid(
-		"jsii-calc.StaticHelloChild",
-		"method",
-		nil, // no parameters
-	)
-}
-
-func StaticHelloChild_Property() *float64 {
-	_init_.Initialize()
-	var returns *float64
-	_jsii_.StaticGet(
-		"jsii-calc.StaticHelloChild",
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-// Static methods that override parent class are technically overrides (the inheritance of statics is part of the ES6 specification), but certain other languages such as Java do not carry statics in the inheritance chain at all, so they cannot be overridden, only hidden.
-//
-// The difference is fairly minor (for typical use-cases, the end result is the
-// same), however this has implications on what the generated code should look
-// like.
-type StaticHelloParent interface {
-}
-
-// The jsii proxy struct for StaticHelloParent
-type jsiiProxy_StaticHelloParent struct {
-	_ byte // padding
-}
-
-func NewStaticHelloParent() StaticHelloParent {
-	_init_.Initialize()
-
-	j := jsiiProxy_StaticHelloParent{}
-
-	_jsii_.Create(
-		"jsii-calc.StaticHelloParent",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewStaticHelloParent_Override(s StaticHelloParent) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.StaticHelloParent",
-		nil, // no parameters
-		s,
-	)
-}
-
-func StaticHelloParent_Method() {
-	_init_.Initialize()
-
-	_jsii_.StaticInvokeVoid(
-		"jsii-calc.StaticHelloParent",
-		"method",
-		nil, // no parameters
-	)
-}
-
-func StaticHelloParent_Property() *float64 {
-	_init_.Initialize()
-	var returns *float64
-	_jsii_.StaticGet(
-		"jsii-calc.StaticHelloParent",
-		"property",
-		&returns,
-	)
-	return returns
-}
-
-type Statics interface {
-	Value() *string
-	JustMethod() *string
-}
-
-// The jsii proxy struct for Statics
-type jsiiProxy_Statics struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_Statics) Value() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewStatics(value *string) Statics {
-	_init_.Initialize()
-
-	j := jsiiProxy_Statics{}
-
-	_jsii_.Create(
-		"jsii-calc.Statics",
-		[]interface{}{value},
-		&j,
-	)
-
-	return &j
-}
-
-func NewStatics_Override(s Statics, value *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Statics",
-		[]interface{}{value},
-		s,
-	)
-}
-
-// Jsdocs for static method.
-func Statics_StaticMethod(name *string) *string {
-	_init_.Initialize()
-
-	var returns *string
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.Statics",
-		"staticMethod",
-		[]interface{}{name},
-		&returns,
-	)
-
-	return returns
-}
-
-func Statics_BAR() *float64 {
-	_init_.Initialize()
-	var returns *float64
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"BAR",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_ConstObj() DoubleTrouble {
-	_init_.Initialize()
-	var returns DoubleTrouble
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"ConstObj",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_Foo() *string {
-	_init_.Initialize()
-	var returns *string
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"Foo",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_Instance() Statics {
-	_init_.Initialize()
-	var returns Statics
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"instance",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_SetInstance(val Statics) {
-	_init_.Initialize()
-	_jsii_.StaticSet(
-		"jsii-calc.Statics",
-		"instance",
-		val,
-	)
-}
-
-func Statics_NonConstStatic() *float64 {
-	_init_.Initialize()
-	var returns *float64
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"nonConstStatic",
-		&returns,
-	)
-	return returns
-}
-
-func Statics_SetNonConstStatic(val *float64) {
-	_init_.Initialize()
-	_jsii_.StaticSet(
-		"jsii-calc.Statics",
-		"nonConstStatic",
-		val,
-	)
-}
-
-func Statics_ZooBar() *map[string]*string {
-	_init_.Initialize()
-	var returns *map[string]*string
-	_jsii_.StaticGet(
-		"jsii-calc.Statics",
-		"zooBar",
-		&returns,
-	)
-	return returns
-}
-
-func (s *jsiiProxy_Statics) JustMethod() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		s,
-		"justMethod",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type StringEnum string
-
-const (
-	StringEnum_A StringEnum = "A"
-	StringEnum_B StringEnum = "B"
-	StringEnum_C StringEnum = "C"
-)
-
-type StripInternal interface {
-	YouSeeMe() *string
-	SetYouSeeMe(val *string)
-}
-
-// The jsii proxy struct for StripInternal
-type jsiiProxy_StripInternal struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_StripInternal) YouSeeMe() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"youSeeMe",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewStripInternal() StripInternal {
-	_init_.Initialize()
-
-	j := jsiiProxy_StripInternal{}
-
-	_jsii_.Create(
-		"jsii-calc.StripInternal",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewStripInternal_Override(s StripInternal) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.StripInternal",
-		nil, // no parameters
-		s,
-	)
-}
-
-func (j *jsiiProxy_StripInternal) SetYouSeeMe(val *string) {
-	_jsii_.Set(
-		j,
-		"youSeeMe",
-		val,
-	)
-}
-
-// We can serialize and deserialize structs without silently ignoring optional fields.
-type StructA struct {
-	RequiredString *string \`field:"required" json:"requiredString" yaml:"requiredString"\`
-	OptionalNumber *float64 \`field:"optional" json:"optionalNumber" yaml:"optionalNumber"\`
-	OptionalString *string \`field:"optional" json:"optionalString" yaml:"optionalString"\`
-}
-
-// This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
-type StructB struct {
-	RequiredString *string \`field:"required" json:"requiredString" yaml:"requiredString"\`
-	OptionalBoolean *bool \`field:"optional" json:"optionalBoolean" yaml:"optionalBoolean"\`
-	OptionalStructA *StructA \`field:"optional" json:"optionalStructA" yaml:"optionalStructA"\`
-}
-
-// Verifies that, in languages that do keyword lifting (e.g: Python), having a struct member with the same name as a positional parameter results in the correct code being emitted.
-//
-// See: https://github.com/aws/aws-cdk/issues/4302
-type StructParameterType struct {
-	Scope *string \`field:"required" json:"scope" yaml:"scope"\`
-	Props *bool \`field:"optional" json:"props" yaml:"props"\`
-}
-
-// Just because we can.
-type StructPassing interface {
-}
-
-// The jsii proxy struct for StructPassing
-type jsiiProxy_StructPassing struct {
-	_ byte // padding
-}
-
-func NewStructPassing() StructPassing {
-	_init_.Initialize()
-
-	j := jsiiProxy_StructPassing{}
-
-	_jsii_.Create(
-		"jsii-calc.StructPassing",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewStructPassing_Override(s StructPassing) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.StructPassing",
-		nil, // no parameters
-		s,
-	)
-}
-
-func StructPassing_HowManyVarArgsDidIPass(_positional *float64, inputs ...*TopLevelStruct) *float64 {
-	_init_.Initialize()
-
-	args := []interface{}{_positional}
-	for _, a := range inputs {
-		args = append(args, a)
-	}
-
-	var returns *float64
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.StructPassing",
-		"howManyVarArgsDidIPass",
-		args,
-		&returns,
-	)
-
-	return returns
-}
-
-func StructPassing_RoundTrip(_positional *float64, input *TopLevelStruct) *TopLevelStruct {
-	_init_.Initialize()
-
-	var returns *TopLevelStruct
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.StructPassing",
-		"roundTrip",
-		[]interface{}{_positional, input},
-		&returns,
-	)
-
-	return returns
-}
-
-type StructUnionConsumer interface {
-}
-
-// The jsii proxy struct for StructUnionConsumer
-type jsiiProxy_StructUnionConsumer struct {
-	_ byte // padding
-}
-
-func StructUnionConsumer_IsStructA(struct_ interface{}) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.StructUnionConsumer",
-		"isStructA",
-		[]interface{}{struct_},
-		&returns,
-	)
-
-	return returns
-}
-
-func StructUnionConsumer_IsStructB(struct_ interface{}) *bool {
-	_init_.Initialize()
-
-	var returns *bool
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.StructUnionConsumer",
-		"isStructB",
-		[]interface{}{struct_},
-		&returns,
-	)
-
-	return returns
-}
-
-type StructWithEnum struct {
-	// An enum value.
-	Foo StringEnum \`field:"required" json:"foo" yaml:"foo"\`
-	// Optional enum value (of type integer).
-	Bar AllTypesEnum \`field:"optional" json:"bar" yaml:"bar"\`
-}
-
-type StructWithJavaReservedWords struct {
-	Default *string \`field:"required" json:"default" yaml:"default"\`
-	Assert *string \`field:"optional" json:"assert" yaml:"assert"\`
-	Result *string \`field:"optional" json:"result" yaml:"result"\`
-	That *string \`field:"optional" json:"that" yaml:"that"\`
-}
-
-// An operation that sums multiple values.
-type Sum interface {
-	composition.CompositeOperation
-	// A set of postfixes to include in a decorated .toString().
-	DecorationPostfixes() *[]*string
-	SetDecorationPostfixes(val *[]*string)
-	// A set of prefixes to include in a decorated .toString().
-	DecorationPrefixes() *[]*string
-	SetDecorationPrefixes(val *[]*string)
-	// The expression that this operation consists of.
-	//
-	// Must be implemented by derived classes.
-	Expression() scopejsiicalclib.NumericValue
-	// The parts to sum.
-	Parts() *[]scopejsiicalclib.NumericValue
-	SetParts(val *[]scopejsiicalclib.NumericValue)
-	// The .toString() style.
-	StringStyle() composition.CompositeOperation_CompositionStringStyle
-	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
-	// The value.
-	Value() *float64
-	// String representation of the value.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Sum
-type jsiiProxy_Sum struct {
-	internal.Type__compositionCompositeOperation
-}
-
-func (j *jsiiProxy_Sum) DecorationPostfixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPostfixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Sum) DecorationPrefixes() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"decorationPrefixes",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Sum) Expression() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"expression",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Sum) Parts() *[]scopejsiicalclib.NumericValue {
-	var returns *[]scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"parts",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Sum) StringStyle() composition.CompositeOperation_CompositionStringStyle {
-	var returns composition.CompositeOperation_CompositionStringStyle
-	_jsii_.Get(
-		j,
-		"stringStyle",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_Sum) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewSum() Sum {
-	_init_.Initialize()
-
-	j := jsiiProxy_Sum{}
-
-	_jsii_.Create(
-		"jsii-calc.Sum",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewSum_Override(s Sum) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Sum",
-		nil, // no parameters
-		s,
-	)
-}
-
-func (j *jsiiProxy_Sum) SetDecorationPostfixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPostfixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Sum) SetDecorationPrefixes(val *[]*string) {
-	_jsii_.Set(
-		j,
-		"decorationPrefixes",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Sum) SetParts(val *[]scopejsiicalclib.NumericValue) {
-	_jsii_.Set(
-		j,
-		"parts",
-		val,
-	)
-}
-
-func (j *jsiiProxy_Sum) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
-	_jsii_.Set(
-		j,
-		"stringStyle",
-		val,
-	)
-}
-
-func (s *jsiiProxy_Sum) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		s,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_Sum) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		s,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type SupportsNiceJavaBuilder interface {
-	SupportsNiceJavaBuilderWithRequiredProps
-	Bar() *float64
-	// some identifier.
-	Id() *float64
-	PropId() *string
-	Rest() *[]*string
-}
-
-// The jsii proxy struct for SupportsNiceJavaBuilder
-type jsiiProxy_SupportsNiceJavaBuilder struct {
-	jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilder) Bar() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"bar",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilder) Id() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"id",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilder) PropId() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"propId",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilder) Rest() *[]*string {
-	var returns *[]*string
-	_jsii_.Get(
-		j,
-		"rest",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewSupportsNiceJavaBuilder(id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) SupportsNiceJavaBuilder {
-	_init_.Initialize()
-
-	args := []interface{}{id, defaultBar, props}
-	for _, a := range rest {
-		args = append(args, a)
-	}
-
-	j := jsiiProxy_SupportsNiceJavaBuilder{}
-
-	_jsii_.Create(
-		"jsii-calc.SupportsNiceJavaBuilder",
-		args,
-		&j,
-	)
-
-	return &j
-}
-
-func NewSupportsNiceJavaBuilder_Override(s SupportsNiceJavaBuilder, id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) {
-	_init_.Initialize()
-
-	args := []interface{}{id, defaultBar, props}
-	for _, a := range rest {
-		args = append(args, a)
-	}
-
-	_jsii_.Create(
-		"jsii-calc.SupportsNiceJavaBuilder",
-		args,
-		s,
-	)
-}
-
-type SupportsNiceJavaBuilderProps struct {
-	// Some number, like 42.
-	Bar *float64 \`field:"required" json:"bar" yaml:"bar"\`
-	// An \`id\` field here is terrible API design, because the constructor of \`SupportsNiceJavaBuilder\` already has a parameter named \`id\`.
-	//
-	// But here we are, doing it like we didn't care.
-	Id *string \`field:"optional" json:"id" yaml:"id"\`
-}
-
-// We can generate fancy builders in Java for classes which take a mix of positional & struct parameters.
-type SupportsNiceJavaBuilderWithRequiredProps interface {
-	Bar() *float64
-	// some identifier of your choice.
-	Id() *float64
-	PropId() *string
-}
-
-// The jsii proxy struct for SupportsNiceJavaBuilderWithRequiredProps
-type jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) Bar() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"bar",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) Id() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"id",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) PropId() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"propId",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewSupportsNiceJavaBuilderWithRequiredProps(id *float64, props *SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredProps {
-	_init_.Initialize()
-
-	j := jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps{}
-
-	_jsii_.Create(
-		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
-		[]interface{}{id, props},
-		&j,
-	)
-
-	return &j
-}
-
-func NewSupportsNiceJavaBuilderWithRequiredProps_Override(s SupportsNiceJavaBuilderWithRequiredProps, id *float64, props *SupportsNiceJavaBuilderProps) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
-		[]interface{}{id, props},
-		s,
-	)
-}
-
-type SyncVirtualMethods interface {
-	A() *float64
-	SetA(val *float64)
-	CallerIsProperty() *float64
-	SetCallerIsProperty(val *float64)
-	OtherProperty() *string
-	SetOtherProperty(val *string)
-	ReadonlyProperty() *string
-	TheProperty() *string
-	SetTheProperty(val *string)
-	ValueOfOtherProperty() *string
-	SetValueOfOtherProperty(val *string)
-	CallerIsAsync() *float64
-	CallerIsMethod() *float64
-	ModifyOtherProperty(value *string)
-	ModifyValueOfTheProperty(value *string)
-	ReadA() *float64
-	RetrieveOtherProperty() *string
-	RetrieveReadOnlyProperty() *string
-	RetrieveValueOfTheProperty() *string
-	VirtualMethod(n *float64) *float64
-	WriteA(value *float64)
-}
-
-// The jsii proxy struct for SyncVirtualMethods
-type jsiiProxy_SyncVirtualMethods struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) A() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"a",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) CallerIsProperty() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"callerIsProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) OtherProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"otherProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) ReadonlyProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"readonlyProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) TheProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"theProperty",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) ValueOfOtherProperty() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"valueOfOtherProperty",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewSyncVirtualMethods() SyncVirtualMethods {
-	_init_.Initialize()
-
-	j := jsiiProxy_SyncVirtualMethods{}
-
-	_jsii_.Create(
-		"jsii-calc.SyncVirtualMethods",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewSyncVirtualMethods_Override(s SyncVirtualMethods) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.SyncVirtualMethods",
-		nil, // no parameters
-		s,
-	)
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) SetA(val *float64) {
-	_jsii_.Set(
-		j,
-		"a",
-		val,
-	)
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) SetCallerIsProperty(val *float64) {
-	_jsii_.Set(
-		j,
-		"callerIsProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) SetOtherProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"otherProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) SetTheProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"theProperty",
-		val,
-	)
-}
-
-func (j *jsiiProxy_SyncVirtualMethods) SetValueOfOtherProperty(val *string) {
-	_jsii_.Set(
-		j,
-		"valueOfOtherProperty",
-		val,
-	)
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) CallerIsAsync() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		s,
-		"callerIsAsync",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) CallerIsMethod() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		s,
-		"callerIsMethod",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) ModifyOtherProperty(value *string) {
-	_jsii_.InvokeVoid(
-		s,
-		"modifyOtherProperty",
-		[]interface{}{value},
-	)
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) ModifyValueOfTheProperty(value *string) {
-	_jsii_.InvokeVoid(
-		s,
-		"modifyValueOfTheProperty",
-		[]interface{}{value},
-	)
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) ReadA() *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		s,
-		"readA",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) RetrieveOtherProperty() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		s,
-		"retrieveOtherProperty",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) RetrieveReadOnlyProperty() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		s,
-		"retrieveReadOnlyProperty",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) RetrieveValueOfTheProperty() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		s,
-		"retrieveValueOfTheProperty",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) VirtualMethod(n *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		s,
-		"virtualMethod",
-		[]interface{}{n},
-		&returns,
-	)
-
-	return returns
-}
-
-func (s *jsiiProxy_SyncVirtualMethods) WriteA(value *float64) {
-	_jsii_.InvokeVoid(
-		s,
-		"writeA",
-		[]interface{}{value},
-	)
-}
-
-type TestStructWithEnum interface {
-	// Returns \`foo: StringEnum.A\`.
-	StructWithFoo() *StructWithEnum
-	// Returns \`foo: StringEnum.C\` and \`bar: AllTypesEnum.MY_ENUM_VALUE\`.
-	StructWithFooBar() *StructWithEnum
-	// Returns true if \`foo\` is \`StringEnum.A\`.
-	IsStringEnumA(input *StructWithEnum) *bool
-	// Returns true if \`foo\` is \`StringEnum.B\` and \`bar\` is \`AllTypesEnum.THIS_IS_GREAT\`.
-	IsStringEnumB(input *StructWithEnum) *bool
-}
-
-// The jsii proxy struct for TestStructWithEnum
-type jsiiProxy_TestStructWithEnum struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_TestStructWithEnum) StructWithFoo() *StructWithEnum {
-	var returns *StructWithEnum
-	_jsii_.Get(
-		j,
-		"structWithFoo",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_TestStructWithEnum) StructWithFooBar() *StructWithEnum {
-	var returns *StructWithEnum
-	_jsii_.Get(
-		j,
-		"structWithFooBar",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewTestStructWithEnum() TestStructWithEnum {
-	_init_.Initialize()
-
-	j := jsiiProxy_TestStructWithEnum{}
-
-	_jsii_.Create(
-		"jsii-calc.TestStructWithEnum",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewTestStructWithEnum_Override(t TestStructWithEnum) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.TestStructWithEnum",
-		nil, // no parameters
-		t,
-	)
-}
-
-func (t *jsiiProxy_TestStructWithEnum) IsStringEnumA(input *StructWithEnum) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		t,
-		"isStringEnumA",
-		[]interface{}{input},
-		&returns,
-	)
-
-	return returns
-}
-
-func (t *jsiiProxy_TestStructWithEnum) IsStringEnumB(input *StructWithEnum) *bool {
-	var returns *bool
-
-	_jsii_.Invoke(
-		t,
-		"isStringEnumB",
-		[]interface{}{input},
-		&returns,
-	)
-
-	return returns
-}
-
-type Thrower interface {
-	ThrowError()
-}
-
-// The jsii proxy struct for Thrower
-type jsiiProxy_Thrower struct {
-	_ byte // padding
-}
-
-func NewThrower() Thrower {
-	_init_.Initialize()
-
-	j := jsiiProxy_Thrower{}
-
-	_jsii_.Create(
-		"jsii-calc.Thrower",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewThrower_Override(t Thrower) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.Thrower",
-		nil, // no parameters
-		t,
-	)
-}
-
-func (t *jsiiProxy_Thrower) ThrowError() {
-	_jsii_.InvokeVoid(
-		t,
-		"throwError",
-		nil, // no parameters
-	)
-}
-
-type TopLevelStruct struct {
-	// This is a required field.
-	Required *string \`field:"required" json:"required" yaml:"required"\`
-	// A union to really stress test our serialization.
-	SecondLevel interface{} \`field:"required" json:"secondLevel" yaml:"secondLevel"\`
-	// You don't have to pass this.
-	Optional *string \`field:"optional" json:"optional" yaml:"optional"\`
-}
-
-// In TypeScript it is possible to have two methods with the same name but different capitalization.
-// See: https://github.com/aws/jsii/issues/2508
-//
-type TwoMethodsWithSimilarCapitalization interface {
-	FooBar() *float64
-	// Deprecated: YES.
-	FooBAR() *float64
-	ToIsoString() *string
-	// Deprecated: python requires that all alternatives are deprecated.
-	ToIsOString() *string
-	// Deprecated: python requires that all alternatives are deprecated.
-	ToISOString() *string
-}
-
-// The jsii proxy struct for TwoMethodsWithSimilarCapitalization
-type jsiiProxy_TwoMethodsWithSimilarCapitalization struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_TwoMethodsWithSimilarCapitalization) FooBar() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"fooBar",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_TwoMethodsWithSimilarCapitalization) FooBAR() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"fooBAR",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewTwoMethodsWithSimilarCapitalization() TwoMethodsWithSimilarCapitalization {
-	_init_.Initialize()
-
-	j := jsiiProxy_TwoMethodsWithSimilarCapitalization{}
-
-	_jsii_.Create(
-		"jsii-calc.TwoMethodsWithSimilarCapitalization",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewTwoMethodsWithSimilarCapitalization_Override(t TwoMethodsWithSimilarCapitalization) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.TwoMethodsWithSimilarCapitalization",
-		nil, // no parameters
-		t,
-	)
-}
-
-func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToIsoString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		t,
-		"toIsoString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToIsOString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		t,
-		"toIsOString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToISOString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		t,
-		"toISOString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Checks the current file permissions are cool (no funky UMASK down-scoping happened).
-// See: https://github.com/aws/jsii/issues/1765
-//
-type UmaskCheck interface {
-}
-
-// The jsii proxy struct for UmaskCheck
-type jsiiProxy_UmaskCheck struct {
-	_ byte // padding
-}
-
-// This should return 0o644 (-rw-r--r--).
-func UmaskCheck_Mode() *float64 {
-	_init_.Initialize()
-
-	var returns *float64
-
-	_jsii_.StaticInvoke(
-		"jsii-calc.UmaskCheck",
-		"mode",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// An operation on a single operand.
-type UnaryOperation interface {
-	scopejsiicalclib.Operation
-	Operand() scopejsiicalclib.NumericValue
-	// The value.
-	// Deprecated.
-	Value() *float64
-	// String representation of the value.
-	// Deprecated.
-	ToString() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for UnaryOperation
-type jsiiProxy_UnaryOperation struct {
-	internal.Type__scopejsiicalclibOperation
-}
-
-func (j *jsiiProxy_UnaryOperation) Operand() scopejsiicalclib.NumericValue {
-	var returns scopejsiicalclib.NumericValue
-	_jsii_.Get(
-		j,
-		"operand",
-		&returns,
-	)
-	return returns
-}
-
-func (j *jsiiProxy_UnaryOperation) Value() *float64 {
-	var returns *float64
-	_jsii_.Get(
-		j,
-		"value",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewUnaryOperation_Override(u UnaryOperation, operand scopejsiicalclib.NumericValue) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.UnaryOperation",
-		[]interface{}{operand},
-		u,
-	)
-}
-
-func (u *jsiiProxy_UnaryOperation) ToString() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		u,
-		"toString",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (u *jsiiProxy_UnaryOperation) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		u,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type UnionProperties struct {
-	Bar interface{} \`field:"required" json:"bar" yaml:"bar"\`
-	Foo interface{} \`field:"optional" json:"foo" yaml:"foo"\`
-}
-
-// Ensures submodule-imported types from dependencies can be used correctly.
-type UpcasingReflectable interface {
-	customsubmodulename.IReflectable
-	Entries() *[]*customsubmodulename.ReflectableEntry
-}
-
-// The jsii proxy struct for UpcasingReflectable
-type jsiiProxy_UpcasingReflectable struct {
-	internal.Type__customsubmodulenameIReflectable
-}
-
-func (j *jsiiProxy_UpcasingReflectable) Entries() *[]*customsubmodulename.ReflectableEntry {
-	var returns *[]*customsubmodulename.ReflectableEntry
-	_jsii_.Get(
-		j,
-		"entries",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewUpcasingReflectable(delegate *map[string]interface{}) UpcasingReflectable {
-	_init_.Initialize()
-
-	j := jsiiProxy_UpcasingReflectable{}
-
-	_jsii_.Create(
-		"jsii-calc.UpcasingReflectable",
-		[]interface{}{delegate},
-		&j,
-	)
-
-	return &j
-}
-
-func NewUpcasingReflectable_Override(u UpcasingReflectable, delegate *map[string]interface{}) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.UpcasingReflectable",
-		[]interface{}{delegate},
-		u,
-	)
-}
-
-func UpcasingReflectable_Reflector() customsubmodulename.Reflector {
-	_init_.Initialize()
-	var returns customsubmodulename.Reflector
-	_jsii_.StaticGet(
-		"jsii-calc.UpcasingReflectable",
-		"reflector",
-		&returns,
-	)
-	return returns
-}
-
-type UseBundledDependency interface {
-	Value() interface{}
-}
-
-// The jsii proxy struct for UseBundledDependency
-type jsiiProxy_UseBundledDependency struct {
-	_ byte // padding
-}
-
-func NewUseBundledDependency() UseBundledDependency {
-	_init_.Initialize()
-
-	j := jsiiProxy_UseBundledDependency{}
-
-	_jsii_.Create(
-		"jsii-calc.UseBundledDependency",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewUseBundledDependency_Override(u UseBundledDependency) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.UseBundledDependency",
-		nil, // no parameters
-		u,
-	)
-}
-
-func (u *jsiiProxy_UseBundledDependency) Value() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		u,
-		"value",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-// Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
-type UseCalcBase interface {
-	Hello() jcb.Base
-}
-
-// The jsii proxy struct for UseCalcBase
-type jsiiProxy_UseCalcBase struct {
-	_ byte // padding
-}
-
-func NewUseCalcBase() UseCalcBase {
-	_init_.Initialize()
-
-	j := jsiiProxy_UseCalcBase{}
-
-	_jsii_.Create(
-		"jsii-calc.UseCalcBase",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewUseCalcBase_Override(u UseCalcBase) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.UseCalcBase",
-		nil, // no parameters
-		u,
-	)
-}
-
-func (u *jsiiProxy_UseCalcBase) Hello() jcb.Base {
-	var returns jcb.Base
-
-	_jsii_.Invoke(
-		u,
-		"hello",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type UsesInterfaceWithProperties interface {
-	Obj() IInterfaceWithProperties
-	JustRead() *string
-	ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) *string
-	WriteAndRead(value *string) *string
-}
-
-// The jsii proxy struct for UsesInterfaceWithProperties
-type jsiiProxy_UsesInterfaceWithProperties struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_UsesInterfaceWithProperties) Obj() IInterfaceWithProperties {
-	var returns IInterfaceWithProperties
-	_jsii_.Get(
-		j,
-		"obj",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewUsesInterfaceWithProperties(obj IInterfaceWithProperties) UsesInterfaceWithProperties {
-	_init_.Initialize()
-
-	j := jsiiProxy_UsesInterfaceWithProperties{}
-
-	_jsii_.Create(
-		"jsii-calc.UsesInterfaceWithProperties",
-		[]interface{}{obj},
-		&j,
-	)
-
-	return &j
-}
-
-func NewUsesInterfaceWithProperties_Override(u UsesInterfaceWithProperties, obj IInterfaceWithProperties) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.UsesInterfaceWithProperties",
-		[]interface{}{obj},
-		u,
-	)
-}
-
-func (u *jsiiProxy_UsesInterfaceWithProperties) JustRead() *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		u,
-		"justRead",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-func (u *jsiiProxy_UsesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		u,
-		"readStringAndNumber",
-		[]interface{}{ext},
-		&returns,
-	)
-
-	return returns
-}
-
-func (u *jsiiProxy_UsesInterfaceWithProperties) WriteAndRead(value *string) *string {
-	var returns *string
-
-	_jsii_.Invoke(
-		u,
-		"writeAndRead",
-		[]interface{}{value},
-		&returns,
-	)
-
-	return returns
-}
-
-type VariadicInvoker interface {
-	AsArray(values ...*float64) *[]*float64
-}
-
-// The jsii proxy struct for VariadicInvoker
-type jsiiProxy_VariadicInvoker struct {
-	_ byte // padding
-}
-
-func NewVariadicInvoker(method VariadicMethod) VariadicInvoker {
-	_init_.Initialize()
-
-	j := jsiiProxy_VariadicInvoker{}
-
-	_jsii_.Create(
-		"jsii-calc.VariadicInvoker",
-		[]interface{}{method},
-		&j,
-	)
-
-	return &j
-}
-
-func NewVariadicInvoker_Override(v VariadicInvoker, method VariadicMethod) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.VariadicInvoker",
-		[]interface{}{method},
-		v,
-	)
-}
-
-func (v *jsiiProxy_VariadicInvoker) AsArray(values ...*float64) *[]*float64 {
-	args := []interface{}{}
-	for _, a := range values {
-		args = append(args, a)
-	}
-
-	var returns *[]*float64
-
-	_jsii_.Invoke(
-		v,
-		"asArray",
-		args,
-		&returns,
-	)
-
-	return returns
-}
-
-type VariadicMethod interface {
-	AsArray(first *float64, others ...*float64) *[]*float64
-}
-
-// The jsii proxy struct for VariadicMethod
-type jsiiProxy_VariadicMethod struct {
-	_ byte // padding
-}
-
-func NewVariadicMethod(prefix ...*float64) VariadicMethod {
-	_init_.Initialize()
-
-	args := []interface{}{}
-	for _, a := range prefix {
-		args = append(args, a)
-	}
-
-	j := jsiiProxy_VariadicMethod{}
-
-	_jsii_.Create(
-		"jsii-calc.VariadicMethod",
-		args,
-		&j,
-	)
-
-	return &j
-}
-
-func NewVariadicMethod_Override(v VariadicMethod, prefix ...*float64) {
-	_init_.Initialize()
-
-	args := []interface{}{}
-	for _, a := range prefix {
-		args = append(args, a)
-	}
-
-	_jsii_.Create(
-		"jsii-calc.VariadicMethod",
-		args,
-		v,
-	)
-}
-
-func (v *jsiiProxy_VariadicMethod) AsArray(first *float64, others ...*float64) *[]*float64 {
-	args := []interface{}{first}
-	for _, a := range others {
-		args = append(args, a)
-	}
-
-	var returns *[]*float64
-
-	_jsii_.Invoke(
-		v,
-		"asArray",
-		args,
-		&returns,
-	)
-
-	return returns
-}
-
-type VirtualMethodPlayground interface {
-	OverrideMeAsync(index *float64) *float64
-	OverrideMeSync(index *float64) *float64
-	ParallelSumAsync(count *float64) *float64
-	SerialSumAsync(count *float64) *float64
-	SumSync(count *float64) *float64
-}
-
-// The jsii proxy struct for VirtualMethodPlayground
-type jsiiProxy_VirtualMethodPlayground struct {
-	_ byte // padding
-}
-
-func NewVirtualMethodPlayground() VirtualMethodPlayground {
-	_init_.Initialize()
-
-	j := jsiiProxy_VirtualMethodPlayground{}
-
-	_jsii_.Create(
-		"jsii-calc.VirtualMethodPlayground",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewVirtualMethodPlayground_Override(v VirtualMethodPlayground) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.VirtualMethodPlayground",
-		nil, // no parameters
-		v,
-	)
-}
-
-func (v *jsiiProxy_VirtualMethodPlayground) OverrideMeAsync(index *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		v,
-		"overrideMeAsync",
-		[]interface{}{index},
-		&returns,
-	)
-
-	return returns
-}
-
-func (v *jsiiProxy_VirtualMethodPlayground) OverrideMeSync(index *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		v,
-		"overrideMeSync",
-		[]interface{}{index},
-		&returns,
-	)
-
-	return returns
-}
-
-func (v *jsiiProxy_VirtualMethodPlayground) ParallelSumAsync(count *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		v,
-		"parallelSumAsync",
-		[]interface{}{count},
-		&returns,
-	)
-
-	return returns
-}
-
-func (v *jsiiProxy_VirtualMethodPlayground) SerialSumAsync(count *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		v,
-		"serialSumAsync",
-		[]interface{}{count},
-		&returns,
-	)
-
-	return returns
-}
-
-func (v *jsiiProxy_VirtualMethodPlayground) SumSync(count *float64) *float64 {
-	var returns *float64
-
-	_jsii_.Invoke(
-		v,
-		"sumSync",
-		[]interface{}{count},
-		&returns,
-	)
-
-	return returns
-}
-
-// This test is used to validate the runtimes can return correctly from a void callback.
-//
-// - Implement \`overrideMe\` (method does not have to do anything).
-// - Invoke \`callMe\`
-// - Verify that \`methodWasCalled\` is \`true\`.
-type VoidCallback interface {
-	MethodWasCalled() *bool
-	CallMe()
-	OverrideMe()
-}
-
-// The jsii proxy struct for VoidCallback
-type jsiiProxy_VoidCallback struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_VoidCallback) MethodWasCalled() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"methodWasCalled",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewVoidCallback_Override(v VoidCallback) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.VoidCallback",
-		nil, // no parameters
-		v,
-	)
-}
-
-func (v *jsiiProxy_VoidCallback) CallMe() {
-	_jsii_.InvokeVoid(
-		v,
-		"callMe",
-		nil, // no parameters
-	)
-}
-
-func (v *jsiiProxy_VoidCallback) OverrideMe() {
-	_jsii_.InvokeVoid(
-		v,
-		"overrideMe",
-		nil, // no parameters
-	)
-}
-
-// Verifies that private property declarations in constructor arguments are hidden.
-type WithPrivatePropertyInConstructor interface {
-	Success() *bool
-}
-
-// The jsii proxy struct for WithPrivatePropertyInConstructor
-type jsiiProxy_WithPrivatePropertyInConstructor struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_WithPrivatePropertyInConstructor) Success() *bool {
-	var returns *bool
-	_jsii_.Get(
-		j,
-		"success",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewWithPrivatePropertyInConstructor(privateField *string) WithPrivatePropertyInConstructor {
-	_init_.Initialize()
-
-	j := jsiiProxy_WithPrivatePropertyInConstructor{}
-
-	_jsii_.Create(
-		"jsii-calc.WithPrivatePropertyInConstructor",
-		[]interface{}{privateField},
-		&j,
-	)
-
-	return &j
-}
-
-func NewWithPrivatePropertyInConstructor_Override(w WithPrivatePropertyInConstructor, privateField *string) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.WithPrivatePropertyInConstructor",
-		[]interface{}{privateField},
-		w,
-	)
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc.init.go 1`] = `
 package jsiicalc
 
 import (
@@ -17590,7 +5974,14566 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AbstractClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AbstractClass interface {
+	AbstractClassBase
+	IInterfaceImplementedByAbstractClass
+	AbstractProperty() *string
+	PropFromInterface() *string
+	AbstractMethod(name *string) *string
+	NonAbstractMethod() *float64
+}
+
+// The jsii proxy struct for AbstractClass
+type jsiiProxy_AbstractClass struct {
+	jsiiProxy_AbstractClassBase
+	jsiiProxy_IInterfaceImplementedByAbstractClass
+}
+
+func (j *jsiiProxy_AbstractClass) AbstractProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"abstractProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AbstractClass) PropFromInterface() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"propFromInterface",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAbstractClass_Override(a AbstractClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AbstractClass",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AbstractClass) AbstractMethod(name *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"abstractMethod",
+		[]interface{}{name},
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AbstractClass) NonAbstractMethod() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"nonAbstractMethod",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AbstractClassBase.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AbstractClassBase interface {
+	AbstractProperty() *string
+}
+
+// The jsii proxy struct for AbstractClassBase
+type jsiiProxy_AbstractClassBase struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_AbstractClassBase) AbstractProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"abstractProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAbstractClassBase_Override(a AbstractClassBase) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AbstractClassBase",
+		nil, // no parameters
+		a,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AbstractClassReturner.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AbstractClassReturner interface {
+	ReturnAbstractFromProperty() AbstractClassBase
+	GiveMeAbstract() AbstractClass
+	GiveMeInterface() IInterfaceImplementedByAbstractClass
+}
+
+// The jsii proxy struct for AbstractClassReturner
+type jsiiProxy_AbstractClassReturner struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_AbstractClassReturner) ReturnAbstractFromProperty() AbstractClassBase {
+	var returns AbstractClassBase
+	_jsii_.Get(
+		j,
+		"returnAbstractFromProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAbstractClassReturner() AbstractClassReturner {
+	_init_.Initialize()
+
+	j := jsiiProxy_AbstractClassReturner{}
+
+	_jsii_.Create(
+		"jsii-calc.AbstractClassReturner",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAbstractClassReturner_Override(a AbstractClassReturner) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AbstractClassReturner",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AbstractClassReturner) GiveMeAbstract() AbstractClass {
+	var returns AbstractClass
+
+	_jsii_.Invoke(
+		a,
+		"giveMeAbstract",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AbstractClassReturner) GiveMeInterface() IInterfaceImplementedByAbstractClass {
+	var returns IInterfaceImplementedByAbstractClass
+
+	_jsii_.Invoke(
+		a,
+		"giveMeInterface",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AbstractSuite.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Ensures abstract members implementations correctly register overrides in various languages.
+type AbstractSuite interface {
+	Property() *string
+	SetProperty(val *string)
+	SomeMethod(str *string) *string
+	// Sets \`seed\` to \`this.property\`, then calls \`someMethod\` with \`this.property\` and returns the result.
+	WorkItAll(seed *string) *string
+}
+
+// The jsii proxy struct for AbstractSuite
+type jsiiProxy_AbstractSuite struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_AbstractSuite) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAbstractSuite_Override(a AbstractSuite) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AbstractSuite",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (j *jsiiProxy_AbstractSuite) SetProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"property",
+		val,
+	)
+}
+
+func (a *jsiiProxy_AbstractSuite) SomeMethod(str *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"someMethod",
+		[]interface{}{str},
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AbstractSuite) WorkItAll(seed *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"workItAll",
+		[]interface{}{seed},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Add.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// The "+" binary operation.
+type Add interface {
+	BinaryOperation
+	// Left-hand side operand.
+	Lhs() scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs() scopejsiicalclib.NumericValue
+	// The value.
+	Value() *float64
+	// Say hello!
+	Hello() *string
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Add
+type jsiiProxy_Add struct {
+	jsiiProxy_BinaryOperation
+}
+
+func (j *jsiiProxy_Add) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"lhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Add) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"rhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Add) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a BinaryOperation.
+func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Add {
+	_init_.Initialize()
+
+	j := jsiiProxy_Add{}
+
+	_jsii_.Create(
+		"jsii-calc.Add",
+		[]interface{}{lhs, rhs},
+		&j,
+	)
+
+	return &j
+}
+
+// Creates a BinaryOperation.
+func NewAdd_Override(a Add, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Add",
+		[]interface{}{lhs, rhs},
+		a,
+	)
+}
+
+func (a *jsiiProxy_Add) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_Add) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_Add) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		a,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AllTypes.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// This class includes property for all types supported by jsii.
+//
+// The setters will validate
+// that the value set is of the expected type and throw otherwise.
+type AllTypes interface {
+	AnyArrayProperty() *[]interface{}
+	SetAnyArrayProperty(val *[]interface{})
+	AnyMapProperty() *map[string]interface{}
+	SetAnyMapProperty(val *map[string]interface{})
+	AnyProperty() interface{}
+	SetAnyProperty(val interface{})
+	ArrayProperty() *[]*string
+	SetArrayProperty(val *[]*string)
+	BooleanProperty() *bool
+	SetBooleanProperty(val *bool)
+	DateProperty() *time.Time
+	SetDateProperty(val *time.Time)
+	EnumProperty() AllTypesEnum
+	SetEnumProperty(val AllTypesEnum)
+	EnumPropertyValue() *float64
+	JsonProperty() *map[string]interface{}
+	SetJsonProperty(val *map[string]interface{})
+	MapProperty() *map[string]scopejsiicalclib.Number
+	SetMapProperty(val *map[string]scopejsiicalclib.Number)
+	NumberProperty() *float64
+	SetNumberProperty(val *float64)
+	OptionalEnumValue() StringEnum
+	SetOptionalEnumValue(val StringEnum)
+	StringProperty() *string
+	SetStringProperty(val *string)
+	UnionArrayProperty() *[]interface{}
+	SetUnionArrayProperty(val *[]interface{})
+	UnionMapProperty() *map[string]interface{}
+	SetUnionMapProperty(val *map[string]interface{})
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
+	UnknownArrayProperty() *[]interface{}
+	SetUnknownArrayProperty(val *[]interface{})
+	UnknownMapProperty() *map[string]interface{}
+	SetUnknownMapProperty(val *map[string]interface{})
+	UnknownProperty() interface{}
+	SetUnknownProperty(val interface{})
+	AnyIn(inp interface{})
+	AnyOut() interface{}
+	EnumMethod(value StringEnum) StringEnum
+}
+
+// The jsii proxy struct for AllTypes
+type jsiiProxy_AllTypes struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_AllTypes) AnyArrayProperty() *[]interface{} {
+	var returns *[]interface{}
+	_jsii_.Get(
+		j,
+		"anyArrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) AnyMapProperty() *map[string]interface{} {
+	var returns *map[string]interface{}
+	_jsii_.Get(
+		j,
+		"anyMapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) AnyProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		j,
+		"anyProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) ArrayProperty() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"arrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) BooleanProperty() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"booleanProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) DateProperty() *time.Time {
+	var returns *time.Time
+	_jsii_.Get(
+		j,
+		"dateProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) EnumProperty() AllTypesEnum {
+	var returns AllTypesEnum
+	_jsii_.Get(
+		j,
+		"enumProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) EnumPropertyValue() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"enumPropertyValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) JsonProperty() *map[string]interface{} {
+	var returns *map[string]interface{}
+	_jsii_.Get(
+		j,
+		"jsonProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) MapProperty() *map[string]scopejsiicalclib.Number {
+	var returns *map[string]scopejsiicalclib.Number
+	_jsii_.Get(
+		j,
+		"mapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) NumberProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"numberProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) OptionalEnumValue() StringEnum {
+	var returns StringEnum
+	_jsii_.Get(
+		j,
+		"optionalEnumValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) StringProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"stringProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnionArrayProperty() *[]interface{} {
+	var returns *[]interface{}
+	_jsii_.Get(
+		j,
+		"unionArrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnionMapProperty() *map[string]interface{} {
+	var returns *map[string]interface{}
+	_jsii_.Get(
+		j,
+		"unionMapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnionProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		j,
+		"unionProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnknownArrayProperty() *[]interface{} {
+	var returns *[]interface{}
+	_jsii_.Get(
+		j,
+		"unknownArrayProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnknownMapProperty() *map[string]interface{} {
+	var returns *map[string]interface{}
+	_jsii_.Get(
+		j,
+		"unknownMapProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AllTypes) UnknownProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		j,
+		"unknownProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAllTypes() AllTypes {
+	_init_.Initialize()
+
+	j := jsiiProxy_AllTypes{}
+
+	_jsii_.Create(
+		"jsii-calc.AllTypes",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAllTypes_Override(a AllTypes) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AllTypes",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetAnyArrayProperty(val *[]interface{}) {
+	_jsii_.Set(
+		j,
+		"anyArrayProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetAnyMapProperty(val *map[string]interface{}) {
+	_jsii_.Set(
+		j,
+		"anyMapProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetAnyProperty(val interface{}) {
+	_jsii_.Set(
+		j,
+		"anyProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetArrayProperty(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"arrayProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetBooleanProperty(val *bool) {
+	_jsii_.Set(
+		j,
+		"booleanProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetDateProperty(val *time.Time) {
+	_jsii_.Set(
+		j,
+		"dateProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetEnumProperty(val AllTypesEnum) {
+	_jsii_.Set(
+		j,
+		"enumProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetJsonProperty(val *map[string]interface{}) {
+	_jsii_.Set(
+		j,
+		"jsonProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetMapProperty(val *map[string]scopejsiicalclib.Number) {
+	_jsii_.Set(
+		j,
+		"mapProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetNumberProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"numberProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetOptionalEnumValue(val StringEnum) {
+	_jsii_.Set(
+		j,
+		"optionalEnumValue",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetStringProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"stringProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnionArrayProperty(val *[]interface{}) {
+	_jsii_.Set(
+		j,
+		"unionArrayProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnionMapProperty(val *map[string]interface{}) {
+	_jsii_.Set(
+		j,
+		"unionMapProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnionProperty(val interface{}) {
+	_jsii_.Set(
+		j,
+		"unionProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnknownArrayProperty(val *[]interface{}) {
+	_jsii_.Set(
+		j,
+		"unknownArrayProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnknownMapProperty(val *map[string]interface{}) {
+	_jsii_.Set(
+		j,
+		"unknownMapProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_AllTypes) SetUnknownProperty(val interface{}) {
+	_jsii_.Set(
+		j,
+		"unknownProperty",
+		val,
+	)
+}
+
+func (a *jsiiProxy_AllTypes) AnyIn(inp interface{}) {
+	_jsii_.InvokeVoid(
+		a,
+		"anyIn",
+		[]interface{}{inp},
+	)
+}
+
+func (a *jsiiProxy_AllTypes) AnyOut() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		a,
+		"anyOut",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AllTypes) EnumMethod(value StringEnum) StringEnum {
+	var returns StringEnum
+
+	_jsii_.Invoke(
+		a,
+		"enumMethod",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AllTypesEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type AllTypesEnum string
+
+const (
+	AllTypesEnum_MY_ENUM_VALUE AllTypesEnum = "MY_ENUM_VALUE"
+	AllTypesEnum_YOUR_ENUM_VALUE AllTypesEnum = "YOUR_ENUM_VALUE"
+	AllTypesEnum_THIS_IS_GREAT AllTypesEnum = "THIS_IS_GREAT"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AllowedMethodNames.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AllowedMethodNames interface {
+	GetBar(_p1 *string, _p2 *float64)
+	// getXxx() is not allowed (see negatives), but getXxx(a, ...) is okay.
+	GetFoo(withParam *string) *string
+	SetBar(_x *string, _y *float64, _z *bool)
+	// setFoo(x) is not allowed (see negatives), but setXxx(a, b, ...) is okay.
+	SetFoo(_x *string, _y *float64)
+}
+
+// The jsii proxy struct for AllowedMethodNames
+type jsiiProxy_AllowedMethodNames struct {
+	_ byte // padding
+}
+
+func NewAllowedMethodNames() AllowedMethodNames {
+	_init_.Initialize()
+
+	j := jsiiProxy_AllowedMethodNames{}
+
+	_jsii_.Create(
+		"jsii-calc.AllowedMethodNames",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAllowedMethodNames_Override(a AllowedMethodNames) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AllowedMethodNames",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AllowedMethodNames) GetBar(_p1 *string, _p2 *float64) {
+	_jsii_.InvokeVoid(
+		a,
+		"getBar",
+		[]interface{}{_p1, _p2},
+	)
+}
+
+func (a *jsiiProxy_AllowedMethodNames) GetFoo(withParam *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		a,
+		"getFoo",
+		[]interface{}{withParam},
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AllowedMethodNames) SetBar(_x *string, _y *float64, _z *bool) {
+	_jsii_.InvokeVoid(
+		a,
+		"setBar",
+		[]interface{}{_x, _y, _z},
+	)
+}
+
+func (a *jsiiProxy_AllowedMethodNames) SetFoo(_x *string, _y *float64) {
+	_jsii_.InvokeVoid(
+		a,
+		"setFoo",
+		[]interface{}{_x, _y},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AmbiguousParameters.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AmbiguousParameters interface {
+	Props() *StructParameterType
+	Scope() Bell
+}
+
+// The jsii proxy struct for AmbiguousParameters
+type jsiiProxy_AmbiguousParameters struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_AmbiguousParameters) Props() *StructParameterType {
+	var returns *StructParameterType
+	_jsii_.Get(
+		j,
+		"props",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_AmbiguousParameters) Scope() Bell {
+	var returns Bell
+	_jsii_.Get(
+		j,
+		"scope",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewAmbiguousParameters(scope Bell, props *StructParameterType) AmbiguousParameters {
+	_init_.Initialize()
+
+	j := jsiiProxy_AmbiguousParameters{}
+
+	_jsii_.Create(
+		"jsii-calc.AmbiguousParameters",
+		[]interface{}{scope, props},
+		&j,
+	)
+
+	return &j
+}
+
+func NewAmbiguousParameters_Override(a AmbiguousParameters, scope Bell, props *StructParameterType) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AmbiguousParameters",
+		[]interface{}{scope, props},
+		a,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AnonymousImplementationProvider.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AnonymousImplementationProvider interface {
+	IAnonymousImplementationProvider
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
+}
+
+// The jsii proxy struct for AnonymousImplementationProvider
+type jsiiProxy_AnonymousImplementationProvider struct {
+	jsiiProxy_IAnonymousImplementationProvider
+}
+
+func NewAnonymousImplementationProvider() AnonymousImplementationProvider {
+	_init_.Initialize()
+
+	j := jsiiProxy_AnonymousImplementationProvider{}
+
+	_jsii_.Create(
+		"jsii-calc.AnonymousImplementationProvider",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAnonymousImplementationProvider_Override(a AnonymousImplementationProvider) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AnonymousImplementationProvider",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsClass() Implementation {
+	var returns Implementation
+
+	_jsii_.Invoke(
+		a,
+		"provideAsClass",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
+	var returns IAnonymouslyImplementMe
+
+	_jsii_.Invoke(
+		a,
+		"provideAsInterface",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AsyncVirtualMethods.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AsyncVirtualMethods interface {
+	CallMe() *float64
+	// Just calls "overrideMeToo".
+	CallMe2() *float64
+	// This method calls the "callMe" async method indirectly, which will then invoke a virtual method.
+	//
+	// This is a "double promise" situation, which
+	// means that callbacks are not going to be available immediate, but only
+	// after an "immediates" cycle.
+	CallMeDoublePromise() *float64
+	DontOverrideMe() *float64
+	OverrideMe(mult *float64) *float64
+	OverrideMeToo() *float64
+}
+
+// The jsii proxy struct for AsyncVirtualMethods
+type jsiiProxy_AsyncVirtualMethods struct {
+	_ byte // padding
+}
+
+func NewAsyncVirtualMethods() AsyncVirtualMethods {
+	_init_.Initialize()
+
+	j := jsiiProxy_AsyncVirtualMethods{}
+
+	_jsii_.Create(
+		"jsii-calc.AsyncVirtualMethods",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAsyncVirtualMethods_Override(a AsyncVirtualMethods) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AsyncVirtualMethods",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) CallMe() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"callMe",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) CallMe2() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"callMe2",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) CallMeDoublePromise() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"callMeDoublePromise",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) DontOverrideMe() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"dontOverrideMe",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) OverrideMe(mult *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"overrideMe",
+		[]interface{}{mult},
+		&returns,
+	)
+
+	return returns
+}
+
+func (a *jsiiProxy_AsyncVirtualMethods) OverrideMeToo() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		a,
+		"overrideMeToo",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_AugmentableClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AugmentableClass interface {
+	MethodOne()
+	MethodTwo()
+}
+
+// The jsii proxy struct for AugmentableClass
+type jsiiProxy_AugmentableClass struct {
+	_ byte // padding
+}
+
+func NewAugmentableClass() AugmentableClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_AugmentableClass{}
+
+	_jsii_.Create(
+		"jsii-calc.AugmentableClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewAugmentableClass_Override(a AugmentableClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.AugmentableClass",
+		nil, // no parameters
+		a,
+	)
+}
+
+func (a *jsiiProxy_AugmentableClass) MethodOne() {
+	_jsii_.InvokeVoid(
+		a,
+		"methodOne",
+		nil, // no parameters
+	)
+}
+
+func (a *jsiiProxy_AugmentableClass) MethodTwo() {
+	_jsii_.InvokeVoid(
+		a,
+		"methodTwo",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_BaseClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type BaseClass interface {
+	Property() *string
+	Method() *float64
+}
+
+// The jsii proxy struct for BaseClass
+type jsiiProxy_BaseClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_BaseClass) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewBaseClass_Override(b BaseClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.BaseClass",
+		nil, // no parameters
+		b,
+	)
+}
+
+func (b *jsiiProxy_BaseClass) Method() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		b,
+		"method",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_BaseJsii976.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type BaseJsii976 interface {
+}
+
+// The jsii proxy struct for BaseJsii976
+type jsiiProxy_BaseJsii976 struct {
+	_ byte // padding
+}
+
+func NewBaseJsii976() BaseJsii976 {
+	_init_.Initialize()
+
+	j := jsiiProxy_BaseJsii976{}
+
+	_jsii_.Create(
+		"jsii-calc.BaseJsii976",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewBaseJsii976_Override(b BaseJsii976) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.BaseJsii976",
+		nil, // no parameters
+		b,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Bell.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Bell interface {
+	IBell
+	Rung() *bool
+	SetRung(val *bool)
+	Ring()
+}
+
+// The jsii proxy struct for Bell
+type jsiiProxy_Bell struct {
+	jsiiProxy_IBell
+}
+
+func (j *jsiiProxy_Bell) Rung() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"rung",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewBell() Bell {
+	_init_.Initialize()
+
+	j := jsiiProxy_Bell{}
+
+	_jsii_.Create(
+		"jsii-calc.Bell",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewBell_Override(b Bell) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Bell",
+		nil, // no parameters
+		b,
+	)
+}
+
+func (j *jsiiProxy_Bell) SetRung(val *bool) {
+	_jsii_.Set(
+		j,
+		"rung",
+		val,
+	)
+}
+
+func (b *jsiiProxy_Bell) Ring() {
+	_jsii_.InvokeVoid(
+		b,
+		"ring",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_BinaryOperation.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// Represents an operation with two operands.
+type BinaryOperation interface {
+	scopejsiicalclib.Operation
+	scopejsiicalclib.IFriendly
+	// Left-hand side operand.
+	Lhs() scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs() scopejsiicalclib.NumericValue
+	// The value.
+	// Deprecated.
+	Value() *float64
+	// Say hello!
+	Hello() *string
+	// String representation of the value.
+	// Deprecated.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for BinaryOperation
+type jsiiProxy_BinaryOperation struct {
+	internal.Type__scopejsiicalclibOperation
+	internal.Type__scopejsiicalclibIFriendly
+}
+
+func (j *jsiiProxy_BinaryOperation) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"lhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_BinaryOperation) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"rhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_BinaryOperation) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a BinaryOperation.
+func NewBinaryOperation_Override(b BinaryOperation, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.BinaryOperation",
+		[]interface{}{lhs, rhs},
+		b,
+	)
+}
+
+func (b *jsiiProxy_BinaryOperation) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		b,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (b *jsiiProxy_BinaryOperation) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		b,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (b *jsiiProxy_BinaryOperation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		b,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_BurriedAnonymousObject.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// See https://github.com/aws/aws-cdk/issues/7977.
+type BurriedAnonymousObject interface {
+	Check() *bool
+	// Implement this method and have it return it's parameter.
+	//
+	// Returns: \`value\`.
+	GiveItBack(value interface{}) interface{}
+}
+
+// The jsii proxy struct for BurriedAnonymousObject
+type jsiiProxy_BurriedAnonymousObject struct {
+	_ byte // padding
+}
+
+func NewBurriedAnonymousObject_Override(b BurriedAnonymousObject) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.BurriedAnonymousObject",
+		nil, // no parameters
+		b,
+	)
+}
+
+func (b *jsiiProxy_BurriedAnonymousObject) Check() *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		b,
+		"check",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (b *jsiiProxy_BurriedAnonymousObject) GiveItBack(value interface{}) interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		b,
+		"giveItBack",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Calculator.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// A calculator which maintains a current value and allows adding operations.
+//
+// Here's how you use it:
+//
+// \`\`\`ts
+// const calculator = new calc.Calculator();
+// calculator.add(5);
+// calculator.mul(3);
+// console.log(calculator.expression.value);
+// \`\`\`
+//
+// I will repeat this example again, but in an @example tag.
+//
+// Example:
+//   calculator := calc.NewCalculator()
+//   calculator.add(jsii.Number(5))
+//   calculator.mul(jsii.Number(3))
+//   fmt.Println(calculator.expression.value)
+//
+type Calculator interface {
+	composition.CompositeOperation
+	// The current value.
+	Curr() scopejsiicalclib.NumericValue
+	SetCurr(val scopejsiicalclib.NumericValue)
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes() *[]*string
+	SetDecorationPostfixes(val *[]*string)
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes() *[]*string
+	SetDecorationPrefixes(val *[]*string)
+	// Returns the expression.
+	Expression() scopejsiicalclib.NumericValue
+	// The maximum value allows in this calculator.
+	MaxValue() *float64
+	SetMaxValue(val *float64)
+	// A log of all operations.
+	OperationsLog() *[]scopejsiicalclib.NumericValue
+	// A map of per operation name of all operations performed.
+	OperationsMap() *map[string]*[]scopejsiicalclib.NumericValue
+	// The .toString() style.
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
+	// Example of a property that accepts a union of types.
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
+	// The value.
+	Value() *float64
+	// Adds a number to the current value.
+	Add(value *float64)
+	// Multiplies the current value by a number.
+	Mul(value *float64)
+	// Negates the current value.
+	Neg()
+	// Raises the current value by a power.
+	Pow(value *float64)
+	// Returns teh value of the union property (if defined).
+	ReadUnionValue() *float64
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Calculator
+type jsiiProxy_Calculator struct {
+	internal.Type__compositionCompositeOperation
+}
+
+func (j *jsiiProxy_Calculator) Curr() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"curr",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) DecorationPostfixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) DecorationPrefixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) MaxValue() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"maxValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) OperationsLog() *[]scopejsiicalclib.NumericValue {
+	var returns *[]scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"operationsLog",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) OperationsMap() *map[string]*[]scopejsiicalclib.NumericValue {
+	var returns *map[string]*[]scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"operationsMap",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) UnionProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		j,
+		"unionProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Calculator) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a Calculator object.
+func NewCalculator(props *CalculatorProps) Calculator {
+	_init_.Initialize()
+
+	j := jsiiProxy_Calculator{}
+
+	_jsii_.Create(
+		"jsii-calc.Calculator",
+		[]interface{}{props},
+		&j,
+	)
+
+	return &j
+}
+
+// Creates a Calculator object.
+func NewCalculator_Override(c Calculator, props *CalculatorProps) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Calculator",
+		[]interface{}{props},
+		c,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetCurr(val scopejsiicalclib.NumericValue) {
+	_jsii_.Set(
+		j,
+		"curr",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetDecorationPostfixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetDecorationPrefixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetMaxValue(val *float64) {
+	_jsii_.Set(
+		j,
+		"maxValue",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Calculator) SetUnionProperty(val interface{}) {
+	_jsii_.Set(
+		j,
+		"unionProperty",
+		val,
+	)
+}
+
+func (c *jsiiProxy_Calculator) Add(value *float64) {
+	_jsii_.InvokeVoid(
+		c,
+		"add",
+		[]interface{}{value},
+	)
+}
+
+func (c *jsiiProxy_Calculator) Mul(value *float64) {
+	_jsii_.InvokeVoid(
+		c,
+		"mul",
+		[]interface{}{value},
+	)
+}
+
+func (c *jsiiProxy_Calculator) Neg() {
+	_jsii_.InvokeVoid(
+		c,
+		"neg",
+		nil, // no parameters
+	)
+}
+
+func (c *jsiiProxy_Calculator) Pow(value *float64) {
+	_jsii_.InvokeVoid(
+		c,
+		"pow",
+		[]interface{}{value},
+	)
+}
+
+func (c *jsiiProxy_Calculator) ReadUnionValue() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		c,
+		"readUnionValue",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_Calculator) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		c,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_Calculator) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_CalculatorProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Properties for Calculator.
+type CalculatorProps struct {
+	// The initial value of the calculator.
+	//
+	// NOTE: Any number works here, it's fine.
+	InitialValue *float64 \`field:"optional" json:"initialValue" yaml:"initialValue"\`
+	// The maximum value the calculator can store.
+	MaximumValue *float64 \`field:"optional" json:"maximumValue" yaml:"maximumValue"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ChildStruct982.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ChildStruct982 struct {
+	Foo *string \`field:"required" json:"foo" yaml:"foo"\`
+	Bar *float64 \`field:"required" json:"bar" yaml:"bar"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassThatImplementsTheInternalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassThatImplementsTheInternalInterface interface {
+	INonInternalInterface
+	A() *string
+	SetA(val *string)
+	B() *string
+	SetB(val *string)
+	C() *string
+	SetC(val *string)
+	D() *string
+	SetD(val *string)
+}
+
+// The jsii proxy struct for ClassThatImplementsTheInternalInterface
+type jsiiProxy_ClassThatImplementsTheInternalInterface struct {
+	jsiiProxy_INonInternalInterface
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) A() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"a",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) B() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"b",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) C() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"c",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) D() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"d",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassThatImplementsTheInternalInterface() ClassThatImplementsTheInternalInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassThatImplementsTheInternalInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassThatImplementsTheInternalInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassThatImplementsTheInternalInterface_Override(c ClassThatImplementsTheInternalInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassThatImplementsTheInternalInterface",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetA(val *string) {
+	_jsii_.Set(
+		j,
+		"a",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetB(val *string) {
+	_jsii_.Set(
+		j,
+		"b",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetC(val *string) {
+	_jsii_.Set(
+		j,
+		"c",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsTheInternalInterface) SetD(val *string) {
+	_jsii_.Set(
+		j,
+		"d",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassThatImplementsThePrivateInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassThatImplementsThePrivateInterface interface {
+	INonInternalInterface
+	A() *string
+	SetA(val *string)
+	B() *string
+	SetB(val *string)
+	C() *string
+	SetC(val *string)
+	E() *string
+	SetE(val *string)
+}
+
+// The jsii proxy struct for ClassThatImplementsThePrivateInterface
+type jsiiProxy_ClassThatImplementsThePrivateInterface struct {
+	jsiiProxy_INonInternalInterface
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) A() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"a",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) B() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"b",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) C() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"c",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) E() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"e",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassThatImplementsThePrivateInterface() ClassThatImplementsThePrivateInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassThatImplementsThePrivateInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassThatImplementsThePrivateInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassThatImplementsThePrivateInterface_Override(c ClassThatImplementsThePrivateInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassThatImplementsThePrivateInterface",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetA(val *string) {
+	_jsii_.Set(
+		j,
+		"a",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetB(val *string) {
+	_jsii_.Set(
+		j,
+		"b",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetC(val *string) {
+	_jsii_.Set(
+		j,
+		"c",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassThatImplementsThePrivateInterface) SetE(val *string) {
+	_jsii_.Set(
+		j,
+		"e",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithCollections.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassWithCollections interface {
+	Array() *[]*string
+	SetArray(val *[]*string)
+	Map() *map[string]*string
+	SetMap(val *map[string]*string)
+}
+
+// The jsii proxy struct for ClassWithCollections
+type jsiiProxy_ClassWithCollections struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ClassWithCollections) Array() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"array",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassWithCollections) Map() *map[string]*string {
+	var returns *map[string]*string
+	_jsii_.Get(
+		j,
+		"map",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassWithCollections(map_ *map[string]*string, array *[]*string) ClassWithCollections {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassWithCollections{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithCollections",
+		[]interface{}{map_, array},
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassWithCollections_Override(c ClassWithCollections, map_ *map[string]*string, array *[]*string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithCollections",
+		[]interface{}{map_, array},
+		c,
+	)
+}
+
+func (j *jsiiProxy_ClassWithCollections) SetArray(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"array",
+		val,
+	)
+}
+
+func (j *jsiiProxy_ClassWithCollections) SetMap(val *map[string]*string) {
+	_jsii_.Set(
+		j,
+		"map",
+		val,
+	)
+}
+
+func ClassWithCollections_CreateAList() *[]*string {
+	_init_.Initialize()
+
+	var returns *[]*string
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ClassWithCollections",
+		"createAList",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func ClassWithCollections_CreateAMap() *map[string]*string {
+	_init_.Initialize()
+
+	var returns *map[string]*string
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ClassWithCollections",
+		"createAMap",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func ClassWithCollections_StaticArray() *[]*string {
+	_init_.Initialize()
+	var returns *[]*string
+	_jsii_.StaticGet(
+		"jsii-calc.ClassWithCollections",
+		"staticArray",
+		&returns,
+	)
+	return returns
+}
+
+func ClassWithCollections_SetStaticArray(val *[]*string) {
+	_init_.Initialize()
+	_jsii_.StaticSet(
+		"jsii-calc.ClassWithCollections",
+		"staticArray",
+		val,
+	)
+}
+
+func ClassWithCollections_StaticMap() *map[string]*string {
+	_init_.Initialize()
+	var returns *map[string]*string
+	_jsii_.StaticGet(
+		"jsii-calc.ClassWithCollections",
+		"staticMap",
+		&returns,
+	)
+	return returns
+}
+
+func ClassWithCollections_SetStaticMap(val *map[string]*string) {
+	_init_.Initialize()
+	_jsii_.StaticSet(
+		"jsii-calc.ClassWithCollections",
+		"staticMap",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithContainerTypes.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassWithContainerTypes interface {
+	Array() *[]*DummyObj
+	Obj() *map[string]*DummyObj
+	Props() *ContainerProps
+	Record() *map[string]*DummyObj
+}
+
+// The jsii proxy struct for ClassWithContainerTypes
+type jsiiProxy_ClassWithContainerTypes struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ClassWithContainerTypes) Array() *[]*DummyObj {
+	var returns *[]*DummyObj
+	_jsii_.Get(
+		j,
+		"array",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassWithContainerTypes) Obj() *map[string]*DummyObj {
+	var returns *map[string]*DummyObj
+	_jsii_.Get(
+		j,
+		"obj",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassWithContainerTypes) Props() *ContainerProps {
+	var returns *ContainerProps
+	_jsii_.Get(
+		j,
+		"props",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassWithContainerTypes) Record() *map[string]*DummyObj {
+	var returns *map[string]*DummyObj
+	_jsii_.Get(
+		j,
+		"record",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassWithContainerTypes(array *[]*DummyObj, record *map[string]*DummyObj, obj *map[string]*DummyObj, props *ContainerProps) ClassWithContainerTypes {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassWithContainerTypes{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithContainerTypes",
+		[]interface{}{array, record, obj, props},
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassWithContainerTypes_Override(c ClassWithContainerTypes, array *[]*DummyObj, record *map[string]*DummyObj, obj *map[string]*DummyObj, props *ContainerProps) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithContainerTypes",
+		[]interface{}{array, record, obj, props},
+		c,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithDocs.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This class has docs.
+//
+// The docs are great. They're a bunch of tags.
+//
+// Example:
+//   func anExample() {
+//   }
+//
+// See: https://aws.amazon.com/
+//
+type ClassWithDocs interface {
+}
+
+// The jsii proxy struct for ClassWithDocs
+type jsiiProxy_ClassWithDocs struct {
+	_ byte // padding
+}
+
+func NewClassWithDocs() ClassWithDocs {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassWithDocs{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithDocs",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassWithDocs_Override(c ClassWithDocs) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithDocs",
+		nil, // no parameters
+		c,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithJavaReservedWords.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassWithJavaReservedWords interface {
+	Int() *string
+	Import(assert *string) *string
+}
+
+// The jsii proxy struct for ClassWithJavaReservedWords
+type jsiiProxy_ClassWithJavaReservedWords struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ClassWithJavaReservedWords) Int() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"int",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassWithJavaReservedWords(int *string) ClassWithJavaReservedWords {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassWithJavaReservedWords{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithJavaReservedWords",
+		[]interface{}{int},
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassWithJavaReservedWords_Override(c ClassWithJavaReservedWords, int *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithJavaReservedWords",
+		[]interface{}{int},
+		c,
+	)
+}
+
+func (c *jsiiProxy_ClassWithJavaReservedWords) Import(assert *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		c,
+		"import",
+		[]interface{}{assert},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithMutableObjectLiteralProperty.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ClassWithMutableObjectLiteralProperty interface {
+	MutableObject() IMutableObjectLiteral
+	SetMutableObject(val IMutableObjectLiteral)
+}
+
+// The jsii proxy struct for ClassWithMutableObjectLiteralProperty
+type jsiiProxy_ClassWithMutableObjectLiteralProperty struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ClassWithMutableObjectLiteralProperty) MutableObject() IMutableObjectLiteral {
+	var returns IMutableObjectLiteral
+	_jsii_.Get(
+		j,
+		"mutableObject",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClassWithMutableObjectLiteralProperty() ClassWithMutableObjectLiteralProperty {
+	_init_.Initialize()
+
+	j := jsiiProxy_ClassWithMutableObjectLiteralProperty{}
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithMutableObjectLiteralProperty",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClassWithMutableObjectLiteralProperty_Override(c ClassWithMutableObjectLiteralProperty) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ClassWithMutableObjectLiteralProperty",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (j *jsiiProxy_ClassWithMutableObjectLiteralProperty) SetMutableObject(val IMutableObjectLiteral) {
+	_jsii_.Set(
+		j,
+		"mutableObject",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ClassWithPrivateConstructorAndAutomaticProperties.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Class that implements interface properties automatically, but using a private constructor.
+type ClassWithPrivateConstructorAndAutomaticProperties interface {
+	IInterfaceWithProperties
+	ReadOnlyString() *string
+	ReadWriteString() *string
+	SetReadWriteString(val *string)
+}
+
+// The jsii proxy struct for ClassWithPrivateConstructorAndAutomaticProperties
+type jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties struct {
+	jsiiProxy_IInterfaceWithProperties
+}
+
+func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) ReadOnlyString() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readOnlyString",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) ReadWriteString() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readWriteString",
+		&returns,
+	)
+	return returns
+}
+
+
+func (j *jsiiProxy_ClassWithPrivateConstructorAndAutomaticProperties) SetReadWriteString(val *string) {
+	_jsii_.Set(
+		j,
+		"readWriteString",
+		val,
+	)
+}
+
+func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString *string, readWriteString *string) ClassWithPrivateConstructorAndAutomaticProperties {
+	_init_.Initialize()
+
+	var returns ClassWithPrivateConstructorAndAutomaticProperties
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ClassWithPrivateConstructorAndAutomaticProperties",
+		"create",
+		[]interface{}{readOnlyString, readWriteString},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConfusingToJackson.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This tries to confuse Jackson by having overloaded property setters.
+// See: https://github.com/aws/aws-cdk/issues/4080
+//
+type ConfusingToJackson interface {
+	UnionProperty() interface{}
+	SetUnionProperty(val interface{})
+}
+
+// The jsii proxy struct for ConfusingToJackson
+type jsiiProxy_ConfusingToJackson struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ConfusingToJackson) UnionProperty() interface{} {
+	var returns interface{}
+	_jsii_.Get(
+		j,
+		"unionProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func (j *jsiiProxy_ConfusingToJackson) SetUnionProperty(val interface{}) {
+	_jsii_.Set(
+		j,
+		"unionProperty",
+		val,
+	)
+}
+
+func ConfusingToJackson_MakeInstance() ConfusingToJackson {
+	_init_.Initialize()
+
+	var returns ConfusingToJackson
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConfusingToJackson",
+		"makeInstance",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func ConfusingToJackson_MakeStructInstance() *ConfusingToJacksonStruct {
+	_init_.Initialize()
+
+	var returns *ConfusingToJacksonStruct
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConfusingToJackson",
+		"makeStructInstance",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConfusingToJacksonStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ConfusingToJacksonStruct struct {
+	UnionProperty interface{} \`field:"optional" json:"unionProperty" yaml:"unionProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConstructorPassesThisOut.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ConstructorPassesThisOut interface {
+}
+
+// The jsii proxy struct for ConstructorPassesThisOut
+type jsiiProxy_ConstructorPassesThisOut struct {
+	_ byte // padding
+}
+
+func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumer) ConstructorPassesThisOut {
+	_init_.Initialize()
+
+	j := jsiiProxy_ConstructorPassesThisOut{}
+
+	_jsii_.Create(
+		"jsii-calc.ConstructorPassesThisOut",
+		[]interface{}{consumer},
+		&j,
+	)
+
+	return &j
+}
+
+func NewConstructorPassesThisOut_Override(c ConstructorPassesThisOut, consumer PartiallyInitializedThisConsumer) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ConstructorPassesThisOut",
+		[]interface{}{consumer},
+		c,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Constructors.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Constructors interface {
+}
+
+// The jsii proxy struct for Constructors
+type jsiiProxy_Constructors struct {
+	_ byte // padding
+}
+
+func NewConstructors() Constructors {
+	_init_.Initialize()
+
+	j := jsiiProxy_Constructors{}
+
+	_jsii_.Create(
+		"jsii-calc.Constructors",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewConstructors_Override(c Constructors) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Constructors",
+		nil, // no parameters
+		c,
+	)
+}
+
+func Constructors_HiddenInterface() IPublicInterface {
+	_init_.Initialize()
+
+	var returns IPublicInterface
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"hiddenInterface",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_HiddenInterfaces() *[]IPublicInterface {
+	_init_.Initialize()
+
+	var returns *[]IPublicInterface
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"hiddenInterfaces",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_HiddenSubInterfaces() *[]IPublicInterface {
+	_init_.Initialize()
+
+	var returns *[]IPublicInterface
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"hiddenSubInterfaces",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_MakeClass() PublicClass {
+	_init_.Initialize()
+
+	var returns PublicClass
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"makeClass",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_MakeInterface() IPublicInterface {
+	_init_.Initialize()
+
+	var returns IPublicInterface
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"makeInterface",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_MakeInterface2() IPublicInterface2 {
+	_init_.Initialize()
+
+	var returns IPublicInterface2
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"makeInterface2",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func Constructors_MakeInterfaces() *[]IPublicInterface {
+	_init_.Initialize()
+
+	var returns *[]IPublicInterface
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Constructors",
+		"makeInterfaces",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConsumePureInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ConsumePureInterface interface {
+	WorkItBaby() *StructB
+}
+
+// The jsii proxy struct for ConsumePureInterface
+type jsiiProxy_ConsumePureInterface struct {
+	_ byte // padding
+}
+
+func NewConsumePureInterface(delegate IStructReturningDelegate) ConsumePureInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ConsumePureInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ConsumePureInterface",
+		[]interface{}{delegate},
+		&j,
+	)
+
+	return &j
+}
+
+func NewConsumePureInterface_Override(c ConsumePureInterface, delegate IStructReturningDelegate) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ConsumePureInterface",
+		[]interface{}{delegate},
+		c,
+	)
+}
+
+func (c *jsiiProxy_ConsumePureInterface) WorkItBaby() *StructB {
+	var returns *StructB
+
+	_jsii_.Invoke(
+		c,
+		"workItBaby",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConsumerCanRingBell.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Test calling back to consumers that implement interfaces.
+//
+// Check that if a JSII consumer implements IConsumerWithInterfaceParam, they can call
+// the method on the argument that they're passed...
+type ConsumerCanRingBell interface {
+	// ...if the interface is implemented using an object literal.
+	//
+	// Returns whether the bell was rung.
+	ImplementedByObjectLiteral(ringer IBellRinger) *bool
+	// ...if the interface is implemented using a private class.
+	//
+	// Return whether the bell was rung.
+	ImplementedByPrivateClass(ringer IBellRinger) *bool
+	// ...if the interface is implemented using a public class.
+	//
+	// Return whether the bell was rung.
+	ImplementedByPublicClass(ringer IBellRinger) *bool
+	// If the parameter is a concrete class instead of an interface.
+	//
+	// Return whether the bell was rung.
+	WhenTypedAsClass(ringer IConcreteBellRinger) *bool
+}
+
+// The jsii proxy struct for ConsumerCanRingBell
+type jsiiProxy_ConsumerCanRingBell struct {
+	_ byte // padding
+}
+
+func NewConsumerCanRingBell() ConsumerCanRingBell {
+	_init_.Initialize()
+
+	j := jsiiProxy_ConsumerCanRingBell{}
+
+	_jsii_.Create(
+		"jsii-calc.ConsumerCanRingBell",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewConsumerCanRingBell_Override(c ConsumerCanRingBell) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ConsumerCanRingBell",
+		nil, // no parameters
+		c,
+	)
+}
+
+// ...if the interface is implemented using an object literal.
+//
+// Returns whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRinger) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConsumerCanRingBell",
+		"staticImplementedByObjectLiteral",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+// ...if the interface is implemented using a private class.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRinger) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConsumerCanRingBell",
+		"staticImplementedByPrivateClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+// ...if the interface is implemented using a public class.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRinger) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConsumerCanRingBell",
+		"staticImplementedByPublicClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+// If the parameter is a concrete class instead of an interface.
+//
+// Return whether the bell was rung.
+func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRinger) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ConsumerCanRingBell",
+		"staticWhenTypedAsClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByObjectLiteral(ringer IBellRinger) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		c,
+		"implementedByObjectLiteral",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByPrivateClass(ringer IBellRinger) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		c,
+		"implementedByPrivateClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_ConsumerCanRingBell) ImplementedByPublicClass(ringer IBellRinger) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		c,
+		"implementedByPublicClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRinger) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		c,
+		"whenTypedAsClass",
+		[]interface{}{ringer},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ConsumersOfThisCrazyTypeSystem.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ConsumersOfThisCrazyTypeSystem interface {
+	ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) *string
+	ConsumeNonInternalInterface(obj INonInternalInterface) interface{}
+}
+
+// The jsii proxy struct for ConsumersOfThisCrazyTypeSystem
+type jsiiProxy_ConsumersOfThisCrazyTypeSystem struct {
+	_ byte // padding
+}
+
+func NewConsumersOfThisCrazyTypeSystem() ConsumersOfThisCrazyTypeSystem {
+	_init_.Initialize()
+
+	j := jsiiProxy_ConsumersOfThisCrazyTypeSystem{}
+
+	_jsii_.Create(
+		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewConsumersOfThisCrazyTypeSystem_Override(c ConsumersOfThisCrazyTypeSystem) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ConsumersOfThisCrazyTypeSystem",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (c *jsiiProxy_ConsumersOfThisCrazyTypeSystem) ConsumeAnotherPublicInterface(obj IAnotherPublicInterface) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		c,
+		"consumeAnotherPublicInterface",
+		[]interface{}{obj},
+		&returns,
+	)
+
+	return returns
+}
+
+func (c *jsiiProxy_ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(obj INonInternalInterface) interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"consumeNonInternalInterface",
+		[]interface{}{obj},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ContainerProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ContainerProps struct {
+	ArrayProp *[]*DummyObj \`field:"required" json:"arrayProp" yaml:"arrayProp"\`
+	ObjProp *map[string]*DummyObj \`field:"required" json:"objProp" yaml:"objProp"\`
+	RecordProp *map[string]*DummyObj \`field:"required" json:"recordProp" yaml:"recordProp"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DataRenderer.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// Verifies proper type handling through dynamic overrides.
+type DataRenderer interface {
+	Render(data *scopejsiicalclib.MyFirstStruct) *string
+	RenderArbitrary(data *map[string]interface{}) *string
+	RenderMap(map_ *map[string]interface{}) *string
+}
+
+// The jsii proxy struct for DataRenderer
+type jsiiProxy_DataRenderer struct {
+	_ byte // padding
+}
+
+func NewDataRenderer() DataRenderer {
+	_init_.Initialize()
+
+	j := jsiiProxy_DataRenderer{}
+
+	_jsii_.Create(
+		"jsii-calc.DataRenderer",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDataRenderer_Override(d DataRenderer) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DataRenderer",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DataRenderer) Render(data *scopejsiicalclib.MyFirstStruct) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"render",
+		[]interface{}{data},
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_DataRenderer) RenderArbitrary(data *map[string]interface{}) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"renderArbitrary",
+		[]interface{}{data},
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_DataRenderer) RenderMap(map_ *map[string]interface{}) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"renderMap",
+		[]interface{}{map_},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Default.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// A class named "Default".
+// See: https://github.com/aws/jsii/issues/2637
+//
+type Default interface {
+	PleaseCompile()
+}
+
+// The jsii proxy struct for Default
+type jsiiProxy_Default struct {
+	_ byte // padding
+}
+
+func NewDefault() Default {
+	_init_.Initialize()
+
+	j := jsiiProxy_Default{}
+
+	_jsii_.Create(
+		"jsii-calc.Default",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDefault_Override(d Default) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Default",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_Default) PleaseCompile() {
+	_jsii_.InvokeVoid(
+		d,
+		"pleaseCompile",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DefaultedConstructorArgument.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type DefaultedConstructorArgument interface {
+	Arg1() *float64
+	Arg2() *string
+	Arg3() *time.Time
+}
+
+// The jsii proxy struct for DefaultedConstructorArgument
+type jsiiProxy_DefaultedConstructorArgument struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_DefaultedConstructorArgument) Arg1() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"arg1",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DefaultedConstructorArgument) Arg2() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"arg2",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DefaultedConstructorArgument) Arg3() *time.Time {
+	var returns *time.Time
+	_jsii_.Get(
+		j,
+		"arg3",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewDefaultedConstructorArgument(arg1 *float64, arg2 *string, arg3 *time.Time) DefaultedConstructorArgument {
+	_init_.Initialize()
+
+	j := jsiiProxy_DefaultedConstructorArgument{}
+
+	_jsii_.Create(
+		"jsii-calc.DefaultedConstructorArgument",
+		[]interface{}{arg1, arg2, arg3},
+		&j,
+	)
+
+	return &j
+}
+
+func NewDefaultedConstructorArgument_Override(d DefaultedConstructorArgument, arg1 *float64, arg2 *string, arg3 *time.Time) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DefaultedConstructorArgument",
+		[]interface{}{arg1, arg2, arg3},
+		d,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Demonstrate982.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// 1.
+//
+// call #takeThis() -> An ObjectRef will be provisioned for the value (it'll be re-used!)
+// 2. call #takeThisToo() -> The ObjectRef from before will need to be down-cased to the ParentStruct982 type
+type Demonstrate982 interface {
+}
+
+// The jsii proxy struct for Demonstrate982
+type jsiiProxy_Demonstrate982 struct {
+	_ byte // padding
+}
+
+func NewDemonstrate982() Demonstrate982 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Demonstrate982{}
+
+	_jsii_.Create(
+		"jsii-calc.Demonstrate982",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDemonstrate982_Override(d Demonstrate982) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Demonstrate982",
+		nil, // no parameters
+		d,
+	)
+}
+
+// It's dangerous to go alone!
+func Demonstrate982_TakeThis() *ChildStruct982 {
+	_init_.Initialize()
+
+	var returns *ChildStruct982
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Demonstrate982",
+		"takeThis",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+// It's dangerous to go alone!
+func Demonstrate982_TakeThisToo() *ParentStruct982 {
+	_init_.Initialize()
+
+	var returns *ParentStruct982
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Demonstrate982",
+		"takeThisToo",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DeprecatedClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Deprecated: a pretty boring class.
+type DeprecatedClass interface {
+	// Deprecated: shouldn't have been mutable.
+	MutableProperty() *float64
+	// Deprecated: shouldn't have been mutable.
+	SetMutableProperty(val *float64)
+	// Deprecated: this is not always "wazoo", be ready to be disappointed.
+	ReadonlyProperty() *string
+	// Deprecated: it was a bad idea.
+	Method()
+}
+
+// The jsii proxy struct for DeprecatedClass
+type jsiiProxy_DeprecatedClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_DeprecatedClass) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DeprecatedClass) ReadonlyProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+// Deprecated: this constructor is "just" okay.
+func NewDeprecatedClass(readonlyString *string, mutableNumber *float64) DeprecatedClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_DeprecatedClass{}
+
+	_jsii_.Create(
+		"jsii-calc.DeprecatedClass",
+		[]interface{}{readonlyString, mutableNumber},
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated: this constructor is "just" okay.
+func NewDeprecatedClass_Override(d DeprecatedClass, readonlyString *string, mutableNumber *float64) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DeprecatedClass",
+		[]interface{}{readonlyString, mutableNumber},
+		d,
+	)
+}
+
+func (j *jsiiProxy_DeprecatedClass) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+func (d *jsiiProxy_DeprecatedClass) Method() {
+	_jsii_.InvokeVoid(
+		d,
+		"method",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DeprecatedEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Deprecated: your deprecated selection of bad options.
+type DeprecatedEnum string
+
+const (
+	// Deprecated: option A is not great.
+	DeprecatedEnum_OPTION_A DeprecatedEnum = "OPTION_A"
+	// Deprecated: option B is kinda bad, too.
+	DeprecatedEnum_OPTION_B DeprecatedEnum = "OPTION_B"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DeprecatedStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Deprecated: it just wraps a string.
+type DeprecatedStruct struct {
+	// Deprecated: well, yeah.
+	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DerivedStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// A struct which derives from another struct.
+type DerivedStruct struct {
+	// An awesome number value.
+	// Deprecated.
+	Anumber *float64 \`field:"required" json:"anumber" yaml:"anumber"\`
+	// A string value.
+	// Deprecated.
+	Astring *string \`field:"required" json:"astring" yaml:"astring"\`
+	// Deprecated.
+	FirstOptional *[]*string \`field:"optional" json:"firstOptional" yaml:"firstOptional"\`
+	AnotherRequired *time.Time \`field:"required" json:"anotherRequired" yaml:"anotherRequired"\`
+	Bool *bool \`field:"required" json:"bool" yaml:"bool"\`
+	// An example of a non primitive property.
+	NonPrimitive DoubleTrouble \`field:"required" json:"nonPrimitive" yaml:"nonPrimitive"\`
+	// This is optional.
+	AnotherOptional *map[string]scopejsiicalclib.NumericValue \`field:"optional" json:"anotherOptional" yaml:"anotherOptional"\`
+	OptionalAny interface{} \`field:"optional" json:"optionalAny" yaml:"optionalAny"\`
+	OptionalArray *[]*string \`field:"optional" json:"optionalArray" yaml:"optionalArray"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DiamondBottom.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+)
+
+type DiamondBottom struct {
+	// Deprecated.
+	HoistedTop *string \`field:"optional" json:"hoistedTop" yaml:"hoistedTop"\`
+	// Deprecated.
+	Left *float64 \`field:"optional" json:"left" yaml:"left"\`
+	// Deprecated.
+	Right *bool \`field:"optional" json:"right" yaml:"right"\`
+	Bottom *time.Time \`field:"optional" json:"bottom" yaml:"bottom"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DiamondInheritanceBaseLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type DiamondInheritanceBaseLevelStruct struct {
+	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DiamondInheritanceFirstMidLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type DiamondInheritanceFirstMidLevelStruct struct {
+	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
+	FirstMidLevelProperty *string \`field:"required" json:"firstMidLevelProperty" yaml:"firstMidLevelProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DiamondInheritanceSecondMidLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type DiamondInheritanceSecondMidLevelStruct struct {
+	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
+	SecondMidLevelProperty *string \`field:"required" json:"secondMidLevelProperty" yaml:"secondMidLevelProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DiamondInheritanceTopLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type DiamondInheritanceTopLevelStruct struct {
+	BaseLevelProperty *string \`field:"required" json:"baseLevelProperty" yaml:"baseLevelProperty"\`
+	FirstMidLevelProperty *string \`field:"required" json:"firstMidLevelProperty" yaml:"firstMidLevelProperty"\`
+	SecondMidLevelProperty *string \`field:"required" json:"secondMidLevelProperty" yaml:"secondMidLevelProperty"\`
+	TopLevelProperty *string \`field:"required" json:"topLevelProperty" yaml:"topLevelProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DisappointingCollectionSource.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Verifies that null/undefined can be returned for optional collections.
+//
+// This source of collections is disappointing - it'll always give you nothing :(.
+type DisappointingCollectionSource interface {
+}
+
+// The jsii proxy struct for DisappointingCollectionSource
+type jsiiProxy_DisappointingCollectionSource struct {
+	_ byte // padding
+}
+
+func DisappointingCollectionSource_MaybeList() *[]*string {
+	_init_.Initialize()
+	var returns *[]*string
+	_jsii_.StaticGet(
+		"jsii-calc.DisappointingCollectionSource",
+		"maybeList",
+		&returns,
+	)
+	return returns
+}
+
+func DisappointingCollectionSource_MaybeMap() *map[string]*float64 {
+	_init_.Initialize()
+	var returns *map[string]*float64
+	_jsii_.StaticGet(
+		"jsii-calc.DisappointingCollectionSource",
+		"maybeMap",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DoNotOverridePrivates.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type DoNotOverridePrivates interface {
+	ChangePrivatePropertyValue(newValue *string)
+	PrivateMethodValue() *string
+	PrivatePropertyValue() *string
+}
+
+// The jsii proxy struct for DoNotOverridePrivates
+type jsiiProxy_DoNotOverridePrivates struct {
+	_ byte // padding
+}
+
+func NewDoNotOverridePrivates() DoNotOverridePrivates {
+	_init_.Initialize()
+
+	j := jsiiProxy_DoNotOverridePrivates{}
+
+	_jsii_.Create(
+		"jsii-calc.DoNotOverridePrivates",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDoNotOverridePrivates_Override(d DoNotOverridePrivates) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DoNotOverridePrivates",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DoNotOverridePrivates) ChangePrivatePropertyValue(newValue *string) {
+	_jsii_.InvokeVoid(
+		d,
+		"changePrivatePropertyValue",
+		[]interface{}{newValue},
+	)
+}
+
+func (d *jsiiProxy_DoNotOverridePrivates) PrivateMethodValue() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"privateMethodValue",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_DoNotOverridePrivates) PrivatePropertyValue() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"privatePropertyValue",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DoNotRecognizeAnyAsOptional.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// jsii#284: do not recognize "any" as an optional argument.
+type DoNotRecognizeAnyAsOptional interface {
+	Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString *string)
+}
+
+// The jsii proxy struct for DoNotRecognizeAnyAsOptional
+type jsiiProxy_DoNotRecognizeAnyAsOptional struct {
+	_ byte // padding
+}
+
+func NewDoNotRecognizeAnyAsOptional() DoNotRecognizeAnyAsOptional {
+	_init_.Initialize()
+
+	j := jsiiProxy_DoNotRecognizeAnyAsOptional{}
+
+	_jsii_.Create(
+		"jsii-calc.DoNotRecognizeAnyAsOptional",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDoNotRecognizeAnyAsOptional_Override(d DoNotRecognizeAnyAsOptional) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DoNotRecognizeAnyAsOptional",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DoNotRecognizeAnyAsOptional) Method(_requiredAny interface{}, _optionalAny interface{}, _optionalString *string) {
+	_jsii_.InvokeVoid(
+		d,
+		"method",
+		[]interface{}{_requiredAny, _optionalAny, _optionalString},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DocumentedClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Here's the first line of the TSDoc comment.
+//
+// This is the meat of the TSDoc comment. It may contain
+// multiple lines and multiple paragraphs.
+//
+// Multiple paragraphs are separated by an empty line.
+//
+// Example:
+//   x := 12 + 44
+//   s1 := "string"
+//   s2 := "string \\nwith new newlines" // see https://github.com/aws/jsii/issues/2569
+//   s3 := "string\\n            with\\n            new lines"
+//
+type DocumentedClass interface {
+	// Greet the indicated person.
+	//
+	// This will print out a friendly greeting intended for the indicated person.
+	//
+	// Returns: A number that everyone knows very well and represents the answer
+	// to the ultimate question.
+	Greet(greetee *Greetee) *float64
+	// Say ¡Hola!
+	// Experimental.
+	Hola()
+}
+
+// The jsii proxy struct for DocumentedClass
+type jsiiProxy_DocumentedClass struct {
+	_ byte // padding
+}
+
+func NewDocumentedClass() DocumentedClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_DocumentedClass{}
+
+	_jsii_.Create(
+		"jsii-calc.DocumentedClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDocumentedClass_Override(d DocumentedClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DocumentedClass",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DocumentedClass) Greet(greetee *Greetee) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		d,
+		"greet",
+		[]interface{}{greetee},
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_DocumentedClass) Hola() {
+	_jsii_.InvokeVoid(
+		d,
+		"hola",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type DontComplainAboutVariadicAfterOptional interface {
+	OptionalAndVariadic(optional *string, things ...*string) *string
+}
+
+// The jsii proxy struct for DontComplainAboutVariadicAfterOptional
+type jsiiProxy_DontComplainAboutVariadicAfterOptional struct {
+	_ byte // padding
+}
+
+func NewDontComplainAboutVariadicAfterOptional() DontComplainAboutVariadicAfterOptional {
+	_init_.Initialize()
+
+	j := jsiiProxy_DontComplainAboutVariadicAfterOptional{}
+
+	_jsii_.Create(
+		"jsii-calc.DontComplainAboutVariadicAfterOptional",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDontComplainAboutVariadicAfterOptional_Override(d DontComplainAboutVariadicAfterOptional) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DontComplainAboutVariadicAfterOptional",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional *string, things ...*string) *string {
+	args := []interface{}{optional}
+	for _, a := range things {
+		args = append(args, a)
+	}
+
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"optionalAndVariadic",
+		args,
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DoubleTrouble.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type DoubleTrouble interface {
+	IFriendlyRandomGenerator
+	// Say hello!
+	Hello() *string
+	// Returns another random number.
+	Next() *float64
+}
+
+// The jsii proxy struct for DoubleTrouble
+type jsiiProxy_DoubleTrouble struct {
+	jsiiProxy_IFriendlyRandomGenerator
+}
+
+func NewDoubleTrouble() DoubleTrouble {
+	_init_.Initialize()
+
+	j := jsiiProxy_DoubleTrouble{}
+
+	_jsii_.Create(
+		"jsii-calc.DoubleTrouble",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewDoubleTrouble_Override(d DoubleTrouble) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DoubleTrouble",
+		nil, // no parameters
+		d,
+	)
+}
+
+func (d *jsiiProxy_DoubleTrouble) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (d *jsiiProxy_DoubleTrouble) Next() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		d,
+		"next",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DummyObj.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type DummyObj struct {
+	Example *string \`field:"required" json:"example" yaml:"example"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DynamicPropertyBearer.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Ensures we can override a dynamic property that was inherited.
+type DynamicPropertyBearer interface {
+	DynamicProperty() *string
+	SetDynamicProperty(val *string)
+	ValueStore() *string
+	SetValueStore(val *string)
+}
+
+// The jsii proxy struct for DynamicPropertyBearer
+type jsiiProxy_DynamicPropertyBearer struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_DynamicPropertyBearer) DynamicProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"dynamicProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DynamicPropertyBearer) ValueStore() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"valueStore",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewDynamicPropertyBearer(valueStore *string) DynamicPropertyBearer {
+	_init_.Initialize()
+
+	j := jsiiProxy_DynamicPropertyBearer{}
+
+	_jsii_.Create(
+		"jsii-calc.DynamicPropertyBearer",
+		[]interface{}{valueStore},
+		&j,
+	)
+
+	return &j
+}
+
+func NewDynamicPropertyBearer_Override(d DynamicPropertyBearer, valueStore *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DynamicPropertyBearer",
+		[]interface{}{valueStore},
+		d,
+	)
+}
+
+func (j *jsiiProxy_DynamicPropertyBearer) SetDynamicProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"dynamicProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_DynamicPropertyBearer) SetValueStore(val *string) {
+	_jsii_.Set(
+		j,
+		"valueStore",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_DynamicPropertyBearerChild.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type DynamicPropertyBearerChild interface {
+	DynamicPropertyBearer
+	DynamicProperty() *string
+	SetDynamicProperty(val *string)
+	OriginalValue() *string
+	ValueStore() *string
+	SetValueStore(val *string)
+	// Sets \`this.dynamicProperty\` to the new value, and returns the old value.
+	//
+	// Returns: the old value that was set.
+	OverrideValue(newValue *string) *string
+}
+
+// The jsii proxy struct for DynamicPropertyBearerChild
+type jsiiProxy_DynamicPropertyBearerChild struct {
+	jsiiProxy_DynamicPropertyBearer
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) DynamicProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"dynamicProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) OriginalValue() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"originalValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) ValueStore() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"valueStore",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewDynamicPropertyBearerChild(originalValue *string) DynamicPropertyBearerChild {
+	_init_.Initialize()
+
+	j := jsiiProxy_DynamicPropertyBearerChild{}
+
+	_jsii_.Create(
+		"jsii-calc.DynamicPropertyBearerChild",
+		[]interface{}{originalValue},
+		&j,
+	)
+
+	return &j
+}
+
+func NewDynamicPropertyBearerChild_Override(d DynamicPropertyBearerChild, originalValue *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.DynamicPropertyBearerChild",
+		[]interface{}{originalValue},
+		d,
+	)
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) SetDynamicProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"dynamicProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_DynamicPropertyBearerChild) SetValueStore(val *string) {
+	_jsii_.Set(
+		j,
+		"valueStore",
+		val,
+	)
+}
+
+func (d *jsiiProxy_DynamicPropertyBearerChild) OverrideValue(newValue *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		d,
+		"overrideValue",
+		[]interface{}{newValue},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Entropy.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This class is used to validate that serialization and deserialization does not interpret ISO-8601-formatted timestampts to the native date/time object, as the jsii protocol has a $jsii$date wrapper for this purpose (node's JSON parsing does *NOT* detect dates automatically in this way, so host libraries should not either).
+type Entropy interface {
+	// Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
+	//
+	// Returns: the time from the \`WallClock\`.
+	Increase() *string
+	// Implement this method such that it returns \`word\`.
+	//
+	// Returns: \`word\`.
+	Repeat(word *string) *string
+}
+
+// The jsii proxy struct for Entropy
+type jsiiProxy_Entropy struct {
+	_ byte // padding
+}
+
+// Creates a new instance of Entropy.
+func NewEntropy_Override(e Entropy, clock IWallClock) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Entropy",
+		[]interface{}{clock},
+		e,
+	)
+}
+
+func (e *jsiiProxy_Entropy) Increase() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		e,
+		"increase",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (e *jsiiProxy_Entropy) Repeat(word *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		e,
+		"repeat",
+		[]interface{}{word},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_EnumDispenser.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type EnumDispenser interface {
+}
+
+// The jsii proxy struct for EnumDispenser
+type jsiiProxy_EnumDispenser struct {
+	_ byte // padding
+}
+
+func EnumDispenser_RandomIntegerLikeEnum() AllTypesEnum {
+	_init_.Initialize()
+
+	var returns AllTypesEnum
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.EnumDispenser",
+		"randomIntegerLikeEnum",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func EnumDispenser_RandomStringLikeEnum() StringEnum {
+	_init_.Initialize()
+
+	var returns StringEnum
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.EnumDispenser",
+		"randomStringLikeEnum",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_EraseUndefinedHashValues.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type EraseUndefinedHashValues interface {
+}
+
+// The jsii proxy struct for EraseUndefinedHashValues
+type jsiiProxy_EraseUndefinedHashValues struct {
+	_ byte // padding
+}
+
+func NewEraseUndefinedHashValues() EraseUndefinedHashValues {
+	_init_.Initialize()
+
+	j := jsiiProxy_EraseUndefinedHashValues{}
+
+	_jsii_.Create(
+		"jsii-calc.EraseUndefinedHashValues",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewEraseUndefinedHashValues_Override(e EraseUndefinedHashValues) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.EraseUndefinedHashValues",
+		nil, // no parameters
+		e,
+	)
+}
+
+// Returns \`true\` if \`key\` is defined in \`opts\`.
+//
+// Used to check that undefined/null hash values
+// are being erased when sending values from native code to JS.
+func EraseUndefinedHashValues_DoesKeyExist(opts *EraseUndefinedHashValuesOptions, key *string) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.EraseUndefinedHashValues",
+		"doesKeyExist",
+		[]interface{}{opts, key},
+		&returns,
+	)
+
+	return returns
+}
+
+// We expect "prop1" to be erased.
+func EraseUndefinedHashValues_Prop1IsNull() *map[string]interface{} {
+	_init_.Initialize()
+
+	var returns *map[string]interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.EraseUndefinedHashValues",
+		"prop1IsNull",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+// We expect "prop2" to be erased.
+func EraseUndefinedHashValues_Prop2IsUndefined() *map[string]interface{} {
+	_init_.Initialize()
+
+	var returns *map[string]interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.EraseUndefinedHashValues",
+		"prop2IsUndefined",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_EraseUndefinedHashValuesOptions.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type EraseUndefinedHashValuesOptions struct {
+	Option1 *string \`field:"optional" json:"option1" yaml:"option1"\`
+	Option2 *string \`field:"optional" json:"option2" yaml:"option2"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExperimentalClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Experimental.
+type ExperimentalClass interface {
+	// Experimental.
+	MutableProperty() *float64
+	// Experimental.
+	SetMutableProperty(val *float64)
+	// Experimental.
+	ReadonlyProperty() *string
+	// Experimental.
+	Method()
+}
+
+// The jsii proxy struct for ExperimentalClass
+type jsiiProxy_ExperimentalClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ExperimentalClass) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ExperimentalClass) ReadonlyProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+// Experimental.
+func NewExperimentalClass(readonlyString *string, mutableNumber *float64) ExperimentalClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_ExperimentalClass{}
+
+	_jsii_.Create(
+		"jsii-calc.ExperimentalClass",
+		[]interface{}{readonlyString, mutableNumber},
+		&j,
+	)
+
+	return &j
+}
+
+// Experimental.
+func NewExperimentalClass_Override(e ExperimentalClass, readonlyString *string, mutableNumber *float64) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ExperimentalClass",
+		[]interface{}{readonlyString, mutableNumber},
+		e,
+	)
+}
+
+func (j *jsiiProxy_ExperimentalClass) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+func (e *jsiiProxy_ExperimentalClass) Method() {
+	_jsii_.InvokeVoid(
+		e,
+		"method",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExperimentalEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Experimental.
+type ExperimentalEnum string
+
+const (
+	// Experimental.
+	ExperimentalEnum_OPTION_A ExperimentalEnum = "OPTION_A"
+	// Experimental.
+	ExperimentalEnum_OPTION_B ExperimentalEnum = "OPTION_B"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExperimentalStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Experimental.
+type ExperimentalStruct struct {
+	// Experimental.
+	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExportedBaseClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ExportedBaseClass interface {
+	Success() *bool
+}
+
+// The jsii proxy struct for ExportedBaseClass
+type jsiiProxy_ExportedBaseClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ExportedBaseClass) Success() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"success",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewExportedBaseClass(success *bool) ExportedBaseClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_ExportedBaseClass{}
+
+	_jsii_.Create(
+		"jsii-calc.ExportedBaseClass",
+		[]interface{}{success},
+		&j,
+	)
+
+	return &j
+}
+
+func NewExportedBaseClass_Override(e ExportedBaseClass, success *bool) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ExportedBaseClass",
+		[]interface{}{success},
+		e,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExtendsInternalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ExtendsInternalInterface struct {
+	Boom *bool \`field:"required" json:"boom" yaml:"boom"\`
+	Prop *string \`field:"required" json:"prop" yaml:"prop"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExternalClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ExternalClass interface {
+	MutableProperty() *float64
+	SetMutableProperty(val *float64)
+	ReadonlyProperty() *string
+	Method()
+}
+
+// The jsii proxy struct for ExternalClass
+type jsiiProxy_ExternalClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ExternalClass) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_ExternalClass) ReadonlyProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewExternalClass(readonlyString *string, mutableNumber *float64) ExternalClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_ExternalClass{}
+
+	_jsii_.Create(
+		"jsii-calc.ExternalClass",
+		[]interface{}{readonlyString, mutableNumber},
+		&j,
+	)
+
+	return &j
+}
+
+func NewExternalClass_Override(e ExternalClass, readonlyString *string, mutableNumber *float64) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ExternalClass",
+		[]interface{}{readonlyString, mutableNumber},
+		e,
+	)
+}
+
+func (j *jsiiProxy_ExternalClass) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+func (e *jsiiProxy_ExternalClass) Method() {
+	_jsii_.InvokeVoid(
+		e,
+		"method",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExternalEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ExternalEnum string
+
+const (
+	ExternalEnum_OPTION_A ExternalEnum = "OPTION_A"
+	ExternalEnum_OPTION_B ExternalEnum = "OPTION_B"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ExternalStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type ExternalStruct struct {
+	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_FullCombo.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type FullCombo interface {
+	BaseClass
+	IIndirectlyImplemented
+	Property() *string
+	Method() *float64
+}
+
+// The jsii proxy struct for FullCombo
+type jsiiProxy_FullCombo struct {
+	jsiiProxy_BaseClass
+	jsiiProxy_IIndirectlyImplemented
+}
+
+func (j *jsiiProxy_FullCombo) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+func (f *jsiiProxy_FullCombo) Method() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		f,
+		"method",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_GiveMeStructs.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type GiveMeStructs interface {
+	StructLiteral() *scopejsiicalclib.StructWithOnlyOptionals
+	// Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
+	DerivedToFirst(derived *DerivedStruct) *scopejsiicalclib.MyFirstStruct
+	// Returns the boolean from a DerivedStruct struct.
+	ReadDerivedNonPrimitive(derived *DerivedStruct) DoubleTrouble
+	// Returns the "anumber" from a MyFirstStruct struct;.
+	ReadFirstNumber(first *scopejsiicalclib.MyFirstStruct) *float64
+}
+
+// The jsii proxy struct for GiveMeStructs
+type jsiiProxy_GiveMeStructs struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_GiveMeStructs) StructLiteral() *scopejsiicalclib.StructWithOnlyOptionals {
+	var returns *scopejsiicalclib.StructWithOnlyOptionals
+	_jsii_.Get(
+		j,
+		"structLiteral",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewGiveMeStructs() GiveMeStructs {
+	_init_.Initialize()
+
+	j := jsiiProxy_GiveMeStructs{}
+
+	_jsii_.Create(
+		"jsii-calc.GiveMeStructs",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewGiveMeStructs_Override(g GiveMeStructs) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.GiveMeStructs",
+		nil, // no parameters
+		g,
+	)
+}
+
+func (g *jsiiProxy_GiveMeStructs) DerivedToFirst(derived *DerivedStruct) *scopejsiicalclib.MyFirstStruct {
+	var returns *scopejsiicalclib.MyFirstStruct
+
+	_jsii_.Invoke(
+		g,
+		"derivedToFirst",
+		[]interface{}{derived},
+		&returns,
+	)
+
+	return returns
+}
+
+func (g *jsiiProxy_GiveMeStructs) ReadDerivedNonPrimitive(derived *DerivedStruct) DoubleTrouble {
+	var returns DoubleTrouble
+
+	_jsii_.Invoke(
+		g,
+		"readDerivedNonPrimitive",
+		[]interface{}{derived},
+		&returns,
+	)
+
+	return returns
+}
+
+func (g *jsiiProxy_GiveMeStructs) ReadFirstNumber(first *scopejsiicalclib.MyFirstStruct) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		g,
+		"readFirstNumber",
+		[]interface{}{first},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Greetee.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// These are some arguments you can pass to a method.
+type Greetee struct {
+	// The name of the greetee.
+	Name *string \`field:"optional" json:"name" yaml:"name"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_GreetingAugmenter.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type GreetingAugmenter interface {
+	BetterGreeting(friendly scopejsiicalclib.IFriendly) *string
+}
+
+// The jsii proxy struct for GreetingAugmenter
+type jsiiProxy_GreetingAugmenter struct {
+	_ byte // padding
+}
+
+func NewGreetingAugmenter() GreetingAugmenter {
+	_init_.Initialize()
+
+	j := jsiiProxy_GreetingAugmenter{}
+
+	_jsii_.Create(
+		"jsii-calc.GreetingAugmenter",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewGreetingAugmenter_Override(g GreetingAugmenter) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.GreetingAugmenter",
+		nil, // no parameters
+		g,
+	)
+}
+
+func (g *jsiiProxy_GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.IFriendly) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		g,
+		"betterGreeting",
+		[]interface{}{friendly},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IAnonymousImplementationProvider.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// We can return an anonymous interface implementation from an override without losing the interface declarations.
+type IAnonymousImplementationProvider interface {
+	ProvideAsClass() Implementation
+	ProvideAsInterface() IAnonymouslyImplementMe
+}
+
+// The jsii proxy for IAnonymousImplementationProvider
+type jsiiProxy_IAnonymousImplementationProvider struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IAnonymousImplementationProvider) ProvideAsClass() Implementation {
+	var returns Implementation
+
+	_jsii_.Invoke(
+		i,
+		"provideAsClass",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (i *jsiiProxy_IAnonymousImplementationProvider) ProvideAsInterface() IAnonymouslyImplementMe {
+	var returns IAnonymouslyImplementMe
+
+	_jsii_.Invoke(
+		i,
+		"provideAsInterface",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IAnonymouslyImplementMe.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IAnonymouslyImplementMe interface {
+	Verb() *string
+	Value() *float64
+}
+
+// The jsii proxy for IAnonymouslyImplementMe
+type jsiiProxy_IAnonymouslyImplementMe struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IAnonymouslyImplementMe) Verb() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"verb",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_IAnonymouslyImplementMe) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IAnotherPublicInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IAnotherPublicInterface interface {
+	A() *string
+	SetA(a *string)
+}
+
+// The jsii proxy for IAnotherPublicInterface
+type jsiiProxy_IAnotherPublicInterface struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IAnotherPublicInterface) A() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"a",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IAnotherPublicInterface) SetA(val *string) {
+	_jsii_.Set(
+		j,
+		"a",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IBell.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IBell interface {
+	Ring()
+}
+
+// The jsii proxy for IBell
+type jsiiProxy_IBell struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IBell) Ring() {
+	_jsii_.InvokeVoid(
+		i,
+		"ring",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IBellRinger.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Takes the object parameter as an interface.
+type IBellRinger interface {
+	YourTurn(bell IBell)
+}
+
+// The jsii proxy for IBellRinger
+type jsiiProxy_IBellRinger struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IBellRinger) YourTurn(bell IBell) {
+	_jsii_.InvokeVoid(
+		i,
+		"yourTurn",
+		[]interface{}{bell},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IConcreteBellRinger.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Takes the object parameter as a calss.
+type IConcreteBellRinger interface {
+	YourTurn(bell Bell)
+}
+
+// The jsii proxy for IConcreteBellRinger
+type jsiiProxy_IConcreteBellRinger struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IConcreteBellRinger) YourTurn(bell Bell) {
+	_jsii_.InvokeVoid(
+		i,
+		"yourTurn",
+		[]interface{}{bell},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IDeprecatedInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Deprecated: useless interface.
+type IDeprecatedInterface interface {
+	// Deprecated: services no purpose.
+	Method()
+	// Deprecated: could be better.
+	MutableProperty() *float64
+	// Deprecated: could be better.
+	SetMutableProperty(m *float64)
+}
+
+// The jsii proxy for IDeprecatedInterface
+type jsiiProxy_IDeprecatedInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IDeprecatedInterface) Method() {
+	_jsii_.InvokeVoid(
+		i,
+		"method",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IDeprecatedInterface) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IDeprecatedInterface) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IExperimentalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Experimental.
+type IExperimentalInterface interface {
+	// Experimental.
+	Method()
+	// Experimental.
+	MutableProperty() *float64
+	// Experimental.
+	SetMutableProperty(m *float64)
+}
+
+// The jsii proxy for IExperimentalInterface
+type jsiiProxy_IExperimentalInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IExperimentalInterface) Method() {
+	_jsii_.InvokeVoid(
+		i,
+		"method",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IExperimentalInterface) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IExperimentalInterface) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IExtendsPrivateInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IExtendsPrivateInterface interface {
+	MoreThings() *[]*string
+	Private() *string
+	SetPrivate(p *string)
+}
+
+// The jsii proxy for IExtendsPrivateInterface
+type jsiiProxy_IExtendsPrivateInterface struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IExtendsPrivateInterface) MoreThings() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"moreThings",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IExtendsPrivateInterface) Private() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"private",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IExtendsPrivateInterface) SetPrivate(val *string) {
+	_jsii_.Set(
+		j,
+		"private",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IExternalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IExternalInterface interface {
+	Method()
+	MutableProperty() *float64
+	SetMutableProperty(m *float64)
+}
+
+// The jsii proxy for IExternalInterface
+type jsiiProxy_IExternalInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IExternalInterface) Method() {
+	_jsii_.InvokeVoid(
+		i,
+		"method",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IExternalInterface) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IExternalInterface) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IFriendlier.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// Even friendlier classes can implement this interface.
+type IFriendlier interface {
+	scopejsiicalclib.IFriendly
+	// Say farewell.
+	Farewell() *string
+	// Say goodbye.
+	//
+	// Returns: A goodbye blessing.
+	Goodbye() *string
+}
+
+// The jsii proxy for IFriendlier
+type jsiiProxy_IFriendlier struct {
+	internal.Type__scopejsiicalclibIFriendly
+}
+
+func (i *jsiiProxy_IFriendlier) Farewell() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"farewell",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (i *jsiiProxy_IFriendlier) Goodbye() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"goodbye",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IFriendlyRandomGenerator.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type IFriendlyRandomGenerator interface {
+	scopejsiicalclib.IFriendly
+	IRandomNumberGenerator
+}
+
+// The jsii proxy for IFriendlyRandomGenerator
+type jsiiProxy_IFriendlyRandomGenerator struct {
+	internal.Type__scopejsiicalclibIFriendly
+	jsiiProxy_IRandomNumberGenerator
+}
+
+func (i *jsiiProxy_IFriendlyRandomGenerator) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (i *jsiiProxy_IFriendlyRandomGenerator) Next() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		i,
+		"next",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IIndirectlyImplemented.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IIndirectlyImplemented interface {
+	Method() *float64
+	Property() *string
+}
+
+// The jsii proxy for IIndirectlyImplemented
+type jsiiProxy_IIndirectlyImplemented struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IIndirectlyImplemented) Method() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		i,
+		"method",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_IIndirectlyImplemented) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceImplementedByAbstractClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// awslabs/jsii#220 Abstract return type.
+type IInterfaceImplementedByAbstractClass interface {
+	PropFromInterface() *string
+}
+
+// The jsii proxy for IInterfaceImplementedByAbstractClass
+type jsiiProxy_IInterfaceImplementedByAbstractClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IInterfaceImplementedByAbstractClass) PropFromInterface() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"propFromInterface",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceThatShouldNotBeADataType.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Even though this interface has only properties, it is disqualified from being a datatype because it inherits from an interface that is not a datatype.
+type IInterfaceThatShouldNotBeADataType interface {
+	IInterfaceWithMethods
+	OtherValue() *string
+}
+
+// The jsii proxy for IInterfaceThatShouldNotBeADataType
+type jsiiProxy_IInterfaceThatShouldNotBeADataType struct {
+	jsiiProxy_IInterfaceWithMethods
+}
+
+func (j *jsiiProxy_IInterfaceThatShouldNotBeADataType) OtherValue() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"otherValue",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceWithInternal.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IInterfaceWithInternal interface {
+	Visible()
+}
+
+// The jsii proxy for IInterfaceWithInternal
+type jsiiProxy_IInterfaceWithInternal struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IInterfaceWithInternal) Visible() {
+	_jsii_.InvokeVoid(
+		i,
+		"visible",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceWithMethods.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IInterfaceWithMethods interface {
+	DoThings()
+	Value() *string
+}
+
+// The jsii proxy for IInterfaceWithMethods
+type jsiiProxy_IInterfaceWithMethods struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IInterfaceWithMethods) DoThings() {
+	_jsii_.InvokeVoid(
+		i,
+		"doThings",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IInterfaceWithMethods) Value() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceWithOptionalMethodArguments.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.
+type IInterfaceWithOptionalMethodArguments interface {
+	Hello(arg1 *string, arg2 *float64)
+}
+
+// The jsii proxy for IInterfaceWithOptionalMethodArguments
+type jsiiProxy_IInterfaceWithOptionalMethodArguments struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IInterfaceWithOptionalMethodArguments) Hello(arg1 *string, arg2 *float64) {
+	_jsii_.InvokeVoid(
+		i,
+		"hello",
+		[]interface{}{arg1, arg2},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceWithProperties.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IInterfaceWithProperties interface {
+	ReadOnlyString() *string
+	ReadWriteString() *string
+	SetReadWriteString(r *string)
+}
+
+// The jsii proxy for IInterfaceWithProperties
+type jsiiProxy_IInterfaceWithProperties struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IInterfaceWithProperties) ReadOnlyString() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readOnlyString",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IInterfaceWithProperties) ReadWriteString() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readWriteString",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IInterfaceWithProperties) SetReadWriteString(val *string) {
+	_jsii_.Set(
+		j,
+		"readWriteString",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IInterfaceWithPropertiesExtension.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IInterfaceWithPropertiesExtension interface {
+	IInterfaceWithProperties
+	Foo() *float64
+	SetFoo(f *float64)
+}
+
+// The jsii proxy for IInterfaceWithPropertiesExtension
+type jsiiProxy_IInterfaceWithPropertiesExtension struct {
+	jsiiProxy_IInterfaceWithProperties
+}
+
+func (j *jsiiProxy_IInterfaceWithPropertiesExtension) Foo() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"foo",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IInterfaceWithPropertiesExtension) SetFoo(val *float64) {
+	_jsii_.Set(
+		j,
+		"foo",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJSII417Derived.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IJSII417Derived interface {
+	IJSII417PublicBaseOfBase
+	Bar()
+	Baz()
+	Property() *string
+}
+
+// The jsii proxy for IJSII417Derived
+type jsiiProxy_IJSII417Derived struct {
+	jsiiProxy_IJSII417PublicBaseOfBase
+}
+
+func (i *jsiiProxy_IJSII417Derived) Bar() {
+	_jsii_.InvokeVoid(
+		i,
+		"bar",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJSII417Derived) Baz() {
+	_jsii_.InvokeVoid(
+		i,
+		"baz",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IJSII417Derived) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJSII417PublicBaseOfBase.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IJSII417PublicBaseOfBase interface {
+	Foo()
+	HasRoot() *bool
+}
+
+// The jsii proxy for IJSII417PublicBaseOfBase
+type jsiiProxy_IJSII417PublicBaseOfBase struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IJSII417PublicBaseOfBase) Foo() {
+	_jsii_.InvokeVoid(
+		i,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IJSII417PublicBaseOfBase) HasRoot() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"hasRoot",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJavaReservedWordsInAnInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IJavaReservedWordsInAnInterface interface {
+	Abstract()
+	Assert()
+	Boolean()
+	Break()
+	Byte()
+	Case()
+	Catch()
+	Char()
+	Class()
+	Const()
+	Continue()
+	Default()
+	Do()
+	Double()
+	Else()
+	Enum()
+	Extends()
+	False()
+	Final()
+	Finally()
+	Float()
+	For()
+	Goto()
+	If()
+	Implements()
+	Import()
+	Instanceof()
+	Int()
+	Interface()
+	Long()
+	Native()
+	Null()
+	Package()
+	Private()
+	Protected()
+	Public()
+	Return()
+	Short()
+	Static()
+	Strictfp()
+	Super()
+	Switch()
+	Synchronized()
+	This()
+	Throw()
+	Throws()
+	Transient()
+	True()
+	Try()
+	Void()
+	Volatile()
+	While() *string
+}
+
+// The jsii proxy for IJavaReservedWordsInAnInterface
+type jsiiProxy_IJavaReservedWordsInAnInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Abstract() {
+	_jsii_.InvokeVoid(
+		i,
+		"abstract",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Assert() {
+	_jsii_.InvokeVoid(
+		i,
+		"assert",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Boolean() {
+	_jsii_.InvokeVoid(
+		i,
+		"boolean",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Break() {
+	_jsii_.InvokeVoid(
+		i,
+		"break",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Byte() {
+	_jsii_.InvokeVoid(
+		i,
+		"byte",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Case() {
+	_jsii_.InvokeVoid(
+		i,
+		"case",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Catch() {
+	_jsii_.InvokeVoid(
+		i,
+		"catch",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Char() {
+	_jsii_.InvokeVoid(
+		i,
+		"char",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Class() {
+	_jsii_.InvokeVoid(
+		i,
+		"class",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Const() {
+	_jsii_.InvokeVoid(
+		i,
+		"const",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Continue() {
+	_jsii_.InvokeVoid(
+		i,
+		"continue",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Default() {
+	_jsii_.InvokeVoid(
+		i,
+		"default",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Do() {
+	_jsii_.InvokeVoid(
+		i,
+		"do",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Double() {
+	_jsii_.InvokeVoid(
+		i,
+		"double",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Else() {
+	_jsii_.InvokeVoid(
+		i,
+		"else",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Enum() {
+	_jsii_.InvokeVoid(
+		i,
+		"enum",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Extends() {
+	_jsii_.InvokeVoid(
+		i,
+		"extends",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) False() {
+	_jsii_.InvokeVoid(
+		i,
+		"false",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Final() {
+	_jsii_.InvokeVoid(
+		i,
+		"final",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Finally() {
+	_jsii_.InvokeVoid(
+		i,
+		"finally",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Float() {
+	_jsii_.InvokeVoid(
+		i,
+		"float",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) For() {
+	_jsii_.InvokeVoid(
+		i,
+		"for",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Goto() {
+	_jsii_.InvokeVoid(
+		i,
+		"goto",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) If() {
+	_jsii_.InvokeVoid(
+		i,
+		"if",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Implements() {
+	_jsii_.InvokeVoid(
+		i,
+		"implements",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Import() {
+	_jsii_.InvokeVoid(
+		i,
+		"import",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Instanceof() {
+	_jsii_.InvokeVoid(
+		i,
+		"instanceof",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Int() {
+	_jsii_.InvokeVoid(
+		i,
+		"int",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Interface() {
+	_jsii_.InvokeVoid(
+		i,
+		"interface",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Long() {
+	_jsii_.InvokeVoid(
+		i,
+		"long",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Native() {
+	_jsii_.InvokeVoid(
+		i,
+		"native",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Null() {
+	_jsii_.InvokeVoid(
+		i,
+		"null",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Package() {
+	_jsii_.InvokeVoid(
+		i,
+		"package",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Private() {
+	_jsii_.InvokeVoid(
+		i,
+		"private",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Protected() {
+	_jsii_.InvokeVoid(
+		i,
+		"protected",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Public() {
+	_jsii_.InvokeVoid(
+		i,
+		"public",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Return() {
+	_jsii_.InvokeVoid(
+		i,
+		"return",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Short() {
+	_jsii_.InvokeVoid(
+		i,
+		"short",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Static() {
+	_jsii_.InvokeVoid(
+		i,
+		"static",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Strictfp() {
+	_jsii_.InvokeVoid(
+		i,
+		"strictfp",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Super() {
+	_jsii_.InvokeVoid(
+		i,
+		"super",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Switch() {
+	_jsii_.InvokeVoid(
+		i,
+		"switch",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Synchronized() {
+	_jsii_.InvokeVoid(
+		i,
+		"synchronized",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) This() {
+	_jsii_.InvokeVoid(
+		i,
+		"this",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Throw() {
+	_jsii_.InvokeVoid(
+		i,
+		"throw",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Throws() {
+	_jsii_.InvokeVoid(
+		i,
+		"throws",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Transient() {
+	_jsii_.InvokeVoid(
+		i,
+		"transient",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) True() {
+	_jsii_.InvokeVoid(
+		i,
+		"true",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Try() {
+	_jsii_.InvokeVoid(
+		i,
+		"try",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Void() {
+	_jsii_.InvokeVoid(
+		i,
+		"void",
+		nil, // no parameters
+	)
+}
+
+func (i *jsiiProxy_IJavaReservedWordsInAnInterface) Volatile() {
+	_jsii_.InvokeVoid(
+		i,
+		"volatile",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IJavaReservedWordsInAnInterface) While() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"while",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJsii487External.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type IJsii487External interface {
+}
+
+// The jsii proxy for IJsii487External
+type jsiiProxy_IJsii487External struct {
+	_ byte // padding
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJsii487External2.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type IJsii487External2 interface {
+}
+
+// The jsii proxy for IJsii487External2
+type jsiiProxy_IJsii487External2 struct {
+	_ byte // padding
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IJsii496.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type IJsii496 interface {
+}
+
+// The jsii proxy for IJsii496
+type jsiiProxy_IJsii496 struct {
+	_ byte // padding
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IMutableObjectLiteral.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IMutableObjectLiteral interface {
+	Value() *string
+	SetValue(v *string)
+}
+
+// The jsii proxy for IMutableObjectLiteral
+type jsiiProxy_IMutableObjectLiteral struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IMutableObjectLiteral) Value() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IMutableObjectLiteral) SetValue(val *string) {
+	_jsii_.Set(
+		j,
+		"value",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_INonInternalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type INonInternalInterface interface {
+	IAnotherPublicInterface
+	B() *string
+	SetB(b *string)
+	C() *string
+	SetC(c *string)
+}
+
+// The jsii proxy for INonInternalInterface
+type jsiiProxy_INonInternalInterface struct {
+	jsiiProxy_IAnotherPublicInterface
+}
+
+func (j *jsiiProxy_INonInternalInterface) B() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"b",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_INonInternalInterface) SetB(val *string) {
+	_jsii_.Set(
+		j,
+		"b",
+		val,
+	)
+}
+
+func (j *jsiiProxy_INonInternalInterface) C() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"c",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_INonInternalInterface) SetC(val *string) {
+	_jsii_.Set(
+		j,
+		"c",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IObjectWithProperty.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Make sure that setters are properly called on objects with interfaces.
+type IObjectWithProperty interface {
+	WasSet() *bool
+	Property() *string
+	SetProperty(p *string)
+}
+
+// The jsii proxy for IObjectWithProperty
+type jsiiProxy_IObjectWithProperty struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IObjectWithProperty) WasSet() *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		i,
+		"wasSet",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_IObjectWithProperty) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IObjectWithProperty) SetProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"property",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IOptionalMethod.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Checks that optional result from interface method code generates correctly.
+type IOptionalMethod interface {
+	Optional() *string
+}
+
+// The jsii proxy for IOptionalMethod
+type jsiiProxy_IOptionalMethod struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IOptionalMethod) Optional() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"optional",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IPrivatelyImplemented.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IPrivatelyImplemented interface {
+	Success() *bool
+}
+
+// The jsii proxy for IPrivatelyImplemented
+type jsiiProxy_IPrivatelyImplemented struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IPrivatelyImplemented) Success() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"success",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IPublicInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IPublicInterface interface {
+	Bye() *string
+}
+
+// The jsii proxy for IPublicInterface
+type jsiiProxy_IPublicInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IPublicInterface) Bye() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"bye",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IPublicInterface2.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IPublicInterface2 interface {
+	Ciao() *string
+}
+
+// The jsii proxy for IPublicInterface2
+type jsiiProxy_IPublicInterface2 struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IPublicInterface2) Ciao() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"ciao",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IRandomNumberGenerator.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Generates random numbers.
+type IRandomNumberGenerator interface {
+	// Returns another random number.
+	//
+	// Returns: A random number.
+	Next() *float64
+}
+
+// The jsii proxy for IRandomNumberGenerator
+type jsiiProxy_IRandomNumberGenerator struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IRandomNumberGenerator) Next() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		i,
+		"next",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IReturnJsii976.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Returns a subclass of a known class which implements an interface.
+type IReturnJsii976 interface {
+	Foo() *float64
+}
+
+// The jsii proxy for IReturnJsii976
+type jsiiProxy_IReturnJsii976 struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_IReturnJsii976) Foo() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"foo",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IReturnsNumber.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type IReturnsNumber interface {
+	ObtainNumber() scopejsiicalclib.IDoublable
+	NumberProp() scopejsiicalclib.Number
+}
+
+// The jsii proxy for IReturnsNumber
+type jsiiProxy_IReturnsNumber struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IReturnsNumber) ObtainNumber() scopejsiicalclib.IDoublable {
+	var returns scopejsiicalclib.IDoublable
+
+	_jsii_.Invoke(
+		i,
+		"obtainNumber",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_IReturnsNumber) NumberProp() scopejsiicalclib.Number {
+	var returns scopejsiicalclib.Number
+	_jsii_.Get(
+		j,
+		"numberProp",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IStableInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IStableInterface interface {
+	Method()
+	MutableProperty() *float64
+	SetMutableProperty(m *float64)
+}
+
+// The jsii proxy for IStableInterface
+type jsiiProxy_IStableInterface struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IStableInterface) Method() {
+	_jsii_.InvokeVoid(
+		i,
+		"method",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_IStableInterface) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_IStableInterface) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IStructReturningDelegate.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Verifies that a "pure" implementation of an interface works correctly.
+type IStructReturningDelegate interface {
+	ReturnStruct() *StructB
+}
+
+// The jsii proxy for IStructReturningDelegate
+type jsiiProxy_IStructReturningDelegate struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IStructReturningDelegate) ReturnStruct() *StructB {
+	var returns *StructB
+
+	_jsii_.Invoke(
+		i,
+		"returnStruct",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_IWallClock.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Implement this interface.
+type IWallClock interface {
+	// Returns the current time, formatted as an ISO-8601 string.
+	Iso8601Now() *string
+}
+
+// The jsii proxy for IWallClock
+type jsiiProxy_IWallClock struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IWallClock) Iso8601Now() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"iso8601Now",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ImplementInternalInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ImplementInternalInterface interface {
+	Prop() *string
+	SetProp(val *string)
+}
+
+// The jsii proxy struct for ImplementInternalInterface
+type jsiiProxy_ImplementInternalInterface struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ImplementInternalInterface) Prop() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"prop",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewImplementInternalInterface() ImplementInternalInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ImplementInternalInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ImplementInternalInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewImplementInternalInterface_Override(i ImplementInternalInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ImplementInternalInterface",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (j *jsiiProxy_ImplementInternalInterface) SetProp(val *string) {
+	_jsii_.Set(
+		j,
+		"prop",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Implementation.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Implementation interface {
+	Value() *float64
+}
+
+// The jsii proxy struct for Implementation
+type jsiiProxy_Implementation struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_Implementation) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewImplementation() Implementation {
+	_init_.Initialize()
+
+	j := jsiiProxy_Implementation{}
+
+	_jsii_.Create(
+		"jsii-calc.Implementation",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewImplementation_Override(i Implementation) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Implementation",
+		nil, // no parameters
+		i,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ImplementsInterfaceWithInternal.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ImplementsInterfaceWithInternal interface {
+	IInterfaceWithInternal
+	Visible()
+}
+
+// The jsii proxy struct for ImplementsInterfaceWithInternal
+type jsiiProxy_ImplementsInterfaceWithInternal struct {
+	jsiiProxy_IInterfaceWithInternal
+}
+
+func NewImplementsInterfaceWithInternal() ImplementsInterfaceWithInternal {
+	_init_.Initialize()
+
+	j := jsiiProxy_ImplementsInterfaceWithInternal{}
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsInterfaceWithInternal",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewImplementsInterfaceWithInternal_Override(i ImplementsInterfaceWithInternal) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsInterfaceWithInternal",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (i *jsiiProxy_ImplementsInterfaceWithInternal) Visible() {
+	_jsii_.InvokeVoid(
+		i,
+		"visible",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ImplementsInterfaceWithInternalSubclass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ImplementsInterfaceWithInternalSubclass interface {
+	ImplementsInterfaceWithInternal
+	Visible()
+}
+
+// The jsii proxy struct for ImplementsInterfaceWithInternalSubclass
+type jsiiProxy_ImplementsInterfaceWithInternalSubclass struct {
+	jsiiProxy_ImplementsInterfaceWithInternal
+}
+
+func NewImplementsInterfaceWithInternalSubclass() ImplementsInterfaceWithInternalSubclass {
+	_init_.Initialize()
+
+	j := jsiiProxy_ImplementsInterfaceWithInternalSubclass{}
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewImplementsInterfaceWithInternalSubclass_Override(i ImplementsInterfaceWithInternalSubclass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsInterfaceWithInternalSubclass",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (i *jsiiProxy_ImplementsInterfaceWithInternalSubclass) Visible() {
+	_jsii_.InvokeVoid(
+		i,
+		"visible",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ImplementsPrivateInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ImplementsPrivateInterface interface {
+	Private() *string
+	SetPrivate(val *string)
+}
+
+// The jsii proxy struct for ImplementsPrivateInterface
+type jsiiProxy_ImplementsPrivateInterface struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ImplementsPrivateInterface) Private() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"private",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewImplementsPrivateInterface() ImplementsPrivateInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ImplementsPrivateInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsPrivateInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewImplementsPrivateInterface_Override(i ImplementsPrivateInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ImplementsPrivateInterface",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (j *jsiiProxy_ImplementsPrivateInterface) SetPrivate(val *string) {
+	_jsii_.Set(
+		j,
+		"private",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ImplictBaseOfBase.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalcbaseofbase/v2"
+)
+
+type ImplictBaseOfBase struct {
+	Foo scopejsiicalcbaseofbase.Very \`field:"required" json:"foo" yaml:"foo"\`
+	Bar *string \`field:"required" json:"bar" yaml:"bar"\`
+	Goo *time.Time \`field:"required" json:"goo" yaml:"goo"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_InbetweenClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type InbetweenClass interface {
+	PublicClass
+	IPublicInterface2
+	Ciao() *string
+	Hello()
+}
+
+// The jsii proxy struct for InbetweenClass
+type jsiiProxy_InbetweenClass struct {
+	jsiiProxy_PublicClass
+	jsiiProxy_IPublicInterface2
+}
+
+func NewInbetweenClass() InbetweenClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_InbetweenClass{}
+
+	_jsii_.Create(
+		"jsii-calc.InbetweenClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewInbetweenClass_Override(i InbetweenClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.InbetweenClass",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (i *jsiiProxy_InbetweenClass) Ciao() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		i,
+		"ciao",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (i *jsiiProxy_InbetweenClass) Hello() {
+	_jsii_.InvokeVoid(
+		i,
+		"hello",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_InterfaceCollections.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Verifies that collections of interfaces or structs are correctly handled.
+//
+// See: https://github.com/aws/jsii/issues/1196
+type InterfaceCollections interface {
+}
+
+// The jsii proxy struct for InterfaceCollections
+type jsiiProxy_InterfaceCollections struct {
+	_ byte // padding
+}
+
+func InterfaceCollections_ListOfInterfaces() *[]IBell {
+	_init_.Initialize()
+
+	var returns *[]IBell
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.InterfaceCollections",
+		"listOfInterfaces",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func InterfaceCollections_ListOfStructs() *[]*StructA {
+	_init_.Initialize()
+
+	var returns *[]*StructA
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.InterfaceCollections",
+		"listOfStructs",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func InterfaceCollections_MapOfInterfaces() *map[string]IBell {
+	_init_.Initialize()
+
+	var returns *map[string]IBell
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.InterfaceCollections",
+		"mapOfInterfaces",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func InterfaceCollections_MapOfStructs() *map[string]*StructA {
+	_init_.Initialize()
+
+	var returns *map[string]*StructA
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.InterfaceCollections",
+		"mapOfStructs",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_InterfacesMaker.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// We can return arrays of interfaces See aws/aws-cdk#2362.
+type InterfacesMaker interface {
+}
+
+// The jsii proxy struct for InterfacesMaker
+type jsiiProxy_InterfacesMaker struct {
+	_ byte // padding
+}
+
+func InterfacesMaker_MakeInterfaces(count *float64) *[]scopejsiicalclib.IDoublable {
+	_init_.Initialize()
+
+	var returns *[]scopejsiicalclib.IDoublable
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.InterfacesMaker",
+		"makeInterfaces",
+		[]interface{}{count},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Isomorphism.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Checks the "same instance" isomorphism is preserved within the constructor.
+//
+// Create a subclass of this, and assert that \`this.myself()\` actually returns
+// \`this\` from within the constructor.
+type Isomorphism interface {
+	Myself() Isomorphism
+}
+
+// The jsii proxy struct for Isomorphism
+type jsiiProxy_Isomorphism struct {
+	_ byte // padding
+}
+
+func NewIsomorphism_Override(i Isomorphism) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Isomorphism",
+		nil, // no parameters
+		i,
+	)
+}
+
+func (i *jsiiProxy_Isomorphism) Myself() Isomorphism {
+	var returns Isomorphism
+
+	_jsii_.Invoke(
+		i,
+		"myself",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Issue2638.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Docstrings with period.
+// See: https://github.com/aws/jsii/issues/2638
+//
+type Issue2638 interface {
+}
+
+// The jsii proxy struct for Issue2638
+type jsiiProxy_Issue2638 struct {
+	_ byte // padding
+}
+
+// First sentence.
+//
+// Second sentence. Third sentence.
+func NewIssue2638() Issue2638 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Issue2638{}
+
+	_jsii_.Create(
+		"jsii-calc.Issue2638",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+// First sentence.
+//
+// Second sentence. Third sentence.
+func NewIssue2638_Override(i Issue2638) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Issue2638",
+		nil, // no parameters
+		i,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Issue2638B.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Issue2638B interface {
+}
+
+// The jsii proxy struct for Issue2638B
+type jsiiProxy_Issue2638B struct {
+	_ byte // padding
+}
+
+func NewIssue2638B() Issue2638B {
+	_init_.Initialize()
+
+	j := jsiiProxy_Issue2638B{}
+
+	_jsii_.Create(
+		"jsii-calc.Issue2638B",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewIssue2638B_Override(i Issue2638B) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Issue2638B",
+		nil, // no parameters
+		i,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JSII417Derived.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type JSII417Derived interface {
+	JSII417PublicBaseOfBase
+	HasRoot() *bool
+	Property() *string
+	Bar()
+	Baz()
+	Foo()
+}
+
+// The jsii proxy struct for JSII417Derived
+type jsiiProxy_JSII417Derived struct {
+	jsiiProxy_JSII417PublicBaseOfBase
+}
+
+func (j *jsiiProxy_JSII417Derived) HasRoot() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"hasRoot",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_JSII417Derived) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewJSII417Derived(property *string) JSII417Derived {
+	_init_.Initialize()
+
+	j := jsiiProxy_JSII417Derived{}
+
+	_jsii_.Create(
+		"jsii-calc.JSII417Derived",
+		[]interface{}{property},
+		&j,
+	)
+
+	return &j
+}
+
+func NewJSII417Derived_Override(j JSII417Derived, property *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JSII417Derived",
+		[]interface{}{property},
+		j,
+	)
+}
+
+func JSII417Derived_MakeInstance() JSII417PublicBaseOfBase {
+	_init_.Initialize()
+
+	var returns JSII417PublicBaseOfBase
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JSII417Derived",
+		"makeInstance",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_JSII417Derived) Bar() {
+	_jsii_.InvokeVoid(
+		j,
+		"bar",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JSII417Derived) Baz() {
+	_jsii_.InvokeVoid(
+		j,
+		"baz",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JSII417Derived) Foo() {
+	_jsii_.InvokeVoid(
+		j,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JSII417PublicBaseOfBase.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type JSII417PublicBaseOfBase interface {
+	HasRoot() *bool
+	Foo()
+}
+
+// The jsii proxy struct for JSII417PublicBaseOfBase
+type jsiiProxy_JSII417PublicBaseOfBase struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_JSII417PublicBaseOfBase) HasRoot() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"hasRoot",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewJSII417PublicBaseOfBase() JSII417PublicBaseOfBase {
+	_init_.Initialize()
+
+	j := jsiiProxy_JSII417PublicBaseOfBase{}
+
+	_jsii_.Create(
+		"jsii-calc.JSII417PublicBaseOfBase",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJSII417PublicBaseOfBase_Override(j JSII417PublicBaseOfBase) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JSII417PublicBaseOfBase",
+		nil, // no parameters
+		j,
+	)
+}
+
+func JSII417PublicBaseOfBase_MakeInstance() JSII417PublicBaseOfBase {
+	_init_.Initialize()
+
+	var returns JSII417PublicBaseOfBase
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JSII417PublicBaseOfBase",
+		"makeInstance",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_JSII417PublicBaseOfBase) Foo() {
+	_jsii_.InvokeVoid(
+		j,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JSObjectLiteralForInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type JSObjectLiteralForInterface interface {
+	GiveMeFriendly() scopejsiicalclib.IFriendly
+	GiveMeFriendlyGenerator() IFriendlyRandomGenerator
+}
+
+// The jsii proxy struct for JSObjectLiteralForInterface
+type jsiiProxy_JSObjectLiteralForInterface struct {
+	_ byte // padding
+}
+
+func NewJSObjectLiteralForInterface() JSObjectLiteralForInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_JSObjectLiteralForInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralForInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJSObjectLiteralForInterface_Override(j JSObjectLiteralForInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralForInterface",
+		nil, // no parameters
+		j,
+	)
+}
+
+func (j *jsiiProxy_JSObjectLiteralForInterface) GiveMeFriendly() scopejsiicalclib.IFriendly {
+	var returns scopejsiicalclib.IFriendly
+
+	_jsii_.Invoke(
+		j,
+		"giveMeFriendly",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (j *jsiiProxy_JSObjectLiteralForInterface) GiveMeFriendlyGenerator() IFriendlyRandomGenerator {
+	var returns IFriendlyRandomGenerator
+
+	_jsii_.Invoke(
+		j,
+		"giveMeFriendlyGenerator",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JSObjectLiteralToNative.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type JSObjectLiteralToNative interface {
+	ReturnLiteral() JSObjectLiteralToNativeClass
+}
+
+// The jsii proxy struct for JSObjectLiteralToNative
+type jsiiProxy_JSObjectLiteralToNative struct {
+	_ byte // padding
+}
+
+func NewJSObjectLiteralToNative() JSObjectLiteralToNative {
+	_init_.Initialize()
+
+	j := jsiiProxy_JSObjectLiteralToNative{}
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralToNative",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJSObjectLiteralToNative_Override(j JSObjectLiteralToNative) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralToNative",
+		nil, // no parameters
+		j,
+	)
+}
+
+func (j *jsiiProxy_JSObjectLiteralToNative) ReturnLiteral() JSObjectLiteralToNativeClass {
+	var returns JSObjectLiteralToNativeClass
+
+	_jsii_.Invoke(
+		j,
+		"returnLiteral",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JSObjectLiteralToNativeClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type JSObjectLiteralToNativeClass interface {
+	PropA() *string
+	SetPropA(val *string)
+	PropB() *float64
+	SetPropB(val *float64)
+}
+
+// The jsii proxy struct for JSObjectLiteralToNativeClass
+type jsiiProxy_JSObjectLiteralToNativeClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_JSObjectLiteralToNativeClass) PropA() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"propA",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_JSObjectLiteralToNativeClass) PropB() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"propB",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewJSObjectLiteralToNativeClass() JSObjectLiteralToNativeClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_JSObjectLiteralToNativeClass{}
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralToNativeClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJSObjectLiteralToNativeClass_Override(j JSObjectLiteralToNativeClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JSObjectLiteralToNativeClass",
+		nil, // no parameters
+		j,
+	)
+}
+
+func (j *jsiiProxy_JSObjectLiteralToNativeClass) SetPropA(val *string) {
+	_jsii_.Set(
+		j,
+		"propA",
+		val,
+	)
+}
+
+func (j *jsiiProxy_JSObjectLiteralToNativeClass) SetPropB(val *float64) {
+	_jsii_.Set(
+		j,
+		"propB",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JavaReservedWords.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type JavaReservedWords interface {
+	While() *string
+	SetWhile(val *string)
+	Abstract()
+	Assert()
+	Boolean()
+	Break()
+	Byte()
+	Case()
+	Catch()
+	Char()
+	Class()
+	Const()
+	Continue()
+	Default()
+	Do()
+	Double()
+	Else()
+	Enum()
+	Extends()
+	False()
+	Final()
+	Finally()
+	Float()
+	For()
+	Goto()
+	If()
+	Implements()
+	Import()
+	Instanceof()
+	Int()
+	Interface()
+	Long()
+	Native()
+	New()
+	Null()
+	Package()
+	Private()
+	Protected()
+	Public()
+	Return()
+	Short()
+	Static()
+	Strictfp()
+	Super()
+	Switch()
+	Synchronized()
+	This()
+	Throw()
+	Throws()
+	Transient()
+	True()
+	Try()
+	Void()
+	Volatile()
+}
+
+// The jsii proxy struct for JavaReservedWords
+type jsiiProxy_JavaReservedWords struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_JavaReservedWords) While() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"while",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewJavaReservedWords() JavaReservedWords {
+	_init_.Initialize()
+
+	j := jsiiProxy_JavaReservedWords{}
+
+	_jsii_.Create(
+		"jsii-calc.JavaReservedWords",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJavaReservedWords_Override(j JavaReservedWords) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JavaReservedWords",
+		nil, // no parameters
+		j,
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) SetWhile(val *string) {
+	_jsii_.Set(
+		j,
+		"while",
+		val,
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Abstract() {
+	_jsii_.InvokeVoid(
+		j,
+		"abstract",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Assert() {
+	_jsii_.InvokeVoid(
+		j,
+		"assert",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Boolean() {
+	_jsii_.InvokeVoid(
+		j,
+		"boolean",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Break() {
+	_jsii_.InvokeVoid(
+		j,
+		"break",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Byte() {
+	_jsii_.InvokeVoid(
+		j,
+		"byte",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Case() {
+	_jsii_.InvokeVoid(
+		j,
+		"case",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Catch() {
+	_jsii_.InvokeVoid(
+		j,
+		"catch",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Char() {
+	_jsii_.InvokeVoid(
+		j,
+		"char",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Class() {
+	_jsii_.InvokeVoid(
+		j,
+		"class",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Const() {
+	_jsii_.InvokeVoid(
+		j,
+		"const",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Continue() {
+	_jsii_.InvokeVoid(
+		j,
+		"continue",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Default() {
+	_jsii_.InvokeVoid(
+		j,
+		"default",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Do() {
+	_jsii_.InvokeVoid(
+		j,
+		"do",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Double() {
+	_jsii_.InvokeVoid(
+		j,
+		"double",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Else() {
+	_jsii_.InvokeVoid(
+		j,
+		"else",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Enum() {
+	_jsii_.InvokeVoid(
+		j,
+		"enum",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Extends() {
+	_jsii_.InvokeVoid(
+		j,
+		"extends",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) False() {
+	_jsii_.InvokeVoid(
+		j,
+		"false",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Final() {
+	_jsii_.InvokeVoid(
+		j,
+		"final",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Finally() {
+	_jsii_.InvokeVoid(
+		j,
+		"finally",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Float() {
+	_jsii_.InvokeVoid(
+		j,
+		"float",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) For() {
+	_jsii_.InvokeVoid(
+		j,
+		"for",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Goto() {
+	_jsii_.InvokeVoid(
+		j,
+		"goto",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) If() {
+	_jsii_.InvokeVoid(
+		j,
+		"if",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Implements() {
+	_jsii_.InvokeVoid(
+		j,
+		"implements",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Import() {
+	_jsii_.InvokeVoid(
+		j,
+		"import",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Instanceof() {
+	_jsii_.InvokeVoid(
+		j,
+		"instanceof",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Int() {
+	_jsii_.InvokeVoid(
+		j,
+		"int",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Interface() {
+	_jsii_.InvokeVoid(
+		j,
+		"interface",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Long() {
+	_jsii_.InvokeVoid(
+		j,
+		"long",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Native() {
+	_jsii_.InvokeVoid(
+		j,
+		"native",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) New() {
+	_jsii_.InvokeVoid(
+		j,
+		"new",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Null() {
+	_jsii_.InvokeVoid(
+		j,
+		"null",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Package() {
+	_jsii_.InvokeVoid(
+		j,
+		"package",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Private() {
+	_jsii_.InvokeVoid(
+		j,
+		"private",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Protected() {
+	_jsii_.InvokeVoid(
+		j,
+		"protected",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Public() {
+	_jsii_.InvokeVoid(
+		j,
+		"public",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Return() {
+	_jsii_.InvokeVoid(
+		j,
+		"return",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Short() {
+	_jsii_.InvokeVoid(
+		j,
+		"short",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Static() {
+	_jsii_.InvokeVoid(
+		j,
+		"static",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Strictfp() {
+	_jsii_.InvokeVoid(
+		j,
+		"strictfp",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Super() {
+	_jsii_.InvokeVoid(
+		j,
+		"super",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Switch() {
+	_jsii_.InvokeVoid(
+		j,
+		"switch",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Synchronized() {
+	_jsii_.InvokeVoid(
+		j,
+		"synchronized",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) This() {
+	_jsii_.InvokeVoid(
+		j,
+		"this",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Throw() {
+	_jsii_.InvokeVoid(
+		j,
+		"throw",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Throws() {
+	_jsii_.InvokeVoid(
+		j,
+		"throws",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Transient() {
+	_jsii_.InvokeVoid(
+		j,
+		"transient",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) True() {
+	_jsii_.InvokeVoid(
+		j,
+		"true",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Try() {
+	_jsii_.InvokeVoid(
+		j,
+		"try",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Void() {
+	_jsii_.InvokeVoid(
+		j,
+		"void",
+		nil, // no parameters
+	)
+}
+
+func (j *jsiiProxy_JavaReservedWords) Volatile() {
+	_jsii_.InvokeVoid(
+		j,
+		"volatile",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Jsii487Derived.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Jsii487Derived interface {
+	IJsii487External
+	IJsii487External2
+}
+
+// The jsii proxy struct for Jsii487Derived
+type jsiiProxy_Jsii487Derived struct {
+	jsiiProxy_IJsii487External
+	jsiiProxy_IJsii487External2
+}
+
+func NewJsii487Derived() Jsii487Derived {
+	_init_.Initialize()
+
+	j := jsiiProxy_Jsii487Derived{}
+
+	_jsii_.Create(
+		"jsii-calc.Jsii487Derived",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJsii487Derived_Override(j Jsii487Derived) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Jsii487Derived",
+		nil, // no parameters
+		j,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Jsii496Derived.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Jsii496Derived interface {
+	IJsii496
+}
+
+// The jsii proxy struct for Jsii496Derived
+type jsiiProxy_Jsii496Derived struct {
+	jsiiProxy_IJsii496
+}
+
+func NewJsii496Derived() Jsii496Derived {
+	_init_.Initialize()
+
+	j := jsiiProxy_Jsii496Derived{}
+
+	_jsii_.Create(
+		"jsii-calc.Jsii496Derived",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJsii496Derived_Override(j Jsii496Derived) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Jsii496Derived",
+		nil, // no parameters
+		j,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JsiiAgent.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Host runtime version should be set via JSII_AGENT.
+type JsiiAgent interface {
+}
+
+// The jsii proxy struct for JsiiAgent
+type jsiiProxy_JsiiAgent struct {
+	_ byte // padding
+}
+
+func NewJsiiAgent() JsiiAgent {
+	_init_.Initialize()
+
+	j := jsiiProxy_JsiiAgent{}
+
+	_jsii_.Create(
+		"jsii-calc.JsiiAgent",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewJsiiAgent_Override(j JsiiAgent) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.JsiiAgent",
+		nil, // no parameters
+		j,
+	)
+}
+
+func JsiiAgent_Value() *string {
+	_init_.Initialize()
+	var returns *string
+	_jsii_.StaticGet(
+		"jsii-calc.JsiiAgent",
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_JsonFormatter.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Make sure structs are un-decorated on the way in.
+// See: https://github.com/aws/aws-cdk/issues/5066
+//
+type JsonFormatter interface {
+}
+
+// The jsii proxy struct for JsonFormatter
+type jsiiProxy_JsonFormatter struct {
+	_ byte // padding
+}
+
+func JsonFormatter_AnyArray() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyArray",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyBooleanFalse() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyBooleanFalse",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyBooleanTrue() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyBooleanTrue",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyDate() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyDate",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyEmptyString() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyEmptyString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyFunction() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyFunction",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyHash() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyHash",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyNull() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyNull",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyNumber() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyNumber",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyRef() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyRef",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyString() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyUndefined() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyUndefined",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_AnyZero() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"anyZero",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func JsonFormatter_Stringify(value interface{}) *string {
+	_init_.Initialize()
+
+	var returns *string
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.JsonFormatter",
+		"stringify",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_LevelOne.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Validates that nested classes get correct code generation for the occasional forward reference.
+type LevelOne interface {
+	Props() *LevelOneProps
+}
+
+// The jsii proxy struct for LevelOne
+type jsiiProxy_LevelOne struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_LevelOne) Props() *LevelOneProps {
+	var returns *LevelOneProps
+	_jsii_.Get(
+		j,
+		"props",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewLevelOne(props *LevelOneProps) LevelOne {
+	_init_.Initialize()
+
+	j := jsiiProxy_LevelOne{}
+
+	_jsii_.Create(
+		"jsii-calc.LevelOne",
+		[]interface{}{props},
+		&j,
+	)
+
+	return &j
+}
+
+func NewLevelOne_Override(l LevelOne, props *LevelOneProps) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.LevelOne",
+		[]interface{}{props},
+		l,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_LevelOne_PropBooleanValue.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type LevelOne_PropBooleanValue struct {
+	Value *bool \`field:"required" json:"value" yaml:"value"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_LevelOne_PropProperty.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type LevelOne_PropProperty struct {
+	Prop *LevelOne_PropBooleanValue \`field:"required" json:"prop" yaml:"prop"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_LevelOneProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type LevelOneProps struct {
+	Prop *LevelOne_PropProperty \`field:"required" json:"prop" yaml:"prop"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_LoadBalancedFargateServiceProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// jsii#298: show default values in sphinx documentation, and respect newlines.
+type LoadBalancedFargateServiceProps struct {
+	// The container port of the application load balancer attached to your Fargate service.
+	//
+	// Corresponds to container port mapping.
+	ContainerPort *float64 \`field:"optional" json:"containerPort" yaml:"containerPort"\`
+	// The number of cpu units used by the task.
+	//
+	// Valid values, which determines your range of valid values for the memory parameter:
+	// 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB
+	// 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB
+	// 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB
+	// 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments
+	// 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments
+	//
+	// This default is set in the underlying FargateTaskDefinition construct.
+	Cpu *string \`field:"optional" json:"cpu" yaml:"cpu"\`
+	// The amount (in MiB) of memory used by the task.
+	//
+	// This field is required and you must use one of the following values, which determines your range of valid values
+	// for the cpu parameter:
+	//
+	// 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU)
+	//
+	// 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU)
+	//
+	// 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU)
+	//
+	// Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
+	//
+	// Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
+	//
+	// This default is set in the underlying FargateTaskDefinition construct.
+	MemoryMiB *string \`field:"optional" json:"memoryMiB" yaml:"memoryMiB"\`
+	// Determines whether the Application Load Balancer will be internet-facing.
+	PublicLoadBalancer *bool \`field:"optional" json:"publicLoadBalancer" yaml:"publicLoadBalancer"\`
+	// Determines whether your Fargate Service will be assigned a public IP address.
+	PublicTasks *bool \`field:"optional" json:"publicTasks" yaml:"publicTasks"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_MethodNamedProperty.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type MethodNamedProperty interface {
+	Elite() *float64
+	Property() *string
+}
+
+// The jsii proxy struct for MethodNamedProperty
+type jsiiProxy_MethodNamedProperty struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_MethodNamedProperty) Elite() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"elite",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewMethodNamedProperty() MethodNamedProperty {
+	_init_.Initialize()
+
+	j := jsiiProxy_MethodNamedProperty{}
+
+	_jsii_.Create(
+		"jsii-calc.MethodNamedProperty",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewMethodNamedProperty_Override(m MethodNamedProperty) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.MethodNamedProperty",
+		nil, // no parameters
+		m,
+	)
+}
+
+func (m *jsiiProxy_MethodNamedProperty) Property() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		m,
+		"property",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Multiply.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// The "*" binary operation.
+type Multiply interface {
+	BinaryOperation
+	IFriendlier
+	IRandomNumberGenerator
+	// Left-hand side operand.
+	Lhs() scopejsiicalclib.NumericValue
+	// Right-hand side operand.
+	Rhs() scopejsiicalclib.NumericValue
+	// The value.
+	Value() *float64
+	// Say farewell.
+	Farewell() *string
+	// Say goodbye.
+	Goodbye() *string
+	// Say hello!
+	Hello() *string
+	// Returns another random number.
+	Next() *float64
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Multiply
+type jsiiProxy_Multiply struct {
+	jsiiProxy_BinaryOperation
+	jsiiProxy_IFriendlier
+	jsiiProxy_IRandomNumberGenerator
+}
+
+func (j *jsiiProxy_Multiply) Lhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"lhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Multiply) Rhs() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"rhs",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Multiply) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a BinaryOperation.
+func NewMultiply(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Multiply {
+	_init_.Initialize()
+
+	j := jsiiProxy_Multiply{}
+
+	_jsii_.Create(
+		"jsii-calc.Multiply",
+		[]interface{}{lhs, rhs},
+		&j,
+	)
+
+	return &j
+}
+
+// Creates a BinaryOperation.
+func NewMultiply_Override(m Multiply, lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Multiply",
+		[]interface{}{lhs, rhs},
+		m,
+	)
+}
+
+func (m *jsiiProxy_Multiply) Farewell() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		m,
+		"farewell",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (m *jsiiProxy_Multiply) Goodbye() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		m,
+		"goodbye",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (m *jsiiProxy_Multiply) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		m,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (m *jsiiProxy_Multiply) Next() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		m,
+		"next",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (m *jsiiProxy_Multiply) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		m,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (m *jsiiProxy_Multiply) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		m,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Negate.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// The negation operation ("-value").
+type Negate interface {
+	UnaryOperation
+	IFriendlier
+	Operand() scopejsiicalclib.NumericValue
+	// The value.
+	Value() *float64
+	// Say farewell.
+	Farewell() *string
+	// Say goodbye.
+	Goodbye() *string
+	// Say hello!
+	Hello() *string
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Negate
+type jsiiProxy_Negate struct {
+	jsiiProxy_UnaryOperation
+	jsiiProxy_IFriendlier
+}
+
+func (j *jsiiProxy_Negate) Operand() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"operand",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Negate) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewNegate(operand scopejsiicalclib.NumericValue) Negate {
+	_init_.Initialize()
+
+	j := jsiiProxy_Negate{}
+
+	_jsii_.Create(
+		"jsii-calc.Negate",
+		[]interface{}{operand},
+		&j,
+	)
+
+	return &j
+}
+
+func NewNegate_Override(n Negate, operand scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Negate",
+		[]interface{}{operand},
+		n,
+	)
+}
+
+func (n *jsiiProxy_Negate) Farewell() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"farewell",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_Negate) Goodbye() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"goodbye",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_Negate) Hello() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_Negate) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_Negate) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		n,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NestedClassInstance.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
+)
+
+type NestedClassInstance interface {
+}
+
+// The jsii proxy struct for NestedClassInstance
+type jsiiProxy_NestedClassInstance struct {
+	_ byte // padding
+}
+
+func NestedClassInstance_MakeInstance() customsubmodulename.NestingClass_NestedClass {
+	_init_.Initialize()
+
+	var returns customsubmodulename.NestingClass_NestedClass
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.NestedClassInstance",
+		"makeInstance",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NestedStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type NestedStruct struct {
+	// When provided, must be > 0.
+	NumberProp *float64 \`field:"required" json:"numberProp" yaml:"numberProp"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NodeStandardLibrary.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Test fixture to verify that jsii modules can use the node standard library.
+type NodeStandardLibrary interface {
+	// Returns the current os.platform() from the "os" node module.
+	OsPlatform() *string
+	// Uses node.js "crypto" module to calculate sha256 of a string.
+	//
+	// Returns: "6a2da20943931e9834fc12cfe5bb47bbd9ae43489a30726962b576f4e3993e50".
+	CryptoSha256() *string
+	// Reads a local resource file (resource.txt) asynchronously.
+	//
+	// Returns: "Hello, resource!"
+	FsReadFile() *string
+	// Sync version of fsReadFile.
+	//
+	// Returns: "Hello, resource! SYNC!"
+	FsReadFileSync() *string
+}
+
+// The jsii proxy struct for NodeStandardLibrary
+type jsiiProxy_NodeStandardLibrary struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_NodeStandardLibrary) OsPlatform() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"osPlatform",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewNodeStandardLibrary() NodeStandardLibrary {
+	_init_.Initialize()
+
+	j := jsiiProxy_NodeStandardLibrary{}
+
+	_jsii_.Create(
+		"jsii-calc.NodeStandardLibrary",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewNodeStandardLibrary_Override(n NodeStandardLibrary) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.NodeStandardLibrary",
+		nil, // no parameters
+		n,
+	)
+}
+
+func (n *jsiiProxy_NodeStandardLibrary) CryptoSha256() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"cryptoSha256",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_NodeStandardLibrary) FsReadFile() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"fsReadFile",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_NodeStandardLibrary) FsReadFileSync() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		n,
+		"fsReadFileSync",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NullShouldBeTreatedAsUndefined.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// jsii#282, aws-cdk#157: null should be treated as "undefined".
+type NullShouldBeTreatedAsUndefined interface {
+	ChangeMeToUndefined() *string
+	SetChangeMeToUndefined(val *string)
+	GiveMeUndefined(value interface{})
+	GiveMeUndefinedInsideAnObject(input *NullShouldBeTreatedAsUndefinedData)
+	VerifyPropertyIsUndefined()
+}
+
+// The jsii proxy struct for NullShouldBeTreatedAsUndefined
+type jsiiProxy_NullShouldBeTreatedAsUndefined struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_NullShouldBeTreatedAsUndefined) ChangeMeToUndefined() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"changeMeToUndefined",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewNullShouldBeTreatedAsUndefined(_param1 *string, optional interface{}) NullShouldBeTreatedAsUndefined {
+	_init_.Initialize()
+
+	j := jsiiProxy_NullShouldBeTreatedAsUndefined{}
+
+	_jsii_.Create(
+		"jsii-calc.NullShouldBeTreatedAsUndefined",
+		[]interface{}{_param1, optional},
+		&j,
+	)
+
+	return &j
+}
+
+func NewNullShouldBeTreatedAsUndefined_Override(n NullShouldBeTreatedAsUndefined, _param1 *string, optional interface{}) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.NullShouldBeTreatedAsUndefined",
+		[]interface{}{_param1, optional},
+		n,
+	)
+}
+
+func (j *jsiiProxy_NullShouldBeTreatedAsUndefined) SetChangeMeToUndefined(val *string) {
+	_jsii_.Set(
+		j,
+		"changeMeToUndefined",
+		val,
+	)
+}
+
+func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) GiveMeUndefined(value interface{}) {
+	_jsii_.InvokeVoid(
+		n,
+		"giveMeUndefined",
+		[]interface{}{value},
+	)
+}
+
+func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) GiveMeUndefinedInsideAnObject(input *NullShouldBeTreatedAsUndefinedData) {
+	_jsii_.InvokeVoid(
+		n,
+		"giveMeUndefinedInsideAnObject",
+		[]interface{}{input},
+	)
+}
+
+func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
+	_jsii_.InvokeVoid(
+		n,
+		"verifyPropertyIsUndefined",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NullShouldBeTreatedAsUndefinedData.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type NullShouldBeTreatedAsUndefinedData struct {
+	ArrayWithThreeElementsAndUndefinedAsSecondArgument *[]interface{} \`field:"required" json:"arrayWithThreeElementsAndUndefinedAsSecondArgument" yaml:"arrayWithThreeElementsAndUndefinedAsSecondArgument"\`
+	ThisShouldBeUndefined interface{} \`field:"optional" json:"thisShouldBeUndefined" yaml:"thisShouldBeUndefined"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_NumberGenerator.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This allows us to test that a reference can be stored for objects that implement interfaces.
+type NumberGenerator interface {
+	Generator() IRandomNumberGenerator
+	SetGenerator(val IRandomNumberGenerator)
+	IsSameGenerator(gen IRandomNumberGenerator) *bool
+	NextTimes100() *float64
+}
+
+// The jsii proxy struct for NumberGenerator
+type jsiiProxy_NumberGenerator struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_NumberGenerator) Generator() IRandomNumberGenerator {
+	var returns IRandomNumberGenerator
+	_jsii_.Get(
+		j,
+		"generator",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewNumberGenerator(generator IRandomNumberGenerator) NumberGenerator {
+	_init_.Initialize()
+
+	j := jsiiProxy_NumberGenerator{}
+
+	_jsii_.Create(
+		"jsii-calc.NumberGenerator",
+		[]interface{}{generator},
+		&j,
+	)
+
+	return &j
+}
+
+func NewNumberGenerator_Override(n NumberGenerator, generator IRandomNumberGenerator) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.NumberGenerator",
+		[]interface{}{generator},
+		n,
+	)
+}
+
+func (j *jsiiProxy_NumberGenerator) SetGenerator(val IRandomNumberGenerator) {
+	_jsii_.Set(
+		j,
+		"generator",
+		val,
+	)
+}
+
+func (n *jsiiProxy_NumberGenerator) IsSameGenerator(gen IRandomNumberGenerator) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		n,
+		"isSameGenerator",
+		[]interface{}{gen},
+		&returns,
+	)
+
+	return returns
+}
+
+func (n *jsiiProxy_NumberGenerator) NextTimes100() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		n,
+		"nextTimes100",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ObjectRefsInCollections.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// Verify that object references can be passed inside collections.
+type ObjectRefsInCollections interface {
+	// Returns the sum of all values.
+	SumFromArray(values *[]scopejsiicalclib.NumericValue) *float64
+	// Returns the sum of all values in a map.
+	SumFromMap(values *map[string]scopejsiicalclib.NumericValue) *float64
+}
+
+// The jsii proxy struct for ObjectRefsInCollections
+type jsiiProxy_ObjectRefsInCollections struct {
+	_ byte // padding
+}
+
+func NewObjectRefsInCollections() ObjectRefsInCollections {
+	_init_.Initialize()
+
+	j := jsiiProxy_ObjectRefsInCollections{}
+
+	_jsii_.Create(
+		"jsii-calc.ObjectRefsInCollections",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewObjectRefsInCollections_Override(o ObjectRefsInCollections) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ObjectRefsInCollections",
+		nil, // no parameters
+		o,
+	)
+}
+
+func (o *jsiiProxy_ObjectRefsInCollections) SumFromArray(values *[]scopejsiicalclib.NumericValue) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		o,
+		"sumFromArray",
+		[]interface{}{values},
+		&returns,
+	)
+
+	return returns
+}
+
+func (o *jsiiProxy_ObjectRefsInCollections) SumFromMap(values *map[string]scopejsiicalclib.NumericValue) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		o,
+		"sumFromMap",
+		[]interface{}{values},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ObjectWithPropertyProvider.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type ObjectWithPropertyProvider interface {
+}
+
+// The jsii proxy struct for ObjectWithPropertyProvider
+type jsiiProxy_ObjectWithPropertyProvider struct {
+	_ byte // padding
+}
+
+func ObjectWithPropertyProvider_Provide() IObjectWithProperty {
+	_init_.Initialize()
+
+	var returns IObjectWithProperty
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.ObjectWithPropertyProvider",
+		"provide",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Old.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Old class.
+// Deprecated: Use the new class or the old class whatever you want because
+// whatever you like is always the best.
+type Old interface {
+	// Doo wop that thing.
+	// Deprecated: Use the new class or the old class whatever you want because
+	// whatever you like is always the best.
+	DoAThing()
+}
+
+// The jsii proxy struct for Old
+type jsiiProxy_Old struct {
+	_ byte // padding
+}
+
+// Deprecated: Use the new class or the old class whatever you want because
+// whatever you like is always the best.
+func NewOld() Old {
+	_init_.Initialize()
+
+	j := jsiiProxy_Old{}
+
+	_jsii_.Create(
+		"jsii-calc.Old",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+// Deprecated: Use the new class or the old class whatever you want because
+// whatever you like is always the best.
+func NewOld_Override(o Old) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Old",
+		nil, // no parameters
+		o,
+	)
+}
+
+func (o *jsiiProxy_Old) DoAThing() {
+	_jsii_.InvokeVoid(
+		o,
+		"doAThing",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OptionalArgumentInvoker.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type OptionalArgumentInvoker interface {
+	InvokeWithOptional()
+	InvokeWithoutOptional()
+}
+
+// The jsii proxy struct for OptionalArgumentInvoker
+type jsiiProxy_OptionalArgumentInvoker struct {
+	_ byte // padding
+}
+
+func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArguments) OptionalArgumentInvoker {
+	_init_.Initialize()
+
+	j := jsiiProxy_OptionalArgumentInvoker{}
+
+	_jsii_.Create(
+		"jsii-calc.OptionalArgumentInvoker",
+		[]interface{}{delegate},
+		&j,
+	)
+
+	return &j
+}
+
+func NewOptionalArgumentInvoker_Override(o OptionalArgumentInvoker, delegate IInterfaceWithOptionalMethodArguments) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.OptionalArgumentInvoker",
+		[]interface{}{delegate},
+		o,
+	)
+}
+
+func (o *jsiiProxy_OptionalArgumentInvoker) InvokeWithOptional() {
+	_jsii_.InvokeVoid(
+		o,
+		"invokeWithOptional",
+		nil, // no parameters
+	)
+}
+
+func (o *jsiiProxy_OptionalArgumentInvoker) InvokeWithoutOptional() {
+	_jsii_.InvokeVoid(
+		o,
+		"invokeWithoutOptional",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OptionalConstructorArgument.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type OptionalConstructorArgument interface {
+	Arg1() *float64
+	Arg2() *string
+	Arg3() *time.Time
+}
+
+// The jsii proxy struct for OptionalConstructorArgument
+type jsiiProxy_OptionalConstructorArgument struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_OptionalConstructorArgument) Arg1() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"arg1",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_OptionalConstructorArgument) Arg2() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"arg2",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_OptionalConstructorArgument) Arg3() *time.Time {
+	var returns *time.Time
+	_jsii_.Get(
+		j,
+		"arg3",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewOptionalConstructorArgument(arg1 *float64, arg2 *string, arg3 *time.Time) OptionalConstructorArgument {
+	_init_.Initialize()
+
+	j := jsiiProxy_OptionalConstructorArgument{}
+
+	_jsii_.Create(
+		"jsii-calc.OptionalConstructorArgument",
+		[]interface{}{arg1, arg2, arg3},
+		&j,
+	)
+
+	return &j
+}
+
+func NewOptionalConstructorArgument_Override(o OptionalConstructorArgument, arg1 *float64, arg2 *string, arg3 *time.Time) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.OptionalConstructorArgument",
+		[]interface{}{arg1, arg2, arg3},
+		o,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OptionalStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type OptionalStruct struct {
+	Field *string \`field:"optional" json:"field" yaml:"field"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OptionalStructConsumer.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type OptionalStructConsumer interface {
+	FieldValue() *string
+	ParameterWasUndefined() *bool
+}
+
+// The jsii proxy struct for OptionalStructConsumer
+type jsiiProxy_OptionalStructConsumer struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_OptionalStructConsumer) FieldValue() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"fieldValue",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_OptionalStructConsumer) ParameterWasUndefined() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"parameterWasUndefined",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewOptionalStructConsumer(optionalStruct *OptionalStruct) OptionalStructConsumer {
+	_init_.Initialize()
+
+	j := jsiiProxy_OptionalStructConsumer{}
+
+	_jsii_.Create(
+		"jsii-calc.OptionalStructConsumer",
+		[]interface{}{optionalStruct},
+		&j,
+	)
+
+	return &j
+}
+
+func NewOptionalStructConsumer_Override(o OptionalStructConsumer, optionalStruct *OptionalStruct) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.OptionalStructConsumer",
+		[]interface{}{optionalStruct},
+		o,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OverridableProtectedMember.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// See: https://github.com/aws/jsii/issues/903
+//
+type OverridableProtectedMember interface {
+	OverrideReadOnly() *string
+	OverrideReadWrite() *string
+	SetOverrideReadWrite(val *string)
+	OverrideMe() *string
+	SwitchModes()
+	ValueFromProtected() *string
+}
+
+// The jsii proxy struct for OverridableProtectedMember
+type jsiiProxy_OverridableProtectedMember struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_OverridableProtectedMember) OverrideReadOnly() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"overrideReadOnly",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_OverridableProtectedMember) OverrideReadWrite() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"overrideReadWrite",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewOverridableProtectedMember() OverridableProtectedMember {
+	_init_.Initialize()
+
+	j := jsiiProxy_OverridableProtectedMember{}
+
+	_jsii_.Create(
+		"jsii-calc.OverridableProtectedMember",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewOverridableProtectedMember_Override(o OverridableProtectedMember) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.OverridableProtectedMember",
+		nil, // no parameters
+		o,
+	)
+}
+
+func (j *jsiiProxy_OverridableProtectedMember) SetOverrideReadWrite(val *string) {
+	_jsii_.Set(
+		j,
+		"overrideReadWrite",
+		val,
+	)
+}
+
+func (o *jsiiProxy_OverridableProtectedMember) OverrideMe() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		o,
+		"overrideMe",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (o *jsiiProxy_OverridableProtectedMember) SwitchModes() {
+	_jsii_.InvokeVoid(
+		o,
+		"switchModes",
+		nil, // no parameters
+	)
+}
+
+func (o *jsiiProxy_OverridableProtectedMember) ValueFromProtected() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		o,
+		"valueFromProtected",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_OverrideReturnsObject.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type OverrideReturnsObject interface {
+	Test(obj IReturnsNumber) *float64
+}
+
+// The jsii proxy struct for OverrideReturnsObject
+type jsiiProxy_OverrideReturnsObject struct {
+	_ byte // padding
+}
+
+func NewOverrideReturnsObject() OverrideReturnsObject {
+	_init_.Initialize()
+
+	j := jsiiProxy_OverrideReturnsObject{}
+
+	_jsii_.Create(
+		"jsii-calc.OverrideReturnsObject",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewOverrideReturnsObject_Override(o OverrideReturnsObject) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.OverrideReturnsObject",
+		nil, // no parameters
+		o,
+	)
+}
+
+func (o *jsiiProxy_OverrideReturnsObject) Test(obj IReturnsNumber) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		o,
+		"test",
+		[]interface{}{obj},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ParentStruct982.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// https://github.com/aws/jsii/issues/982.
+type ParentStruct982 struct {
+	Foo *string \`field:"required" json:"foo" yaml:"foo"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_PartiallyInitializedThisConsumer.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type PartiallyInitializedThisConsumer interface {
+	ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt *time.Time, ev AllTypesEnum) *string
+}
+
+// The jsii proxy struct for PartiallyInitializedThisConsumer
+type jsiiProxy_PartiallyInitializedThisConsumer struct {
+	_ byte // padding
+}
+
+func NewPartiallyInitializedThisConsumer_Override(p PartiallyInitializedThisConsumer) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.PartiallyInitializedThisConsumer",
+		nil, // no parameters
+		p,
+	)
+}
+
+func (p *jsiiProxy_PartiallyInitializedThisConsumer) ConsumePartiallyInitializedThis(obj ConstructorPassesThisOut, dt *time.Time, ev AllTypesEnum) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		p,
+		"consumePartiallyInitializedThis",
+		[]interface{}{obj, dt, ev},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Polymorphism.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+type Polymorphism interface {
+	SayHello(friendly scopejsiicalclib.IFriendly) *string
+}
+
+// The jsii proxy struct for Polymorphism
+type jsiiProxy_Polymorphism struct {
+	_ byte // padding
+}
+
+func NewPolymorphism() Polymorphism {
+	_init_.Initialize()
+
+	j := jsiiProxy_Polymorphism{}
+
+	_jsii_.Create(
+		"jsii-calc.Polymorphism",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewPolymorphism_Override(p Polymorphism) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Polymorphism",
+		nil, // no parameters
+		p,
+	)
+}
+
+func (p *jsiiProxy_Polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		p,
+		"sayHello",
+		[]interface{}{friendly},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Power.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// The power operation.
+type Power interface {
+	composition.CompositeOperation
+	// The base of the power.
+	Base() scopejsiicalclib.NumericValue
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes() *[]*string
+	SetDecorationPostfixes(val *[]*string)
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes() *[]*string
+	SetDecorationPrefixes(val *[]*string)
+	// The expression that this operation consists of.
+	//
+	// Must be implemented by derived classes.
+	Expression() scopejsiicalclib.NumericValue
+	// The number of times to multiply.
+	Pow() scopejsiicalclib.NumericValue
+	// The .toString() style.
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
+	// The value.
+	Value() *float64
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Power
+type jsiiProxy_Power struct {
+	internal.Type__compositionCompositeOperation
+}
+
+func (j *jsiiProxy_Power) Base() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"base",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) DecorationPostfixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) DecorationPrefixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) Pow() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"pow",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Power) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+// Creates a Power operation.
+func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) Power {
+	_init_.Initialize()
+
+	j := jsiiProxy_Power{}
+
+	_jsii_.Create(
+		"jsii-calc.Power",
+		[]interface{}{base, pow},
+		&j,
+	)
+
+	return &j
+}
+
+// Creates a Power operation.
+func NewPower_Override(p Power, base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Power",
+		[]interface{}{base, pow},
+		p,
+	)
+}
+
+func (j *jsiiProxy_Power) SetDecorationPostfixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Power) SetDecorationPrefixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Power) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
+		val,
+	)
+}
+
+func (p *jsiiProxy_Power) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		p,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (p *jsiiProxy_Power) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		p,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_PropertyNamedProperty.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Reproduction for https://github.com/aws/jsii/issues/1113 Where a method or property named "property" would result in impossible to load Python code.
+type PropertyNamedProperty interface {
+	Property() *string
+	YetAnoterOne() *bool
+}
+
+// The jsii proxy struct for PropertyNamedProperty
+type jsiiProxy_PropertyNamedProperty struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_PropertyNamedProperty) Property() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_PropertyNamedProperty) YetAnoterOne() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"yetAnoterOne",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewPropertyNamedProperty() PropertyNamedProperty {
+	_init_.Initialize()
+
+	j := jsiiProxy_PropertyNamedProperty{}
+
+	_jsii_.Create(
+		"jsii-calc.PropertyNamedProperty",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewPropertyNamedProperty_Override(p PropertyNamedProperty) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.PropertyNamedProperty",
+		nil, // no parameters
+		p,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_PublicClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type PublicClass interface {
+	Hello()
+}
+
+// The jsii proxy struct for PublicClass
+type jsiiProxy_PublicClass struct {
+	_ byte // padding
+}
+
+func NewPublicClass() PublicClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_PublicClass{}
+
+	_jsii_.Create(
+		"jsii-calc.PublicClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewPublicClass_Override(p PublicClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.PublicClass",
+		nil, // no parameters
+		p,
+	)
+}
+
+func (p *jsiiProxy_PublicClass) Hello() {
+	_jsii_.InvokeVoid(
+		p,
+		"hello",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_PythonReservedWords.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type PythonReservedWords interface {
+	And()
+	As()
+	Assert()
+	Async()
+	Await()
+	Break()
+	Class()
+	Continue()
+	Def()
+	Del()
+	Elif()
+	Else()
+	Except()
+	Finally()
+	For()
+	From()
+	Global()
+	If()
+	Import()
+	In()
+	Is()
+	Lambda()
+	Nonlocal()
+	Not()
+	Or()
+	Pass()
+	Raise()
+	Return()
+	Try()
+	While()
+	With()
+	Yield()
+}
+
+// The jsii proxy struct for PythonReservedWords
+type jsiiProxy_PythonReservedWords struct {
+	_ byte // padding
+}
+
+func NewPythonReservedWords() PythonReservedWords {
+	_init_.Initialize()
+
+	j := jsiiProxy_PythonReservedWords{}
+
+	_jsii_.Create(
+		"jsii-calc.PythonReservedWords",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewPythonReservedWords_Override(p PythonReservedWords) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.PythonReservedWords",
+		nil, // no parameters
+		p,
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) And() {
+	_jsii_.InvokeVoid(
+		p,
+		"and",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) As() {
+	_jsii_.InvokeVoid(
+		p,
+		"as",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Assert() {
+	_jsii_.InvokeVoid(
+		p,
+		"assert",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Async() {
+	_jsii_.InvokeVoid(
+		p,
+		"async",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Await() {
+	_jsii_.InvokeVoid(
+		p,
+		"await",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Break() {
+	_jsii_.InvokeVoid(
+		p,
+		"break",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Class() {
+	_jsii_.InvokeVoid(
+		p,
+		"class",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Continue() {
+	_jsii_.InvokeVoid(
+		p,
+		"continue",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Def() {
+	_jsii_.InvokeVoid(
+		p,
+		"def",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Del() {
+	_jsii_.InvokeVoid(
+		p,
+		"del",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Elif() {
+	_jsii_.InvokeVoid(
+		p,
+		"elif",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Else() {
+	_jsii_.InvokeVoid(
+		p,
+		"else",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Except() {
+	_jsii_.InvokeVoid(
+		p,
+		"except",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Finally() {
+	_jsii_.InvokeVoid(
+		p,
+		"finally",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) For() {
+	_jsii_.InvokeVoid(
+		p,
+		"for",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) From() {
+	_jsii_.InvokeVoid(
+		p,
+		"from",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Global() {
+	_jsii_.InvokeVoid(
+		p,
+		"global",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) If() {
+	_jsii_.InvokeVoid(
+		p,
+		"if",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Import() {
+	_jsii_.InvokeVoid(
+		p,
+		"import",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) In() {
+	_jsii_.InvokeVoid(
+		p,
+		"in",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Is() {
+	_jsii_.InvokeVoid(
+		p,
+		"is",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Lambda() {
+	_jsii_.InvokeVoid(
+		p,
+		"lambda",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Nonlocal() {
+	_jsii_.InvokeVoid(
+		p,
+		"nonlocal",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Not() {
+	_jsii_.InvokeVoid(
+		p,
+		"not",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Or() {
+	_jsii_.InvokeVoid(
+		p,
+		"or",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Pass() {
+	_jsii_.InvokeVoid(
+		p,
+		"pass",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Raise() {
+	_jsii_.InvokeVoid(
+		p,
+		"raise",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Return() {
+	_jsii_.InvokeVoid(
+		p,
+		"return",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Try() {
+	_jsii_.InvokeVoid(
+		p,
+		"try",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) While() {
+	_jsii_.InvokeVoid(
+		p,
+		"while",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) With() {
+	_jsii_.InvokeVoid(
+		p,
+		"with",
+		nil, // no parameters
+	)
+}
+
+func (p *jsiiProxy_PythonReservedWords) Yield() {
+	_jsii_.InvokeVoid(
+		p,
+		"yield",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ReferenceEnumFromScopedPackage.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// See awslabs/jsii#138.
+type ReferenceEnumFromScopedPackage interface {
+	Foo() scopejsiicalclib.EnumFromScopedModule
+	SetFoo(val scopejsiicalclib.EnumFromScopedModule)
+	LoadFoo() scopejsiicalclib.EnumFromScopedModule
+	SaveFoo(value scopejsiicalclib.EnumFromScopedModule)
+}
+
+// The jsii proxy struct for ReferenceEnumFromScopedPackage
+type jsiiProxy_ReferenceEnumFromScopedPackage struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ReferenceEnumFromScopedPackage) Foo() scopejsiicalclib.EnumFromScopedModule {
+	var returns scopejsiicalclib.EnumFromScopedModule
+	_jsii_.Get(
+		j,
+		"foo",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewReferenceEnumFromScopedPackage() ReferenceEnumFromScopedPackage {
+	_init_.Initialize()
+
+	j := jsiiProxy_ReferenceEnumFromScopedPackage{}
+
+	_jsii_.Create(
+		"jsii-calc.ReferenceEnumFromScopedPackage",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewReferenceEnumFromScopedPackage_Override(r ReferenceEnumFromScopedPackage) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ReferenceEnumFromScopedPackage",
+		nil, // no parameters
+		r,
+	)
+}
+
+func (j *jsiiProxy_ReferenceEnumFromScopedPackage) SetFoo(val scopejsiicalclib.EnumFromScopedModule) {
+	_jsii_.Set(
+		j,
+		"foo",
+		val,
+	)
+}
+
+func (r *jsiiProxy_ReferenceEnumFromScopedPackage) LoadFoo() scopejsiicalclib.EnumFromScopedModule {
+	var returns scopejsiicalclib.EnumFromScopedModule
+
+	_jsii_.Invoke(
+		r,
+		"loadFoo",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (r *jsiiProxy_ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalclib.EnumFromScopedModule) {
+	_jsii_.InvokeVoid(
+		r,
+		"saveFoo",
+		[]interface{}{value},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ReturnsPrivateImplementationOfInterface.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Helps ensure the JSII kernel & runtime cooperate correctly when an un-exported instance of a class is returned with a declared type that is an exported interface, and the instance inherits from an exported class.
+//
+// Returns: an instance of an un-exported class that extends \`ExportedBaseClass\`, declared as \`IPrivatelyImplemented\`.
+// See: https://github.com/aws/jsii/issues/320
+//
+type ReturnsPrivateImplementationOfInterface interface {
+	PrivateImplementation() IPrivatelyImplemented
+}
+
+// The jsii proxy struct for ReturnsPrivateImplementationOfInterface
+type jsiiProxy_ReturnsPrivateImplementationOfInterface struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_ReturnsPrivateImplementationOfInterface) PrivateImplementation() IPrivatelyImplemented {
+	var returns IPrivatelyImplemented
+	_jsii_.Get(
+		j,
+		"privateImplementation",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewReturnsPrivateImplementationOfInterface() ReturnsPrivateImplementationOfInterface {
+	_init_.Initialize()
+
+	j := jsiiProxy_ReturnsPrivateImplementationOfInterface{}
+
+	_jsii_.Create(
+		"jsii-calc.ReturnsPrivateImplementationOfInterface",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewReturnsPrivateImplementationOfInterface_Override(r ReturnsPrivateImplementationOfInterface) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ReturnsPrivateImplementationOfInterface",
+		nil, // no parameters
+		r,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_RootStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// This is here to check that we can pass a nested struct into a kwargs by specifying it as an in-line dictionary.
+//
+// This is cheating with the (current) declared types, but this is the "more
+// idiomatic" way for Pythonists.
+type RootStruct struct {
+	// May not be empty.
+	StringProp *string \`field:"required" json:"stringProp" yaml:"stringProp"\`
+	NestedStruct *NestedStruct \`field:"optional" json:"nestedStruct" yaml:"nestedStruct"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_RootStructValidator.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type RootStructValidator interface {
+}
+
+// The jsii proxy struct for RootStructValidator
+type jsiiProxy_RootStructValidator struct {
+	_ byte // padding
+}
+
+func RootStructValidator_Validate(struct_ *RootStruct) {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"jsii-calc.RootStructValidator",
+		"validate",
+		[]interface{}{struct_},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_RuntimeTypeChecking.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	"time"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type RuntimeTypeChecking interface {
+	MethodWithDefaultedArguments(arg1 *float64, arg2 *string, arg3 *time.Time)
+	MethodWithOptionalAnyArgument(arg interface{})
+	// Used to verify verification of number of method arguments.
+	MethodWithOptionalArguments(arg1 *float64, arg2 *string, arg3 *time.Time)
+}
+
+// The jsii proxy struct for RuntimeTypeChecking
+type jsiiProxy_RuntimeTypeChecking struct {
+	_ byte // padding
+}
+
+func NewRuntimeTypeChecking() RuntimeTypeChecking {
+	_init_.Initialize()
+
+	j := jsiiProxy_RuntimeTypeChecking{}
+
+	_jsii_.Create(
+		"jsii-calc.RuntimeTypeChecking",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewRuntimeTypeChecking_Override(r RuntimeTypeChecking) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.RuntimeTypeChecking",
+		nil, // no parameters
+		r,
+	)
+}
+
+func (r *jsiiProxy_RuntimeTypeChecking) MethodWithDefaultedArguments(arg1 *float64, arg2 *string, arg3 *time.Time) {
+	_jsii_.InvokeVoid(
+		r,
+		"methodWithDefaultedArguments",
+		[]interface{}{arg1, arg2, arg3},
+	)
+}
+
+func (r *jsiiProxy_RuntimeTypeChecking) MethodWithOptionalAnyArgument(arg interface{}) {
+	_jsii_.InvokeVoid(
+		r,
+		"methodWithOptionalAnyArgument",
+		[]interface{}{arg},
+	)
+}
+
+func (r *jsiiProxy_RuntimeTypeChecking) MethodWithOptionalArguments(arg1 *float64, arg2 *string, arg3 *time.Time) {
+	_jsii_.InvokeVoid(
+		r,
+		"methodWithOptionalArguments",
+		[]interface{}{arg1, arg2, arg3},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SecondLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type SecondLevelStruct struct {
+	// It's long and required.
+	DeeperRequiredProp *string \`field:"required" json:"deeperRequiredProp" yaml:"deeperRequiredProp"\`
+	// It's long, but you'll almost never pass it.
+	DeeperOptionalProp *string \`field:"optional" json:"deeperOptionalProp" yaml:"deeperOptionalProp"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SingleInstanceTwoTypes.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Test that a single instance can be returned under two different FQNs.
+//
+// JSII clients can instantiate 2 different strongly-typed wrappers for the same
+// object. Unfortunately, this will break object equality, but if we didn't do
+// this it would break runtime type checks in the JVM or CLR.
+type SingleInstanceTwoTypes interface {
+	Interface1() InbetweenClass
+	Interface2() IPublicInterface
+}
+
+// The jsii proxy struct for SingleInstanceTwoTypes
+type jsiiProxy_SingleInstanceTwoTypes struct {
+	_ byte // padding
+}
+
+func NewSingleInstanceTwoTypes() SingleInstanceTwoTypes {
+	_init_.Initialize()
+
+	j := jsiiProxy_SingleInstanceTwoTypes{}
+
+	_jsii_.Create(
+		"jsii-calc.SingleInstanceTwoTypes",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSingleInstanceTwoTypes_Override(s SingleInstanceTwoTypes) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.SingleInstanceTwoTypes",
+		nil, // no parameters
+		s,
+	)
+}
+
+func (s *jsiiProxy_SingleInstanceTwoTypes) Interface1() InbetweenClass {
+	var returns InbetweenClass
+
+	_jsii_.Invoke(
+		s,
+		"interface1",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SingleInstanceTwoTypes) Interface2() IPublicInterface {
+	var returns IPublicInterface
+
+	_jsii_.Invoke(
+		s,
+		"interface2",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SingletonInt.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Verifies that singleton enums are handled correctly.
+//
+// https://github.com/aws/jsii/issues/231
+type SingletonInt interface {
+	IsSingletonInt(value *float64) *bool
+}
+
+// The jsii proxy struct for SingletonInt
+type jsiiProxy_SingletonInt struct {
+	_ byte // padding
+}
+
+func (s *jsiiProxy_SingletonInt) IsSingletonInt(value *float64) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		s,
+		"isSingletonInt",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SingletonIntEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// A singleton integer.
+type SingletonIntEnum string
+
+const (
+	// Elite!
+	SingletonIntEnum_SINGLETON_INT SingletonIntEnum = "SINGLETON_INT"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SingletonString.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+// Verifies that singleton enums are handled correctly.
+//
+// https://github.com/aws/jsii/issues/231
+type SingletonString interface {
+	IsSingletonString(value *string) *bool
+}
+
+// The jsii proxy struct for SingletonString
+type jsiiProxy_SingletonString struct {
+	_ byte // padding
+}
+
+func (s *jsiiProxy_SingletonString) IsSingletonString(value *string) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		s,
+		"isSingletonString",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SingletonStringEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// A singleton string.
+type SingletonStringEnum string
+
+const (
+	// 1337.
+	SingletonStringEnum_SINGLETON_STRING SingletonStringEnum = "SINGLETON_STRING"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SmellyStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type SmellyStruct struct {
+	Property *string \`field:"required" json:"property" yaml:"property"\`
+	YetAnoterOne *bool \`field:"required" json:"yetAnoterOne" yaml:"yetAnoterOne"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SomeTypeJsii976.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type SomeTypeJsii976 interface {
+}
+
+// The jsii proxy struct for SomeTypeJsii976
+type jsiiProxy_SomeTypeJsii976 struct {
+	_ byte // padding
+}
+
+func NewSomeTypeJsii976() SomeTypeJsii976 {
+	_init_.Initialize()
+
+	j := jsiiProxy_SomeTypeJsii976{}
+
+	_jsii_.Create(
+		"jsii-calc.SomeTypeJsii976",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSomeTypeJsii976_Override(s SomeTypeJsii976) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.SomeTypeJsii976",
+		nil, // no parameters
+		s,
+	)
+}
+
+func SomeTypeJsii976_ReturnAnonymous() interface{} {
+	_init_.Initialize()
+
+	var returns interface{}
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.SomeTypeJsii976",
+		"returnAnonymous",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func SomeTypeJsii976_ReturnReturn() IReturnJsii976 {
+	_init_.Initialize()
+
+	var returns IReturnJsii976
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.SomeTypeJsii976",
+		"returnReturn",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StableClass.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type StableClass interface {
+	MutableProperty() *float64
+	SetMutableProperty(val *float64)
+	ReadonlyProperty() *string
+	Method()
+}
+
+// The jsii proxy struct for StableClass
+type jsiiProxy_StableClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_StableClass) MutableProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"mutableProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_StableClass) ReadonlyProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewStableClass(readonlyString *string, mutableNumber *float64) StableClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_StableClass{}
+
+	_jsii_.Create(
+		"jsii-calc.StableClass",
+		[]interface{}{readonlyString, mutableNumber},
+		&j,
+	)
+
+	return &j
+}
+
+func NewStableClass_Override(s StableClass, readonlyString *string, mutableNumber *float64) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.StableClass",
+		[]interface{}{readonlyString, mutableNumber},
+		s,
+	)
+}
+
+func (j *jsiiProxy_StableClass) SetMutableProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"mutableProperty",
+		val,
+	)
+}
+
+func (s *jsiiProxy_StableClass) Method() {
+	_jsii_.InvokeVoid(
+		s,
+		"method",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StableEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type StableEnum string
+
+const (
+	StableEnum_OPTION_A StableEnum = "OPTION_A"
+	StableEnum_OPTION_B StableEnum = "OPTION_B"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StableStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type StableStruct struct {
+	ReadonlyProperty *string \`field:"required" json:"readonlyProperty" yaml:"readonlyProperty"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StaticContext.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This is used to validate the ability to use \`this\` from within a static context.
+//
+// https://github.com/awslabs/aws-cdk/issues/2304
+type StaticContext interface {
+}
+
+// The jsii proxy struct for StaticContext
+type jsiiProxy_StaticContext struct {
+	_ byte // padding
+}
+
+func StaticContext_CanAccessStaticContext() *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.StaticContext",
+		"canAccessStaticContext",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func StaticContext_StaticVariable() *bool {
+	_init_.Initialize()
+	var returns *bool
+	_jsii_.StaticGet(
+		"jsii-calc.StaticContext",
+		"staticVariable",
+		&returns,
+	)
+	return returns
+}
+
+func StaticContext_SetStaticVariable(val *bool) {
+	_init_.Initialize()
+	_jsii_.StaticSet(
+		"jsii-calc.StaticContext",
+		"staticVariable",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StaticHelloChild.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type StaticHelloChild interface {
+	StaticHelloParent
+}
+
+// The jsii proxy struct for StaticHelloChild
+type jsiiProxy_StaticHelloChild struct {
+	jsiiProxy_StaticHelloParent
+}
+
+func StaticHelloChild_Method() {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"jsii-calc.StaticHelloChild",
+		"method",
+		nil, // no parameters
+	)
+}
+
+func StaticHelloChild_Property() *float64 {
+	_init_.Initialize()
+	var returns *float64
+	_jsii_.StaticGet(
+		"jsii-calc.StaticHelloChild",
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StaticHelloParent.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Static methods that override parent class are technically overrides (the inheritance of statics is part of the ES6 specification), but certain other languages such as Java do not carry statics in the inheritance chain at all, so they cannot be overridden, only hidden.
+//
+// The difference is fairly minor (for typical use-cases, the end result is the
+// same), however this has implications on what the generated code should look
+// like.
+type StaticHelloParent interface {
+}
+
+// The jsii proxy struct for StaticHelloParent
+type jsiiProxy_StaticHelloParent struct {
+	_ byte // padding
+}
+
+func NewStaticHelloParent() StaticHelloParent {
+	_init_.Initialize()
+
+	j := jsiiProxy_StaticHelloParent{}
+
+	_jsii_.Create(
+		"jsii-calc.StaticHelloParent",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewStaticHelloParent_Override(s StaticHelloParent) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.StaticHelloParent",
+		nil, // no parameters
+		s,
+	)
+}
+
+func StaticHelloParent_Method() {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"jsii-calc.StaticHelloParent",
+		"method",
+		nil, // no parameters
+	)
+}
+
+func StaticHelloParent_Property() *float64 {
+	_init_.Initialize()
+	var returns *float64
+	_jsii_.StaticGet(
+		"jsii-calc.StaticHelloParent",
+		"property",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Statics.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Statics interface {
+	Value() *string
+	JustMethod() *string
+}
+
+// The jsii proxy struct for Statics
+type jsiiProxy_Statics struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_Statics) Value() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewStatics(value *string) Statics {
+	_init_.Initialize()
+
+	j := jsiiProxy_Statics{}
+
+	_jsii_.Create(
+		"jsii-calc.Statics",
+		[]interface{}{value},
+		&j,
+	)
+
+	return &j
+}
+
+func NewStatics_Override(s Statics, value *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Statics",
+		[]interface{}{value},
+		s,
+	)
+}
+
+// Jsdocs for static method.
+func Statics_StaticMethod(name *string) *string {
+	_init_.Initialize()
+
+	var returns *string
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.Statics",
+		"staticMethod",
+		[]interface{}{name},
+		&returns,
+	)
+
+	return returns
+}
+
+func Statics_BAR() *float64 {
+	_init_.Initialize()
+	var returns *float64
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"BAR",
+		&returns,
+	)
+	return returns
+}
+
+func Statics_ConstObj() DoubleTrouble {
+	_init_.Initialize()
+	var returns DoubleTrouble
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"ConstObj",
+		&returns,
+	)
+	return returns
+}
+
+func Statics_Foo() *string {
+	_init_.Initialize()
+	var returns *string
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"Foo",
+		&returns,
+	)
+	return returns
+}
+
+func Statics_Instance() Statics {
+	_init_.Initialize()
+	var returns Statics
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"instance",
+		&returns,
+	)
+	return returns
+}
+
+func Statics_SetInstance(val Statics) {
+	_init_.Initialize()
+	_jsii_.StaticSet(
+		"jsii-calc.Statics",
+		"instance",
+		val,
+	)
+}
+
+func Statics_NonConstStatic() *float64 {
+	_init_.Initialize()
+	var returns *float64
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"nonConstStatic",
+		&returns,
+	)
+	return returns
+}
+
+func Statics_SetNonConstStatic(val *float64) {
+	_init_.Initialize()
+	_jsii_.StaticSet(
+		"jsii-calc.Statics",
+		"nonConstStatic",
+		val,
+	)
+}
+
+func Statics_ZooBar() *map[string]*string {
+	_init_.Initialize()
+	var returns *map[string]*string
+	_jsii_.StaticGet(
+		"jsii-calc.Statics",
+		"zooBar",
+		&returns,
+	)
+	return returns
+}
+
+func (s *jsiiProxy_Statics) JustMethod() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		s,
+		"justMethod",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StringEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type StringEnum string
+
+const (
+	StringEnum_A StringEnum = "A"
+	StringEnum_B StringEnum = "B"
+	StringEnum_C StringEnum = "C"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StripInternal.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type StripInternal interface {
+	YouSeeMe() *string
+	SetYouSeeMe(val *string)
+}
+
+// The jsii proxy struct for StripInternal
+type jsiiProxy_StripInternal struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_StripInternal) YouSeeMe() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"youSeeMe",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewStripInternal() StripInternal {
+	_init_.Initialize()
+
+	j := jsiiProxy_StripInternal{}
+
+	_jsii_.Create(
+		"jsii-calc.StripInternal",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewStripInternal_Override(s StripInternal) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.StripInternal",
+		nil, // no parameters
+		s,
+	)
+}
+
+func (j *jsiiProxy_StripInternal) SetYouSeeMe(val *string) {
+	_jsii_.Set(
+		j,
+		"youSeeMe",
+		val,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructA.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// We can serialize and deserialize structs without silently ignoring optional fields.
+type StructA struct {
+	RequiredString *string \`field:"required" json:"requiredString" yaml:"requiredString"\`
+	OptionalNumber *float64 \`field:"optional" json:"optionalNumber" yaml:"optionalNumber"\`
+	OptionalString *string \`field:"optional" json:"optionalString" yaml:"optionalString"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructB.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// This intentionally overlaps with StructA (where only requiredString is provided) to test htat the kernel properly disambiguates those.
+type StructB struct {
+	RequiredString *string \`field:"required" json:"requiredString" yaml:"requiredString"\`
+	OptionalBoolean *bool \`field:"optional" json:"optionalBoolean" yaml:"optionalBoolean"\`
+	OptionalStructA *StructA \`field:"optional" json:"optionalStructA" yaml:"optionalStructA"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructParameterType.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+// Verifies that, in languages that do keyword lifting (e.g: Python), having a struct member with the same name as a positional parameter results in the correct code being emitted.
+//
+// See: https://github.com/aws/aws-cdk/issues/4302
+type StructParameterType struct {
+	Scope *string \`field:"required" json:"scope" yaml:"scope"\`
+	Props *bool \`field:"optional" json:"props" yaml:"props"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructPassing.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Just because we can.
+type StructPassing interface {
+}
+
+// The jsii proxy struct for StructPassing
+type jsiiProxy_StructPassing struct {
+	_ byte // padding
+}
+
+func NewStructPassing() StructPassing {
+	_init_.Initialize()
+
+	j := jsiiProxy_StructPassing{}
+
+	_jsii_.Create(
+		"jsii-calc.StructPassing",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewStructPassing_Override(s StructPassing) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.StructPassing",
+		nil, // no parameters
+		s,
+	)
+}
+
+func StructPassing_HowManyVarArgsDidIPass(_positional *float64, inputs ...*TopLevelStruct) *float64 {
+	_init_.Initialize()
+
+	args := []interface{}{_positional}
+	for _, a := range inputs {
+		args = append(args, a)
+	}
+
+	var returns *float64
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.StructPassing",
+		"howManyVarArgsDidIPass",
+		args,
+		&returns,
+	)
+
+	return returns
+}
+
+func StructPassing_RoundTrip(_positional *float64, input *TopLevelStruct) *TopLevelStruct {
+	_init_.Initialize()
+
+	var returns *TopLevelStruct
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.StructPassing",
+		"roundTrip",
+		[]interface{}{_positional, input},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructUnionConsumer.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type StructUnionConsumer interface {
+}
+
+// The jsii proxy struct for StructUnionConsumer
+type jsiiProxy_StructUnionConsumer struct {
+	_ byte // padding
+}
+
+func StructUnionConsumer_IsStructA(struct_ interface{}) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.StructUnionConsumer",
+		"isStructA",
+		[]interface{}{struct_},
+		&returns,
+	)
+
+	return returns
+}
+
+func StructUnionConsumer_IsStructB(struct_ interface{}) *bool {
+	_init_.Initialize()
+
+	var returns *bool
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.StructUnionConsumer",
+		"isStructB",
+		[]interface{}{struct_},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructWithEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type StructWithEnum struct {
+	// An enum value.
+	Foo StringEnum \`field:"required" json:"foo" yaml:"foo"\`
+	// Optional enum value (of type integer).
+	Bar AllTypesEnum \`field:"optional" json:"bar" yaml:"bar"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_StructWithJavaReservedWords.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type StructWithJavaReservedWords struct {
+	Default *string \`field:"required" json:"default" yaml:"default"\`
+	Assert *string \`field:"optional" json:"assert" yaml:"assert"\`
+	Result *string \`field:"optional" json:"result" yaml:"result"\`
+	That *string \`field:"optional" json:"that" yaml:"that"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Sum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/composition"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// An operation that sums multiple values.
+type Sum interface {
+	composition.CompositeOperation
+	// A set of postfixes to include in a decorated .toString().
+	DecorationPostfixes() *[]*string
+	SetDecorationPostfixes(val *[]*string)
+	// A set of prefixes to include in a decorated .toString().
+	DecorationPrefixes() *[]*string
+	SetDecorationPrefixes(val *[]*string)
+	// The expression that this operation consists of.
+	//
+	// Must be implemented by derived classes.
+	Expression() scopejsiicalclib.NumericValue
+	// The parts to sum.
+	Parts() *[]scopejsiicalclib.NumericValue
+	SetParts(val *[]scopejsiicalclib.NumericValue)
+	// The .toString() style.
+	StringStyle() composition.CompositeOperation_CompositionStringStyle
+	SetStringStyle(val composition.CompositeOperation_CompositionStringStyle)
+	// The value.
+	Value() *float64
+	// String representation of the value.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Sum
+type jsiiProxy_Sum struct {
+	internal.Type__compositionCompositeOperation
+}
+
+func (j *jsiiProxy_Sum) DecorationPostfixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPostfixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) DecorationPrefixes() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"decorationPrefixes",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) Expression() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"expression",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) Parts() *[]scopejsiicalclib.NumericValue {
+	var returns *[]scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"parts",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) StringStyle() composition.CompositeOperation_CompositionStringStyle {
+	var returns composition.CompositeOperation_CompositionStringStyle
+	_jsii_.Get(
+		j,
+		"stringStyle",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_Sum) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewSum() Sum {
+	_init_.Initialize()
+
+	j := jsiiProxy_Sum{}
+
+	_jsii_.Create(
+		"jsii-calc.Sum",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSum_Override(s Sum) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Sum",
+		nil, // no parameters
+		s,
+	)
+}
+
+func (j *jsiiProxy_Sum) SetDecorationPostfixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPostfixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Sum) SetDecorationPrefixes(val *[]*string) {
+	_jsii_.Set(
+		j,
+		"decorationPrefixes",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Sum) SetParts(val *[]scopejsiicalclib.NumericValue) {
+	_jsii_.Set(
+		j,
+		"parts",
+		val,
+	)
+}
+
+func (j *jsiiProxy_Sum) SetStringStyle(val composition.CompositeOperation_CompositionStringStyle) {
+	_jsii_.Set(
+		j,
+		"stringStyle",
+		val,
+	)
+}
+
+func (s *jsiiProxy_Sum) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		s,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_Sum) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		s,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SupportsNiceJavaBuilder.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type SupportsNiceJavaBuilder interface {
+	SupportsNiceJavaBuilderWithRequiredProps
+	Bar() *float64
+	// some identifier.
+	Id() *float64
+	PropId() *string
+	Rest() *[]*string
+}
+
+// The jsii proxy struct for SupportsNiceJavaBuilder
+type jsiiProxy_SupportsNiceJavaBuilder struct {
+	jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilder) Bar() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"bar",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilder) Id() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"id",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilder) PropId() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"propId",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilder) Rest() *[]*string {
+	var returns *[]*string
+	_jsii_.Get(
+		j,
+		"rest",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewSupportsNiceJavaBuilder(id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) SupportsNiceJavaBuilder {
+	_init_.Initialize()
+
+	args := []interface{}{id, defaultBar, props}
+	for _, a := range rest {
+		args = append(args, a)
+	}
+
+	j := jsiiProxy_SupportsNiceJavaBuilder{}
+
+	_jsii_.Create(
+		"jsii-calc.SupportsNiceJavaBuilder",
+		args,
+		&j,
+	)
+
+	return &j
+}
+
+func NewSupportsNiceJavaBuilder_Override(s SupportsNiceJavaBuilder, id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) {
+	_init_.Initialize()
+
+	args := []interface{}{id, defaultBar, props}
+	for _, a := range rest {
+		args = append(args, a)
+	}
+
+	_jsii_.Create(
+		"jsii-calc.SupportsNiceJavaBuilder",
+		args,
+		s,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SupportsNiceJavaBuilderProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type SupportsNiceJavaBuilderProps struct {
+	// Some number, like 42.
+	Bar *float64 \`field:"required" json:"bar" yaml:"bar"\`
+	// An \`id\` field here is terrible API design, because the constructor of \`SupportsNiceJavaBuilder\` already has a parameter named \`id\`.
+	//
+	// But here we are, doing it like we didn't care.
+	Id *string \`field:"optional" json:"id" yaml:"id"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SupportsNiceJavaBuilderWithRequiredProps.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// We can generate fancy builders in Java for classes which take a mix of positional & struct parameters.
+type SupportsNiceJavaBuilderWithRequiredProps interface {
+	Bar() *float64
+	// some identifier of your choice.
+	Id() *float64
+	PropId() *string
+}
+
+// The jsii proxy struct for SupportsNiceJavaBuilderWithRequiredProps
+type jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) Bar() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"bar",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) Id() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"id",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps) PropId() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"propId",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewSupportsNiceJavaBuilderWithRequiredProps(id *float64, props *SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredProps {
+	_init_.Initialize()
+
+	j := jsiiProxy_SupportsNiceJavaBuilderWithRequiredProps{}
+
+	_jsii_.Create(
+		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
+		[]interface{}{id, props},
+		&j,
+	)
+
+	return &j
+}
+
+func NewSupportsNiceJavaBuilderWithRequiredProps_Override(s SupportsNiceJavaBuilderWithRequiredProps, id *float64, props *SupportsNiceJavaBuilderProps) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.SupportsNiceJavaBuilderWithRequiredProps",
+		[]interface{}{id, props},
+		s,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_SyncVirtualMethods.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type SyncVirtualMethods interface {
+	A() *float64
+	SetA(val *float64)
+	CallerIsProperty() *float64
+	SetCallerIsProperty(val *float64)
+	OtherProperty() *string
+	SetOtherProperty(val *string)
+	ReadonlyProperty() *string
+	TheProperty() *string
+	SetTheProperty(val *string)
+	ValueOfOtherProperty() *string
+	SetValueOfOtherProperty(val *string)
+	CallerIsAsync() *float64
+	CallerIsMethod() *float64
+	ModifyOtherProperty(value *string)
+	ModifyValueOfTheProperty(value *string)
+	ReadA() *float64
+	RetrieveOtherProperty() *string
+	RetrieveReadOnlyProperty() *string
+	RetrieveValueOfTheProperty() *string
+	VirtualMethod(n *float64) *float64
+	WriteA(value *float64)
+}
+
+// The jsii proxy struct for SyncVirtualMethods
+type jsiiProxy_SyncVirtualMethods struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) A() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"a",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) CallerIsProperty() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"callerIsProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) OtherProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"otherProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) ReadonlyProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"readonlyProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) TheProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"theProperty",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) ValueOfOtherProperty() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"valueOfOtherProperty",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewSyncVirtualMethods() SyncVirtualMethods {
+	_init_.Initialize()
+
+	j := jsiiProxy_SyncVirtualMethods{}
+
+	_jsii_.Create(
+		"jsii-calc.SyncVirtualMethods",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSyncVirtualMethods_Override(s SyncVirtualMethods) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.SyncVirtualMethods",
+		nil, // no parameters
+		s,
+	)
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) SetA(val *float64) {
+	_jsii_.Set(
+		j,
+		"a",
+		val,
+	)
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) SetCallerIsProperty(val *float64) {
+	_jsii_.Set(
+		j,
+		"callerIsProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) SetOtherProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"otherProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) SetTheProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"theProperty",
+		val,
+	)
+}
+
+func (j *jsiiProxy_SyncVirtualMethods) SetValueOfOtherProperty(val *string) {
+	_jsii_.Set(
+		j,
+		"valueOfOtherProperty",
+		val,
+	)
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) CallerIsAsync() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		s,
+		"callerIsAsync",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) CallerIsMethod() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		s,
+		"callerIsMethod",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) ModifyOtherProperty(value *string) {
+	_jsii_.InvokeVoid(
+		s,
+		"modifyOtherProperty",
+		[]interface{}{value},
+	)
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) ModifyValueOfTheProperty(value *string) {
+	_jsii_.InvokeVoid(
+		s,
+		"modifyValueOfTheProperty",
+		[]interface{}{value},
+	)
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) ReadA() *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		s,
+		"readA",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) RetrieveOtherProperty() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		s,
+		"retrieveOtherProperty",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) RetrieveReadOnlyProperty() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		s,
+		"retrieveReadOnlyProperty",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) RetrieveValueOfTheProperty() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		s,
+		"retrieveValueOfTheProperty",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) VirtualMethod(n *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		s,
+		"virtualMethod",
+		[]interface{}{n},
+		&returns,
+	)
+
+	return returns
+}
+
+func (s *jsiiProxy_SyncVirtualMethods) WriteA(value *float64) {
+	_jsii_.InvokeVoid(
+		s,
+		"writeA",
+		[]interface{}{value},
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_TestStructWithEnum.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type TestStructWithEnum interface {
+	// Returns \`foo: StringEnum.A\`.
+	StructWithFoo() *StructWithEnum
+	// Returns \`foo: StringEnum.C\` and \`bar: AllTypesEnum.MY_ENUM_VALUE\`.
+	StructWithFooBar() *StructWithEnum
+	// Returns true if \`foo\` is \`StringEnum.A\`.
+	IsStringEnumA(input *StructWithEnum) *bool
+	// Returns true if \`foo\` is \`StringEnum.B\` and \`bar\` is \`AllTypesEnum.THIS_IS_GREAT\`.
+	IsStringEnumB(input *StructWithEnum) *bool
+}
+
+// The jsii proxy struct for TestStructWithEnum
+type jsiiProxy_TestStructWithEnum struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_TestStructWithEnum) StructWithFoo() *StructWithEnum {
+	var returns *StructWithEnum
+	_jsii_.Get(
+		j,
+		"structWithFoo",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_TestStructWithEnum) StructWithFooBar() *StructWithEnum {
+	var returns *StructWithEnum
+	_jsii_.Get(
+		j,
+		"structWithFooBar",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewTestStructWithEnum() TestStructWithEnum {
+	_init_.Initialize()
+
+	j := jsiiProxy_TestStructWithEnum{}
+
+	_jsii_.Create(
+		"jsii-calc.TestStructWithEnum",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewTestStructWithEnum_Override(t TestStructWithEnum) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.TestStructWithEnum",
+		nil, // no parameters
+		t,
+	)
+}
+
+func (t *jsiiProxy_TestStructWithEnum) IsStringEnumA(input *StructWithEnum) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		t,
+		"isStringEnumA",
+		[]interface{}{input},
+		&returns,
+	)
+
+	return returns
+}
+
+func (t *jsiiProxy_TestStructWithEnum) IsStringEnumB(input *StructWithEnum) *bool {
+	var returns *bool
+
+	_jsii_.Invoke(
+		t,
+		"isStringEnumB",
+		[]interface{}{input},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_Thrower.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Thrower interface {
+	ThrowError()
+}
+
+// The jsii proxy struct for Thrower
+type jsiiProxy_Thrower struct {
+	_ byte // padding
+}
+
+func NewThrower() Thrower {
+	_init_.Initialize()
+
+	j := jsiiProxy_Thrower{}
+
+	_jsii_.Create(
+		"jsii-calc.Thrower",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewThrower_Override(t Thrower) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.Thrower",
+		nil, // no parameters
+		t,
+	)
+}
+
+func (t *jsiiProxy_Thrower) ThrowError() {
+	_jsii_.InvokeVoid(
+		t,
+		"throwError",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_TopLevelStruct.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type TopLevelStruct struct {
+	// This is a required field.
+	Required *string \`field:"required" json:"required" yaml:"required"\`
+	// A union to really stress test our serialization.
+	SecondLevel interface{} \`field:"required" json:"secondLevel" yaml:"secondLevel"\`
+	// You don't have to pass this.
+	Optional *string \`field:"optional" json:"optional" yaml:"optional"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_TwoMethodsWithSimilarCapitalization.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// In TypeScript it is possible to have two methods with the same name but different capitalization.
+// See: https://github.com/aws/jsii/issues/2508
+//
+type TwoMethodsWithSimilarCapitalization interface {
+	FooBar() *float64
+	// Deprecated: YES.
+	FooBAR() *float64
+	ToIsoString() *string
+	// Deprecated: python requires that all alternatives are deprecated.
+	ToIsOString() *string
+	// Deprecated: python requires that all alternatives are deprecated.
+	ToISOString() *string
+}
+
+// The jsii proxy struct for TwoMethodsWithSimilarCapitalization
+type jsiiProxy_TwoMethodsWithSimilarCapitalization struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_TwoMethodsWithSimilarCapitalization) FooBar() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"fooBar",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_TwoMethodsWithSimilarCapitalization) FooBAR() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"fooBAR",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewTwoMethodsWithSimilarCapitalization() TwoMethodsWithSimilarCapitalization {
+	_init_.Initialize()
+
+	j := jsiiProxy_TwoMethodsWithSimilarCapitalization{}
+
+	_jsii_.Create(
+		"jsii-calc.TwoMethodsWithSimilarCapitalization",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewTwoMethodsWithSimilarCapitalization_Override(t TwoMethodsWithSimilarCapitalization) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.TwoMethodsWithSimilarCapitalization",
+		nil, // no parameters
+		t,
+	)
+}
+
+func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToIsoString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		t,
+		"toIsoString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToIsOString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		t,
+		"toIsOString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToISOString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		t,
+		"toISOString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UmaskCheck.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Checks the current file permissions are cool (no funky UMASK down-scoping happened).
+// See: https://github.com/aws/jsii/issues/1765
+//
+type UmaskCheck interface {
+}
+
+// The jsii proxy struct for UmaskCheck
+type jsiiProxy_UmaskCheck struct {
+	_ byte // padding
+}
+
+// This should return 0o644 (-rw-r--r--).
+func UmaskCheck_Mode() *float64 {
+	_init_.Initialize()
+
+	var returns *float64
+
+	_jsii_.StaticInvoke(
+		"jsii-calc.UmaskCheck",
+		"mode",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UnaryOperation.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// An operation on a single operand.
+type UnaryOperation interface {
+	scopejsiicalclib.Operation
+	Operand() scopejsiicalclib.NumericValue
+	// The value.
+	// Deprecated.
+	Value() *float64
+	// String representation of the value.
+	// Deprecated.
+	ToString() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for UnaryOperation
+type jsiiProxy_UnaryOperation struct {
+	internal.Type__scopejsiicalclibOperation
+}
+
+func (j *jsiiProxy_UnaryOperation) Operand() scopejsiicalclib.NumericValue {
+	var returns scopejsiicalclib.NumericValue
+	_jsii_.Get(
+		j,
+		"operand",
+		&returns,
+	)
+	return returns
+}
+
+func (j *jsiiProxy_UnaryOperation) Value() *float64 {
+	var returns *float64
+	_jsii_.Get(
+		j,
+		"value",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewUnaryOperation_Override(u UnaryOperation, operand scopejsiicalclib.NumericValue) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.UnaryOperation",
+		[]interface{}{operand},
+		u,
+	)
+}
+
+func (u *jsiiProxy_UnaryOperation) ToString() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		u,
+		"toString",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (u *jsiiProxy_UnaryOperation) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		u,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UnionProperties.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+
+type UnionProperties struct {
+	Bar interface{} \`field:"required" json:"bar" yaml:"bar"\`
+	Foo interface{} \`field:"optional" json:"foo" yaml:"foo"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UpcasingReflectable.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/internal"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib/customsubmodulename"
+)
+
+// Ensures submodule-imported types from dependencies can be used correctly.
+type UpcasingReflectable interface {
+	customsubmodulename.IReflectable
+	Entries() *[]*customsubmodulename.ReflectableEntry
+}
+
+// The jsii proxy struct for UpcasingReflectable
+type jsiiProxy_UpcasingReflectable struct {
+	internal.Type__customsubmodulenameIReflectable
+}
+
+func (j *jsiiProxy_UpcasingReflectable) Entries() *[]*customsubmodulename.ReflectableEntry {
+	var returns *[]*customsubmodulename.ReflectableEntry
+	_jsii_.Get(
+		j,
+		"entries",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewUpcasingReflectable(delegate *map[string]interface{}) UpcasingReflectable {
+	_init_.Initialize()
+
+	j := jsiiProxy_UpcasingReflectable{}
+
+	_jsii_.Create(
+		"jsii-calc.UpcasingReflectable",
+		[]interface{}{delegate},
+		&j,
+	)
+
+	return &j
+}
+
+func NewUpcasingReflectable_Override(u UpcasingReflectable, delegate *map[string]interface{}) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.UpcasingReflectable",
+		[]interface{}{delegate},
+		u,
+	)
+}
+
+func UpcasingReflectable_Reflector() customsubmodulename.Reflector {
+	_init_.Initialize()
+	var returns customsubmodulename.Reflector
+	_jsii_.StaticGet(
+		"jsii-calc.UpcasingReflectable",
+		"reflector",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UseBundledDependency.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type UseBundledDependency interface {
+	Value() interface{}
+}
+
+// The jsii proxy struct for UseBundledDependency
+type jsiiProxy_UseBundledDependency struct {
+	_ byte // padding
+}
+
+func NewUseBundledDependency() UseBundledDependency {
+	_init_.Initialize()
+
+	j := jsiiProxy_UseBundledDependency{}
+
+	_jsii_.Create(
+		"jsii-calc.UseBundledDependency",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewUseBundledDependency_Override(u UseBundledDependency) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.UseBundledDependency",
+		nil, // no parameters
+		u,
+	)
+}
+
+func (u *jsiiProxy_UseBundledDependency) Value() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		u,
+		"value",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UseCalcBase.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+)
+
+// Depend on a type from jsii-calc-base as a test for awslabs/jsii#128.
+type UseCalcBase interface {
+	Hello() jcb.Base
+}
+
+// The jsii proxy struct for UseCalcBase
+type jsiiProxy_UseCalcBase struct {
+	_ byte // padding
+}
+
+func NewUseCalcBase() UseCalcBase {
+	_init_.Initialize()
+
+	j := jsiiProxy_UseCalcBase{}
+
+	_jsii_.Create(
+		"jsii-calc.UseCalcBase",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewUseCalcBase_Override(u UseCalcBase) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.UseCalcBase",
+		nil, // no parameters
+		u,
+	)
+}
+
+func (u *jsiiProxy_UseCalcBase) Hello() jcb.Base {
+	var returns jcb.Base
+
+	_jsii_.Invoke(
+		u,
+		"hello",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_UsesInterfaceWithProperties.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type UsesInterfaceWithProperties interface {
+	Obj() IInterfaceWithProperties
+	JustRead() *string
+	ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) *string
+	WriteAndRead(value *string) *string
+}
+
+// The jsii proxy struct for UsesInterfaceWithProperties
+type jsiiProxy_UsesInterfaceWithProperties struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_UsesInterfaceWithProperties) Obj() IInterfaceWithProperties {
+	var returns IInterfaceWithProperties
+	_jsii_.Get(
+		j,
+		"obj",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewUsesInterfaceWithProperties(obj IInterfaceWithProperties) UsesInterfaceWithProperties {
+	_init_.Initialize()
+
+	j := jsiiProxy_UsesInterfaceWithProperties{}
+
+	_jsii_.Create(
+		"jsii-calc.UsesInterfaceWithProperties",
+		[]interface{}{obj},
+		&j,
+	)
+
+	return &j
+}
+
+func NewUsesInterfaceWithProperties_Override(u UsesInterfaceWithProperties, obj IInterfaceWithProperties) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.UsesInterfaceWithProperties",
+		[]interface{}{obj},
+		u,
+	)
+}
+
+func (u *jsiiProxy_UsesInterfaceWithProperties) JustRead() *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		u,
+		"justRead",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+func (u *jsiiProxy_UsesInterfaceWithProperties) ReadStringAndNumber(ext IInterfaceWithPropertiesExtension) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		u,
+		"readStringAndNumber",
+		[]interface{}{ext},
+		&returns,
+	)
+
+	return returns
+}
+
+func (u *jsiiProxy_UsesInterfaceWithProperties) WriteAndRead(value *string) *string {
+	var returns *string
+
+	_jsii_.Invoke(
+		u,
+		"writeAndRead",
+		[]interface{}{value},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VariadicInvoker.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type VariadicInvoker interface {
+	AsArray(values ...*float64) *[]*float64
+}
+
+// The jsii proxy struct for VariadicInvoker
+type jsiiProxy_VariadicInvoker struct {
+	_ byte // padding
+}
+
+func NewVariadicInvoker(method VariadicMethod) VariadicInvoker {
+	_init_.Initialize()
+
+	j := jsiiProxy_VariadicInvoker{}
+
+	_jsii_.Create(
+		"jsii-calc.VariadicInvoker",
+		[]interface{}{method},
+		&j,
+	)
+
+	return &j
+}
+
+func NewVariadicInvoker_Override(v VariadicInvoker, method VariadicMethod) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.VariadicInvoker",
+		[]interface{}{method},
+		v,
+	)
+}
+
+func (v *jsiiProxy_VariadicInvoker) AsArray(values ...*float64) *[]*float64 {
+	args := []interface{}{}
+	for _, a := range values {
+		args = append(args, a)
+	}
+
+	var returns *[]*float64
+
+	_jsii_.Invoke(
+		v,
+		"asArray",
+		args,
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VariadicMethod.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type VariadicMethod interface {
+	AsArray(first *float64, others ...*float64) *[]*float64
+}
+
+// The jsii proxy struct for VariadicMethod
+type jsiiProxy_VariadicMethod struct {
+	_ byte // padding
+}
+
+func NewVariadicMethod(prefix ...*float64) VariadicMethod {
+	_init_.Initialize()
+
+	args := []interface{}{}
+	for _, a := range prefix {
+		args = append(args, a)
+	}
+
+	j := jsiiProxy_VariadicMethod{}
+
+	_jsii_.Create(
+		"jsii-calc.VariadicMethod",
+		args,
+		&j,
+	)
+
+	return &j
+}
+
+func NewVariadicMethod_Override(v VariadicMethod, prefix ...*float64) {
+	_init_.Initialize()
+
+	args := []interface{}{}
+	for _, a := range prefix {
+		args = append(args, a)
+	}
+
+	_jsii_.Create(
+		"jsii-calc.VariadicMethod",
+		args,
+		v,
+	)
+}
+
+func (v *jsiiProxy_VariadicMethod) AsArray(first *float64, others ...*float64) *[]*float64 {
+	args := []interface{}{first}
+	for _, a := range others {
+		args = append(args, a)
+	}
+
+	var returns *[]*float64
+
+	_jsii_.Invoke(
+		v,
+		"asArray",
+		args,
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VirtualMethodPlayground.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type VirtualMethodPlayground interface {
+	OverrideMeAsync(index *float64) *float64
+	OverrideMeSync(index *float64) *float64
+	ParallelSumAsync(count *float64) *float64
+	SerialSumAsync(count *float64) *float64
+	SumSync(count *float64) *float64
+}
+
+// The jsii proxy struct for VirtualMethodPlayground
+type jsiiProxy_VirtualMethodPlayground struct {
+	_ byte // padding
+}
+
+func NewVirtualMethodPlayground() VirtualMethodPlayground {
+	_init_.Initialize()
+
+	j := jsiiProxy_VirtualMethodPlayground{}
+
+	_jsii_.Create(
+		"jsii-calc.VirtualMethodPlayground",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewVirtualMethodPlayground_Override(v VirtualMethodPlayground) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.VirtualMethodPlayground",
+		nil, // no parameters
+		v,
+	)
+}
+
+func (v *jsiiProxy_VirtualMethodPlayground) OverrideMeAsync(index *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		v,
+		"overrideMeAsync",
+		[]interface{}{index},
+		&returns,
+	)
+
+	return returns
+}
+
+func (v *jsiiProxy_VirtualMethodPlayground) OverrideMeSync(index *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		v,
+		"overrideMeSync",
+		[]interface{}{index},
+		&returns,
+	)
+
+	return returns
+}
+
+func (v *jsiiProxy_VirtualMethodPlayground) ParallelSumAsync(count *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		v,
+		"parallelSumAsync",
+		[]interface{}{count},
+		&returns,
+	)
+
+	return returns
+}
+
+func (v *jsiiProxy_VirtualMethodPlayground) SerialSumAsync(count *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		v,
+		"serialSumAsync",
+		[]interface{}{count},
+		&returns,
+	)
+
+	return returns
+}
+
+func (v *jsiiProxy_VirtualMethodPlayground) SumSync(count *float64) *float64 {
+	var returns *float64
+
+	_jsii_.Invoke(
+		v,
+		"sumSync",
+		[]interface{}{count},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VoidCallback.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This test is used to validate the runtimes can return correctly from a void callback.
+//
+// - Implement \`overrideMe\` (method does not have to do anything).
+// - Invoke \`callMe\`
+// - Verify that \`methodWasCalled\` is \`true\`.
+type VoidCallback interface {
+	MethodWasCalled() *bool
+	CallMe()
+	OverrideMe()
+}
+
+// The jsii proxy struct for VoidCallback
+type jsiiProxy_VoidCallback struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_VoidCallback) MethodWasCalled() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"methodWasCalled",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewVoidCallback_Override(v VoidCallback) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.VoidCallback",
+		nil, // no parameters
+		v,
+	)
+}
+
+func (v *jsiiProxy_VoidCallback) CallMe() {
+	_jsii_.InvokeVoid(
+		v,
+		"callMe",
+		nil, // no parameters
+	)
+}
+
+func (v *jsiiProxy_VoidCallback) OverrideMe() {
+	_jsii_.InvokeVoid(
+		v,
+		"overrideMe",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_WithPrivatePropertyInConstructor.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Verifies that private property declarations in constructor arguments are hidden.
+type WithPrivatePropertyInConstructor interface {
+	Success() *bool
+}
+
+// The jsii proxy struct for WithPrivatePropertyInConstructor
+type jsiiProxy_WithPrivatePropertyInConstructor struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_WithPrivatePropertyInConstructor) Success() *bool {
+	var returns *bool
+	_jsii_.Get(
+		j,
+		"success",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewWithPrivatePropertyInConstructor(privateField *string) WithPrivatePropertyInConstructor {
+	_init_.Initialize()
+
+	j := jsiiProxy_WithPrivatePropertyInConstructor{}
+
+	_jsii_.Create(
+		"jsii-calc.WithPrivatePropertyInConstructor",
+		[]interface{}{privateField},
+		&j,
+	)
+
+	return &j
+}
+
+func NewWithPrivatePropertyInConstructor_Override(w WithPrivatePropertyInConstructor, privateField *string) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.WithPrivatePropertyInConstructor",
+		[]interface{}{privateField},
+		w,
+	)
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/module2530.go 1`] = `
+package module2530
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.module2530.MyClass",
+		reflect.TypeOf((*MyClass)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+		},
+		func() interface{} {
+			return &jsiiProxy_MyClass{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/module2530_MyClass.go 1`] = `
 package module2530
 
 import (
@@ -17655,8 +20598,8 @@ func (m *jsiiProxy_MyClass) Foo(_arg *string) {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/module2530.init.go 1`] = `
-package module2530
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/module2617.go 1`] = `
+package module2617
 
 import (
 	"reflect"
@@ -17666,20 +20609,18 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.module2530.MyClass",
-		reflect.TypeOf((*MyClass)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
-		},
+		"jsii-calc.module2617.OnlyStatics",
+		reflect.TypeOf((*OnlyStatics)(nil)).Elem(),
+		nil, // no members
 		func() interface{} {
-			return &jsiiProxy_MyClass{}
+			return &jsiiProxy_OnlyStatics{}
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/module2617.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/module2617_OnlyStatics.go 1`] = `
 package module2617
 
 import (
@@ -17718,28 +20659,6 @@ func OnlyStatics_Foo() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/module2617.init.go 1`] = `
-package module2617
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.module2617.OnlyStatics",
-		reflect.TypeOf((*OnlyStatics)(nil)).Elem(),
-		nil, // no members
-		func() interface{} {
-			return &jsiiProxy_OnlyStatics{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/internal/types.go 1`] = `
 package internal
 import (
@@ -17751,6 +20670,35 @@ type Type__scopejsiicalclibIFriendly = scopejsiicalclib.IFriendly
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/module2647.go 1`] = `
+package module2647
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.module2647.ExtendAndImplement",
+		reflect.TypeOf((*ExtendAndImplement)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+			_jsii_.MemberMethod{JsiiMethod: "hello", GoMethod: "Hello"},
+			_jsii_.MemberMethod{JsiiMethod: "localMethod", GoMethod: "LocalMethod"},
+		},
+		func() interface{} {
+			j := jsiiProxy_ExtendAndImplement{}
+			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibBaseFor2647)
+			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibIFriendly)
+			return &j
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/module2647_ExtendAndImplement.go 1`] = `
 package module2647
 
 import (
@@ -17845,8 +20793,8 @@ func (e *jsiiProxy_ExtendAndImplement) LocalMethod() *string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/module2647.init.go 1`] = `
-package module2647
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/methods.go 1`] = `
+package methods
 
 import (
 	"reflect"
@@ -17856,25 +20804,21 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.module2647.ExtendAndImplement",
-		reflect.TypeOf((*ExtendAndImplement)(nil)).Elem(),
+		"jsii-calc.module2689.methods.MyClass",
+		reflect.TypeOf((*MyClass)(nil)).Elem(),
 		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
 			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
-			_jsii_.MemberMethod{JsiiMethod: "hello", GoMethod: "Hello"},
-			_jsii_.MemberMethod{JsiiMethod: "localMethod", GoMethod: "LocalMethod"},
 		},
 		func() interface{} {
-			j := jsiiProxy_ExtendAndImplement{}
-			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibBaseFor2647)
-			_jsii_.InitJsiiProxy(&j.Type__scopejsiicalclibIFriendly)
-			return &j
+			return &jsiiProxy_MyClass{}
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/methods.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/methods_MyClass.go 1`] = `
 package methods
 
 import (
@@ -17938,8 +20882,8 @@ func (m *jsiiProxy_MyClass) Foo(_values *[]scopejsiicalclib.Number) {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/methods.init.go 1`] = `
-package methods
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/props.go 1`] = `
+package props
 
 import (
 	"reflect"
@@ -17949,11 +20893,11 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.module2689.methods.MyClass",
+		"jsii-calc.module2689.props.MyClass",
 		reflect.TypeOf((*MyClass)(nil)).Elem(),
 		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
+			_jsii_.MemberProperty{JsiiProperty: "bar", GoGetter: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "foo", GoGetter: "Foo"},
 		},
 		func() interface{} {
 			return &jsiiProxy_MyClass{}
@@ -17963,14 +20907,7 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/module2689.go 1`] = `
-package module2689
-
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/props.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/props_MyClass.go 1`] = `
 package props
 
 import (
@@ -18039,8 +20976,8 @@ func NewMyClass_Override(m MyClass) {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/props.init.go 1`] = `
-package props
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/retval.go 1`] = `
+package retval
 
 import (
 	"reflect"
@@ -18050,11 +20987,11 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.module2689.props.MyClass",
+		"jsii-calc.module2689.retval.MyClass",
 		reflect.TypeOf((*MyClass)(nil)).Elem(),
 		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "bar", GoGetter: "Bar"},
-			_jsii_.MemberProperty{JsiiProperty: "foo", GoGetter: "Foo"},
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
 		},
 		func() interface{} {
 			return &jsiiProxy_MyClass{}
@@ -18064,7 +21001,7 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/retval.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/retval_MyClass.go 1`] = `
 package retval
 
 import (
@@ -18138,48 +21075,7 @@ func (m *jsiiProxy_MyClass) Foo() *[]scopejsiicalclib.Number {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/retval.init.go 1`] = `
-package retval
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.module2689.retval.MyClass",
-		reflect.TypeOf((*MyClass)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberMethod{JsiiMethod: "foo", GoMethod: "Foo"},
-		},
-		func() interface{} {
-			return &jsiiProxy_MyClass{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/structs/structs.go 1`] = `
-package structs
-
-import (
-	"github.com/aws/jsii/jsii-calc/go/jcb"
-	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
-)
-
-type MyStruct struct {
-	BaseMap *map[string]*jcb.BaseProps \`field:"required" json:"baseMap" yaml:"baseMap"\`
-	Numbers *[]scopejsiicalclib.Number \`field:"required" json:"numbers" yaml:"numbers"\`
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/structs/structs.init.go 1`] = `
 package structs
 
 import (
@@ -18197,25 +21093,23 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/module2692.go 1`] = `
-package module2692
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/structs/structs_MyStruct.go 1`] = `
+package structs
 
+import (
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
 
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/submodule1.go 1`] = `
-package submodule1
-
-
-type Bar struct {
-	Bar1 *string \`field:"required" json:"bar1" yaml:"bar1"\`
+type MyStruct struct {
+	BaseMap *map[string]*jcb.BaseProps \`field:"required" json:"baseMap" yaml:"baseMap"\`
+	Numbers *[]scopejsiicalclib.Number \`field:"required" json:"numbers" yaml:"numbers"\`
 }
 
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/submodule1.init.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/submodule1.go 1`] = `
 package submodule1
 
 import (
@@ -18233,24 +21127,18 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/submodule2.go 1`] = `
-package submodule2
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/submodule1_Bar.go 1`] = `
+package submodule1
 
 
 type Bar struct {
-	Bar2 *string \`field:"required" json:"bar2" yaml:"bar2"\`
-}
-
-type Foo struct {
-	Bar2 *string \`field:"required" json:"bar2" yaml:"bar2"\`
 	Bar1 *string \`field:"required" json:"bar1" yaml:"bar1"\`
-	Foo2 *string \`field:"required" json:"foo2" yaml:"foo2"\`
 }
 
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/submodule2.init.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/submodule2.go 1`] = `
 package submodule2
 
 import (
@@ -18272,7 +21160,84 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/submodule2_Bar.go 1`] = `
+package submodule2
+
+
+type Bar struct {
+	Bar2 *string \`field:"required" json:"bar2" yaml:"bar2"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/submodule2_Foo.go 1`] = `
+package submodule2
+
+
+type Foo struct {
+	Bar2 *string \`field:"required" json:"bar2" yaml:"bar2"\`
+	Bar1 *string \`field:"required" json:"bar1" yaml:"bar1"\`
+	Foo2 *string \`field:"required" json:"foo2" yaml:"foo2"\`
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700.go 1`] = `
+package module2700
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.module2700.Base",
+		reflect.TypeOf((*Base)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Base{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
+			return &j
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.module2700.Derived",
+		reflect.TypeOf((*Derived)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+			_jsii_.MemberMethod{JsiiMethod: "zoo", GoMethod: "Zoo"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Derived{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_Base)
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
+			return &j
+		},
+	)
+	_jsii_.RegisterInterface(
+		"jsii-calc.module2700.IFoo",
+		reflect.TypeOf((*IFoo)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
+			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
+		},
+		func() interface{} {
+			return &jsiiProxy_IFoo{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700_Base.go 1`] = `
 package module2700
 
 import (
@@ -18338,6 +21303,17 @@ func (b *jsiiProxy_Base) Bar() *string {
 
 	return returns
 }
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700_Derived.go 1`] = `
+package module2700
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
 
 type Derived interface {
 	Base
@@ -18414,6 +21390,16 @@ func (d *jsiiProxy_Derived) Zoo() *string {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700_IFoo.go 1`] = `
+package module2700
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
 type IFoo interface {
 	Bar() *string
 	Baz() *float64
@@ -18450,59 +21436,6 @@ func (j *jsiiProxy_IFoo) Baz() *float64 {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/module2700.init.go 1`] = `
-package module2700
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.module2700.Base",
-		reflect.TypeOf((*Base)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
-		},
-		func() interface{} {
-			j := jsiiProxy_Base{}
-			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
-			return &j
-		},
-	)
-	_jsii_.RegisterClass(
-		"jsii-calc.module2700.Derived",
-		reflect.TypeOf((*Derived)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
-			_jsii_.MemberMethod{JsiiMethod: "zoo", GoMethod: "Zoo"},
-		},
-		func() interface{} {
-			j := jsiiProxy_Derived{}
-			_jsii_.InitJsiiProxy(&j.jsiiProxy_Base)
-			_jsii_.InitJsiiProxy(&j.jsiiProxy_IFoo)
-			return &j
-		},
-	)
-	_jsii_.RegisterInterface(
-		"jsii-calc.module2700.IFoo",
-		reflect.TypeOf((*IFoo)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "bar", GoMethod: "Bar"},
-			_jsii_.MemberProperty{JsiiProperty: "baz", GoGetter: "Baz"},
-		},
-		func() interface{} {
-			return &jsiiProxy_IFoo{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/internal/types.go 1`] = `
 package internal
 import (
@@ -18514,502 +21447,6 @@ type Type__jcbIBaseInterface = jcb.IBaseInterface
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702.go 1`] = `
-package module2702
-
-import (
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
-
-	"github.com/aws/jsii/jsii-calc/go/jcb"
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
-)
-
-type Baz interface {
-	Class3
-	IBaz
-	Bar()
-	BazMethod()
-	Foo()
-	IBaseInterface()
-}
-
-// The jsii proxy struct for Baz
-type jsiiProxy_Baz struct {
-	jsiiProxy_Class3
-	jsiiProxy_IBaz
-}
-
-func NewBaz() Baz {
-	_init_.Initialize()
-
-	j := jsiiProxy_Baz{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Baz",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewBaz_Override(b Baz) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Baz",
-		nil, // no parameters
-		b,
-	)
-}
-
-func (b *jsiiProxy_Baz) Bar() {
-	_jsii_.InvokeVoid(
-		b,
-		"bar",
-		nil, // no parameters
-	)
-}
-
-func (b *jsiiProxy_Baz) BazMethod() {
-	_jsii_.InvokeVoid(
-		b,
-		"bazMethod",
-		nil, // no parameters
-	)
-}
-
-func (b *jsiiProxy_Baz) Foo() {
-	_jsii_.InvokeVoid(
-		b,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-func (b *jsiiProxy_Baz) IBaseInterface() {
-	_jsii_.InvokeVoid(
-		b,
-		"iBaseInterface",
-		nil, // no parameters
-	)
-}
-
-type Class1 interface {
-	jcb.Base
-	Base()
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Class1
-type jsiiProxy_Class1 struct {
-	internal.Type__jcbBase
-}
-
-func NewClass1() Class1 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Class1{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class1",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClass1_Override(c Class1) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class1",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (c *jsiiProxy_Class1) Base() {
-	_jsii_.InvokeVoid(
-		c,
-		"base",
-		nil, // no parameters
-	)
-}
-
-func (c *jsiiProxy_Class1) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		c,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type Class2 interface {
-	jcb.Base
-	Base() *string
-	// Returns: the name of the class (to verify native type names are created for derived classes).
-	TypeName() interface{}
-}
-
-// The jsii proxy struct for Class2
-type jsiiProxy_Class2 struct {
-	internal.Type__jcbBase
-}
-
-func (j *jsiiProxy_Class2) Base() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"base",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewClass2() Class2 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Class2{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class2",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClass2_Override(c Class2) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class2",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (c *jsiiProxy_Class2) TypeName() interface{} {
-	var returns interface{}
-
-	_jsii_.Invoke(
-		c,
-		"typeName",
-		nil, // no parameters
-		&returns,
-	)
-
-	return returns
-}
-
-type Class3 interface {
-	jcb.IBaseInterface
-	Bar()
-	Foo()
-	IBaseInterface()
-}
-
-// The jsii proxy struct for Class3
-type jsiiProxy_Class3 struct {
-	internal.Type__jcbIBaseInterface
-}
-
-func NewClass3() Class3 {
-	_init_.Initialize()
-
-	j := jsiiProxy_Class3{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class3",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewClass3_Override(c Class3) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Class3",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (c *jsiiProxy_Class3) Bar() {
-	_jsii_.InvokeVoid(
-		c,
-		"bar",
-		nil, // no parameters
-	)
-}
-
-func (c *jsiiProxy_Class3) Foo() {
-	_jsii_.InvokeVoid(
-		c,
-		"foo",
-		nil, // no parameters
-	)
-}
-
-func (c *jsiiProxy_Class3) IBaseInterface() {
-	_jsii_.InvokeVoid(
-		c,
-		"iBaseInterface",
-		nil, // no parameters
-	)
-}
-
-type Construct interface {
-	IConstruct
-	ConstructMethod()
-}
-
-// The jsii proxy struct for Construct
-type jsiiProxy_Construct struct {
-	jsiiProxy_IConstruct
-}
-
-func NewConstruct() Construct {
-	_init_.Initialize()
-
-	j := jsiiProxy_Construct{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Construct",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewConstruct_Override(c Construct) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Construct",
-		nil, // no parameters
-		c,
-	)
-}
-
-func (c *jsiiProxy_Construct) ConstructMethod() {
-	_jsii_.InvokeVoid(
-		c,
-		"constructMethod",
-		nil, // no parameters
-	)
-}
-
-type IBaz interface {
-	jcb.IBaseInterface
-	BazMethod()
-}
-
-// The jsii proxy for IBaz
-type jsiiProxy_IBaz struct {
-	internal.Type__jcbIBaseInterface
-}
-
-func (i *jsiiProxy_IBaz) BazMethod() {
-	_jsii_.InvokeVoid(
-		i,
-		"bazMethod",
-		nil, // no parameters
-	)
-}
-
-type IConstruct interface {
-	ConstructMethod()
-}
-
-// The jsii proxy for IConstruct
-type jsiiProxy_IConstruct struct {
-	_ byte // padding
-}
-
-func (i *jsiiProxy_IConstruct) ConstructMethod() {
-	_jsii_.InvokeVoid(
-		i,
-		"constructMethod",
-		nil, // no parameters
-	)
-}
-
-type IFoo interface {
-	jcb.IBaseInterface
-	IBaseInterface() *string
-}
-
-// The jsii proxy for IFoo
-type jsiiProxy_IFoo struct {
-	internal.Type__jcbIBaseInterface
-}
-
-func (j *jsiiProxy_IFoo) IBaseInterface() *string {
-	var returns *string
-	_jsii_.Get(
-		j,
-		"iBaseInterface",
-		&returns,
-	)
-	return returns
-}
-
-type IResource interface {
-	IConstruct
-	ResourceMethod()
-}
-
-// The jsii proxy for IResource
-type jsiiProxy_IResource struct {
-	jsiiProxy_IConstruct
-}
-
-func (i *jsiiProxy_IResource) ResourceMethod() {
-	_jsii_.InvokeVoid(
-		i,
-		"resourceMethod",
-		nil, // no parameters
-	)
-}
-
-type IVpc interface {
-	IResource
-	VpcMethod()
-}
-
-// The jsii proxy for IVpc
-type jsiiProxy_IVpc struct {
-	jsiiProxy_IResource
-}
-
-func (i *jsiiProxy_IVpc) VpcMethod() {
-	_jsii_.InvokeVoid(
-		i,
-		"vpcMethod",
-		nil, // no parameters
-	)
-}
-
-type Resource interface {
-	Construct
-	IResource
-	ConstructMethod()
-	ResourceMethod()
-}
-
-// The jsii proxy struct for Resource
-type jsiiProxy_Resource struct {
-	jsiiProxy_Construct
-	jsiiProxy_IResource
-}
-
-func NewResource_Override(r Resource) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Resource",
-		nil, // no parameters
-		r,
-	)
-}
-
-func (r *jsiiProxy_Resource) ConstructMethod() {
-	_jsii_.InvokeVoid(
-		r,
-		"constructMethod",
-		nil, // no parameters
-	)
-}
-
-func (r *jsiiProxy_Resource) ResourceMethod() {
-	_jsii_.InvokeVoid(
-		r,
-		"resourceMethod",
-		nil, // no parameters
-	)
-}
-
-type Vpc interface {
-	Resource
-	IVpc
-	ConstructMethod()
-	ResourceMethod()
-	VpcMethod()
-}
-
-// The jsii proxy struct for Vpc
-type jsiiProxy_Vpc struct {
-	jsiiProxy_Resource
-	jsiiProxy_IVpc
-}
-
-func NewVpc() Vpc {
-	_init_.Initialize()
-
-	j := jsiiProxy_Vpc{}
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Vpc",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewVpc_Override(v Vpc) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.module2702.Vpc",
-		nil, // no parameters
-		v,
-	)
-}
-
-func (v *jsiiProxy_Vpc) ConstructMethod() {
-	_jsii_.InvokeVoid(
-		v,
-		"constructMethod",
-		nil, // no parameters
-	)
-}
-
-func (v *jsiiProxy_Vpc) ResourceMethod() {
-	_jsii_.InvokeVoid(
-		v,
-		"resourceMethod",
-		nil, // no parameters
-	)
-}
-
-func (v *jsiiProxy_Vpc) VpcMethod() {
-	_jsii_.InvokeVoid(
-		v,
-		"vpcMethod",
-		nil, // no parameters
-	)
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702.init.go 1`] = `
 package module2702
 
 import (
@@ -19185,14 +21622,655 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/nodirect.go 1`] = `
-package nodirect
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Baz.go 1`] = `
+package module2702
 
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Baz interface {
+	Class3
+	IBaz
+	Bar()
+	BazMethod()
+	Foo()
+	IBaseInterface()
+}
+
+// The jsii proxy struct for Baz
+type jsiiProxy_Baz struct {
+	jsiiProxy_Class3
+	jsiiProxy_IBaz
+}
+
+func NewBaz() Baz {
+	_init_.Initialize()
+
+	j := jsiiProxy_Baz{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Baz",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewBaz_Override(b Baz) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Baz",
+		nil, // no parameters
+		b,
+	)
+}
+
+func (b *jsiiProxy_Baz) Bar() {
+	_jsii_.InvokeVoid(
+		b,
+		"bar",
+		nil, // no parameters
+	)
+}
+
+func (b *jsiiProxy_Baz) BazMethod() {
+	_jsii_.InvokeVoid(
+		b,
+		"bazMethod",
+		nil, // no parameters
+	)
+}
+
+func (b *jsiiProxy_Baz) Foo() {
+	_jsii_.InvokeVoid(
+		b,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+func (b *jsiiProxy_Baz) IBaseInterface() {
+	_jsii_.InvokeVoid(
+		b,
+		"iBaseInterface",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Class1.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
+)
+
+type Class1 interface {
+	jcb.Base
+	Base()
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Class1
+type jsiiProxy_Class1 struct {
+	internal.Type__jcbBase
+}
+
+func NewClass1() Class1 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Class1{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class1",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClass1_Override(c Class1) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class1",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (c *jsiiProxy_Class1) Base() {
+	_jsii_.InvokeVoid(
+		c,
+		"base",
+		nil, // no parameters
+	)
+}
+
+func (c *jsiiProxy_Class1) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Class2.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
+)
+
+type Class2 interface {
+	jcb.Base
+	Base() *string
+	// Returns: the name of the class (to verify native type names are created for derived classes).
+	TypeName() interface{}
+}
+
+// The jsii proxy struct for Class2
+type jsiiProxy_Class2 struct {
+	internal.Type__jcbBase
+}
+
+func (j *jsiiProxy_Class2) Base() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"base",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewClass2() Class2 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Class2{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class2",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClass2_Override(c Class2) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class2",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (c *jsiiProxy_Class2) TypeName() interface{} {
+	var returns interface{}
+
+	_jsii_.Invoke(
+		c,
+		"typeName",
+		nil, // no parameters
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Class3.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
+)
+
+type Class3 interface {
+	jcb.IBaseInterface
+	Bar()
+	Foo()
+	IBaseInterface()
+}
+
+// The jsii proxy struct for Class3
+type jsiiProxy_Class3 struct {
+	internal.Type__jcbIBaseInterface
+}
+
+func NewClass3() Class3 {
+	_init_.Initialize()
+
+	j := jsiiProxy_Class3{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class3",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewClass3_Override(c Class3) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Class3",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (c *jsiiProxy_Class3) Bar() {
+	_jsii_.InvokeVoid(
+		c,
+		"bar",
+		nil, // no parameters
+	)
+}
+
+func (c *jsiiProxy_Class3) Foo() {
+	_jsii_.InvokeVoid(
+		c,
+		"foo",
+		nil, // no parameters
+	)
+}
+
+func (c *jsiiProxy_Class3) IBaseInterface() {
+	_jsii_.InvokeVoid(
+		c,
+		"iBaseInterface",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Construct.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Construct interface {
+	IConstruct
+	ConstructMethod()
+}
+
+// The jsii proxy struct for Construct
+type jsiiProxy_Construct struct {
+	jsiiProxy_IConstruct
+}
+
+func NewConstruct() Construct {
+	_init_.Initialize()
+
+	j := jsiiProxy_Construct{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Construct",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewConstruct_Override(c Construct) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Construct",
+		nil, // no parameters
+		c,
+	)
+}
+
+func (c *jsiiProxy_Construct) ConstructMethod() {
+	_jsii_.InvokeVoid(
+		c,
+		"constructMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_IBaz.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
+)
+
+type IBaz interface {
+	jcb.IBaseInterface
+	BazMethod()
+}
+
+// The jsii proxy for IBaz
+type jsiiProxy_IBaz struct {
+	internal.Type__jcbIBaseInterface
+}
+
+func (i *jsiiProxy_IBaz) BazMethod() {
+	_jsii_.InvokeVoid(
+		i,
+		"bazMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_IConstruct.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IConstruct interface {
+	ConstructMethod()
+}
+
+// The jsii proxy for IConstruct
+type jsiiProxy_IConstruct struct {
+	_ byte // padding
+}
+
+func (i *jsiiProxy_IConstruct) ConstructMethod() {
+	_jsii_.InvokeVoid(
+		i,
+		"constructMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_IFoo.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
+	"github.com/aws/jsii/jsii-calc/go/jcb"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/module2702/internal"
+)
+
+type IFoo interface {
+	jcb.IBaseInterface
+	IBaseInterface() *string
+}
+
+// The jsii proxy for IFoo
+type jsiiProxy_IFoo struct {
+	internal.Type__jcbIBaseInterface
+}
+
+func (j *jsiiProxy_IFoo) IBaseInterface() *string {
+	var returns *string
+	_jsii_.Get(
+		j,
+		"iBaseInterface",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_IResource.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IResource interface {
+	IConstruct
+	ResourceMethod()
+}
+
+// The jsii proxy for IResource
+type jsiiProxy_IResource struct {
+	jsiiProxy_IConstruct
+}
+
+func (i *jsiiProxy_IResource) ResourceMethod() {
+	_jsii_.InvokeVoid(
+		i,
+		"resourceMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_IVpc.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+type IVpc interface {
+	IResource
+	VpcMethod()
+}
+
+// The jsii proxy for IVpc
+type jsiiProxy_IVpc struct {
+	jsiiProxy_IResource
+}
+
+func (i *jsiiProxy_IVpc) VpcMethod() {
+	_jsii_.InvokeVoid(
+		i,
+		"vpcMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Resource.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Resource interface {
+	Construct
+	IResource
+	ConstructMethod()
+	ResourceMethod()
+}
+
+// The jsii proxy struct for Resource
+type jsiiProxy_Resource struct {
+	jsiiProxy_Construct
+	jsiiProxy_IResource
+}
+
+func NewResource_Override(r Resource) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Resource",
+		nil, // no parameters
+		r,
+	)
+}
+
+func (r *jsiiProxy_Resource) ConstructMethod() {
+	_jsii_.InvokeVoid(
+		r,
+		"constructMethod",
+		nil, // no parameters
+	)
+}
+
+func (r *jsiiProxy_Resource) ResourceMethod() {
+	_jsii_.InvokeVoid(
+		r,
+		"resourceMethod",
+		nil, // no parameters
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/module2702_Vpc.go 1`] = `
+package module2702
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Vpc interface {
+	Resource
+	IVpc
+	ConstructMethod()
+	ResourceMethod()
+	VpcMethod()
+}
+
+// The jsii proxy struct for Vpc
+type jsiiProxy_Vpc struct {
+	jsiiProxy_Resource
+	jsiiProxy_IVpc
+}
+
+func NewVpc() Vpc {
+	_init_.Initialize()
+
+	j := jsiiProxy_Vpc{}
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Vpc",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewVpc_Override(v Vpc) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.module2702.Vpc",
+		nil, // no parameters
+		v,
+	)
+}
+
+func (v *jsiiProxy_Vpc) ConstructMethod() {
+	_jsii_.InvokeVoid(
+		v,
+		"constructMethod",
+		nil, // no parameters
+	)
+}
+
+func (v *jsiiProxy_Vpc) ResourceMethod() {
+	_jsii_.InvokeVoid(
+		v,
+		"resourceMethod",
+		nil, // no parameters
+	)
+}
+
+func (v *jsiiProxy_Vpc) VpcMethod() {
+	_jsii_.InvokeVoid(
+		v,
+		"vpcMethod",
+		nil, // no parameters
+	)
+}
 
 
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub1/sub1.go 1`] = `
+package sub1
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.nodirect.sub1.TypeFromSub1",
+		reflect.TypeOf((*TypeFromSub1)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "sub1", GoMethod: "Sub1"},
+		},
+		func() interface{} {
+			return &jsiiProxy_TypeFromSub1{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub1/sub1_TypeFromSub1.go 1`] = `
 package sub1
 
 import (
@@ -19249,8 +22327,8 @@ func (t *jsiiProxy_TypeFromSub1) Sub1() *string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub1/sub1.init.go 1`] = `
-package sub1
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/sub2.go 1`] = `
+package sub2
 
 import (
 	"reflect"
@@ -19260,20 +22338,20 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.nodirect.sub1.TypeFromSub1",
-		reflect.TypeOf((*TypeFromSub1)(nil)).Elem(),
+		"jsii-calc.nodirect.sub2.TypeFromSub2",
+		reflect.TypeOf((*TypeFromSub2)(nil)).Elem(),
 		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "sub1", GoMethod: "Sub1"},
+			_jsii_.MemberMethod{JsiiMethod: "sub2", GoMethod: "Sub2"},
 		},
 		func() interface{} {
-			return &jsiiProxy_TypeFromSub1{}
+			return &jsiiProxy_TypeFromSub2{}
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/sub2.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/sub2_TypeFromSub2.go 1`] = `
 package sub2
 
 import (
@@ -19330,8 +22408,8 @@ func (t *jsiiProxy_TypeFromSub2) Sub2() *string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/sub2.init.go 1`] = `
-package sub2
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/onlystatic.go 1`] = `
+package onlystatic
 
 import (
 	"reflect"
@@ -19341,20 +22419,18 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.nodirect.sub2.TypeFromSub2",
-		reflect.TypeOf((*TypeFromSub2)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "sub2", GoMethod: "Sub2"},
-		},
+		"jsii-calc.onlystatic.OnlyStaticMethods",
+		reflect.TypeOf((*OnlyStaticMethods)(nil)).Elem(),
+		nil, // no members
 		func() interface{} {
-			return &jsiiProxy_TypeFromSub2{}
+			return &jsiiProxy_OnlyStaticMethods{}
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/onlystatic.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/onlystatic_OnlyStaticMethods.go 1`] = `
 package onlystatic
 
 import (
@@ -19389,8 +22465,8 @@ func OnlyStaticMethods_StaticMethod() *string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/onlystatic.init.go 1`] = `
-package onlystatic
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself.go 1`] = `
+package pythonself
 
 import (
 	"reflect"
@@ -19400,18 +22476,45 @@ import (
 
 func init() {
 	_jsii_.RegisterClass(
-		"jsii-calc.onlystatic.OnlyStaticMethods",
-		reflect.TypeOf((*OnlyStaticMethods)(nil)).Elem(),
-		nil, // no members
-		func() interface{} {
-			return &jsiiProxy_OnlyStaticMethods{}
+		"jsii-calc.PythonSelf.ClassWithSelf",
+		reflect.TypeOf((*ClassWithSelf)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "method", GoMethod: "Method"},
+			_jsii_.MemberProperty{JsiiProperty: "self", GoGetter: "Self"},
 		},
+		func() interface{} {
+			return &jsiiProxy_ClassWithSelf{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.PythonSelf.ClassWithSelfKwarg",
+		reflect.TypeOf((*ClassWithSelfKwarg)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "props", GoGetter: "Props"},
+		},
+		func() interface{} {
+			return &jsiiProxy_ClassWithSelfKwarg{}
+		},
+	)
+	_jsii_.RegisterInterface(
+		"jsii-calc.PythonSelf.IInterfaceWithSelf",
+		reflect.TypeOf((*IInterfaceWithSelf)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "method", GoMethod: "Method"},
+		},
+		func() interface{} {
+			return &jsiiProxy_IInterfaceWithSelf{}
+		},
+	)
+	_jsii_.RegisterStruct(
+		"jsii-calc.PythonSelf.StructWithSelf",
+		reflect.TypeOf((*StructWithSelf)(nil)).Elem(),
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself_ClassWithSelf.go 1`] = `
 package pythonself
 
 import (
@@ -19477,6 +22580,17 @@ func (c *jsiiProxy_ClassWithSelf) Method(self *float64) *string {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself_ClassWithSelfKwarg.go 1`] = `
+package pythonself
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
 type ClassWithSelfKwarg interface {
 	Props() *StructWithSelf
 }
@@ -19521,6 +22635,16 @@ func NewClassWithSelfKwarg_Override(c ClassWithSelfKwarg, props *StructWithSelf)
 	)
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself_IInterfaceWithSelf.go 1`] = `
+package pythonself
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
 type IInterfaceWithSelf interface {
 	Method(self *float64) *string
 }
@@ -19543,59 +22667,17 @@ func (i *jsiiProxy_IInterfaceWithSelf) Method(self *float64) *string {
 	return returns
 }
 
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself_StructWithSelf.go 1`] = `
+package pythonself
+
+
 type StructWithSelf struct {
 	Self *string \`field:"required" json:"self" yaml:"self"\`
 }
 
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/pythonself.init.go 1`] = `
-package pythonself
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.PythonSelf.ClassWithSelf",
-		reflect.TypeOf((*ClassWithSelf)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "method", GoMethod: "Method"},
-			_jsii_.MemberProperty{JsiiProperty: "self", GoGetter: "Self"},
-		},
-		func() interface{} {
-			return &jsiiProxy_ClassWithSelf{}
-		},
-	)
-	_jsii_.RegisterClass(
-		"jsii-calc.PythonSelf.ClassWithSelfKwarg",
-		reflect.TypeOf((*ClassWithSelfKwarg)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "props", GoGetter: "Props"},
-		},
-		func() interface{} {
-			return &jsiiProxy_ClassWithSelfKwarg{}
-		},
-	)
-	_jsii_.RegisterInterface(
-		"jsii-calc.PythonSelf.IInterfaceWithSelf",
-		reflect.TypeOf((*IInterfaceWithSelf)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "method", GoMethod: "Method"},
-		},
-		func() interface{} {
-			return &jsiiProxy_IInterfaceWithSelf{}
-		},
-	)
-	_jsii_.RegisterStruct(
-		"jsii-calc.PythonSelf.StructWithSelf",
-		reflect.TypeOf((*StructWithSelf)(nil)).Elem(),
-	)
-}
 
 `;
 
@@ -19607,20 +22689,6 @@ This is the readme of the \`jsii-calc.submodule\` module.
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/backreferences.go 1`] = `
-package backreferences
-
-import (
-	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule"
-)
-
-type MyClassReference struct {
-	Reference submodule.MyClass \`field:"required" json:"reference" yaml:"reference"\`
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/backreferences.init.go 1`] = `
 package backreferences
 
 import (
@@ -19638,145 +22706,21 @@ func init() {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child.go 1`] = `
-package child
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/backreferences_MyClassReference.go 1`] = `
+package backreferences
 
 import (
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule"
 )
 
-type Awesomeness string
-
-const (
-	// It was awesome!
-	Awesomeness_AWESOME Awesomeness = "AWESOME"
-)
-
-type Goodness string
-
-const (
-	// It's pretty good.
-	Goodness_PRETTY_GOOD Goodness = "PRETTY_GOOD"
-	// It's really good.
-	Goodness_REALLY_GOOD Goodness = "REALLY_GOOD"
-	// It's amazingly good.
-	Goodness_AMAZINGLY_GOOD Goodness = "AMAZINGLY_GOOD"
-)
-
-type InnerClass interface {
-}
-
-// The jsii proxy struct for InnerClass
-type jsiiProxy_InnerClass struct {
-	_ byte // padding
-}
-
-func NewInnerClass() InnerClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_InnerClass{}
-
-	_jsii_.Create(
-		"jsii-calc.submodule.child.InnerClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewInnerClass_Override(i InnerClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.submodule.child.InnerClass",
-		nil, // no parameters
-		i,
-	)
-}
-
-func InnerClass_StaticProp() *SomeStruct {
-	_init_.Initialize()
-	var returns *SomeStruct
-	_jsii_.StaticGet(
-		"jsii-calc.submodule.child.InnerClass",
-		"staticProp",
-		&returns,
-	)
-	return returns
-}
-
-type KwargsProps struct {
-	Prop SomeEnum \`field:"required" json:"prop" yaml:"prop"\`
-	Extra *string \`field:"optional" json:"extra" yaml:"extra"\`
-}
-
-// Checks that classes can self-reference during initialization.
-// See: : https://github.com/aws/jsii/pull/1706
-//
-type OuterClass interface {
-	InnerClass() InnerClass
-}
-
-// The jsii proxy struct for OuterClass
-type jsiiProxy_OuterClass struct {
-	_ byte // padding
-}
-
-func (j *jsiiProxy_OuterClass) InnerClass() InnerClass {
-	var returns InnerClass
-	_jsii_.Get(
-		j,
-		"innerClass",
-		&returns,
-	)
-	return returns
-}
-
-
-func NewOuterClass() OuterClass {
-	_init_.Initialize()
-
-	j := jsiiProxy_OuterClass{}
-
-	_jsii_.Create(
-		"jsii-calc.submodule.child.OuterClass",
-		nil, // no parameters
-		&j,
-	)
-
-	return &j
-}
-
-func NewOuterClass_Override(o OuterClass) {
-	_init_.Initialize()
-
-	_jsii_.Create(
-		"jsii-calc.submodule.child.OuterClass",
-		nil, // no parameters
-		o,
-	)
-}
-
-type SomeEnum string
-
-const (
-	SomeEnum_SOME SomeEnum = "SOME"
-)
-
-type SomeStruct struct {
-	Prop SomeEnum \`field:"required" json:"prop" yaml:"prop"\`
-}
-
-type Structure struct {
-	Bool *bool \`field:"required" json:"bool" yaml:"bool"\`
+type MyClassReference struct {
+	Reference submodule.MyClass \`field:"required" json:"reference" yaml:"reference"\`
 }
 
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child.init.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child.go 1`] = `
 package child
 
 import (
@@ -19843,6 +22787,197 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_Awesomeness.go 1`] = `
+package child
+
+
+type Awesomeness string
+
+const (
+	// It was awesome!
+	Awesomeness_AWESOME Awesomeness = "AWESOME"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_Goodness.go 1`] = `
+package child
+
+
+type Goodness string
+
+const (
+	// It's pretty good.
+	Goodness_PRETTY_GOOD Goodness = "PRETTY_GOOD"
+	// It's really good.
+	Goodness_REALLY_GOOD Goodness = "REALLY_GOOD"
+	// It's amazingly good.
+	Goodness_AMAZINGLY_GOOD Goodness = "AMAZINGLY_GOOD"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_InnerClass.go 1`] = `
+package child
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type InnerClass interface {
+}
+
+// The jsii proxy struct for InnerClass
+type jsiiProxy_InnerClass struct {
+	_ byte // padding
+}
+
+func NewInnerClass() InnerClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_InnerClass{}
+
+	_jsii_.Create(
+		"jsii-calc.submodule.child.InnerClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewInnerClass_Override(i InnerClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.submodule.child.InnerClass",
+		nil, // no parameters
+		i,
+	)
+}
+
+func InnerClass_StaticProp() *SomeStruct {
+	_init_.Initialize()
+	var returns *SomeStruct
+	_jsii_.StaticGet(
+		"jsii-calc.submodule.child.InnerClass",
+		"staticProp",
+		&returns,
+	)
+	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_KwargsProps.go 1`] = `
+package child
+
+
+type KwargsProps struct {
+	Prop SomeEnum \`field:"required" json:"prop" yaml:"prop"\`
+	Extra *string \`field:"optional" json:"extra" yaml:"extra"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_OuterClass.go 1`] = `
+package child
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// Checks that classes can self-reference during initialization.
+// See: : https://github.com/aws/jsii/pull/1706
+//
+type OuterClass interface {
+	InnerClass() InnerClass
+}
+
+// The jsii proxy struct for OuterClass
+type jsiiProxy_OuterClass struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_OuterClass) InnerClass() InnerClass {
+	var returns InnerClass
+	_jsii_.Get(
+		j,
+		"innerClass",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewOuterClass() OuterClass {
+	_init_.Initialize()
+
+	j := jsiiProxy_OuterClass{}
+
+	_jsii_.Create(
+		"jsii-calc.submodule.child.OuterClass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewOuterClass_Override(o OuterClass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.submodule.child.OuterClass",
+		nil, // no parameters
+		o,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_SomeEnum.go 1`] = `
+package child
+
+
+type SomeEnum string
+
+const (
+	SomeEnum_SOME SomeEnum = "SOME"
+)
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_SomeStruct.go 1`] = `
+package child
+
+
+type SomeStruct struct {
+	Prop SomeEnum \`field:"required" json:"prop" yaml:"prop"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/child_Structure.go 1`] = `
+package child
+
+
+type Structure struct {
+	Bool *bool \`field:"required" json:"bool" yaml:"bool"\`
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/internal/types.go 1`] = `
 package internal
 import (
@@ -19860,6 +22995,28 @@ This is the readme of the \`jsii-calc.submodule.isolated\` module.
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/isolated.go 1`] = `
+package isolated
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.submodule.isolated.Kwargs",
+		reflect.TypeOf((*Kwargs)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_Kwargs{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/isolated_Kwargs.go 1`] = `
 package isolated
 
 import (
@@ -19896,8 +23053,8 @@ func Kwargs_Method(props *child.KwargsProps) *bool {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/isolated.init.go 1`] = `
-package isolated
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/deeplynested.go 1`] = `
+package deeplynested
 
 import (
 	"reflect"
@@ -19906,19 +23063,21 @@ import (
 )
 
 func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.submodule.isolated.Kwargs",
-		reflect.TypeOf((*Kwargs)(nil)).Elem(),
-		nil, // no members
+	_jsii_.RegisterInterface(
+		"jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced",
+		reflect.TypeOf((*INamespaced)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
+		},
 		func() interface{} {
-			return &jsiiProxy_Kwargs{}
+			return &jsiiProxy_INamespaced{}
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/deeplynested.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/deeplynested_INamespaced.go 1`] = `
 package deeplynested
 
 import (
@@ -19947,30 +23106,6 @@ func (j *jsiiProxy_INamespaced) DefinedAt() *string {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/deeplynested.init.go 1`] = `
-package deeplynested
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterInterface(
-		"jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced",
-		reflect.TypeOf((*INamespaced)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
-		},
-		func() interface{} {
-			return &jsiiProxy_INamespaced{}
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/internal/types.go 1`] = `
 package internal
 import (
@@ -19981,6 +23116,33 @@ type Type__deeplynestedINamespaced = deeplynested.INamespaced
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/nestedsubmodule.go 1`] = `
+package nestedsubmodule
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.submodule.nested_submodule.Namespaced",
+		reflect.TypeOf((*Namespaced)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
+			_jsii_.MemberProperty{JsiiProperty: "goodness", GoGetter: "Goodness"},
+		},
+		func() interface{} {
+			j := jsiiProxy_Namespaced{}
+			_jsii_.InitJsiiProxy(&j.Type__deeplynestedINamespaced)
+			return &j
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/nestedsubmodule_Namespaced.go 1`] = `
 package nestedsubmodule
 
 import (
@@ -20026,45 +23188,7 @@ func (j *jsiiProxy_Namespaced) Goodness() child.Goodness {
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/nestedsubmodule.init.go 1`] = `
-package nestedsubmodule
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterClass(
-		"jsii-calc.submodule.nested_submodule.Namespaced",
-		reflect.TypeOf((*Namespaced)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
-			_jsii_.MemberProperty{JsiiProperty: "goodness", GoGetter: "Goodness"},
-		},
-		func() interface{} {
-			j := jsiiProxy_Namespaced{}
-			_jsii_.InitJsiiProxy(&j.Type__deeplynestedINamespaced)
-			return &j
-		},
-	)
-}
-
-`;
-
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/param/param.go 1`] = `
-package param
-
-
-type SpecialParameter struct {
-	Value *string \`field:"required" json:"value" yaml:"value"\`
-}
-
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/param/param.init.go 1`] = `
 package param
 
 import (
@@ -20082,7 +23206,42 @@ func init() {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/param/param_SpecialParameter.go 1`] = `
+package param
+
+
+type SpecialParameter struct {
+	Value *string \`field:"required" json:"value" yaml:"value"\`
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/returnsparam/returnsparam.go 1`] = `
+package returnsparam
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.submodule.returnsparam.ReturnsSpecialParameter",
+		reflect.TypeOf((*ReturnsSpecialParameter)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "returnsSpecialParam", GoMethod: "ReturnsSpecialParam"},
+		},
+		func() interface{} {
+			return &jsiiProxy_ReturnsSpecialParameter{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/returnsparam/returnsparam_ReturnsSpecialParameter.go 1`] = `
 package returnsparam
 
 import (
@@ -20141,8 +23300,8 @@ func (r *jsiiProxy_ReturnsSpecialParameter) ReturnsSpecialParam() *param.Special
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/returnsparam/returnsparam.init.go 1`] = `
-package returnsparam
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/submodule.go 1`] = `
+package submodule
 
 import (
 	"reflect"
@@ -20151,21 +23310,46 @@ import (
 )
 
 func init() {
+	_jsii_.RegisterStruct(
+		"jsii-calc.submodule.Default",
+		reflect.TypeOf((*Default)(nil)).Elem(),
+	)
 	_jsii_.RegisterClass(
-		"jsii-calc.submodule.returnsparam.ReturnsSpecialParameter",
-		reflect.TypeOf((*ReturnsSpecialParameter)(nil)).Elem(),
+		"jsii-calc.submodule.MyClass",
+		reflect.TypeOf((*MyClass)(nil)).Elem(),
 		[]_jsii_.Member{
-			_jsii_.MemberMethod{JsiiMethod: "returnsSpecialParam", GoMethod: "ReturnsSpecialParam"},
+			_jsii_.MemberProperty{JsiiProperty: "allTypes", GoGetter: "AllTypes"},
+			_jsii_.MemberProperty{JsiiProperty: "awesomeness", GoGetter: "Awesomeness"},
+			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
+			_jsii_.MemberProperty{JsiiProperty: "goodness", GoGetter: "Goodness"},
+			_jsii_.MemberMethod{JsiiMethod: "methodWithSpecialParam", GoMethod: "MethodWithSpecialParam"},
+			_jsii_.MemberProperty{JsiiProperty: "props", GoGetter: "Props"},
 		},
 		func() interface{} {
-			return &jsiiProxy_ReturnsSpecialParameter{}
+			j := jsiiProxy_MyClass{}
+			_jsii_.InitJsiiProxy(&j.Type__deeplynestedINamespaced)
+			return &j
 		},
 	)
 }
 
 `;
 
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/submodule.go 1`] = `
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/submodule_Default.go 1`] = `
+package submodule
+
+
+// A struct named "Default".
+// See: https://github.com/aws/jsii/issues/2637
+//
+type Default struct {
+	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/submodule_MyClass.go 1`] = `
 package submodule
 
 import (
@@ -20178,13 +23362,6 @@ import (
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/nestedsubmodule/deeplynested"
 	"github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/submodule/param"
 )
-
-// A struct named "Default".
-// See: https://github.com/aws/jsii/issues/2637
-//
-type Default struct {
-	Foo *float64 \`field:"required" json:"foo" yaml:"foo"\`
-}
 
 type MyClass interface {
 	deeplynested.INamespaced
@@ -20298,41 +23475,6 @@ func (m *jsiiProxy_MyClass) MethodWithSpecialParam(param *param.SpecialParameter
 	return returns
 }
 
-
-`;
-
-exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/submodule.init.go 1`] = `
-package submodule
-
-import (
-	"reflect"
-
-	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-)
-
-func init() {
-	_jsii_.RegisterStruct(
-		"jsii-calc.submodule.Default",
-		reflect.TypeOf((*Default)(nil)).Elem(),
-	)
-	_jsii_.RegisterClass(
-		"jsii-calc.submodule.MyClass",
-		reflect.TypeOf((*MyClass)(nil)).Elem(),
-		[]_jsii_.Member{
-			_jsii_.MemberProperty{JsiiProperty: "allTypes", GoGetter: "AllTypes"},
-			_jsii_.MemberProperty{JsiiProperty: "awesomeness", GoGetter: "Awesomeness"},
-			_jsii_.MemberProperty{JsiiProperty: "definedAt", GoGetter: "DefinedAt"},
-			_jsii_.MemberProperty{JsiiProperty: "goodness", GoGetter: "Goodness"},
-			_jsii_.MemberMethod{JsiiMethod: "methodWithSpecialParam", GoMethod: "MethodWithSpecialParam"},
-			_jsii_.MemberProperty{JsiiProperty: "props", GoGetter: "Props"},
-		},
-		func() interface{} {
-			j := jsiiProxy_MyClass{}
-			_jsii_.InitJsiiProxy(&j.Type__deeplynestedINamespaced)
-			return &j
-		},
-	)
-}
 
 `;
 


### PR DESCRIPTION
Instead of generating one file will ALL the types in a given
(sub)module, emit one file per type within the (sub)module,
so that the compiler operates on smaller compilation units.
This should reduce the memory pressure the compiler
experiences when dealing with large libraries.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
