### PR TITLE
perf(jsii-pacmak): cache type lookups for go

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -379,6 +379,7 @@ export class RootPackage extends Package {
   public readonly assembly: Assembly;
   public readonly version: string;
   private readonly versionFile: VersionFile;
+  private typeCache: Record<string, GoType | undefined> = {};
 
   // This cache of root packages is shared across all root packages derived created by this one (via dependencies).
   private readonly rootPackageCache: Map<string, RootPackage>;
@@ -459,15 +460,18 @@ export class RootPackage extends Package {
    * This allows resolving type references from other JSII modules
    */
   public findType(fqn: string): GoType | undefined {
-    return this.packageDependencies.reduce(
-      (accum: GoType | undefined, current: RootPackage) => {
-        if (accum) {
-          return accum;
-        }
-        return current.findType(fqn);
-      },
-      super.findType(fqn),
-    );
+    if (!this.typeCache[fqn]) {
+      this.typeCache[fqn] = this.packageDependencies.reduce(
+        (accum: GoType | undefined, current: RootPackage) => {
+          if (accum) {
+            return accum;
+          }
+          return current.findType(fqn);
+        },
+        super.findType(fqn),
+      );
+    }
+    return this.typeCache[fqn];
   }
 
   /*


### PR DESCRIPTION
This improved the performance of cdktf get on our go/azure example by two minutes



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
