### PR TITLE
fix: type unions in variadic position leads to invalid code-gen

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/TypeCheckingTests.cs
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/TypeCheckingTests.cs
@@ -97,5 +97,18 @@ namespace Amazon.JSII.Runtime.IntegrationTests
                 }));
             Assert.Equal("Expected argument unionProperty[0][\"bad\"] to be one of: Amazon.JSII.Tests.CalculatorNamespace.IStructA, Amazon.JSII.Tests.CalculatorNamespace.IStructB; received System.String (Parameter 'unionProperty')", exception3.Message);
         }
+
+        [Fact(DisplayName = Prefix + nameof(Variadic))]
+        public void Variadic()
+        {
+            var exception1 = Assert.Throws<System.ArgumentException>(() =>
+                new VariadicTypeUnion(
+                    new StructA{RequiredString = "present"},
+                    1337.42
+                ));
+            Assert.Equal("Expected argument union[1] to be one of: Amazon.JSII.Tests.CalculatorNamespace.IStructA, Amazon.JSII.Tests.CalculatorNamespace.IStructB; received System.Double (Parameter 'union')", exception1.Message);
+
+            Assert.NotNull(new VariadicTypeUnion());
+        }
     }
 }

--- a/packages/@jsii/go-runtime-test/project/runtime_type_checking_test.go
+++ b/packages/@jsii/go-runtime-test/project/runtime_type_checking_test.go
@@ -79,6 +79,16 @@ func TestNestedUnion(t *testing.T) {
 	}()
 }
 
+func TestVariadic(t *testing.T) {
+	func() {
+		defer expectPanic(t, "parameter union[1] must be one of the allowed types: *StructA, *StructB; received 1337.42 (a float64)")
+		jsiicalc.NewVariadicTypeUnion(jsiicalc.StructA{RequiredString: jsii.String("present")}, 1337.42)
+	}()
+
+	// Should not raise
+	jsiicalc.NewVariadicTypeUnion()
+}
+
 func expectPanic(t *testing.T, expected string) {
 	if err := recover(); err != nil {
 		actual := fmt.Sprintf("%v", err)

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -126,3 +126,25 @@ class TestRuntimeTypeChecking:
 
         iface = jsii_calc.anonymous.UseOptions.provide("A")
         assert jsii_calc.anonymous.UseOptions.consume(iface) == "A"
+
+    def test_nested_union(self):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "type of argument union_property[0] must be one of (Mapping[str, Union[jsii_calc.StructA, Dict[str, Any], jsii_calc.StructB]], Sequence[Union[jsii_calc.StructA, Dict[str, Any], jsii_calc.StructB]]); got float instead"
+            ),
+        ):
+            jsii_calc.ClassWithNestedUnion([1337.42])  # type:ignore
+
+    def test_variadic(self):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "type of argument union[1] must be one of (jsii_calc.StructA, jsii_calc.StructB); got float instead"
+            ),
+        ):
+            jsii_calc.VariadicTypeUnion(
+                jsii_calc.StructA(required_string="present"), 1337.42  # type:ignore
+            )
+
+        jsii_calc.VariadicTypeUnion()

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -3082,3 +3082,11 @@ export class ClassWithNestedUnion {
     >,
   ) {}
 }
+
+export class VariadicTypeUnion {
+  public union: Array<StructA | StructB>;
+
+  public constructor(...union: Array<StructA | StructB>) {
+    this.union = union;
+  }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -15428,6 +15428,77 @@
       "name": "VariadicMethod",
       "symbolId": "lib/compliance:VariadicMethod"
     },
+    "jsii-calc.VariadicTypeUnion": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.VariadicTypeUnion",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "lib/compliance.ts",
+          "line": 3089
+        },
+        "parameters": [
+          {
+            "name": "union",
+            "type": {
+              "union": {
+                "types": [
+                  {
+                    "fqn": "jsii-calc.StructA"
+                  },
+                  {
+                    "fqn": "jsii-calc.StructB"
+                  }
+                ]
+              }
+            },
+            "variadic": true
+          }
+        ],
+        "variadic": true
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 3086
+      },
+      "name": "VariadicTypeUnion",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 3087
+          },
+          "name": "union",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "jsii-calc.StructA"
+                    },
+                    {
+                      "fqn": "jsii-calc.StructB"
+                    }
+                  ]
+                }
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ],
+      "symbolId": "lib/compliance:VariadicTypeUnion"
+    },
     "jsii-calc.VirtualMethodPlayground": {
       "assembly": "jsii-calc",
       "docs": {
@@ -18131,5 +18202,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "LBLJQQycukWu6zWQmp2/IbKS/Sfd+4e2zWrX+1KA+Aw="
+  "fingerprint": "Ze43eowG9ImRufT3MQ8yO+bW8JzOQlZIYtFsjpc960E="
 }

--- a/packages/jsii-pacmak/lib/targets/dotnet/runtime-type-checking.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/runtime-type-checking.ts
@@ -1,3 +1,4 @@
+import { CollectionKind } from '@jsii/spec';
 import { CodeMaker } from 'codemaker';
 import { createHash } from 'crypto';
 import { Parameter, TypeReference } from 'jsii-reflect';
@@ -27,7 +28,14 @@ export class ParameterValidator {
         argName,
         expr,
         `${noMangle ? '' : 'argument '}{${argName}}`,
-        param.type,
+        param.variadic
+          ? new TypeReference(param.system, {
+              collection: {
+                kind: CollectionKind.Array,
+                elementtype: param.type.spec!,
+              },
+            })
+          : param.type,
         param.optional,
       );
       if (validation) {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -3174,6 +3174,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 UsesInterfaceWithProperties.cs
        ┃           ┣━ 📄 VariadicInvoker.cs
        ┃           ┣━ 📄 VariadicMethod.cs
+       ┃           ┣━ 📄 VariadicTypeUnion.cs
        ┃           ┣━ 📄 VirtualMethodPlayground.cs
        ┃           ┣━ 📄 VoidCallback.cs
        ┃           ┗━ 📄 WithPrivatePropertyInConstructor.cs
@@ -20096,6 +20097,54 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicTypeUnion.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.VariadicTypeUnion), fullyQualifiedName: "jsii-calc.VariadicTypeUnion", parametersJson: "[{\\"name\\":\\"union\\",\\"type\\":{\\"union\\":{\\"types\\":[{\\"fqn\\":\\"jsii-calc.StructA\\"},{\\"fqn\\":\\"jsii-calc.StructB\\"}]}},\\"variadic\\":true}]")]
+    public class VariadicTypeUnion : DeputyBase
+    {
+        public VariadicTypeUnion(params object[] union): base(_MakeDeputyProps(union))
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps(params object[] union)
+        {
+            return new DeputyProps(new object?[]{union});
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected VariadicTypeUnion(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected VariadicTypeUnion(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiProperty(name: "union", typeJson: "{\\"collection\\":{\\"elementtype\\":{\\"union\\":{\\"types\\":[{\\"fqn\\":\\"jsii-calc.StructA\\"},{\\"fqn\\":\\"jsii-calc.StructB\\"}]}},\\"kind\\":\\"array\\"}}")]
+        public virtual object[] Union
+        {
+            get => GetInstanceProperty<object[]>()!;
+            set
+            {
+                SetInstanceProperty(value);
+            }
+        }
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VirtualMethodPlayground.cs 1`] = `
 using Amazon.JSII.Runtime.Deputy;
 
@@ -20534,7 +20583,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
                    ┣━ 📄 StructUnionConsumer.cs.diff
                    ┣━ 📄 StructWithCollectionOfUnionts.cs.diff
                    ┣━ 📄 TopLevelStruct.cs.diff
-                   ┗━ 📄 UnionProperties.cs.diff
+                   ┣━ 📄 UnionProperties.cs.diff
+                   ┗━ 📄 VariadicTypeUnion.cs.diff
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AllTypes.cs.diff 1`] = `
@@ -21293,6 +21343,73 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/dotnet/Amazon
 +                    }
 +                }
                  _foo = value;
+             }
+         }
+     }
+ }
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicTypeUnion.cs.diff 1`] = `
+--- dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicTypeUnion.cs	--no-runtime-type-checking
++++ dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/VariadicTypeUnion.cs	--runtime-type-checking
+@@ -12,10 +12,30 @@
+         }
+ 
+         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+         private static DeputyProps _MakeDeputyProps(params object[] union)
+         {
++            if (Amazon.JSII.Runtime.Configuration.RuntimeTypeChecking)
++            {
++                for (var __idx_ef3ff7 = 0 ; __idx_ef3ff7 < union.Length ; __idx_ef3ff7++)
++                {
++                    switch (union[__idx_ef3ff7])
++                    {
++                        case Amazon.JSII.Tests.CalculatorNamespace.IStructA cast_0af1d4:
++                            break;
++                        case Amazon.JSII.Tests.CalculatorNamespace.IStructB cast_0af1d4:
++                            break;
++                        case Amazon.JSII.Runtime.Deputy.AnonymousObject cast_0af1d4:
++                            // Not enough information to type-check...
++                            break;
++                        case null:
++                            throw new System.ArgumentException($"Expected argument {nameof(union)}[{__idx_ef3ff7}] to be one of: {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructA).FullName}, {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructB).FullName}; received null", nameof(union));
++                        default:
++                            throw new System.ArgumentException($"Expected argument {nameof(union)}[{__idx_ef3ff7}] to be one of: {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructA).FullName}, {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructB).FullName}; received {union[__idx_ef3ff7].GetType().FullName}", nameof(union));
++                    }
++                }
++            }
+             return new DeputyProps(new object?[]{union});
+         }
+ 
+         /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+         /// <param name="reference">The Javascript-owned object reference</param>
+@@ -35,10 +55,30 @@
+         public virtual object[] Union
+         {
+             get => GetInstanceProperty<object[]>()!;
+             set
+             {
++                if (Amazon.JSII.Runtime.Configuration.RuntimeTypeChecking)
++                {
++                    for (var __idx_cd4240 = 0 ; __idx_cd4240 < value.Length ; __idx_cd4240++)
++                    {
++                        switch (value[__idx_cd4240])
++                        {
++                            case Amazon.JSII.Tests.CalculatorNamespace.IStructA cast_e9c63e:
++                                break;
++                            case Amazon.JSII.Tests.CalculatorNamespace.IStructB cast_e9c63e:
++                                break;
++                            case Amazon.JSII.Runtime.Deputy.AnonymousObject cast_e9c63e:
++                                // Not enough information to type-check...
++                                break;
++                            case null:
++                                throw new System.ArgumentException($"Expected {nameof(value)}[{__idx_cd4240}] to be one of: {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructA).FullName}, {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructB).FullName}; received null", nameof(value));
++                            default:
++                                throw new System.ArgumentException($"Expected {nameof(value)}[{__idx_cd4240}] to be one of: {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructA).FullName}, {typeof(Amazon.JSII.Tests.CalculatorNamespace.IStructB).FullName}; received {value[__idx_cd4240].GetType().FullName}", nameof(value));
++                        }
++                    }
++                }
+                 SetInstanceProperty(value);
              }
          }
      }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -494,71 +494,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/version 1`]
 
 exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/ 1`] = `
 <runtime-type-check-diff>
- ┗━ 📁 go
-    ┗━ 📁 jcb
-       ┣━ 🆕 jcb_StaticConsumer__no_runtime_type_checking.go
-       ┣━ 🆕 jcb_StaticConsumer__runtime_type_checks.go
-       ┗━ 📄 jcb_StaticConsumer.go.diff
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/go/jcb/jcb_StaticConsumer.go.diff 1`] = `
---- go/jcb/jcb_StaticConsumer.go	--no-runtime-type-checking
-+++ go/jcb/jcb_StaticConsumer.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
- }
- 
- func StaticConsumer_Consume(args ...interface{}) {
- 	_init_.Initialize()
- 
-+	if err := validateStaticConsumer_ConsumeParameters(args); err != nil {
-+		panic(err)
-+	}
- 	args_ := []interface{}{}
- 	for _, a := range args {
- 		args_ = append(args_, a)
- 	}
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/go/jcb/jcb_StaticConsumer__no_runtime_type_checking.go.diff 1`] = `
---- go/jcb/jcb_StaticConsumer__no_runtime_type_checking.go	--no-runtime-type-checking
-+++ go/jcb/jcb_StaticConsumer__no_runtime_type_checking.go	--runtime-type-checking
-@@ -0,0 +1,12 @@
-+//go:build no_runtime_type_checking
-+// +build no_runtime_type_checking
-+
-+// An example direct dependency for jsii-calc.
-+package jcb
-+
-+// Building without runtime type checking enabled, so all the below just return nil
-+
-+func validateStaticConsumer_ConsumeParameters(args []interface{}) error {
-+	return nil
-+}
-+
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/go/jcb/jcb_StaticConsumer__runtime_type_checks.go.diff 1`] = `
---- go/jcb/jcb_StaticConsumer__runtime_type_checks.go	--no-runtime-type-checking
-+++ go/jcb/jcb_StaticConsumer__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,18 @@
-+//go:build !no_runtime_type_checking
-+// +build !no_runtime_type_checking
-+
-+// An example direct dependency for jsii-calc.
-+package jcb
-+
-+import (
-+	"fmt"
-+)
-+
-+func validateStaticConsumer_ConsumeParameters(args []interface{}) error {
-+	if args == nil {
-+		return fmt.Errorf("parameter args is required, but nil was provided")
-+	}
-+
-+	return nil
-+}
-+
+┗━ 🕳 There is nothing here
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
@@ -1019,71 +955,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejs
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/ 1`] = `
 <runtime-type-check-diff>
- ┗━ 📁 go
-    ┗━ 📁 scopejsiicalcbaseofbase
-       ┣━ 🆕 scopejsiicalcbaseofbase_StaticConsumer__no_runtime_type_checking.go
-       ┣━ 🆕 scopejsiicalcbaseofbase_StaticConsumer__runtime_type_checks.go
-       ┗━ 📄 scopejsiicalcbaseofbase_StaticConsumer.go.diff
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer.go.diff 1`] = `
---- go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer.go	--no-runtime-type-checking
-+++ go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer.go	--runtime-type-checking
-@@ -15,10 +15,13 @@
- }
- 
- func StaticConsumer_Consume(_args ...interface{}) {
- 	_init_.Initialize()
- 
-+	if err := validateStaticConsumer_ConsumeParameters(_args); err != nil {
-+		panic(err)
-+	}
- 	args := []interface{}{}
- 	for _, a := range _args {
- 		args = append(args, a)
- 	}
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__no_runtime_type_checking.go.diff 1`] = `
---- go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__no_runtime_type_checking.go	--no-runtime-type-checking
-+++ go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__no_runtime_type_checking.go	--runtime-type-checking
-@@ -0,0 +1,12 @@
-+//go:build no_runtime_type_checking
-+// +build no_runtime_type_checking
-+
-+// An example transitive dependency for jsii-calc.
-+package scopejsiicalcbaseofbase
-+
-+// Building without runtime type checking enabled, so all the below just return nil
-+
-+func validateStaticConsumer_ConsumeParameters(_args []interface{}) error {
-+	return nil
-+}
-+
-`;
-
-exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__runtime_type_checks.go.diff 1`] = `
---- go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__runtime_type_checks.go	--no-runtime-type-checking
-+++ go/scopejsiicalcbaseofbase/scopejsiicalcbaseofbase_StaticConsumer__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,18 @@
-+//go:build !no_runtime_type_checking
-+// +build !no_runtime_type_checking
-+
-+// An example transitive dependency for jsii-calc.
-+package scopejsiicalcbaseofbase
-+
-+import (
-+	"fmt"
-+)
-+
-+func validateStaticConsumer_ConsumeParameters(_args []interface{}) error {
-+	if _args == nil {
-+		return fmt.Errorf("parameter _args is required, but nil was provided")
-+	}
-+
-+	return nil
-+}
-+
+┗━ 🕳 There is nothing here
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
@@ -2821,6 +2693,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┣━ 📄 jsiicalc_UsesInterfaceWithProperties.go
        ┣━ 📄 jsiicalc_VariadicInvoker.go
        ┣━ 📄 jsiicalc_VariadicMethod.go
+       ┣━ 📄 jsiicalc_VariadicTypeUnion.go
        ┣━ 📄 jsiicalc_VirtualMethodPlayground.go
        ┣━ 📄 jsiicalc_VoidCallback.go
        ┣━ 📄 jsiicalc_WithPrivatePropertyInConstructor.go
@@ -6498,6 +6371,16 @@ func init() {
 		},
 		func() interface{} {
 			return &jsiiProxy_VariadicMethod{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.VariadicTypeUnion",
+		reflect.TypeOf((*VariadicTypeUnion)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberProperty{JsiiProperty: "union", GoGetter: "Union"},
+		},
+		func() interface{} {
+			return &jsiiProxy_VariadicTypeUnion{}
 		},
 	)
 	_jsii_.RegisterClass(
@@ -20996,6 +20879,81 @@ func (v *jsiiProxy_VariadicMethod) AsArray(first *float64, others ...*float64) *
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VariadicTypeUnion.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type VariadicTypeUnion interface {
+	Union() *[]interface{}
+	SetUnion(val *[]interface{})
+}
+
+// The jsii proxy struct for VariadicTypeUnion
+type jsiiProxy_VariadicTypeUnion struct {
+	_ byte // padding
+}
+
+func (j *jsiiProxy_VariadicTypeUnion) Union() *[]interface{} {
+	var returns *[]interface{}
+	_jsii_.Get(
+		j,
+		"union",
+		&returns,
+	)
+	return returns
+}
+
+
+func NewVariadicTypeUnion(union ...interface{}) VariadicTypeUnion {
+	_init_.Initialize()
+
+	args := []interface{}{}
+	for _, a := range union {
+		args = append(args, a)
+	}
+
+	j := jsiiProxy_VariadicTypeUnion{}
+
+	_jsii_.Create(
+		"jsii-calc.VariadicTypeUnion",
+		args,
+		&j,
+	)
+
+	return &j
+}
+
+func NewVariadicTypeUnion_Override(v VariadicTypeUnion, union ...interface{}) {
+	_init_.Initialize()
+
+	args := []interface{}{}
+	for _, a := range union {
+		args = append(args, a)
+	}
+
+	_jsii_.Create(
+		"jsii-calc.VariadicTypeUnion",
+		args,
+		v,
+	)
+}
+
+func (j *jsiiProxy_VariadicTypeUnion)SetUnion(val *[]interface{}) {
+	_jsii_.Set(
+		j,
+		"union",
+		val,
+	)
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_VirtualMethodPlayground.go 1`] = `
 // A simple calcuator built on JSII.
 package jsiicalc
@@ -24326,9 +24284,6 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
        ┣━ 🆕 jsiicalc_DoNotRecognizeAnyAsOptional__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_DoNotRecognizeAnyAsOptional__runtime_type_checks.go
        ┣━ 📄 jsiicalc_DoNotRecognizeAnyAsOptional.go.diff
-       ┣━ 🆕 jsiicalc_DontComplainAboutVariadicAfterOptional__no_runtime_type_checking.go
-       ┣━ 🆕 jsiicalc_DontComplainAboutVariadicAfterOptional__runtime_type_checks.go
-       ┣━ 📄 jsiicalc_DontComplainAboutVariadicAfterOptional.go.diff
        ┣━ 🆕 jsiicalc_DynamicPropertyBearer__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_DynamicPropertyBearer__runtime_type_checks.go
        ┣━ 📄 jsiicalc_DynamicPropertyBearer.go.diff
@@ -24508,6 +24463,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
        ┣━ 🆕 jsiicalc_VariadicMethod__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_VariadicMethod__runtime_type_checks.go
        ┣━ 📄 jsiicalc_VariadicMethod.go.diff
+       ┣━ 🆕 jsiicalc_VariadicTypeUnion__no_runtime_type_checking.go
+       ┣━ 🆕 jsiicalc_VariadicTypeUnion__runtime_type_checks.go
+       ┣━ 📄 jsiicalc_VariadicTypeUnion.go.diff
        ┣━ 🆕 jsiicalc_VirtualMethodPlayground__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_VirtualMethodPlayground__runtime_type_checks.go
        ┣━ 📄 jsiicalc_VirtualMethodPlayground.go.diff
@@ -28892,66 +28850,6 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +
 `;
 
-exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional.go.diff 1`] = `
---- go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional.go	--no-runtime-type-checking
-+++ go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional.go	--runtime-type-checking
-@@ -38,10 +38,13 @@
- 		d,
- 	)
- }
- 
- func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(optional *string, things ...*string) *string {
-+	if err := d.validateOptionalAndVariadicParameters(things); err != nil {
-+		panic(err)
-+	}
- 	args := []interface{}{optional}
- 	for _, a := range things {
- 		args = append(args, a)
- 	}
-`;
-
-exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__no_runtime_type_checking.go.diff 1`] = `
---- go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__no_runtime_type_checking.go	--no-runtime-type-checking
-+++ go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__no_runtime_type_checking.go	--runtime-type-checking
-@@ -0,0 +1,12 @@
-+//go:build no_runtime_type_checking
-+// +build no_runtime_type_checking
-+
-+// A simple calcuator built on JSII.
-+package jsiicalc
-+
-+// Building without runtime type checking enabled, so all the below just return nil
-+
-+func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) validateOptionalAndVariadicParameters(things []*string) error {
-+	return nil
-+}
-+
-`;
-
-exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__runtime_type_checks.go.diff 1`] = `
---- go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__runtime_type_checks.go	--no-runtime-type-checking
-+++ go/jsiicalc/jsiicalc_DontComplainAboutVariadicAfterOptional__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,18 @@
-+//go:build !no_runtime_type_checking
-+// +build !no_runtime_type_checking
-+
-+// A simple calcuator built on JSII.
-+package jsiicalc
-+
-+import (
-+	"fmt"
-+)
-+
-+func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) validateOptionalAndVariadicParameters(things []*string) error {
-+	if things == nil {
-+		return fmt.Errorf("parameter things is required, but nil was provided")
-+	}
-+
-+	return nil
-+}
-+
-`;
-
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_DynamicPropertyBearer.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_DynamicPropertyBearer.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_DynamicPropertyBearer.go	--runtime-type-checking
@@ -32451,7 +32349,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
  func StructPassing_HowManyVarArgsDidIPass(_positional *float64, inputs ...*TopLevelStruct) *float64 {
  	_init_.Initialize()
  
-+	if err := validateStructPassing_HowManyVarArgsDidIPassParameters(_positional, inputs); err != nil {
++	if err := validateStructPassing_HowManyVarArgsDidIPassParameters(_positional, &inputs); err != nil {
 +		panic(err)
 +	}
  	args := []interface{}{_positional}
@@ -32487,7 +32385,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +
 +// Building without runtime type checking enabled, so all the below just return nil
 +
-+func validateStructPassing_HowManyVarArgsDidIPassParameters(_positional *float64, inputs []*TopLevelStruct) error {
++func validateStructPassing_HowManyVarArgsDidIPassParameters(_positional *float64, inputs *[]*TopLevelStruct) error {
 +	return nil
 +}
 +
@@ -32500,7 +32398,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_StructPassing__runtime_type_checks.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_StructPassing__runtime_type_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_StructPassing__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,41 @@
 +//go:build !no_runtime_type_checking
 +// +build !no_runtime_type_checking
 +
@@ -32513,16 +32411,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 +)
 +
-+func validateStructPassing_HowManyVarArgsDidIPassParameters(_positional *float64, inputs []*TopLevelStruct) error {
++func validateStructPassing_HowManyVarArgsDidIPassParameters(_positional *float64, inputs *[]*TopLevelStruct) error {
 +	if _positional == nil {
 +		return fmt.Errorf("parameter _positional is required, but nil was provided")
 +	}
 +
-+	if inputs == nil {
-+		return fmt.Errorf("parameter inputs is required, but nil was provided")
-+	}
-+	if err := _jsii_.ValidateStruct(inputs, func() string { return "parameter inputs" }); err != nil {
-+		return err
++	for idx_323815, v := range *inputs {
++		if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter inputs[%#v]", idx_323815) }); err != nil {
++			return err
++		}
 +	}
 +
 +	return nil
@@ -32858,7 +32755,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
  func NewSupportsNiceJavaBuilder(id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) SupportsNiceJavaBuilder {
  	_init_.Initialize()
  
-+	if err := validateNewSupportsNiceJavaBuilderParameters(id, props, rest); err != nil {
++	if err := validateNewSupportsNiceJavaBuilderParameters(id, props); err != nil {
 +		panic(err)
 +	}
  	args := []interface{}{id, defaultBar, props}
@@ -32879,7 +32776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +
 +// Building without runtime type checking enabled, so all the below just return nil
 +
-+func validateNewSupportsNiceJavaBuilderParameters(id *float64, props *SupportsNiceJavaBuilderProps, rest []*string) error {
++func validateNewSupportsNiceJavaBuilderParameters(id *float64, props *SupportsNiceJavaBuilderProps) error {
 +	return nil
 +}
 +
@@ -32888,7 +32785,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_SupportsNiceJavaBuilder__runtime_type_checks.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_SupportsNiceJavaBuilder__runtime_type_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_SupportsNiceJavaBuilder__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +// +build !no_runtime_type_checking
 +
@@ -32901,17 +32798,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 +)
 +
-+func validateNewSupportsNiceJavaBuilderParameters(id *float64, props *SupportsNiceJavaBuilderProps, rest []*string) error {
++func validateNewSupportsNiceJavaBuilderParameters(id *float64, props *SupportsNiceJavaBuilderProps) error {
 +	if id == nil {
 +		return fmt.Errorf("parameter id is required, but nil was provided")
 +	}
 +
 +	if err := _jsii_.ValidateStruct(props, func() string { return "parameter props" }); err != nil {
 +		return err
-+	}
-+
-+	if rest == nil {
-+		return fmt.Errorf("parameter rest is required, but nil was provided")
 +	}
 +
 +	return nil
@@ -33573,25 +33466,12 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
  	_jsii_.Create(
  		"jsii-calc.VariadicInvoker",
  		[]interface{}{method},
-@@ -38,10 +41,13 @@
- 		v,
- 	)
- }
- 
- func (v *jsiiProxy_VariadicInvoker) AsArray(values ...*float64) *[]*float64 {
-+	if err := v.validateAsArrayParameters(values); err != nil {
-+		panic(err)
-+	}
- 	args := []interface{}{}
- 	for _, a := range values {
- 		args = append(args, a)
- 	}
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicInvoker__no_runtime_type_checking.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_VariadicInvoker__no_runtime_type_checking.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_VariadicInvoker__no_runtime_type_checking.go	--runtime-type-checking
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,12 @@
 +//go:build no_runtime_type_checking
 +// +build no_runtime_type_checking
 +
@@ -33599,10 +33479,6 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
-+
-+func (v *jsiiProxy_VariadicInvoker) validateAsArrayParameters(values []*float64) error {
-+	return nil
-+}
 +
 +func validateNewVariadicInvokerParameters(method VariadicMethod) error {
 +	return nil
@@ -33613,7 +33489,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicInvoker__runtime_type_checks.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_VariadicInvoker__runtime_type_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_VariadicInvoker__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +// +build !no_runtime_type_checking
 +
@@ -33623,14 +33499,6 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +import (
 +	"fmt"
 +)
-+
-+func (v *jsiiProxy_VariadicInvoker) validateAsArrayParameters(values []*float64) error {
-+	if values == nil {
-+		return fmt.Errorf("parameter values is required, but nil was provided")
-+	}
-+
-+	return nil
-+}
 +
 +func validateNewVariadicInvokerParameters(method VariadicMethod) error {
 +	if method == nil {
@@ -33645,27 +33513,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicMethod.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_VariadicMethod.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_VariadicMethod.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
- }
- 
- func NewVariadicMethod(prefix ...*float64) VariadicMethod {
- 	_init_.Initialize()
- 
-+	if err := validateNewVariadicMethodParameters(prefix); err != nil {
-+		panic(err)
-+	}
- 	args := []interface{}{}
- 	for _, a := range prefix {
- 		args = append(args, a)
- 	}
- 
-@@ -48,10 +51,13 @@
+@@ -48,10 +48,13 @@
  		v,
  	)
  }
  
  func (v *jsiiProxy_VariadicMethod) AsArray(first *float64, others ...*float64) *[]*float64 {
-+	if err := v.validateAsArrayParameters(first, others); err != nil {
++	if err := v.validateAsArrayParameters(first); err != nil {
 +		panic(err)
 +	}
  	args := []interface{}{first}
@@ -33677,7 +33531,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicMethod__no_runtime_type_checking.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_VariadicMethod__no_runtime_type_checking.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_VariadicMethod__no_runtime_type_checking.go	--runtime-type-checking
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,12 @@
 +//go:build no_runtime_type_checking
 +// +build no_runtime_type_checking
 +
@@ -33686,11 +33540,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +
 +// Building without runtime type checking enabled, so all the below just return nil
 +
-+func (v *jsiiProxy_VariadicMethod) validateAsArrayParameters(first *float64, others []*float64) error {
-+	return nil
-+}
-+
-+func validateNewVariadicMethodParameters(prefix []*float64) error {
++func (v *jsiiProxy_VariadicMethod) validateAsArrayParameters(first *float64) error {
 +	return nil
 +}
 +
@@ -33699,7 +33549,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicMethod__runtime_type_checks.go.diff 1`] = `
 --- go/jsiicalc/jsiicalc_VariadicMethod__runtime_type_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/jsiicalc_VariadicMethod__runtime_type_checks.go	--runtime-type-checking
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +// +build !no_runtime_type_checking
 +
@@ -33710,21 +33560,155 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +	"fmt"
 +)
 +
-+func (v *jsiiProxy_VariadicMethod) validateAsArrayParameters(first *float64, others []*float64) error {
++func (v *jsiiProxy_VariadicMethod) validateAsArrayParameters(first *float64) error {
 +	if first == nil {
 +		return fmt.Errorf("parameter first is required, but nil was provided")
-+	}
-+
-+	if others == nil {
-+		return fmt.Errorf("parameter others is required, but nil was provided")
 +	}
 +
 +	return nil
 +}
 +
-+func validateNewVariadicMethodParameters(prefix []*float64) error {
-+	if prefix == nil {
-+		return fmt.Errorf("parameter prefix is required, but nil was provided")
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicTypeUnion.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_VariadicTypeUnion.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_VariadicTypeUnion.go	--runtime-type-checking
+@@ -28,10 +28,13 @@
+ 
+ 
+ func NewVariadicTypeUnion(union ...interface{}) VariadicTypeUnion {
+ 	_init_.Initialize()
+ 
++	if err := validateNewVariadicTypeUnionParameters(&union); err != nil {
++		panic(err)
++	}
+ 	args := []interface{}{}
+ 	for _, a := range union {
+ 		args = append(args, a)
+ 	}
+ 
+@@ -60,10 +63,13 @@
+ 		v,
+ 	)
+ }
+ 
+ func (j *jsiiProxy_VariadicTypeUnion)SetUnion(val *[]interface{}) {
++	if err := j.validateSetUnionParameters(val); err != nil {
++		panic(err)
++	}
+ 	_jsii_.Set(
+ 		j,
+ 		"union",
+ 		val,
+ 	)
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicTypeUnion__no_runtime_type_checking.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_VariadicTypeUnion__no_runtime_type_checking.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_VariadicTypeUnion__no_runtime_type_checking.go	--runtime-type-checking
+@@ -0,0 +1,16 @@
++//go:build no_runtime_type_checking
++// +build no_runtime_type_checking
++
++// A simple calcuator built on JSII.
++package jsiicalc
++
++// Building without runtime type checking enabled, so all the below just return nil
++
++func (j *jsiiProxy_VariadicTypeUnion) validateSetUnionParameters(val *[]interface{}) error {
++	return nil
++}
++
++func validateNewVariadicTypeUnionParameters(union *[]interface{}) error {
++	return nil
++}
++
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_VariadicTypeUnion__runtime_type_checks.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_VariadicTypeUnion__runtime_type_checks.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_VariadicTypeUnion__runtime_type_checks.go	--runtime-type-checking
+@@ -0,0 +1,85 @@
++//go:build !no_runtime_type_checking
++// +build !no_runtime_type_checking
++
++// A simple calcuator built on JSII.
++package jsiicalc
++
++import (
++	"fmt"
++
++	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
++)
++
++func (j *jsiiProxy_VariadicTypeUnion) validateSetUnionParameters(val *[]interface{}) error {
++	if val == nil {
++		return fmt.Errorf("parameter val is required, but nil was provided")
++	}
++	for idx_97dfc6, v := range *val {
++		switch v.(type) {
++		case *StructA:
++			v := v.(*StructA)
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter val[%#v]", idx_97dfc6) }); err != nil {
++				return err
++			}
++		case StructA:
++			v_ := v.(StructA)
++			v := &v_
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter val[%#v]", idx_97dfc6) }); err != nil {
++				return err
++			}
++		case *StructB:
++			v := v.(*StructB)
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter val[%#v]", idx_97dfc6) }); err != nil {
++				return err
++			}
++		case StructB:
++			v_ := v.(StructB)
++			v := &v_
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter val[%#v]", idx_97dfc6) }); err != nil {
++				return err
++			}
++		default:
++			if !_jsii_.IsAnonymousProxy(v) {
++				return fmt.Errorf("parameter val[%#v] must be one of the allowed types: *StructA, *StructB; received %#v (a %T)", idx_97dfc6, v, v)
++			}
++		}
++	}
++
++	return nil
++}
++
++func validateNewVariadicTypeUnionParameters(union *[]interface{}) error {
++	for idx_ef3ff7, v := range *union {
++		switch v.(type) {
++		case *StructA:
++			v := v.(*StructA)
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter union[%#v]", idx_ef3ff7) }); err != nil {
++				return err
++			}
++		case StructA:
++			v_ := v.(StructA)
++			v := &v_
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter union[%#v]", idx_ef3ff7) }); err != nil {
++				return err
++			}
++		case *StructB:
++			v := v.(*StructB)
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter union[%#v]", idx_ef3ff7) }); err != nil {
++				return err
++			}
++		case StructB:
++			v_ := v.(StructB)
++			v := &v_
++			if err := _jsii_.ValidateStruct(v, func() string { return fmt.Sprintf("parameter union[%#v]", idx_ef3ff7) }); err != nil {
++				return err
++			}
++		default:
++			if !_jsii_.IsAnonymousProxy(v) {
++				return fmt.Errorf("parameter union[%#v] must be one of the allowed types: *StructA, *StructB; received %#v (a %T)", idx_ef3ff7, v, v)
++			}
++		}
 +	}
 +
 +	return nil

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -3905,6 +3905,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 UsesInterfaceWithProperties.java
           ┃                 ┣━ 📄 VariadicInvoker.java
           ┃                 ┣━ 📄 VariadicMethod.java
+          ┃                 ┣━ 📄 VariadicTypeUnion.java
           ┃                 ┣━ 📄 VirtualMethodPlayground.java
           ┃                 ┣━ 📄 VoidCallback.java
           ┃                 ┗━ 📄 WithPrivatePropertyInConstructor.java
@@ -23130,6 +23131,50 @@ public class VariadicMethod extends software.amazon.jsii.JsiiObject {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicTypeUnion.java 1`] = `
+package software.amazon.jsii.tests.calculator;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.VariadicTypeUnion")
+public class VariadicTypeUnion extends software.amazon.jsii.JsiiObject {
+
+    protected VariadicTypeUnion(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected VariadicTypeUnion(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * @param union This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public VariadicTypeUnion(final @org.jetbrains.annotations.NotNull java.lang.Object... union) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, java.util.Arrays.<Object>stream(union).toArray(Object[]::new));
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> getUnion() {
+        return java.util.Collections.unmodifiableList(software.amazon.jsii.Kernel.get(this, "union", software.amazon.jsii.NativeType.listOf(software.amazon.jsii.NativeType.forClass(java.lang.Object.class))));
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public void setUnion(final @org.jetbrains.annotations.NotNull java.util.List<java.lang.Object> value) {
+        software.amazon.jsii.Kernel.set(this, "union", java.util.Objects.requireNonNull(value, "union is required"));
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/VirtualMethodPlayground.java 1`] = `
 package software.amazon.jsii.tests.calculator;
 
@@ -27768,6 +27813,7 @@ jsii-calc.UseCalcBase=software.amazon.jsii.tests.calculator.UseCalcBase
 jsii-calc.UsesInterfaceWithProperties=software.amazon.jsii.tests.calculator.UsesInterfaceWithProperties
 jsii-calc.VariadicInvoker=software.amazon.jsii.tests.calculator.VariadicInvoker
 jsii-calc.VariadicMethod=software.amazon.jsii.tests.calculator.VariadicMethod
+jsii-calc.VariadicTypeUnion=software.amazon.jsii.tests.calculator.VariadicTypeUnion
 jsii-calc.VirtualMethodPlayground=software.amazon.jsii.tests.calculator.VirtualMethodPlayground
 jsii-calc.VoidCallback=software.amazon.jsii.tests.calculator.VoidCallback
 jsii-calc.WithPrivatePropertyInConstructor=software.amazon.jsii.tests.calculator.WithPrivatePropertyInConstructor

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -10292,6 +10292,26 @@ class VariadicMethod(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicMetho
         return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
 
 
+class VariadicTypeUnion(
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.VariadicTypeUnion",
+):
+    def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
+        '''
+        :param union: -
+        '''
+        jsii.create(self.__class__, self, [*union])
+
+    @builtins.property
+    @jsii.member(jsii_name="union")
+    def union(self) -> typing.List[typing.Union[StructA, StructB]]:
+        return typing.cast(typing.List[typing.Union[StructA, StructB]], jsii.get(self, "union"))
+
+    @union.setter
+    def union(self, value: typing.List[typing.Union[StructA, StructB]]) -> None:
+        jsii.set(self, "union", value)
+
+
 class VirtualMethodPlayground(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.VirtualMethodPlayground",
@@ -11107,6 +11127,7 @@ __all__ = [
     "UsesInterfaceWithProperties",
     "VariadicInvoker",
     "VariadicMethod",
+    "VariadicTypeUnion",
     "VirtualMethodPlayground",
     "VoidCallback",
     "WithPrivatePropertyInConstructor",
@@ -16449,9 +16470,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
  
  
+ class VariadicTypeUnion(
+     metaclass=jsii.JSIIMeta,
+@@ -7477,19 +8156,25 @@
+ ):
+     def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
+         '''
+         :param union: -
+         '''
++        if __debug__:
++            type_hints = typing.get_type_hints(VariadicTypeUnion.__init__)
++            check_type(argname="argument union", value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
+         jsii.create(self.__class__, self, [*union])
+ 
+     @builtins.property
+     @jsii.member(jsii_name="union")
+     def union(self) -> typing.List[typing.Union[StructA, StructB]]:
+         return typing.cast(typing.List[typing.Union[StructA, StructB]], jsii.get(self, "union"))
+ 
+     @union.setter
+     def union(self, value: typing.List[typing.Union[StructA, StructB]]) -> None:
++        if __debug__:
++            type_hints = typing.get_type_hints(getattr(VariadicTypeUnion, "union").fset)
++            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
+         jsii.set(self, "union", value)
+ 
+ 
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7481,38 +8160,53 @@
+@@ -7501,38 +8186,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -16505,7 +16552,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7560,10 +8254,13 @@
+@@ -7580,10 +8280,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16519,7 +16566,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7604,10 +8301,13 @@
+@@ -7624,10 +8327,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -16533,7 +16580,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7623,10 +8323,14 @@
+@@ -7643,10 +8349,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16548,7 +16595,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7670,10 +8374,13 @@
+@@ -7690,10 +8400,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -16562,7 +16609,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7684,10 +8391,14 @@
+@@ -7704,10 +8417,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -16577,7 +16624,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7728,37 +8439,49 @@
+@@ -7748,37 +8465,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16627,7 +16674,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -7773,37 +8496,49 @@
+@@ -7793,37 +8522,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16677,7 +16724,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -7821,10 +8556,14 @@
+@@ -7841,10 +8582,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -16692,7 +16739,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -7835,10 +8574,13 @@
+@@ -7855,10 +8600,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16706,7 +16753,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -7953,10 +8695,13 @@
+@@ -7973,10 +8721,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -16720,7 +16767,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -7977,10 +8722,13 @@
+@@ -7997,10 +8748,13 @@
  
      def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
          '''
@@ -16734,7 +16781,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8040,10 +8788,16 @@
+@@ -8060,10 +8814,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -2409,6 +2409,16 @@ exports[`jsii-tree --all 1`] = `
  │   │     │   ├── type: number
  │   │     │   └── variadic
  │   │     └── returns: Array<number>
+ │   ├─┬ class VariadicTypeUnion (stable)
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>(union) initializer (stable)
+ │   │   │ ├── variadic
+ │   │   │ └─┬ parameters
+ │   │   │   └─┬ union
+ │   │   │     ├── type: jsii-calc.StructA | jsii-calc.StructB
+ │   │   │     └── variadic
+ │   │   └─┬ union property (stable)
+ │   │     └── type: Array<jsii-calc.StructA | jsii-calc.StructB>
  │   ├─┬ class VirtualMethodPlayground (stable)
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer (stable)
@@ -3838,6 +3848,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class UsesInterfaceWithProperties
  │   ├── class VariadicInvoker
  │   ├── class VariadicMethod
+ │   ├── class VariadicTypeUnion
  │   ├── class VirtualMethodPlayground
  │   ├── class VoidCallback
  │   ├── class WithPrivatePropertyInConstructor
@@ -5112,6 +5123,10 @@ exports[`jsii-tree --members 1`] = `
  │   │ └─┬ members
  │   │   ├── <initializer>(prefix) initializer
  │   │   └── asArray(first,others) method
+ │   ├─┬ class VariadicTypeUnion
+ │   │ └─┬ members
+ │   │   ├── <initializer>(union) initializer
+ │   │   └── union property
  │   ├─┬ class VirtualMethodPlayground
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -5912,6 +5927,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class UsesInterfaceWithProperties
  │   ├── class VariadicInvoker
  │   ├── class VariadicMethod
+ │   ├── class VariadicTypeUnion
  │   ├── class VirtualMethodPlayground
  │   ├── class VoidCallback
  │   ├── class WithPrivatePropertyInConstructor

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -2565,6 +2565,16 @@ exports[`showAll 1`] = `
  │   │     │   ├── type: number
  │   │     │   └── variadic
  │   │     └── returns: Array<number>
+ │   ├─┬ class VariadicTypeUnion
+ │   │ └─┬ members
+ │   │   ├─┬ <initializer>(union) initializer
+ │   │   │ ├── variadic
+ │   │   │ └─┬ parameters
+ │   │   │   └─┬ union
+ │   │   │     ├── type: jsii-calc.StructA | jsii-calc.StructB
+ │   │   │     └── variadic
+ │   │   └─┬ union property
+ │   │     └── type: Array<jsii-calc.StructA | jsii-calc.StructB>
  │   ├─┬ class VirtualMethodPlayground
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -3981,6 +3991,7 @@ exports[`types 1`] = `
  │   ├── class UsesInterfaceWithProperties
  │   ├── class VariadicInvoker
  │   ├── class VariadicMethod
+ │   ├── class VariadicTypeUnion
  │   ├── class VirtualMethodPlayground
  │   ├── class VoidCallback
  │   ├── class WithPrivatePropertyInConstructor

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -156,6 +156,7 @@ Array [
   "jsii-calc.UsesInterfaceWithProperties",
   "jsii-calc.VariadicInvoker",
   "jsii-calc.VariadicMethod",
+  "jsii-calc.VariadicTypeUnion",
   "jsii-calc.VirtualMethodPlayground",
   "jsii-calc.VoidCallback",
   "jsii-calc.WithPrivatePropertyInConstructor",


### PR DESCRIPTION
The code-gen for type unions was incorrect, as the value is typically
array-typed, and the generated code hence needs to treat the value as
such.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
