### PR TITLE
fix(kernel): EPERM on rename operation on Windows

### DIFF
--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -110,9 +110,6 @@ export class Kernel {
     // Force umask to have npm-install-like permissions
     const originalUmask = process.umask(0o022);
     try {
-      // Create the install directory (there may be several path components for @scoped/packages)
-      fs.mkdirSync(path.dirname(packageDir), { recursive: true });
-
       // untar the archive to its final location
       const { cache } = this._debugTime(
         () =>

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -1,7 +1,6 @@
 import * as spec from '@jsii/spec';
 import { loadAssemblyFromPath } from '@jsii/spec';
 import * as cp from 'child_process';
-import { renameSync } from 'fs';
 import * as fs from 'fs-extra';
 import { createRequire } from 'module';
 import * as os from 'os';
@@ -9,7 +8,6 @@ import * as path from 'path';
 
 import * as api from './api';
 import { TOKEN_REF } from './api';
-import { link } from './link';
 import { jsiiTypeFqn, ObjectTable, tagJsiiConstructor } from './objects';
 import * as onExit from './on-exit';
 import * as wire from './serialization';
@@ -112,11 +110,15 @@ export class Kernel {
     // Force umask to have npm-install-like permissions
     const originalUmask = process.umask(0o022);
     try {
+      // Create the install directory (there may be several path components for @scoped/packages)
+      fs.mkdirSync(path.dirname(packageDir), { recursive: true });
+
       // untar the archive to its final location
-      const { path: extractedTo, cache } = this._debugTime(
+      const { cache } = this._debugTime(
         () =>
           tar.extract(
             req.tarball,
+            packageDir,
             {
               strict: true,
               strip: 1, // Removes the 'package/' path element from entries
@@ -128,21 +130,10 @@ export class Kernel {
         `tar.extract(${req.tarball}) => ${packageDir}`,
       );
 
-      // Create the install directory (there may be several path components for @scoped/packages)
-      fs.mkdirSync(path.dirname(packageDir), { recursive: true });
       if (cache != null) {
         this._debug(
           `Package cache enabled, extraction resulted in a cache ${cache}`,
         );
-
-        // Link the package into place.
-        this._debugTime(
-          () => link(extractedTo, packageDir),
-          `link(${extractedTo}, ${packageDir})`,
-        );
-      } else {
-        // This is not from cache, so we move it around instead of copying.
-        renameSync(extractedTo, packageDir);
       }
     } finally {
       // Reset umask to the initial value

--- a/packages/@jsii/kernel/src/tar-cache/index.ts
+++ b/packages/@jsii/kernel/src/tar-cache/index.ts
@@ -41,12 +41,18 @@ export function extract(
   options: ExtractOptions,
   ...comments: readonly string[]
 ): ExtractResult {
-  return (packageCacheEnabled ? extractViaCache : extractToOutDir)(
-    file,
-    outDir,
-    options,
-    ...comments,
-  );
+  mkdirSync(outDir, { recursive: true });
+  try {
+    return (packageCacheEnabled ? extractViaCache : extractToOutDir)(
+      file,
+      outDir,
+      options,
+      ...comments,
+    );
+  } catch (err) {
+    rmSync(outDir, { force: true, recursive: true });
+    throw err;
+  }
 }
 
 function extractViaCache(


### PR DESCRIPTION
Windows does not allow renaming files that are currently open, or directories that contain open files. When antivirus software is used, files are open for analysis by the A/V software, making it impossible to rename files too quickly after they've been created.

This was already reported in #992 and addressed, however the issue was re-introduced in #3724, in which tarballs were extracted into temporary directories that were then renamed.

Changed the code back to a form taht extracts files directly into their final place instead of staging via a temporary space, and added comments warning maintainers about the specific issue being solved here, so that hopefully the problem does not get re-introduced again in the future.

Fixes #3751



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
