### PR TITLE
fix(python): reference to type does not use alias

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -593,6 +593,7 @@ abstract class BaseMethod implements PythonBase {
           const paramType = toTypeName(prop.prop).pythonType({
             ...context,
             parameterType: true,
+            typeAnnotation: true,
           });
           const paramDefault = prop.prop.optional ? ' = None' : '';
 
@@ -1133,10 +1134,10 @@ class Struct extends BasePythonClassType {
     // Re-type struct arguments that were passed as "dict". Do this before validating argument types...
     for (const member of members.filter((m) => m.isStruct(this.generator))) {
       // Note that "None" is NOT an instance of dict (that's convenient!)
-      const typeName = toPythonFullName(
-        (member.type.type as spec.NamedTypeReference).fqn,
-        context.assembly,
-      );
+      const typeName = toTypeName(member.type.type).pythonType({
+        ...context,
+        typeAnnotation: false,
+      });
       code.openBlock(`if isinstance(${member.pythonName}, dict)`);
       code.line(`${member.pythonName} = ${typeName}(**${member.pythonName})`);
       code.closeBlock();

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -335,7 +335,7 @@ class UserType implements TypeName {
       // Identify declarations that are not yet initialized and hence cannot be
       // used as part of a type qualification. Since this is not a forward
       // reference, the type was already emitted and its un-qualified name must
-      // be used instead of it's locally qualified name.
+      // be used instead of its locally qualified name.
       const nestingParent = surroundingTypeFqns
         ?.map((fqn) => toPythonFqn(fqn, assembly).pythonFqn)
         ?.reverse()
@@ -357,7 +357,7 @@ class UserType implements TypeName {
         // This is not for a type annotation, so we should be at a point in time
         // where the surrounding symbol has been defined entirely, so we can
         // refer to it "normally" now.
-        return { pythonType: pythonFqn.substring(nestingParent.length + 1) };
+        return { pythonType: pythonFqn.slice(packageName.length + 1) };
       }
 
       // We'll just make a module-qualified reference at this point.
@@ -380,7 +380,7 @@ class UserType implements TypeName {
     const alias = `_${toImport}_${aliasSuffix}`;
 
     return {
-      pythonType: [alias, ...nested].join('.'),
+      pythonType: wrapType([alias, ...nested].join('.')),
       requiredImport: {
         sourcePackage: relativeImportPath(
           submodulePythonName,


### PR DESCRIPTION
Type references in a keyword property position may not have used
the aliased import as intended, resulting in a runtime error due
to referring to an undefined symbol.

Additionally, keyword properties referencing structs did not
allow dicts to be used in lieu of a struct instance.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
