### PR TITLE
fix(jsii): unable to return Promise<void>

### DIFF
--- a/packages/jsii/test/__snapshots__/negatives.test.js.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.js.snap
@@ -624,19 +624,19 @@ neg.omit.2.ts:7:32 - error JSII3004: Illegal implements clause for an exported A
 `;
 
 exports[`omit.3 1`] = `
-neg.omit.3.ts:8:3 - error JSII1003: Only string-indexed map types are supported
+neg.omit.3.ts:8:10 - error JSII1003: Only string-indexed map types are supported
 
 8   bar(): Omit<FooBar, 'foo'>;
-    ~~~
+           ~~~~~~~~~~~~~~~~~~~
 
 
 `;
 
 exports[`omit.4 1`] = `
-neg.omit.4.ts:8:7 - error JSII1003: Only string-indexed map types are supported
+neg.omit.4.ts:8:13 - error JSII1003: Only string-indexed map types are supported
 
 8   bar(opts: Omit<FooBar, 'foo'>): void;
-        ~~~~
+              ~~~~~~~~~~~~~~~~~~~
 
 
 `;

--- a/packages/jsii/test/promise.test.ts
+++ b/packages/jsii/test/promise.test.ts
@@ -1,0 +1,40 @@
+import { sourceToAssemblyHelper } from '../lib';
+
+// ----------------------------------------------------------------------
+test('Promise<void> is a valid return type', () => {
+  const assembly = sourceToAssemblyHelper(`
+    export class PromiseMaker {
+      public static staticPromise(): Promise<void> {
+        return Promise.resolve();
+      }
+
+      public instancePromise(): Promise<void> {
+        return Promise.resolve();
+      }
+
+      private constructor() {}
+    }
+  `);
+
+  expect(assembly.types!['testpkg.PromiseMaker']).toEqual({
+    assembly: 'testpkg',
+    fqn: 'testpkg.PromiseMaker',
+    kind: 'class',
+    methods: [
+      {
+        async: true,
+        locationInModule: { filename: 'index.ts', line: 3 },
+        name: 'staticPromise',
+        static: true,
+      },
+      {
+        async: true,
+        locationInModule: { filename: 'index.ts', line: 7 },
+        name: 'instancePromise',
+      },
+    ],
+    locationInModule: { filename: 'index.ts', line: 2 },
+    name: 'PromiseMaker',
+    symbolId: 'index:PromiseMaker',
+  });
+});


### PR DESCRIPTION
The void-check only accounted for the literal `void` type, but failed to account for the `Promise<void>` case. This is now fixed.

Fixes #51



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
