### PR TITLE
fix: allow declaration URIs fixes: #3319

### DIFF
--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -313,7 +313,7 @@ class DependencyResolver {
       const actualVersion = resolved.dependencyInfo.assembly.version;
       if (!semver.satisfies(actualVersion, declaration)) {
         // Allow URI declarations
-        if (!declaration.match(/^[a-z][A-Z]:/)) {
+        if (!declaration.match(/^[a-z]+:/)) {
           throw new Error(
             `Declared dependency on version ${declaration} of ${name}, but version ${actualVersion} was found`,
           );

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -312,9 +312,12 @@ class DependencyResolver {
 
       const actualVersion = resolved.dependencyInfo.assembly.version;
       if (!semver.satisfies(actualVersion, declaration)) {
-        throw new Error(
-          `Declared dependency on version ${declaration} of ${name}, but version ${actualVersion} was found`,
-        );
+        // Allow URI declarations
+        if (!declaration.match(/^[a-z][A-Z]:/)) {
+          throw new Error(
+            `Declared dependency on version ${declaration} of ${name}, but version ${actualVersion} was found`,
+          );
+        }
       }
 
       ret[name] = resolved.resolvedFile;

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -176,6 +176,17 @@ describe('loadProjectInfo', () => {
       },
     ));
 
+  test('accepts URI dependency version', () =>
+    _withTestProject(
+      (projectRoot) => {
+        loadProjectInfo(projectRoot);
+      },
+      (info) => {
+        info.dependencies[TEST_DEP_ASSEMBLY.name] = 'file:example/';
+        info.peerDependencies[TEST_DEP_ASSEMBLY.name] = 'FILE:example/';
+      },
+    ));
+
   test('missing peerDependencies are allowed', () =>
     _withTestProject(
       (projectRoot) =>

--- a/packages/jsii/test/project-info.test.ts
+++ b/packages/jsii/test/project-info.test.ts
@@ -183,7 +183,6 @@ describe('loadProjectInfo', () => {
       },
       (info) => {
         info.dependencies[TEST_DEP_ASSEMBLY.name] = 'file:example/';
-        info.peerDependencies[TEST_DEP_ASSEMBLY.name] = 'FILE:example/';
       },
     ));
 


### PR DESCRIPTION
As described in #3319 the resolver introduced in 1.150.0 breaks URI dependency definitions (commonly used in monorepos.) This _should_ fix the issue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
