### PR TITLE
feat(superchain): add 'acl' package to support projen GHA

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -128,6 +128,7 @@ RUN apt-get update                                                              
   sudo                                                                                                                  \
   unzip                                                                                                                 \
   zip                                                                                                                   \
+  acl                                                                                                                   \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono


### PR DESCRIPTION
Adds the `acl` package to the superchain image.

A recent [projen PR](https://github.com/projen/projen/issues/2103) added a build-time dependency on the `getfacl` and `setfacl` tools in this package to workaround a bug in GitHub Actions. The package is included in the GHA `ubuntu-latest` image, but not superchain.

Should address: https://github.com/projen/projen/issues/2134

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
