### PR TITLE
chore(spec): improve assembly validation error messages

### DIFF
--- a/packages/@jsii/spec/src/assembly-utils.test.ts
+++ b/packages/@jsii/spec/src/assembly-utils.test.ts
@@ -128,11 +128,9 @@ describe(loadAssemblyFromPath, () => {
       filename: '.jsii.7z',
     });
 
-    expect(() => loadAssemblyFromPath(tmpdir))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Invalid assembly redirect:
-       * must be equal to one of the allowed values"
-    `);
+    expect(() => loadAssemblyFromPath(tmpdir)).toThrowError(
+      /Error: Invalid assembly redirect:\n \* redirect\/compression must be equal to one of the allowed values/m,
+    );
   });
 
   test('throws if redirect object is missing filename', () => {
@@ -140,11 +138,9 @@ describe(loadAssemblyFromPath, () => {
       schema: 'jsii/file-redirect',
     });
 
-    expect(() => loadAssemblyFromPath(tmpdir))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Invalid assembly redirect:
-       * must have required property 'filename'"
-    `);
+    expect(() => loadAssemblyFromPath(tmpdir)).toThrowError(
+      /Error: Invalid assembly redirect:\n \* redirect must have required property 'filename'/m,
+    );
   });
 
   test('throws if assembly is invalid', () => {

--- a/packages/@jsii/spec/src/assembly-utils.ts
+++ b/packages/@jsii/spec/src/assembly-utils.ts
@@ -151,11 +151,7 @@ export function loadAssemblyFromPath(
   validate = true,
 ): Assembly {
   const assemblyFile = findAssemblyFile(directory);
-  try {
-    return loadAssemblyFromFile(assemblyFile, validate);
-  } catch (e: any) {
-    throw new Error(`Error loading assembly from path ${directory}:\n${e}`);
-  }
+  return loadAssemblyFromFile(assemblyFile, validate);
 }
 
 /**

--- a/packages/@jsii/spec/src/assembly-utils.ts
+++ b/packages/@jsii/spec/src/assembly-utils.ts
@@ -151,7 +151,11 @@ export function loadAssemblyFromPath(
   validate = true,
 ): Assembly {
   const assemblyFile = findAssemblyFile(directory);
-  return loadAssemblyFromFile(assemblyFile, validate);
+  try {
+    return loadAssemblyFromFile(assemblyFile, validate);
+  } catch (e: any) {
+    throw new Error(`Error loading assembly from path ${directory}:\n${e}`);
+  }
 }
 
 /**
@@ -167,11 +171,15 @@ export function loadAssemblyFromFile(
   validate = true,
 ): Assembly {
   const data = fs.readFileSync(pathToFile);
-  return loadAssemblyFromBuffer(
-    data,
-    (filename) => fs.readFileSync(path.resolve(pathToFile, '..', filename)),
-    validate,
-  );
+  try {
+    return loadAssemblyFromBuffer(
+      data,
+      (filename) => fs.readFileSync(path.resolve(pathToFile, '..', filename)),
+      validate,
+    );
+  } catch (e: any) {
+    throw new Error(`Error loading assembly from file ${pathToFile}:\n${e}`);
+  }
 }
 
 function followRedirect(

--- a/packages/@jsii/spec/src/redirect.ts
+++ b/packages/@jsii/spec/src/redirect.ts
@@ -43,16 +43,18 @@ export function isAssemblyRedirect(obj: unknown): obj is AssemblyRedirect {
  * @returns the validated value.
  */
 export function validateAssemblyRedirect(obj: unknown): AssemblyRedirect {
-  const ajv = new Ajv();
+  const ajv = new Ajv({
+    allErrors: true,
+  });
   const validate = ajv.compile(assemblyRedirectSchema);
   validate(obj);
 
   if (validate.errors) {
     throw new Error(
-      `Invalid assembly redirect:\n${validate.errors
-        .map((e) => ` * ${e.message}`)
-        .join('\n')
-        .toString()}`,
+      `Invalid assembly redirect:\n * ${ajv.errorsText(validate.errors, {
+        separator: '\n * ',
+        dataVar: 'redirect',
+      })}`,
     );
   }
 

--- a/packages/@jsii/spec/src/validate-assembly.test.ts
+++ b/packages/@jsii/spec/src/validate-assembly.test.ts
@@ -6,16 +6,16 @@ import { validateAssembly } from './validate-assembly';
 test('rejects invalid assembly', () =>
   expect(() => validateAssembly({})).toThrowErrorMatchingInlineSnapshot(`
     "Invalid assembly:
-    * assembly must have required property 'author'
-    * assembly must have required property 'description'
-    * assembly must have required property 'fingerprint'
-    * assembly must have required property 'homepage'
-    * assembly must have required property 'jsiiVersion'
-    * assembly must have required property 'license'
-    * assembly must have required property 'name'
-    * assembly must have required property 'repository'
-    * assembly must have required property 'schema'
-    * assembly must have required property 'version'"
+     * assembly must have required property 'author'
+     * assembly must have required property 'description'
+     * assembly must have required property 'fingerprint'
+     * assembly must have required property 'homepage'
+     * assembly must have required property 'jsiiVersion'
+     * assembly must have required property 'license'
+     * assembly must have required property 'name'
+     * assembly must have required property 'repository'
+     * assembly must have required property 'schema'
+     * assembly must have required property 'version'"
   `));
 
 test('rejects invalid assembly (alt)', () =>
@@ -32,15 +32,15 @@ test('rejects invalid assembly (alt)', () =>
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
     "Invalid assembly dummy-assembly:
-    * assembly must have required property 'fingerprint'
-    * assembly must have required property 'homepage'
-    * assembly must have required property 'jsiiVersion'
-    * assembly must have required property 'license'
-    * assembly must have required property 'repository'
-    * assembly must have required property 'schema'
-    * assembly must have required property 'version'
-    * assembly/author must have required property 'roles'
-    * assembly/author/organization must be boolean"
+     * assembly must have required property 'fingerprint'
+     * assembly must have required property 'homepage'
+     * assembly must have required property 'jsiiVersion'
+     * assembly must have required property 'license'
+     * assembly must have required property 'repository'
+     * assembly must have required property 'schema'
+     * assembly must have required property 'version'
+     * assembly/author must have required property 'roles'
+     * assembly/author/organization must be boolean"
   `));
 
 describe('can load older assemblies', () => {

--- a/packages/@jsii/spec/src/validate-assembly.test.ts
+++ b/packages/@jsii/spec/src/validate-assembly.test.ts
@@ -4,7 +4,44 @@ import { resolve } from 'path';
 import { validateAssembly } from './validate-assembly';
 
 test('rejects invalid assembly', () =>
-  expect(() => validateAssembly({})).toThrow(/Invalid assembly:/));
+  expect(() => validateAssembly({})).toThrowErrorMatchingInlineSnapshot(`
+    "Invalid assembly:
+    * assembly must have required property 'author'
+    * assembly must have required property 'description'
+    * assembly must have required property 'fingerprint'
+    * assembly must have required property 'homepage'
+    * assembly must have required property 'jsiiVersion'
+    * assembly must have required property 'license'
+    * assembly must have required property 'name'
+    * assembly must have required property 'repository'
+    * assembly must have required property 'schema'
+    * assembly must have required property 'version'"
+  `));
+
+test('rejects invalid assembly (alt)', () =>
+  expect(() =>
+    validateAssembly({
+      author: {
+        name: 'John Doe',
+        email: 'john.doe@nowhere.blackhole',
+        organization: 'Nowhere, Inc.',
+      },
+
+      description: 'Yada yada',
+      name: 'dummy-assembly',
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Invalid assembly dummy-assembly:
+    * assembly must have required property 'fingerprint'
+    * assembly must have required property 'homepage'
+    * assembly must have required property 'jsiiVersion'
+    * assembly must have required property 'license'
+    * assembly must have required property 'repository'
+    * assembly must have required property 'schema'
+    * assembly must have required property 'version'
+    * assembly/author must have required property 'roles'
+    * assembly/author/organization must be boolean"
+  `));
 
 describe('can load older assemblies', () => {
   const samplesDir = resolve(

--- a/packages/@jsii/spec/src/validate-assembly.ts
+++ b/packages/@jsii/spec/src/validate-assembly.ts
@@ -6,16 +6,25 @@ import { Assembly } from './assembly';
 export const schema = require('../schema/jsii-spec.schema.json');
 
 export function validateAssembly(obj: any): Assembly {
-  const ajv = new Ajv();
+  const ajv = new Ajv({
+    allErrors: true,
+  });
   const validate = ajv.compile(schema);
   validate(obj);
 
   if (validate.errors) {
+    let descr = '';
+    if (typeof obj.name === 'string' && obj.name !== '') {
+      descr =
+        typeof obj.version === 'string'
+          ? ` ${obj.name}@${obj.version}`
+          : ` ${obj.name}`;
+    }
     throw new Error(
-      `Invalid assembly:\n${validate.errors
-        .map((e) => ` * ${e.message}`)
-        .join('\n')
-        .toString()}`,
+      `Invalid assembly${descr}:\n* ${ajv.errorsText(validate.errors, {
+        separator: '\n* ',
+        dataVar: 'assembly',
+      })}`,
     );
   }
   return obj;

--- a/packages/@jsii/spec/src/validate-assembly.ts
+++ b/packages/@jsii/spec/src/validate-assembly.ts
@@ -21,8 +21,8 @@ export function validateAssembly(obj: any): Assembly {
           : ` ${obj.name}`;
     }
     throw new Error(
-      `Invalid assembly${descr}:\n* ${ajv.errorsText(validate.errors, {
-        separator: '\n* ',
+      `Invalid assembly${descr}:\n * ${ajv.errorsText(validate.errors, {
+        separator: '\n * ',
         dataVar: 'assembly',
       })}`,
     );


### PR DESCRIPTION
use the ajv error message formatter instead of only outputting the `e.message` as the later fails to include useful information to determine where the actual error is.

Turn the validation test into a snapshot test to draw attention on the error message format.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
