### PR TITLE
fix(java): type generation code-gen issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,8 +395,8 @@ jobs:
     name: Integration test (jsii-pacmak)
     runs-on: ubuntu-latest
     needs: create-release-package
-    jobs:
-      - # Check out the code
+    steps:
+      # Check out the code
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -432,10 +432,16 @@ jobs:
       # Show time!
       - name: Prepare Work Tree
         run: |-
-          npm install --no-save aws-cdk-lib@2                                   \
+          npm install --no-save aws-cdk-lib@2 constructs@10                     \
                                 ${{ runner.temp }}/release-package/js/*.tgz     \
                                 ${{ runner.temp }}/release-package/private/*.tgz
       - name: Run jsii-pacmak on aws-cdk-lib
         run: |-
-          ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
-        working-directory: node_modules/aws-cdk-lib
+          ./node_modules/.bin/jsii-pacmak ./node_modules/aws-cdk-lib
+      # Upload artifact (we'll tar it up to save time)
+      - name: 'Upload Artifact: integtest_aws-cdk-lib'
+        uses: actions/upload-artifact@v3
+        with:
+          name: integtest_aws-cdk-lib
+          path: ./node_modules/aws-cdk-lib/dist/
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -422,7 +422,6 @@ jobs:
       - name: Set up Node 14
         uses: actions/setup-node@v3
         with:
-          cache: yarn
           node-version: '14'
       - name: Set up Python 3.7
         uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
-          cache: maven
           distribution: 'zulu'
           java-version: '8'
       - name: Set up Node 14
@@ -58,6 +57,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |-
+            ~/.m2/repository
+            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
           key: ${{ runner.os }}-${{ hashFiles('**/Directory.Build.targets') }}
@@ -121,7 +122,6 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
-          cache: maven
           distribution: 'zulu'
           java-version: '8'
       - name: Set up Node 14
@@ -140,6 +140,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |-
+            ~/.m2/repository
+            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
           key: ${{ runner.os }}-${{ hashFiles('**/Directory.Build.targets') }}
@@ -295,7 +297,6 @@ jobs:
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          cache: maven
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Set up Node ${{ matrix.node }}
@@ -315,6 +316,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |-
+            ~/.m2/repository
+            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
           # Not including .NET / Java in the cache keys, those artifacts are SDK-version-independent
@@ -414,7 +417,6 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
-          cache: maven
           distribution: 'zulu'
           java-version: '8'
       - name: Set up Node 14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -437,4 +437,5 @@ jobs:
                                 ${{ runner.temp }}/release-package/private/*.tgz
       - name: Run jsii-pacmak on aws-cdk-lib
         run: |-
-          node_modules/.bin/jsii-pacmak node_modules/aws-cdk-lib
+          node_modules/.bin/jsii-pacmak
+        working-directory: node_modules/aws-cdk-lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -437,5 +437,5 @@ jobs:
                                 ${{ runner.temp }}/release-package/private/*.tgz
       - name: Run jsii-pacmak on aws-cdk-lib
         run: |-
-          node_modules/.bin/jsii-pacmak
+          ${{ github.workspace }}/node_modules/.bin/jsii-pacmak
         working-directory: node_modules/aws-cdk-lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -427,7 +427,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-          cache: pip
       - name: Install python3-venv
         run: sudo apt install -y python3-venv
       # Show time!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          cache: maven
           distribution: 'zulu'
+          java-version: '8'
       - name: Set up Node 14
         uses: actions/setup-node@v3
         with:
@@ -50,30 +51,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
+          cache: pip
       - name: Install python3-venv
         run: sudo apt install -y python3-venv
-      - name: Locate Caches
-        id: cache-locations
-        run: |-
-          echo "::group::Upgrade pip"
-          # Need to have PIP >= 20.1 for "pip cache dir" to work
-          python3 -m pip install --upgrade pip
-          echo "::endgroup"
-
-          echo "::set-output name=pip-cache::$(python3 -m pip cache dir)"
       - name: Cache
         uses: actions/cache@v3
         with:
           path: |-
-            ${{ steps.cache-locations.outputs.pip-cache }}
-            ~/.m2/repository
-            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
-          key: ${{ runner.os }}-node@14-python@3.7-${{ hashFiles('**/yarn.lock', '**/Directory.Build.targets') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/Directory.Build.targets') }}
           restore-keys: |-
-            ${{ runner.os }}-node@14-python@3.7-
-            ${{ runner.os }}-node@14-
             ${{ runner.os }}-
       # Prepare dependencies and build
       - name: Install Dependencies
@@ -133,8 +121,9 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          cache: maven
           distribution: 'zulu'
+          java-version: '8'
       - name: Set up Node 14
         uses: actions/setup-node@v3
         with:
@@ -144,30 +133,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.7'
+          cache: pip
       - name: Install python3-venv
         run: sudo apt install -y python3-venv
-      - name: Locate Caches
-        id: cache-locations
-        run: |-
-          echo "::group::Upgrade pip"
-          # Need to have PIP >= 20.1 for "pip cache dir" to work
-          python3 -m pip install --upgrade pip
-          echo "::endgroup"
-
-          echo "::set-output name=pip-cache::$(python3 -m pip cache dir)"
       - name: Cache
         uses: actions/cache@v3
         with:
           path: |-
-            ${{ steps.cache-locations.outputs.pip-cache }}
-            ~/.m2/repository
-            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
-          key: ${{ runner.os }}-node@14-python@3.7-${{ hashFiles('**/yarn.lock', '**/Directory.Build.targets') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/Directory.Build.targets') }}
           restore-keys: |-
-            ${{ runner.os }}-node@14-python@3.7-
-            ${{ runner.os }}-node@14-
             ${{ runner.os }}-
       # Prepare dependencies and build
       - name: Install Dependencies
@@ -319,8 +295,9 @@ jobs:
       - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          cache: maven
           distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Set up Node ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:
@@ -330,32 +307,19 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
       - name: 'Linux: Install python3-venv'
         if: runner.os == 'Linux'
         run: sudo apt install -y python3-venv
-      - name: Locate Caches
-        id: cache-locations
-        run: |-
-          echo "::group::Upgrade pip"
-          # Need to have PIP >= 20.1 for "pip cache dir" to work
-          python3 -m pip install --upgrade pip
-          echo "::endgroup"
-
-          echo "::set-output name=pip-cache::$(python3 -m pip cache dir)"
       - name: Cache
         uses: actions/cache@v3
         with:
           path: |-
-            ${{ steps.cache-locations.outputs.pip-cache }}
-            ~/.m2/repository
-            !~/.m2/repository/software/amazon/jsii/
             ~/.nuget/packages
             !~/.nuget/packages/amazon.jsii.*
           # Not including .NET / Java in the cache keys, those artifacts are SDK-version-independent
-          key: ${{ runner.os }}-node@${{ matrix.node }}-python@${{ matrix.python }}-${{ hashFiles('**/yarn.lock', '**/Directory.Build.targets') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/Directory.Build.targets') }}
           restore-keys: |-
-            ${{ runner.os }}-node@${{ matrix.node }}-python@${{ matrix.python }}-
-            ${{ runner.os }}-node@${{ matrix.node }}-
             ${{ runner.os }}-
       # Run the tests
       - name: Install Dependencies
@@ -426,3 +390,51 @@ jobs:
           output-file-path: ${{ runner.temp }}/bench-output.json
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           auto-push: true
+
+  pacmak-integration-test:
+    name: Integration test (jsii-pacmak)
+    runs-on: ubuntu-latest
+    needs: create-release-package
+    jobs:
+      - # Check out the code
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: release-package
+          path: ${{ runner.temp }}/release-package
+      # Set up all of our standard runtimes
+      - name: Set up .NET 6
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - name: Set up Java 8
+        uses: actions/setup-java@v3
+        with:
+          cache: maven
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Set up Node 14
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: '14'
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+          cache: pip
+      - name: Install python3-venv
+        run: sudo apt install -y python3-venv
+      # Show time!
+      - name: Prepare Work Tree
+        run: |-
+          yarn install --no-save aws-cdk-lib@2                                  \
+                                ${{ runner.temp }}/release-package/js/*.tgz    \
+                                ${{ runner.temp }}/release-package/private/*.tgz
+      - name: Run jsii-pacmak on aws-cdk-lib
+        run: |-
+          node_modules/.bin/jsii-pacmak node_modules/aws-cdk-lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -432,8 +432,8 @@ jobs:
       # Show time!
       - name: Prepare Work Tree
         run: |-
-          yarn install --no-save aws-cdk-lib@2                                  \
-                                ${{ runner.temp }}/release-package/js/*.tgz    \
+          npm install --no-save aws-cdk-lib@2                                   \
+                                ${{ runner.temp }}/release-package/js/*.tgz     \
                                 ${{ runner.temp }}/release-package/private/*.tgz
       - name: Run jsii-pacmak on aws-cdk-lib
         run: |-

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert';
 import * as spec from '@jsii/spec';
 import * as clone from 'clone';
 import { toSnakeCase } from 'codemaker/lib/case-utils';
@@ -1472,9 +1473,9 @@ class JavaGenerator extends Generator {
           // so we should not emit these checks for primitive-only unions.
           // Also, Java does not allow us to perform these checks if the types
           // have no overlap (eg if a String instanceof Number).
-          if (type.includes('java.lang.Object')) {
+          if (type.includes('java.lang.Object') && (!spec.isPrimitiveTypeReference(prop.type) || prop.type.primitive === spec.PrimitiveType.Any)) {
             this.emitUnionParameterValdation([
-              { name: 'value', type: prop.type },
+              { name: 'value', type: this.filterType(prop.type, { covariant: prop.static, optional: prop.optional }, type) },
             ]);
           }
           if (prop.static) {
@@ -1491,6 +1492,27 @@ class JavaGenerator extends Generator {
         }
       }
     }
+  }
+
+  /**
+   * Filters types from a union to select only those that correspond to the
+   * specified javaType.
+   *
+   * @param ref the type to be filtered.
+   * @param javaType the java type that is expected.
+   * @param covariant whether collections should use the covariant form.
+   * @param optional whether the type at an optional location or not
+   *
+   * @returns a type reference that matches the provided javaType.
+   */
+  private filterType(ref: spec.TypeReference, { covariant, optional }: { covariant?: boolean, optional?: boolean }, javaType: string): spec.TypeReference {
+    if (!spec.isUnionTypeReference(ref)) {
+      // No filterning needed -- this isn't a type union!
+      return ref;
+    }
+    const types = ref.union.types.filter((t) => this.toDecoratedJavaType({ optional, type: t }, { covariant }) === javaType);
+    assert(types.length > 0, `No type found in ${spec.describeTypeReference(ref)} has Java type ${javaType}`);
+    return { union: { types } };
   }
 
   private emitMethod(
@@ -1715,68 +1737,74 @@ class JavaGenerator extends Generator {
       type: spec.UnionTypeReference,
       parameterName: string,
     ) {
-      this.code.indent('if (');
       let emitAnd = false;
-      const nestedCollectionUnionTypes = [];
+      const nestedCollectionUnionTypes = new Map<string, spec.TypeReference>();
       const typeRefs = type.union.types;
+      if (typeRefs.length > 1) { this.code.indent('if ('); }
+      const checked = new Set<string>();
       for (const typeRef of typeRefs) {
         const prefix = emitAnd ? '&&' : '';
-        const javaType = this.toJavaTypeNoGenerics(typeRef);
-        if (javaType !== this.toJavaType(typeRef)) {
-          nestedCollectionUnionTypes.push(typeRef);
+        const javaRawType = this.toJavaTypeNoGenerics(typeRef);
+        if (checked.has(javaRawType)) {
+          continue;
+        } else {
+          checked.add(javaRawType);
         }
-        const test = `${value} instanceof ${javaType}`;
-        this.code.line(`${prefix} !(${test})`);
+        const javaType = this.toJavaType(typeRef);
+        if (javaRawType !== javaType) {
+          nestedCollectionUnionTypes.set(javaType, typeRef);
+        }
+        const test = `${value} instanceof ${javaRawType}`;
+        if (typeRefs.length > 1) { this.code.line(`${prefix} !(${test})`); }
         emitAnd = true;
       }
-      // Only anonymous objects at runtime can be `JsiiObject`s.
-      this.code.line(
-        `&& !(${value}.getClass().equals(software.amazon.jsii.JsiiObject.class))`,
-      );
-
-      this.code.unindent(')');
-      this.code.openBlock('');
-
-      const placeholders = typeRefs
-        .map((typeRef) => {
-          return `${this.toJavaType(typeRef)}`;
-        })
-        .join(', ');
-
-      this.code.indent(`throw new IllegalArgumentException(`);
-      this.code.indent(`new java.lang.StringBuilder("Expected ")`);
-      this.code.line(descr);
-      this.code.line(`.append(" to be one of: ${placeholders}; received ")`);
-      this.code.line(`.append(${value}.getClass()).toString());`);
-      this.code.unindent(false);
-      this.code.unindent(false);
-      this.code.closeBlock();
-
-      for (const typeRef of nestedCollectionUnionTypes) {
-        this.code.openBlock(
-          `if (${value} instanceof ${this.toJavaTypeNoGenerics(typeRef)})`,
+      if (typeRefs.length > 1 && typeRefs.some(t => spec.isNamedTypeReference(t) && spec.isInterfaceType(this.findType(t.fqn)))) {
+        // Only anonymous objects at runtime can be `JsiiObject`s.
+        this.code.line(
+          `&& !(${value}.getClass().equals(software.amazon.jsii.JsiiObject.class))`,
         );
-        const varName = `__cast_${createHash('sha256')
+      }
+
+      if (typeRefs.length > 1) {
+        this.code.unindent(false);
+        this.code.openBlock(')');
+
+        const placeholders = typeRefs
+          .map((typeRef) => {
+            return `${this.toJavaType(typeRef)}`;
+          })
+          .join(', ');
+
+        this.code.indent(`throw new IllegalArgumentException(`);
+        this.code.indent(`new java.lang.StringBuilder("Expected ")`);
+        this.code.line(descr);
+        this.code.line(`.append(" to be one of: ${placeholders}; received ")`);
+        this.code.line(`.append(${value}.getClass()).toString());`);
+        this.code.unindent(false);
+        this.code.unindent(false);
+        this.code.closeBlock();
+      }
+
+      for (const [javaType, typeRef] of nestedCollectionUnionTypes) {
+        const varName = typeRefs.length > 1
+        ?  `__cast_${createHash('sha256')
           .update(value)
           .digest('hex')
-          .slice(0, 6)}`;
-        const javaTypeFull = this.toJavaType(typeRef);
-        this.code.line(`@SuppressWarnings("unchecked")`);
-        this.code.line(
-          `final ${javaTypeFull} ${varName} = (${javaTypeFull})${value};`,
-        );
+            .slice(0, 6)}`
+          : value;
+        if (typeRefs.length > 1) {
+          this.code.openBlock(
+            `if (${value} instanceof ${this.toJavaTypeNoGenerics(typeRef)})`,
+          );
+          this.code.line(`@SuppressWarnings("unchecked")`);
+          this.code.line(
+            `final ${javaType} ${varName} = (${javaType})${value};`,
+          );
+        }
         validate.call(this, varName, descr, typeRef, parameterName);
-        validate.call(
-          this,
-          // we must cast Collections to access their methods
-          // if they are nested in a union type,
-          // since that union will be rendered as an Object.
-          `((${this.toJavaType(typeRef)})(${varName}))`,
-          descr,
-          typeRef,
-          parameterName,
-        );
-        this.code.closeBlock();
+        if (typeRefs.length > 1) {
+          this.code.closeBlock();
+        }
       }
     }
   }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -27899,7 +27899,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/AllTypes.java	--runtime-type-checking
-@@ -220,10 +220,27 @@
+@@ -220,10 +220,25 @@
  
      /**
       */
@@ -27911,9 +27911,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                if (
 +                     !(__val_ac66f0 instanceof java.lang.Number)
 +                    && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.lib.NumericValue)
-+                    && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("value").append(".get(").append(__idx_ac66f0).append(")")
@@ -27927,7 +27925,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
  
      /**
       */
-@@ -234,10 +251,35 @@
+@@ -234,10 +249,33 @@
  
      /**
       */
@@ -27947,9 +27945,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                     !(__val_ac66f0 instanceof java.lang.String)
 +                    && !(__val_ac66f0 instanceof java.lang.Number)
 +                    && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.lib.Number)
-+                    && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("value").append(".get(\\"").append((__item_ac66f0.getKey())).append("\\")")
@@ -27968,7 +27964,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollectionOfUnions.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollectionOfUnions.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithCollectionOfUnions.java	--runtime-type-checking
-@@ -19,10 +19,37 @@
+@@ -19,10 +19,36 @@
       * @param unionProperty This parameter is required.
       */
      @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -27990,8 +27986,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                         !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructA)
 +                        && !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructB)
 +                        && !(__val_fb617d.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                    )
-+                     {
++                    ) {
 +                        throw new IllegalArgumentException(
 +                            new java.lang.StringBuilder("Expected ")
 +                                .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".get(\\"").append((__item_fb617d.getKey())).append("\\")")
@@ -28006,7 +28001,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
  
      /**
       */
-@@ -33,8 +60,35 @@
+@@ -33,8 +59,34 @@
  
      /**
       */
@@ -28028,8 +28023,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                         !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructA)
 +                        && !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructB)
 +                        && !(__val_58ec25.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                    )
-+                     {
++                    ) {
 +                        throw new IllegalArgumentException(
 +                            new java.lang.StringBuilder("Expected ")
 +                                .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".get(\\"").append((__item_58ec25.getKey())).append("\\")")
@@ -28047,7 +28041,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithNestedUnion.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithNestedUnion.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/ClassWithNestedUnion.java	--runtime-type-checking
-@@ -19,10 +19,109 @@
+@@ -19,10 +19,68 @@
       * @param unionProperty This parameter is required.
       */
      @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -28059,9 +28053,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                if (
 +                     !(__val_1ccdf0 instanceof java.util.Map)
 +                    && !(__val_1ccdf0 instanceof java.util.List)
-+                    && !(__val_1ccdf0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")")
@@ -28084,30 +28076,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                             !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructA)
 +                            && !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructB)
 +                            && !(__val_fb617d.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
-+                            throw new IllegalArgumentException(
-+                                new java.lang.StringBuilder("Expected ")
-+                                    .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".get(\\"").append((__item_fb617d.getKey())).append("\\")")
-+                                    .append(" to be one of: software.amazon.jsii.tests.calculator.StructA, software.amazon.jsii.tests.calculator.StructB; received ")
-+                                    .append(__val_fb617d.getClass()).toString());
-+                        }
-+                    }
-+                    if (!(((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7c6d77)).keySet().toArray()[0] instanceof String)) {
-+                        throw new IllegalArgumentException(
-+                            new java.lang.StringBuilder("Expected ")
-+                                .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".keySet()")
-+                                .append(" to contain class String; received ")
-+                                .append(((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7c6d77)).keySet().toArray()[0].getClass()).toString());
-+                    }
-+                    for (final java.util.Map.Entry<String, java.lang.Object> __item_fb617d: ((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7c6d77)).entrySet()) {
-+                        final java.lang.Object __val_fb617d = __item_fb617d.getValue();
-+                        if (
-+                             !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructA)
-+                            && !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructB)
-+                            && !(__val_fb617d.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
++                        ) {
 +                            throw new IllegalArgumentException(
 +                                new java.lang.StringBuilder("Expected ")
 +                                    .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".get(\\"").append((__item_fb617d.getKey())).append("\\")")
@@ -28125,23 +28094,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                             !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructA)
 +                            && !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructB)
 +                            && !(__val_fb617d.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
-+                            throw new IllegalArgumentException(
-+                                new java.lang.StringBuilder("Expected ")
-+                                    .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".get(").append(__idx_fb617d).append(")")
-+                                    .append(" to be one of: software.amazon.jsii.tests.calculator.StructA, software.amazon.jsii.tests.calculator.StructB; received ")
-+                                    .append(__val_fb617d.getClass()).toString());
-+                        }
-+                    }
-+                    for (int __idx_fb617d = 0; __idx_fb617d < ((java.util.List<java.lang.Object>)(__cast_7c6d77)).size(); __idx_fb617d++) {
-+                        final java.lang.Object __val_fb617d = ((java.util.List<java.lang.Object>)(__cast_7c6d77)).get(__idx_fb617d);
-+                        if (
-+                             !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructA)
-+                            && !(__val_fb617d instanceof software.amazon.jsii.tests.calculator.StructB)
-+                            && !(__val_fb617d.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
++                        ) {
 +                            throw new IllegalArgumentException(
 +                                new java.lang.StringBuilder("Expected ")
 +                                    .append("unionProperty").append(".get(").append(__idx_1ccdf0).append(")").append(".get(").append(__idx_fb617d).append(")")
@@ -28157,7 +28110,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
  
      /**
       */
-@@ -33,8 +132,107 @@
+@@ -33,8 +91,66 @@
  
      /**
       */
@@ -28169,9 +28122,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                if (
 +                     !(__val_ac66f0 instanceof java.util.Map)
 +                    && !(__val_ac66f0 instanceof java.util.List)
-+                    && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("value").append(".get(").append(__idx_ac66f0).append(")")
@@ -28194,30 +28145,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                             !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructA)
 +                            && !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructB)
 +                            && !(__val_58ec25.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
-+                            throw new IllegalArgumentException(
-+                                new java.lang.StringBuilder("Expected ")
-+                                    .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".get(\\"").append((__item_58ec25.getKey())).append("\\")")
-+                                    .append(" to be one of: software.amazon.jsii.tests.calculator.StructA, software.amazon.jsii.tests.calculator.StructB; received ")
-+                                    .append(__val_58ec25.getClass()).toString());
-+                        }
-+                    }
-+                    if (!(((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7fc174)).keySet().toArray()[0] instanceof String)) {
-+                        throw new IllegalArgumentException(
-+                            new java.lang.StringBuilder("Expected ")
-+                                .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".keySet()")
-+                                .append(" to contain class String; received ")
-+                                .append(((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7fc174)).keySet().toArray()[0].getClass()).toString());
-+                    }
-+                    for (final java.util.Map.Entry<String, java.lang.Object> __item_58ec25: ((java.util.Map<java.lang.String, java.lang.Object>)(__cast_7fc174)).entrySet()) {
-+                        final java.lang.Object __val_58ec25 = __item_58ec25.getValue();
-+                        if (
-+                             !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructA)
-+                            && !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructB)
-+                            && !(__val_58ec25.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
++                        ) {
 +                            throw new IllegalArgumentException(
 +                                new java.lang.StringBuilder("Expected ")
 +                                    .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".get(\\"").append((__item_58ec25.getKey())).append("\\")")
@@ -28235,23 +28163,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                             !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructA)
 +                            && !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructB)
 +                            && !(__val_58ec25.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
-+                            throw new IllegalArgumentException(
-+                                new java.lang.StringBuilder("Expected ")
-+                                    .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".get(").append(__idx_58ec25).append(")")
-+                                    .append(" to be one of: software.amazon.jsii.tests.calculator.StructA, software.amazon.jsii.tests.calculator.StructB; received ")
-+                                    .append(__val_58ec25.getClass()).toString());
-+                        }
-+                    }
-+                    for (int __idx_58ec25 = 0; __idx_58ec25 < ((java.util.List<java.lang.Object>)(__cast_7fc174)).size(); __idx_58ec25++) {
-+                        final java.lang.Object __val_58ec25 = ((java.util.List<java.lang.Object>)(__cast_7fc174)).get(__idx_58ec25);
-+                        if (
-+                             !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructA)
-+                            && !(__val_58ec25 instanceof software.amazon.jsii.tests.calculator.StructB)
-+                            && !(__val_58ec25.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                        )
-+                         {
++                        ) {
 +                            throw new IllegalArgumentException(
 +                                new java.lang.StringBuilder("Expected ")
 +                                    .append("value").append(".get(").append(__idx_ac66f0).append(")").append(".get(").append(__idx_58ec25).append(")")
@@ -28270,57 +28182,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJackson.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJackson.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/ConfusingToJackson.java	--runtime-type-checking
-@@ -48,8 +48,56 @@
+@@ -48,8 +48,24 @@
  
      /**
       */
      @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
      public void setUnionProperty(final @org.jetbrains.annotations.Nullable java.util.List<java.lang.Object> value) {
 +        if (software.amazon.jsii.Configuration.getRuntimeTypeChecking()) {
-+            if (
-+                 !(value instanceof software.amazon.jsii.tests.calculator.lib.IFriendly)
-+                && !(value instanceof java.util.List)
-+                && !(value.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+            )
-+             {
-+                throw new IllegalArgumentException(
-+                    new java.lang.StringBuilder("Expected ")
-+                        .append("value")
-+                        .append(" to be one of: software.amazon.jsii.tests.calculator.lib.IFriendly, java.util.List<java.lang.Object>; received ")
-+                        .append(value.getClass()).toString());
-+            }
-+            if (value instanceof java.util.List) {
-+                @SuppressWarnings("unchecked")
-+                final java.util.List<java.lang.Object> __cast_cd4240 = (java.util.List<java.lang.Object>)value;
-+                for (int __idx_ac66f0 = 0; __idx_ac66f0 < __cast_cd4240.size(); __idx_ac66f0++) {
-+                    final java.lang.Object __val_ac66f0 = __cast_cd4240.get(__idx_ac66f0);
-+                    if (
-+                         !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.lib.IFriendly)
-+                        && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.AbstractClass)
-+                        && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                    )
-+                     {
-+                        throw new IllegalArgumentException(
-+                            new java.lang.StringBuilder("Expected ")
-+                                .append("value").append(".get(").append(__idx_ac66f0).append(")")
-+                                .append(" to be one of: software.amazon.jsii.tests.calculator.lib.IFriendly, software.amazon.jsii.tests.calculator.AbstractClass; received ")
-+                                .append(__val_ac66f0.getClass()).toString());
-+                    }
-+                }
-+                for (int __idx_ac66f0 = 0; __idx_ac66f0 < ((java.util.List<java.lang.Object>)(__cast_cd4240)).size(); __idx_ac66f0++) {
-+                    final java.lang.Object __val_ac66f0 = ((java.util.List<java.lang.Object>)(__cast_cd4240)).get(__idx_ac66f0);
-+                    if (
-+                         !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.lib.IFriendly)
-+                        && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.AbstractClass)
-+                        && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                    )
-+                     {
-+                        throw new IllegalArgumentException(
-+                            new java.lang.StringBuilder("Expected ")
-+                                .append("value").append(".get(").append(__idx_ac66f0).append(")")
-+                                .append(" to be one of: software.amazon.jsii.tests.calculator.lib.IFriendly, software.amazon.jsii.tests.calculator.AbstractClass; received ")
-+                                .append(__val_ac66f0.getClass()).toString());
-+                    }
++            for (int __idx_ac66f0 = 0; __idx_ac66f0 < value.size(); __idx_ac66f0++) {
++                final java.lang.Object __val_ac66f0 = value.get(__idx_ac66f0);
++                if (
++                     !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.lib.IFriendly)
++                    && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.AbstractClass)
++                    && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
++                ) {
++                    throw new IllegalArgumentException(
++                        new java.lang.StringBuilder("Expected ")
++                            .append("value").append(".get(").append(__idx_ac66f0).append(")")
++                            .append(" to be one of: software.amazon.jsii.tests.calculator.lib.IFriendly, software.amazon.jsii.tests.calculator.AbstractClass; received ")
++                            .append(__val_ac66f0.getClass()).toString());
 +                }
 +            }
 +        }
@@ -28332,7 +28212,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/StructUnionConsumer.java	--runtime-type-checking
-@@ -18,18 +18,46 @@
+@@ -18,18 +18,44 @@
      /**
       * @param struct This parameter is required.
       */
@@ -28343,8 +28223,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                 !(struct instanceof software.amazon.jsii.tests.calculator.StructA)
 +                && !(struct instanceof software.amazon.jsii.tests.calculator.StructB)
 +                && !(struct.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+            )
-+             {
++            ) {
 +                throw new IllegalArgumentException(
 +                    new java.lang.StringBuilder("Expected ")
 +                        .append("struct")
@@ -28365,8 +28244,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                 !(struct instanceof software.amazon.jsii.tests.calculator.StructA)
 +                && !(struct instanceof software.amazon.jsii.tests.calculator.StructB)
 +                && !(struct.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+            )
-+             {
++            ) {
 +                throw new IllegalArgumentException(
 +                    new java.lang.StringBuilder("Expected ")
 +                        .append("struct")
@@ -28384,7 +28262,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/VariadicTypeUnion.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/VariadicTypeUnion.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/VariadicTypeUnion.java	--runtime-type-checking
-@@ -19,10 +19,28 @@
+@@ -19,10 +19,27 @@
       * @param union This parameter is required.
       */
      @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -28398,8 +28276,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                     !(__val_1046bb instanceof software.amazon.jsii.tests.calculator.StructA)
 +                    && !(__val_1046bb instanceof software.amazon.jsii.tests.calculator.StructB)
 +                    && !(__val_1046bb.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("union").append("[").append(__idx_1046bb).append("]")
@@ -28413,7 +28290,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
  
      /**
       */
-@@ -33,8 +51,25 @@
+@@ -33,8 +50,24 @@
  
      /**
       */
@@ -28426,8 +28303,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                     !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.StructA)
 +                    && !(__val_ac66f0 instanceof software.amazon.jsii.tests.calculator.StructB)
 +                    && !(__val_ac66f0.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+                )
-+                 {
++                ) {
 +                    throw new IllegalArgumentException(
 +                        new java.lang.StringBuilder("Expected ")
 +                            .append("value").append(".get(").append(__idx_ac66f0).append(")")
@@ -28444,7 +28320,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main/java/software/amazon/jsii/tests/calculator/anonymous/UseOptions.java.diff 1`] = `
 --- java/src/main/java/software/amazon/jsii/tests/calculator/anonymous/UseOptions.java	--no-runtime-type-checking
 +++ java/src/main/java/software/amazon/jsii/tests/calculator/anonymous/UseOptions.java	--runtime-type-checking
-@@ -18,10 +18,24 @@
+@@ -18,10 +18,23 @@
      /**
       * @param option This parameter is required.
       */
@@ -28455,8 +28331,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/java/src/main
 +                 !(option instanceof software.amazon.jsii.tests.calculator.anonymous.IOptionA)
 +                && !(option instanceof software.amazon.jsii.tests.calculator.anonymous.IOptionB)
 +                && !(option.getClass().equals(software.amazon.jsii.JsiiObject.class))
-+            )
-+             {
++            ) {
 +                throw new IllegalArgumentException(
 +                    new java.lang.StringBuilder("Expected ")
 +                        .append("option")


### PR DESCRIPTION
Some collection validations were emitted twice, due to a bad merge
conflict resolution.

Additionally, in certain cases where overrides are being emitted for
type unions, the type checking code made unnecessary assertions, some of
which ending up being prohibited by the compiler.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
