### PR TITLE
fix(python): KeyError in type checks when decorating methods

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_runtime.py
+++ b/packages/@jsii/python-runtime/src/jsii/_runtime.py
@@ -4,13 +4,22 @@ import sys
 
 import attr
 
-from typing import Sequence, cast, Any, Callable, List, Optional, Mapping, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    cast,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
 
 from . import _reference_map
 from ._compat import importlib_resources
 from ._kernel import Kernel
 from .python import _ClassPropertyMeta
-from ._kernel.types import ObjRef
 
 
 # Yea, a global here is kind of gross, however, there's not really a better way of

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -21,6 +21,30 @@ class TestRuntimeTypeChecking:
         ):
             jsii_calc.Calculator(initial_value="nope")  # type:ignore
 
+    def test_constructor_decorated(self):
+        """
+        This test verifies that runtime type checking is not broken when a function is wrapped with a decorator, as was
+        the case with the original implementation (due to a dynamic access to type_hints for the method via the type).
+        """
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "type of argument maximum_value must be one of (int, float, NoneType); got str instead"
+            ),
+        ):
+            orig_init = jsii_calc.Calculator.__init__
+            # For toy, swap initial_value and maximum_values here
+            jsii_calc.Calculator.__init__ = (
+                lambda self, *, initial_value=None, maximum_value=None: orig_init(
+                    self, initial_value=maximum_value, maximum_value=initial_value
+                )
+            )
+            try:
+                jsii_calc.Calculator(initial_value="nope")  # type:ignore
+            finally:
+                jsii_calc.Calculator.__init__ = orig_init
+
     def test_struct(self):
         with pytest.raises(
             TypeError,

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -404,20 +404,6 @@ export function toPythonFqn(fqn: string, rootAssm: Assembly) {
 }
 
 /**
- * Computes the nesting-qualified name of a type.
- *
- * @param fqn      the fully qualified jsii name of the type.
- * @param rootAssm the root assembly for the project.
- *
- * @returns the nesting-qualified python type name (the name of the class,
- *          qualified with all nesting parent classes).
- */
-export function toPythonFullName(fqn: string, rootAssm: Assembly): string {
-  const { packageName, pythonFqn } = toPythonFqn(fqn, rootAssm);
-  return pythonFqn.slice(packageName.length + 1);
-}
-
-/**
  * Computes the python relative import path from `fromModule` to `toModule`.
  *
  * @param fromPkg the package where the relative import statement is located.

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -1344,7 +1344,9 @@ class Foo:
         :param foo: -
         '''
         if __debug__:
-            type_hints = typing.get_type_hints(Foo.__init__)
+            def stub(*, foo: jsii.Number) -> None:
+                ...
+            type_hints = typing.get_type_hints(stub)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
@@ -1385,7 +1387,13 @@ class FooBar:
         :param bar: -
         '''
         if __debug__:
-            type_hints = typing.get_type_hints(FooBar.__init__)
+            def stub(
+                *,
+                foo: jsii.Number,
+                bar: typing.Optional[builtins.str] = None,
+            ) -> None:
+                ...
+            type_hints = typing.get_type_hints(stub)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
         self._values: typing.Dict[str, typing.Any] = {
@@ -1436,7 +1444,14 @@ class Baz(Foo, FooBar):
         :param baz: -
         '''
         if __debug__:
-            type_hints = typing.get_type_hints(Baz.__init__)
+            def stub(
+                *,
+                foo: jsii.Number,
+                bar: typing.Optional[builtins.str] = None,
+                baz: builtins.bool,
+            ) -> None:
+                ...
+            type_hints = typing.get_type_hints(stub)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             check_type(argname="argument baz", value=baz, expected_type=type_hints["baz"])
@@ -2729,7 +2744,9 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
             :param bar: -
             '''
             if __debug__:
-                type_hints = typing.get_type_hints(Namespace1.Foo.__init__)
+                def stub(*, bar: builtins.str) -> None:
+                    ...
+                type_hints = typing.get_type_hints(stub)
                 check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             self._values: typing.Dict[str, typing.Any] = {
                 "bar": bar,

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -503,14 +503,20 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/ 
 exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base/__init__.py	--runtime-type-checking
-@@ -50,10 +50,14 @@
+@@ -50,10 +50,20 @@
      ) -> None:
          '''
          :param foo: -
          :param bar: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(BaseProps.__init__)
++            def stub(
++                *,
++                foo: scope.jsii_calc_base_of_base.Very,
++                bar: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -518,14 +524,16 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
              "bar": bar,
          }
  
-@@ -117,10 +121,13 @@
+@@ -117,10 +127,15 @@
      @builtins.classmethod
      def consume(cls, *args: typing.Any) -> None:
          '''
          :param args: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StaticConsumer.consume)
++            def stub(*args: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument args", value=args, expected_type=typing.Tuple[type_hints["args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*args]))
  
@@ -1008,28 +1016,32 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base_of_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base_of_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base_of_base/__init__.py	--runtime-type-checking
-@@ -39,10 +39,13 @@
+@@ -39,10 +39,15 @@
      @builtins.classmethod
      def consume(cls, *_args: typing.Any) -> None:
          '''
          :param _args: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StaticConsumer.consume)
++            def stub(*_args: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _args", value=_args, expected_type=typing.Tuple[type_hints["_args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*_args]))
  
  
  class Very(metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-base-of-base.Very"):
      '''(experimental) Something here.
-@@ -69,10 +72,13 @@
+@@ -69,10 +74,15 @@
  class VeryBaseProps:
      def __init__(self, *, foo: Very) -> None:
          '''
          :param foo: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VeryBaseProps.__init__)
++            def stub(*, foo: Very) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
@@ -2294,14 +2306,16 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/ 1
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/__init__.py	--runtime-type-checking
-@@ -34,19 +34,25 @@
+@@ -34,19 +34,29 @@
          '''
          :param very: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(BaseFor2647.__init__)
++            def stub(very: scope.jsii_calc_base_of_base.Very) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
@@ -2313,21 +2327,29 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(BaseFor2647.foo)
++            def stub(obj: scope.jsii_calc_base.IBaseInterface) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(None, jsii.invoke(self, "foo", [obj]))
  
  
  @jsii.data_type(
      jsii_type="@scope/jsii-calc-lib.DiamondLeft",
-@@ -64,10 +70,14 @@
+@@ -64,10 +74,20 @@
          :param hoisted_top: 
          :param left: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondLeft.__init__)
++            def stub(
++                *,
++                hoisted_top: typing.Optional[builtins.str] = None,
++                left: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -2335,14 +2357,20 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -116,10 +126,14 @@
+@@ -116,10 +136,20 @@
          :param hoisted_top: 
          :param right: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondRight.__init__)
++            def stub(
++                *,
++                hoisted_top: typing.Optional[builtins.str] = None,
++                right: typing.Optional[builtins.bool] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -2350,14 +2378,21 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if right is not None:
              self._values["right"] = right
-@@ -317,10 +331,15 @@
+@@ -317,10 +347,22 @@
          :param astring: (deprecated) A string value.
          :param first_optional: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyFirstStruct.__init__)
++            def stub(
++                *,
++                anumber: jsii.Number,
++                astring: builtins.str,
++                first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
 +            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
@@ -2366,14 +2401,21 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              "astring": astring,
          }
          if first_optional is not None:
-@@ -477,10 +496,15 @@
+@@ -477,10 +519,22 @@
          :param optional2: 
          :param optional3: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructWithOnlyOptionals.__init__)
++            def stub(
++                *,
++                optional1: typing.Optional[builtins.str] = None,
++                optional2: typing.Optional[jsii.Number] = None,
++                optional3: typing.Optional[builtins.bool] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument optional1", value=optional1, expected_type=type_hints["optional1"])
 +            check_type(argname="argument optional2", value=optional2, expected_type=type_hints["optional2"])
 +            check_type(argname="argument optional3", value=optional3, expected_type=type_hints["optional3"])
@@ -2382,14 +2424,16 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["optional1"] = optional1
          if optional2 is not None:
              self._values["optional2"] = optional2
-@@ -540,10 +564,13 @@
+@@ -540,10 +594,15 @@
  
          :param value: The number.
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Number.__init__)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
@@ -2401,28 +2445,32 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--runtime-type-checking
-@@ -97,10 +97,13 @@
+@@ -97,10 +97,15 @@
  
              :param name: 
  
              :stability: deprecated
              '''
 +            if __debug__:
-+                type_hints = typing.get_type_hints(NestingClass.NestedStruct.__init__)
++                def stub(*, name: builtins.str) -> None:
++                    ...
++                type_hints = typing.get_type_hints(stub)
 +                check_type(argname="argument name", value=name, expected_type=type_hints["name"])
              self._values: typing.Dict[str, typing.Any] = {
                  "name": name,
              }
  
          @builtins.property
-@@ -135,10 +138,14 @@
+@@ -135,10 +140,16 @@
          :param key: 
          :param value: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ReflectableEntry.__init__)
++            def stub(*, key: builtins.str, value: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -2430,14 +2478,16 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              "value": value,
          }
  
-@@ -194,10 +201,13 @@
+@@ -194,10 +205,15 @@
          '''
          :param reflectable: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Reflector.as_map)
++            def stub(reflectable: IReflectable) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument reflectable", value=reflectable, expected_type=type_hints["reflectable"])
          return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
  
@@ -13846,28 +13896,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/__init__.py	--runtime-type-checking
-@@ -111,10 +111,13 @@
+@@ -111,10 +111,15 @@
      def work_it_all(self, seed: builtins.str) -> builtins.str:
          '''Sets \`\`seed\`\` to \`\`this.property\`\`, then calls \`\`someMethod\`\` with \`\`this.property\`\` and returns the result.
  
          :param seed: a \`\`string\`\`.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AbstractSuite.work_it_all)
++            def stub(seed: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument seed", value=seed, expected_type=type_hints["seed"])
          return typing.cast(builtins.str, jsii.invoke(self, "workItAll", [seed]))
  
      @builtins.property
      @jsii.member(jsii_name="property")
      @abc.abstractmethod
-@@ -131,19 +134,25 @@
+@@ -131,19 +136,29 @@
      @jsii.member(jsii_name="someMethod")
      def _some_method(self, str: builtins.str) -> builtins.str:
          '''
          :param str: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AbstractSuite._some_method)
++            def stub(str: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
          return typing.cast(builtins.str, jsii.invoke(self, "someMethod", [str]))
  
@@ -13879,49 +13933,57 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @_property.setter
      def _property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AbstractSuite, "_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractSuite).__jsii_proxy_class__ = lambda : _AbstractSuiteProxy
  
-@@ -161,10 +170,13 @@
+@@ -161,10 +176,15 @@
      @jsii.member(jsii_name="anyIn")
      def any_in(self, inp: typing.Any) -> None:
          '''
          :param inp: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllTypes.any_in)
++            def stub(inp: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument inp", value=inp, expected_type=type_hints["inp"])
          return typing.cast(None, jsii.invoke(self, "anyIn", [inp]))
  
      @jsii.member(jsii_name="anyOut")
      def any_out(self) -> typing.Any:
          return typing.cast(typing.Any, jsii.invoke(self, "anyOut", []))
-@@ -172,10 +184,13 @@
+@@ -172,10 +192,15 @@
      @jsii.member(jsii_name="enumMethod")
      def enum_method(self, value: "StringEnum") -> "StringEnum":
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllTypes.enum_method)
++            def stub(value: "StringEnum") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast("StringEnum", jsii.invoke(self, "enumMethod", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="enumPropertyValue")
      def enum_property_value(self) -> jsii.Number:
-@@ -186,73 +201,97 @@
+@@ -186,73 +211,113 @@
      def any_array_property(self) -> typing.List[typing.Any]:
          return typing.cast(typing.List[typing.Any], jsii.get(self, "anyArrayProperty"))
  
      @any_array_property.setter
      def any_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "any_array_property").fset)
++            def stub(value: typing.List[typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyArrayProperty", value)
  
@@ -13933,7 +13995,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @any_map_property.setter
      def any_map_property(self, value: typing.Mapping[builtins.str, typing.Any]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "any_map_property").fset)
++            def stub(value: typing.Mapping[builtins.str, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyMapProperty", value)
  
@@ -13945,7 +14009,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @any_property.setter
      def any_property(self, value: typing.Any) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "any_property").fset)
++            def stub(value: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyProperty", value)
  
@@ -13957,7 +14023,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @array_property.setter
      def array_property(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "array_property").fset)
++            def stub(value: typing.List[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "arrayProperty", value)
  
@@ -13969,7 +14037,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @boolean_property.setter
      def boolean_property(self, value: builtins.bool) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "boolean_property").fset)
++            def stub(value: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "booleanProperty", value)
  
@@ -13981,7 +14051,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @date_property.setter
      def date_property(self, value: datetime.datetime) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "date_property").fset)
++            def stub(value: datetime.datetime) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dateProperty", value)
  
@@ -13993,7 +14065,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @enum_property.setter
      def enum_property(self, value: "AllTypesEnum") -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "enum_property").fset)
++            def stub(value: "AllTypesEnum") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "enumProperty", value)
  
@@ -14005,21 +14079,27 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @json_property.setter
      def json_property(self, value: typing.Mapping[typing.Any, typing.Any]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "json_property").fset)
++            def stub(value: typing.Mapping[typing.Any, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "jsonProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="mapProperty")
      def map_property(self) -> typing.Mapping[builtins.str, scope.jsii_calc_lib.Number]:
-@@ -261,28 +300,37 @@
+@@ -261,28 +326,45 @@
      @map_property.setter
      def map_property(
          self,
          value: typing.Mapping[builtins.str, scope.jsii_calc_lib.Number],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "map_property").fset)
++            def stub(
++                value: typing.Mapping[builtins.str, scope.jsii_calc_lib.Number],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mapProperty", value)
  
@@ -14031,7 +14111,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @number_property.setter
      def number_property(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "number_property").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "numberProperty", value)
  
@@ -14043,49 +14125,63 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @string_property.setter
      def string_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "string_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionArrayProperty")
      def union_array_property(
-@@ -293,10 +341,13 @@
+@@ -293,10 +375,17 @@
      @union_array_property.setter
      def union_array_property(
          self,
          value: typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "union_array_property").fset)
++            def stub(
++                value: typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionArrayProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionMapProperty")
      def union_map_property(
-@@ -307,10 +358,13 @@
+@@ -307,10 +396,17 @@
      @union_map_property.setter
      def union_map_property(
          self,
          value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "union_map_property").fset)
++            def stub(
++                value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionMapProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -321,19 +375,25 @@
+@@ -321,19 +417,31 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "union_property").fset)
++            def stub(
++                value: typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
@@ -14097,21 +14193,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @unknown_array_property.setter
      def unknown_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "unknown_array_property").fset)
++            def stub(value: typing.List[typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownArrayProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unknownMapProperty")
      def unknown_map_property(self) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -342,28 +402,37 @@
+@@ -342,28 +450,43 @@
      @unknown_map_property.setter
      def unknown_map_property(
          self,
          value: typing.Mapping[builtins.str, typing.Any],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "unknown_map_property").fset)
++            def stub(value: typing.Mapping[builtins.str, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownMapProperty", value)
  
@@ -14123,7 +14223,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @unknown_property.setter
      def unknown_property(self, value: typing.Any) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "unknown_property").fset)
++            def stub(value: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownProperty", value)
  
@@ -14135,21 +14237,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @optional_enum_value.setter
      def optional_enum_value(self, value: typing.Optional["StringEnum"]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(AllTypes, "optional_enum_value").fset)
++            def stub(value: typing.Optional["StringEnum"]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "optionalEnumValue", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.AllTypesEnum")
  class AllTypesEnum(enum.Enum):
-@@ -383,36 +452,52 @@
+@@ -383,36 +506,60 @@
      def get_bar(self, _p1: builtins.str, _p2: jsii.Number) -> None:
          '''
          :param _p1: -
          :param _p2: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllowedMethodNames.get_bar)
++            def stub(_p1: builtins.str, _p2: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _p1", value=_p1, expected_type=type_hints["_p1"])
 +            check_type(argname="argument _p2", value=_p2, expected_type=type_hints["_p2"])
          return typing.cast(None, jsii.invoke(self, "getBar", [_p1, _p2]))
@@ -14161,7 +14267,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param with_param: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllowedMethodNames.get_foo)
++            def stub(with_param: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument with_param", value=with_param, expected_type=type_hints["with_param"])
          return typing.cast(builtins.str, jsii.invoke(self, "getFoo", [with_param]))
  
@@ -14173,7 +14281,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _z: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllowedMethodNames.set_bar)
++            def stub(_x: builtins.str, _y: jsii.Number, _z: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
 +            check_type(argname="argument _z", value=_z, expected_type=type_hints["_z"])
@@ -14187,7 +14297,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _y: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AllowedMethodNames.set_foo)
++            def stub(_x: builtins.str, _y: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
          return typing.cast(None, jsii.invoke(self, "setFoo", [_x, _y]))
@@ -14195,42 +14307,56 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class AmbiguousParameters(
      metaclass=jsii.JSIIMeta,
-@@ -428,10 +513,13 @@
+@@ -428,10 +575,20 @@
          '''
          :param scope_: -
          :param scope: 
          :param props: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AmbiguousParameters.__init__)
++            def stub(
++                scope_: "Bell",
++                *,
++                scope: builtins.str,
++                props: typing.Optional[builtins.bool] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument scope_", value=scope_, expected_type=type_hints["scope_"])
          props_ = StructParameterType(scope=scope, props=props)
  
          jsii.create(self.__class__, self, [scope_, props_])
  
      @builtins.property
-@@ -478,10 +566,13 @@
+@@ -478,10 +635,15 @@
      @jsii.member(jsii_name="overrideMe")
      def override_me(self, mult: jsii.Number) -> jsii.Number:
          '''
          :param mult: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AsyncVirtualMethods.override_me)
++            def stub(mult: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument mult", value=mult, expected_type=type_hints["mult"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMe", [mult]))
  
      @jsii.member(jsii_name="overrideMeToo")
      def override_me_too(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeToo", []))
-@@ -542,10 +633,14 @@
+@@ -542,10 +704,19 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(BinaryOperation.__init__)
++            def stub(
++                lhs: scope.jsii_calc_lib.NumericValue,
++                rhs: scope.jsii_calc_lib.NumericValue,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -14238,28 +14364,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
-@@ -606,10 +701,13 @@
+@@ -606,10 +777,15 @@
  
          :param value: the value that should be returned.
  
          :return: \`\`value\`\`
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(BurriedAnonymousObject.give_it_back)
++            def stub(value: typing.Any) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Any, jsii.invoke(self, "giveItBack", [value]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, BurriedAnonymousObject).__jsii_proxy_class__ = lambda : _BurriedAnonymousObjectProxy
  
-@@ -659,18 +757,24 @@
+@@ -659,18 +835,28 @@
      def add(self, value: jsii.Number) -> None:
          '''Adds a number to the current value.
  
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Calculator.add)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "add", [value]))
  
@@ -14270,35 +14400,41 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Calculator.mul)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "mul", [value]))
  
      @jsii.member(jsii_name="neg")
      def neg(self) -> None:
          '''Negates the current value.'''
-@@ -680,10 +784,13 @@
+@@ -680,10 +866,15 @@
      def pow(self, value: jsii.Number) -> None:
          '''Raises the current value by a power.
  
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Calculator.pow)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "pow", [value]))
  
      @jsii.member(jsii_name="readUnionValue")
      def read_union_value(self) -> jsii.Number:
          '''Returns teh value of the union property (if defined).'''
-@@ -715,20 +822,26 @@
+@@ -715,20 +906,30 @@
          '''The current value.'''
          return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "curr"))
  
      @curr.setter
      def curr(self, value: scope.jsii_calc_lib.NumericValue) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Calculator, "curr").fset)
++            def stub(value: scope.jsii_calc_lib.NumericValue) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "curr", value)
  
@@ -14311,35 +14447,47 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @max_value.setter
      def max_value(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Calculator, "max_value").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "maxValue", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -740,10 +853,13 @@
+@@ -740,10 +941,17 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.Optional[typing.Union["Add", "Multiply", "Power"]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Calculator, "union_property").fset)
++            def stub(
++                value: typing.Optional[typing.Union["Add", "Multiply", "Power"]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.CalculatorProps",
-@@ -760,10 +876,14 @@
+@@ -760,10 +968,20 @@
          '''Properties for Calculator.
  
          :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
          :param maximum_value: The maximum value the calculator can store. Default: none
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(CalculatorProps.__init__)
++            def stub(
++                *,
++                initial_value: typing.Optional[jsii.Number] = None,
++                maximum_value: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument initial_value", value=initial_value, expected_type=type_hints["initial_value"])
 +            check_type(argname="argument maximum_value", value=maximum_value, expected_type=type_hints["maximum_value"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -14347,42 +14495,55 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["initial_value"] = initial_value
          if maximum_value is not None:
              self._values["maximum_value"] = maximum_value
-@@ -809,10 +929,13 @@
+@@ -809,10 +1027,17 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]],
      ) -> None:
          '''
          :param union_property: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithCollectionOfUnions.__init__)
++            def stub(
++                union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -823,10 +946,13 @@
+@@ -823,10 +1048,17 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.List[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithCollectionOfUnions, "union_property").fset)
++            def stub(
++                value: typing.List[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  class ClassWithCollections(
      metaclass=jsii.JSIIMeta,
-@@ -839,10 +965,14 @@
+@@ -839,10 +1071,19 @@
      ) -> None:
          '''
          :param map: -
          :param array: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithCollections.__init__)
++            def stub(
++                map: typing.Mapping[builtins.str, builtins.str],
++                array: typing.Sequence[builtins.str],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
          jsii.create(self.__class__, self, [map, array])
@@ -14390,14 +14551,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="createAList")
      @builtins.classmethod
      def create_a_list(cls) -> typing.List[builtins.str]:
-@@ -858,37 +988,49 @@
+@@ -858,37 +1099,57 @@
      def static_array(cls) -> typing.List[builtins.str]:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[builtins.str], jsii.sget(cls, "staticArray"))
  
      @static_array.setter # type: ignore[no-redef]
      def static_array(cls, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithCollections, "static_array").fset)
++            def stub(value: typing.List[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticArray", value)
  
@@ -14409,7 +14572,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @static_map.setter # type: ignore[no-redef]
      def static_map(cls, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithCollections, "static_map").fset)
++            def stub(value: typing.Mapping[builtins.str, builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticMap", value)
  
@@ -14421,7 +14586,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @array.setter
      def array(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithCollections, "array").fset)
++            def stub(value: typing.List[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "array", value)
  
@@ -14433,21 +14600,33 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @map.setter
      def map(self, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithCollections, "map").fset)
++            def stub(value: typing.Mapping[builtins.str, builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "map", value)
  
  
  class ClassWithContainerTypes(
      metaclass=jsii.JSIIMeta,
-@@ -910,10 +1052,15 @@
+@@ -910,10 +1171,25 @@
          :param obj: -
          :param array_prop: 
          :param obj_prop: 
          :param record_prop: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithContainerTypes.__init__)
++            def stub(
++                array: typing.Sequence[typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                record: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                obj: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                *,
++                array_prop: typing.Sequence[typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                obj_prop: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                record_prop: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
 +            check_type(argname="argument record", value=record, expected_type=type_hints["record"])
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
@@ -14456,14 +14635,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          jsii.create(self.__class__, self, [array, record, obj, props])
-@@ -963,17 +1110,23 @@
+@@ -963,17 +1239,27 @@
  ):
      def __init__(self, int: builtins.str) -> None:
          '''
          :param int: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithJavaReservedWords.__init__)
++            def stub(int: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument int", value=int, expected_type=type_hints["int"])
          jsii.create(self.__class__, self, [int])
  
@@ -14473,161 +14654,194 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param assert_: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithJavaReservedWords.import_)
++            def stub(assert_: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
          return typing.cast(builtins.str, jsii.invoke(self, "import", [assert_]))
  
      @builtins.property
      @jsii.member(jsii_name="int")
      def int(self) -> builtins.str:
-@@ -992,10 +1145,13 @@
+@@ -992,10 +1278,15 @@
      def mutable_object(self) -> "IMutableObjectLiteral":
          return typing.cast("IMutableObjectLiteral", jsii.get(self, "mutableObject"))
  
      @mutable_object.setter
      def mutable_object(self, value: "IMutableObjectLiteral") -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithMutableObjectLiteralProperty, "mutable_object").fset)
++            def stub(value: "IMutableObjectLiteral") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableObject", value)
  
  
  class ClassWithNestedUnion(
      metaclass=jsii.JSIIMeta,
-@@ -1006,10 +1162,13 @@
+@@ -1006,10 +1297,17 @@
          union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]]],
      ) -> None:
          '''
          :param union_property: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithNestedUnion.__init__)
++            def stub(
++                union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -1020,10 +1179,13 @@
+@@ -1020,10 +1318,17 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]], typing.List[typing.Union["StructA", "StructB"]]]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithNestedUnion, "union_property").fset)
++            def stub(
++                value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]], typing.List[typing.Union["StructA", "StructB"]]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  class ConfusingToJackson(
      metaclass=jsii.JSIIMeta,
-@@ -1054,10 +1216,13 @@
+@@ -1054,10 +1359,17 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ConfusingToJackson, "union_property").fset)
++            def stub(
++                value: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ConfusingToJacksonStruct",
-@@ -1071,10 +1236,13 @@
+@@ -1071,10 +1383,18 @@
          union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.Sequence[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]] = None,
      ) -> None:
          '''
          :param union_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConfusingToJacksonStruct.__init__)
++            def stub(
++                *,
++                union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.Sequence[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[str, typing.Any] = {}
          if union_property is not None:
              self._values["union_property"] = union_property
  
      @builtins.property
-@@ -1102,10 +1270,13 @@
+@@ -1102,10 +1422,15 @@
  ):
      def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
          '''
          :param consumer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConstructorPassesThisOut.__init__)
++            def stub(consumer: "PartiallyInitializedThisConsumer") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument consumer", value=consumer, expected_type=type_hints["consumer"])
          jsii.create(self.__class__, self, [consumer])
  
  
  class Constructors(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Constructors"):
      def __init__(self) -> None:
-@@ -1153,10 +1324,13 @@
+@@ -1153,10 +1478,15 @@
  ):
      def __init__(self, delegate: "IStructReturningDelegate") -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumePureInterface.__init__)
++            def stub(delegate: "IStructReturningDelegate") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="workItBaby")
      def work_it_baby(self) -> "StructB":
          return typing.cast("StructB", jsii.invoke(self, "workItBaby", []))
-@@ -1185,10 +1359,13 @@
+@@ -1185,10 +1515,15 @@
  
          Returns whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.static_implemented_by_object_literal)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPrivateClass")
      @builtins.classmethod
      def static_implemented_by_private_class(
-@@ -1199,10 +1376,13 @@
+@@ -1199,10 +1534,15 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.static_implemented_by_private_class)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPublicClass")
      @builtins.classmethod
      def static_implemented_by_public_class(cls, ringer: "IBellRinger") -> builtins.bool:
-@@ -1210,10 +1390,13 @@
+@@ -1210,10 +1550,15 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.static_implemented_by_public_class)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
  
      @jsii.member(jsii_name="staticWhenTypedAsClass")
      @builtins.classmethod
      def static_when_typed_as_class(cls, ringer: "IConcreteBellRinger") -> builtins.bool:
-@@ -1221,50 +1404,65 @@
+@@ -1221,50 +1566,75 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.static_when_typed_as_class)
++            def stub(ringer: "IConcreteBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
  
@@ -14640,7 +14854,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.implemented_by_object_literal)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
  
@@ -14653,7 +14869,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.implemented_by_private_class)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
  
@@ -14666,7 +14884,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.implemented_by_public_class)
++            def stub(ringer: "IBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
  
@@ -14679,21 +14899,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumerCanRingBell.when_typed_as_class)
++            def stub(ringer: "IConcreteBellRinger") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
  
  
  class ConsumersOfThisCrazyTypeSystem(
      metaclass=jsii.JSIIMeta,
-@@ -1279,20 +1477,26 @@
+@@ -1279,20 +1649,30 @@
          obj: "IAnotherPublicInterface",
      ) -> builtins.str:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumersOfThisCrazyTypeSystem.consume_another_public_interface)
++            def stub(obj: "IAnotherPublicInterface") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
  
@@ -14706,21 +14930,30 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param obj: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumersOfThisCrazyTypeSystem.consume_non_internal_interface)
++            def stub(obj: "INonInternalInterface") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ContainerProps",
-@@ -1314,10 +1518,15 @@
+@@ -1314,10 +1694,22 @@
          '''
          :param array_prop: 
          :param obj_prop: 
          :param record_prop: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ContainerProps.__init__)
++            def stub(
++                *,
++                array_prop: typing.Sequence[typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                obj_prop: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++                record_prop: typing.Mapping[builtins.str, typing.Union["DummyObj", typing.Dict[str, typing.Any]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument array_prop", value=array_prop, expected_type=type_hints["array_prop"])
 +            check_type(argname="argument obj_prop", value=obj_prop, expected_type=type_hints["obj_prop"])
 +            check_type(argname="argument record_prop", value=record_prop, expected_type=type_hints["record_prop"])
@@ -14729,14 +14962,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "obj_prop": obj_prop,
              "record_prop": record_prop,
          }
-@@ -1383,17 +1592,23 @@
+@@ -1383,17 +1775,27 @@
          data: typing.Mapping[builtins.str, typing.Any],
      ) -> builtins.str:
          '''
          :param data: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DataRenderer.render_arbitrary)
++            def stub(data: typing.Mapping[builtins.str, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument data", value=data, expected_type=type_hints["data"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderArbitrary", [data]))
  
@@ -14746,21 +14981,29 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param map: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DataRenderer.render_map)
++            def stub(map: typing.Mapping[builtins.str, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderMap", [map]))
  
  
  class Default(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Default"):
      '''A class named "Default".
-@@ -1422,10 +1637,15 @@
+@@ -1422,10 +1824,21 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DefaultedConstructorArgument.__init__)
++            def stub(
++                arg1: typing.Optional[jsii.Number] = None,
++                arg2: typing.Optional[builtins.str] = None,
++                arg3: typing.Optional[datetime.datetime] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -14769,14 +15012,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -1483,10 +1703,14 @@
+@@ -1483,10 +1896,19 @@
  
          :deprecated: this constructor is "just" okay
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DeprecatedClass.__init__)
++            def stub(
++                readonly_string: builtins.str,
++                mutable_number: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -14784,42 +15032,59 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -1516,10 +1740,13 @@
+@@ -1516,10 +1938,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(DeprecatedClass, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.DeprecatedEnum")
  class DeprecatedEnum(enum.Enum):
-@@ -1555,10 +1782,13 @@
+@@ -1555,10 +1982,15 @@
  
          :deprecated: it just wraps a string
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DeprecatedStruct.__init__)
++            def stub(*, readonly_property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -1623,10 +1853,21 @@
+@@ -1623,10 +2055,34 @@
          :param non_primitive: An example of a non primitive property.
          :param another_optional: This is optional.
          :param optional_any: 
          :param optional_array: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DerivedStruct.__init__)
++            def stub(
++                *,
++                anumber: jsii.Number,
++                astring: builtins.str,
++                first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
++                another_required: datetime.datetime,
++                bool: builtins.bool,
++                non_primitive: "DoubleTrouble",
++                another_optional: typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]] = None,
++                optional_any: typing.Any = None,
++                optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
 +            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
@@ -14834,14 +15099,22 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "astring": astring,
              "another_required": another_required,
              "bool": bool,
-@@ -1743,10 +1984,16 @@
+@@ -1743,10 +2199,24 @@
          :param hoisted_top: 
          :param left: 
          :param right: 
          :param bottom: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondBottom.__init__)
++            def stub(
++                *,
++                hoisted_top: typing.Optional[builtins.str] = None,
++                left: typing.Optional[jsii.Number] = None,
++                right: typing.Optional[builtins.bool] = None,
++                bottom: typing.Optional[datetime.datetime] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
 +            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
@@ -14851,28 +15124,36 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -1804,10 +2051,13 @@
+@@ -1804,10 +2274,15 @@
  class DiamondInheritanceBaseLevelStruct:
      def __init__(self, *, base_level_property: builtins.str) -> None:
          '''
          :param base_level_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondInheritanceBaseLevelStruct.__init__)
++            def stub(*, base_level_property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "base_level_property": base_level_property,
          }
  
      @builtins.property
-@@ -1845,10 +2095,14 @@
+@@ -1845,10 +2320,20 @@
      ) -> None:
          '''
          :param base_level_property: 
          :param first_mid_level_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondInheritanceFirstMidLevelStruct.__init__)
++            def stub(
++                *,
++                base_level_property: builtins.str,
++                first_mid_level_property: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -14880,14 +15161,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
          }
  
-@@ -1893,10 +2147,14 @@
+@@ -1893,10 +2378,20 @@
      ) -> None:
          '''
          :param base_level_property: 
          :param second_mid_level_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondInheritanceSecondMidLevelStruct.__init__)
++            def stub(
++                *,
++                base_level_property: builtins.str,
++                second_mid_level_property: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -14895,14 +15182,22 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_mid_level_property": second_mid_level_property,
          }
  
-@@ -1952,10 +2210,16 @@
+@@ -1952,10 +2447,24 @@
          :param base_level_property: 
          :param first_mid_level_property: 
          :param second_mid_level_property: 
          :param top_level_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DiamondInheritanceTopLevelStruct.__init__)
++            def stub(
++                *,
++                base_level_property: builtins.str,
++                first_mid_level_property: builtins.str,
++                second_mid_level_property: builtins.str,
++                top_level_property: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
 +            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
@@ -14912,28 +15207,36 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
              "second_mid_level_property": second_mid_level_property,
              "top_level_property": top_level_property,
-@@ -2035,10 +2299,13 @@
+@@ -2035,10 +2544,15 @@
      @jsii.member(jsii_name="changePrivatePropertyValue")
      def change_private_property_value(self, new_value: builtins.str) -> None:
          '''
          :param new_value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DoNotOverridePrivates.change_private_property_value)
++            def stub(new_value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(None, jsii.invoke(self, "changePrivatePropertyValue", [new_value]))
  
      @jsii.member(jsii_name="privateMethodValue")
      def private_method_value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "privateMethodValue", []))
-@@ -2067,10 +2334,15 @@
+@@ -2067,10 +2581,21 @@
          '''
          :param _required_any: -
          :param _optional_any: -
          :param _optional_string: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DoNotRecognizeAnyAsOptional.method)
++            def stub(
++                _required_any: typing.Any,
++                _optional_any: typing.Any = None,
++                _optional_string: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _required_any", value=_required_any, expected_type=type_hints["_required_any"])
 +            check_type(argname="argument _optional_any", value=_optional_any, expected_type=type_hints["_optional_any"])
 +            check_type(argname="argument _optional_string", value=_optional_string, expected_type=type_hints["_optional_string"])
@@ -14942,14 +15245,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2134,10 +2406,14 @@
+@@ -2134,10 +2659,19 @@
      ) -> builtins.str:
          '''
          :param optional: -
          :param things: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DontComplainAboutVariadicAfterOptional.optional_and_variadic)
++            def stub(
++                optional: typing.Optional[builtins.str] = None,
++                *things: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
 +            check_type(argname="argument things", value=things, expected_type=typing.Tuple[type_hints["things"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.str, jsii.invoke(self, "optionalAndVariadic", [optional, *things]))
@@ -14957,28 +15265,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DummyObj",
-@@ -2147,10 +2423,13 @@
+@@ -2147,10 +2681,15 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
          :param example: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DummyObj.__init__)
++            def stub(*, example: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument example", value=example, expected_type=type_hints["example"])
          self._values: typing.Dict[str, typing.Any] = {
              "example": example,
          }
  
      @builtins.property
-@@ -2179,28 +2458,37 @@
+@@ -2179,28 +2718,43 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
          :param value_store: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DynamicPropertyBearer.__init__)
++            def stub(value_store: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value_store", value=value_store, expected_type=type_hints["value_store"])
          jsii.create(self.__class__, self, [value_store])
  
@@ -14990,7 +15302,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @dynamic_property.setter
      def dynamic_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(DynamicPropertyBearer, "dynamic_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dynamicProperty", value)
  
@@ -15002,21 +15316,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @value_store.setter
      def value_store(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(DynamicPropertyBearer, "value_store").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueStore", value)
  
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2209,20 +2497,26 @@
+@@ -2209,20 +2763,30 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
          :param original_value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DynamicPropertyBearerChild.__init__)
++            def stub(original_value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument original_value", value=original_value, expected_type=type_hints["original_value"])
          jsii.create(self.__class__, self, [original_value])
  
@@ -15029,49 +15347,60 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :return: the old value that was set.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(DynamicPropertyBearerChild.override_value)
++            def stub(new_value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(builtins.str, jsii.invoke(self, "overrideValue", [new_value]))
  
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2235,10 +2529,13 @@
+@@ -2235,10 +2799,15 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
          :param clock: your implementation of \`\`WallClock\`\`.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Entropy.__init__)
++            def stub(clock: "IWallClock") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument clock", value=clock, expected_type=type_hints["clock"])
          jsii.create(self.__class__, self, [clock])
  
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2266,10 +2563,13 @@
+@@ -2266,10 +2835,15 @@
  
          :param word: the value to return.
  
          :return: \`\`word\`\`.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Entropy.repeat)
++            def stub(word: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument word", value=word, expected_type=type_hints["word"])
          return typing.cast(builtins.str, jsii.invoke(self, "repeat", [word]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2306,10 +2606,14 @@
+@@ -2306,10 +2880,19 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
          :param key: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(EraseUndefinedHashValues.does_key_exist)
++            def stub(
++                opts: typing.Union["EraseUndefinedHashValuesOptions", typing.Dict[str, typing.Any]],
++                key: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument opts", value=opts, expected_type=type_hints["opts"])
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "doesKeyExist", [opts, key]))
@@ -15079,14 +15408,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2337,10 +2641,14 @@
+@@ -2337,10 +2920,20 @@
      ) -> None:
          '''
          :param option1: 
          :param option2: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(EraseUndefinedHashValuesOptions.__init__)
++            def stub(
++                *,
++                option1: typing.Optional[builtins.str] = None,
++                option2: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument option1", value=option1, expected_type=type_hints["option1"])
 +            check_type(argname="argument option2", value=option2, expected_type=type_hints["option2"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -15094,14 +15429,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2384,10 +2692,14 @@
+@@ -2384,10 +2977,19 @@
          :param readonly_string: -
          :param mutable_number: -
  
          :stability: experimental
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExperimentalClass.__init__)
++            def stub(
++                readonly_string: builtins.str,
++                mutable_number: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -15109,56 +15449,64 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2411,10 +2723,13 @@
+@@ -2411,10 +3013,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ExperimentalClass, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2442,10 +2757,13 @@
+@@ -2442,10 +3049,15 @@
          '''
          :param readonly_property: 
  
          :stability: experimental
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExperimentalStruct.__init__)
++            def stub(*, readonly_property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -2475,10 +2793,13 @@
+@@ -2475,10 +3087,15 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
          :param success: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExportedBaseClass.__init__)
++            def stub(success: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument success", value=success, expected_type=type_hints["success"])
          jsii.create(self.__class__, self, [success])
  
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2494,10 +2815,14 @@
+@@ -2494,10 +3111,16 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
          :param prop: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExtendsInternalInterface.__init__)
++            def stub(*, boom: builtins.bool, prop: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument boom", value=boom, expected_type=type_hints["boom"])
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15166,14 +15514,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2539,10 +2864,14 @@
+@@ -2539,10 +3162,19 @@
          :param readonly_string: -
          :param mutable_number: -
  
          :external: true
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExternalClass.__init__)
++            def stub(
++                readonly_string: builtins.str,
++                mutable_number: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -15181,168 +15534,195 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2566,10 +2895,13 @@
+@@ -2566,10 +3198,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ExternalClass, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2597,10 +2929,13 @@
+@@ -2597,10 +3234,15 @@
          '''
          :param readonly_property: 
  
          :external: true
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExternalStruct.__init__)
++            def stub(*, readonly_property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -2743,10 +3078,13 @@
+@@ -2743,10 +3385,15 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
          :param name: The name of the greetee. Default: world
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Greetee.__init__)
++            def stub(*, name: typing.Optional[builtins.str] = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          self._values: typing.Dict[str, typing.Any] = {}
          if name is not None:
              self._values["name"] = name
  
      @builtins.property
-@@ -2780,10 +3118,13 @@
+@@ -2780,10 +3427,15 @@
      @jsii.member(jsii_name="betterGreeting")
      def better_greeting(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
          '''
          :param friendly: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(GreetingAugmenter.better_greeting)
++            def stub(friendly: scope.jsii_calc_lib.IFriendly) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
  
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2863,10 +3204,13 @@
+@@ -2863,10 +3515,15 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IAnotherPublicInterface, "a").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2909,10 +3253,13 @@
+@@ -2909,10 +3566,15 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
          :param bell: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(IBellRinger.your_turn)
++            def stub(bell: IBell) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -2937,10 +3284,13 @@
+@@ -2937,10 +3599,15 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
          :param bell: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(IConcreteBellRinger.your_turn)
++            def stub(bell: "Bell") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -2996,10 +3346,13 @@
+@@ -2996,10 +3663,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IDeprecatedInterface, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3054,10 +3407,13 @@
+@@ -3054,10 +3726,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IExperimentalInterface, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3099,10 +3455,13 @@
+@@ -3099,10 +3776,15 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
      @private.setter
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IExtendsPrivateInterface, "private").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3148,10 +3507,13 @@
+@@ -3148,10 +3830,15 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IExternalInterface, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3333,10 +3695,14 @@
+@@ -3333,10 +4020,19 @@
      ) -> None:
          '''
          :param arg1: -
          :param arg2: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(IInterfaceWithOptionalMethodArguments.hello)
++            def stub(
++                arg1: builtins.str,
++                arg2: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
          return typing.cast(None, jsii.invoke(self, "hello", [arg1, arg2]))
@@ -15350,56 +15730,64 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3371,10 +3737,13 @@
+@@ -3371,10 +4067,15 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IInterfaceWithProperties, "read_write_string").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3404,10 +3773,13 @@
+@@ -3404,10 +4105,15 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
      @foo.setter
      def foo(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IInterfaceWithPropertiesExtension, "foo").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -3927,10 +4299,13 @@
+@@ -3927,10 +4633,15 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
      @value.setter
      def value(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IMutableObjectLiteral, "value").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "value", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -3966,19 +4341,25 @@
+@@ -3966,19 +4677,29 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(INonInternalInterface, "b").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -15411,77 +15799,94 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(INonInternalInterface, "c").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4011,10 +4392,13 @@
+@@ -4011,10 +4732,15 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
      @property.setter
      def property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IObjectWithProperty, "property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4207,10 +4591,13 @@
+@@ -4207,10 +4933,15 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(IStableInterface, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4277,10 +4664,13 @@
+@@ -4277,10 +5008,15 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ImplementInternalInterface, "prop").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4326,10 +4716,13 @@
+@@ -4326,10 +5062,15 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
      @private.setter
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ImplementsPrivateInterface, "private").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4347,10 +4740,15 @@
+@@ -4347,10 +5088,22 @@
          '''
          :param foo: -
          :param bar: -
          :param goo: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ImplictBaseOfBase.__init__)
++            def stub(
++                *,
++                foo: scope.jsii_calc_base_of_base.Very,
++                bar: builtins.str,
++                goo: datetime.datetime,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument goo", value=goo, expected_type=type_hints["goo"])
@@ -15490,28 +15895,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4425,10 +4823,13 @@
+@@ -4425,10 +5178,15 @@
          count: jsii.Number,
      ) -> typing.List[scope.jsii_calc_lib.IDoublable]:
          '''
          :param count: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(InterfacesMaker.make_interfaces)
++            def stub(count: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(typing.List[scope.jsii_calc_lib.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
  
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4533,19 +4934,25 @@
+@@ -4533,19 +5291,29 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
      @prop_a.setter
      def prop_a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(JSObjectLiteralToNativeClass, "prop_a").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propA", value)
  
@@ -15523,91 +15932,118 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @prop_b.setter
      def prop_b(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(JSObjectLiteralToNativeClass, "prop_b").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propB", value)
  
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4767,10 +5174,13 @@
+@@ -4767,10 +5535,15 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
      @while_.setter
      def while_(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(JavaReservedWords, "while_").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "while", value)
  
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4872,10 +5282,13 @@
+@@ -4872,10 +5645,15 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(JsonFormatter.stringify)
++            def stub(value: typing.Any = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Optional[builtins.str], jsii.sinvoke(cls, "stringify", [value]))
  
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4905,10 +5318,13 @@
+@@ -4905,10 +5683,15 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
              :param value: 
              '''
 +            if __debug__:
-+                type_hints = typing.get_type_hints(LevelOne.PropBooleanValue.__init__)
++                def stub(*, value: builtins.bool) -> None:
++                    ...
++                type_hints = typing.get_type_hints(stub)
 +                check_type(argname="argument value", value=value, expected_type=type_hints["value"])
              self._values: typing.Dict[str, typing.Any] = {
                  "value": value,
              }
  
          @builtins.property
-@@ -4942,10 +5358,13 @@
+@@ -4942,10 +5725,18 @@
              '''
              :param prop: 
              '''
              if isinstance(prop, dict):
                  prop = LevelOne.PropBooleanValue(**prop)
 +            if __debug__:
-+                type_hints = typing.get_type_hints(LevelOne.PropProperty.__init__)
++                def stub(
++                    *,
++                    prop: typing.Union["LevelOne.PropBooleanValue", typing.Dict[str, typing.Any]],
++                ) -> None:
++                    ...
++                type_hints = typing.get_type_hints(stub)
 +                check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
              self._values: typing.Dict[str, typing.Any] = {
                  "prop": prop,
              }
  
          @builtins.property
-@@ -4980,10 +5399,13 @@
+@@ -4980,10 +5771,18 @@
          '''
          :param prop: 
          '''
          if isinstance(prop, dict):
              prop = LevelOne.PropProperty(**prop)
 +        if __debug__:
-+            type_hints = typing.get_type_hints(LevelOneProps.__init__)
++            def stub(
++                *,
++                prop: typing.Union[LevelOne.PropProperty, typing.Dict[str, typing.Any]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "prop": prop,
          }
  
      @builtins.property
-@@ -5031,10 +5453,17 @@
+@@ -5031,10 +5830,26 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
          :param public_tasks: Determines whether your Fargate Service will be assigned a public IP address. Default: false
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(LoadBalancedFargateServiceProps.__init__)
++            def stub(
++                *,
++                container_port: typing.Optional[jsii.Number] = None,
++                cpu: typing.Optional[builtins.str] = None,
++                memory_mib: typing.Optional[builtins.str] = None,
++                public_load_balancer: typing.Optional[builtins.bool] = None,
++                public_tasks: typing.Optional[builtins.bool] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument container_port", value=container_port, expected_type=type_hints["container_port"])
 +            check_type(argname="argument cpu", value=cpu, expected_type=type_hints["cpu"])
 +            check_type(argname="argument memory_mib", value=memory_mib, expected_type=type_hints["memory_mib"])
@@ -15618,14 +16054,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5161,10 +5590,14 @@
+@@ -5161,10 +5976,19 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Multiply.__init__)
++            def stub(
++                lhs: scope.jsii_calc_lib.NumericValue,
++                rhs: scope.jsii_calc_lib.NumericValue,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -15633,28 +16074,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5212,10 +5645,13 @@
+@@ -5212,10 +6036,15 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
          :param number_prop: When provided, must be > 0.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NestedStruct.__init__)
++            def stub(*, number_prop: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument number_prop", value=number_prop, expected_type=type_hints["number_prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "number_prop": number_prop,
          }
  
      @builtins.property
-@@ -5286,17 +5722,24 @@
+@@ -5286,17 +6115,28 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
          :param optional: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NullShouldBeTreatedAsUndefined.__init__)
++            def stub(_param1: builtins.str, optional: typing.Any = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _param1", value=_param1, expected_type=type_hints["_param1"])
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
          jsii.create(self.__class__, self, [_param1, optional])
@@ -15665,35 +16110,45 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NullShouldBeTreatedAsUndefined.give_me_undefined)
++            def stub(value: typing.Any = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "giveMeUndefined", [value]))
  
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5324,10 +5767,13 @@
+@@ -5324,10 +6164,15 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
      @change_me_to_undefined.setter
      def change_me_to_undefined(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(NullShouldBeTreatedAsUndefined, "change_me_to_undefined").fset)
++            def stub(value: typing.Optional[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "changeMeToUndefined", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5346,10 +5792,14 @@
+@@ -5346,10 +6191,20 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
          :param this_should_be_undefined: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NullShouldBeTreatedAsUndefinedData.__init__)
++            def stub(
++                *,
++                array_with_three_elements_and_undefined_as_second_argument: typing.Sequence[typing.Any],
++                this_should_be_undefined: typing.Any = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument array_with_three_elements_and_undefined_as_second_argument", value=array_with_three_elements_and_undefined_as_second_argument, expected_type=type_hints["array_with_three_elements_and_undefined_as_second_argument"])
 +            check_type(argname="argument this_should_be_undefined", value=this_should_be_undefined, expected_type=type_hints["this_should_be_undefined"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15701,14 +16156,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5384,17 +5834,23 @@
+@@ -5384,17 +6239,27 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
          :param generator: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NumberGenerator.__init__)
++            def stub(generator: IRandomNumberGenerator) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument generator", value=generator, expected_type=type_hints["generator"])
          jsii.create(self.__class__, self, [generator])
  
@@ -15718,77 +16175,95 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param gen: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(NumberGenerator.is_same_generator)
++            def stub(gen: IRandomNumberGenerator) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
  
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5404,10 +5860,13 @@
+@@ -5404,10 +6269,15 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
      @generator.setter
      def generator(self, value: IRandomNumberGenerator) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(NumberGenerator, "generator").fset)
++            def stub(value: IRandomNumberGenerator) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "generator", value)
  
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5425,10 +5884,13 @@
+@@ -5425,10 +6295,15 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
          :param values: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ObjectRefsInCollections.sum_from_array)
++            def stub(values: typing.Sequence[scope.jsii_calc_lib.NumericValue]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromArray", [values]))
  
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5436,10 +5898,13 @@
+@@ -5436,10 +6311,17 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
          :param values: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ObjectRefsInCollections.sum_from_map)
++            def stub(
++                values: typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromMap", [values]))
  
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5480,10 +5945,13 @@
+@@ -5480,10 +6362,15 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(OptionalArgumentInvoker.__init__)
++            def stub(delegate: IInterfaceWithOptionalMethodArguments) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5506,10 +5974,15 @@
+@@ -5506,10 +6393,21 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(OptionalConstructorArgument.__init__)
++            def stub(
++                arg1: jsii.Number,
++                arg2: builtins.str,
++                arg3: typing.Optional[datetime.datetime] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -15797,70 +16272,84 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5534,10 +6007,13 @@
+@@ -5534,10 +6432,15 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
          :param field: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(OptionalStruct.__init__)
++            def stub(*, field: typing.Optional[builtins.str] = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument field", value=field, expected_type=type_hints["field"])
          self._values: typing.Dict[str, typing.Any] = {}
          if field is not None:
              self._values["field"] = field
  
      @builtins.property
-@@ -5613,10 +6089,13 @@
+@@ -5613,10 +6516,15 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
      @_override_read_write.setter
      def _override_read_write(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(OverridableProtectedMember, "_override_read_write").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "overrideReadWrite", value)
  
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5628,10 +6107,13 @@
+@@ -5628,10 +6536,15 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(OverrideReturnsObject.test)
++            def stub(obj: IReturnsNumber) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5642,10 +6124,13 @@
+@@ -5642,10 +6555,15 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
          :param foo: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ParentStruct982.__init__)
++            def stub(*, foo: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -5700,10 +6185,15 @@
+@@ -5700,10 +6618,21 @@
          '''
          :param obj: -
          :param dt: -
          :param ev: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(PartiallyInitializedThisConsumer.consume_partially_initialized_this)
++            def stub(
++                obj: ConstructorPassesThisOut,
++                dt: datetime.datetime,
++                ev: AllTypesEnum,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
 +            check_type(argname="argument dt", value=dt, expected_type=type_hints["dt"])
 +            check_type(argname="argument ev", value=ev, expected_type=type_hints["ev"])
@@ -15869,28 +16358,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5715,10 +6205,13 @@
+@@ -5715,10 +6644,15 @@
      @jsii.member(jsii_name="sayHello")
      def say_hello(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
          '''
          :param friendly: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Polymorphism.say_hello)
++            def stub(friendly: scope.jsii_calc_lib.IFriendly) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
  
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5735,10 +6228,14 @@
+@@ -5735,10 +6669,19 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
          :param pow: The number of times to multiply.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Power.__init__)
++            def stub(
++                base: scope.jsii_calc_lib.NumericValue,
++                pow: scope.jsii_calc_lib.NumericValue,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base", value=base, expected_type=type_hints["base"])
 +            check_type(argname="argument pow", value=pow, expected_type=type_hints["pow"])
          jsii.create(self.__class__, self, [base, pow])
@@ -15898,42 +16394,54 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> scope.jsii_calc_lib.NumericValue:
-@@ -5942,10 +6439,13 @@
+@@ -5942,10 +6885,15 @@
      @jsii.member(jsii_name="saveFoo")
      def save_foo(self, value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ReferenceEnumFromScopedPackage.save_foo)
++            def stub(value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "saveFoo", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
-@@ -5954,10 +6454,13 @@
+@@ -5954,10 +6902,17 @@
      @foo.setter
      def foo(
          self,
          value: typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule],
      ) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ReferenceEnumFromScopedPackage, "foo").fset)
++            def stub(
++                value: typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -5999,10 +6502,14 @@
+@@ -5999,10 +6954,20 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
          if isinstance(nested_struct, dict):
              nested_struct = NestedStruct(**nested_struct)
 +        if __debug__:
-+            type_hints = typing.get_type_hints(RootStruct.__init__)
++            def stub(
++                *,
++                string_prop: builtins.str,
++                nested_struct: typing.Optional[typing.Union[NestedStruct, typing.Dict[str, typing.Any]]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument string_prop", value=string_prop, expected_type=type_hints["string_prop"])
 +            check_type(argname="argument nested_struct", value=nested_struct, expected_type=type_hints["nested_struct"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15941,14 +16449,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6069,17 +6576,25 @@
+@@ -6069,17 +7034,33 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(RuntimeTypeChecking.method_with_defaulted_arguments)
++            def stub(
++                arg1: typing.Optional[jsii.Number] = None,
++                arg2: typing.Optional[builtins.str] = None,
++                arg3: typing.Optional[datetime.datetime] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -15960,21 +16474,29 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(RuntimeTypeChecking.method_with_optional_any_argument)
++            def stub(arg: typing.Any = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg", value=arg, expected_type=type_hints["arg"])
          return typing.cast(None, jsii.invoke(self, "methodWithOptionalAnyArgument", [arg]))
  
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6091,10 +6606,15 @@
+@@ -6091,10 +7072,21 @@
  
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(RuntimeTypeChecking.method_with_optional_arguments)
++            def stub(
++                arg1: jsii.Number,
++                arg2: builtins.str,
++                arg3: typing.Optional[datetime.datetime] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -15983,14 +16505,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6113,10 +6633,14 @@
+@@ -6113,10 +7105,20 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
          :param deeper_optional_prop: It's long, but you'll almost never pass it.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SecondLevelStruct.__init__)
++            def stub(
++                *,
++                deeper_required_prop: builtins.str,
++                deeper_optional_prop: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument deeper_required_prop", value=deeper_required_prop, expected_type=type_hints["deeper_required_prop"])
 +            check_type(argname="argument deeper_optional_prop", value=deeper_optional_prop, expected_type=type_hints["deeper_optional_prop"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15998,42 +16526,48 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6178,10 +6702,13 @@
+@@ -6178,10 +7180,15 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SingletonInt.is_singleton_int)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonInt", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6200,10 +6727,13 @@
+@@ -6200,10 +7207,15 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SingletonString.is_singleton_string)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonString", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6227,10 +6757,14 @@
+@@ -6227,10 +7239,16 @@
      ) -> None:
          '''
          :param property: 
          :param yet_anoter_one: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SmellyStruct.__init__)
++            def stub(*, property: builtins.str, yet_anoter_one: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
 +            check_type(argname="argument yet_anoter_one", value=yet_anoter_one, expected_type=type_hints["yet_anoter_one"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16041,14 +16575,19 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6281,10 +6815,14 @@
+@@ -6281,10 +7299,19 @@
      ) -> None:
          '''
          :param readonly_string: -
          :param mutable_number: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StableClass.__init__)
++            def stub(
++                readonly_string: builtins.str,
++                mutable_number: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -16056,56 +16595,64 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6299,10 +6837,13 @@
+@@ -6299,10 +7326,15 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(StableClass, "mutable_property").fset)
++            def stub(value: typing.Optional[jsii.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6318,10 +6859,13 @@
+@@ -6318,10 +7350,15 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
          :param readonly_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StableStruct.__init__)
++            def stub(*, readonly_property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -6358,10 +6902,13 @@
+@@ -6358,10 +7395,15 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
      @static_variable.setter # type: ignore[no-redef]
      def static_variable(cls, value: builtins.bool) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(StaticContext, "static_variable").fset)
++            def stub(value: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticVariable", value)
  
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6391,19 +6938,25 @@
+@@ -6391,19 +7433,29 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Statics.__init__)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
@@ -16117,21 +16664,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param name: The name of the person to say hello to.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Statics.static_method)
++            def stub(name: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "staticMethod", [name]))
  
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6440,19 +6993,25 @@
+@@ -6440,19 +7492,29 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
      @instance.setter # type: ignore[no-redef]
      def instance(cls, value: "Statics") -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Statics, "instance").fset)
++            def stub(value: "Statics") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "instance", value)
  
@@ -16143,35 +16694,46 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @non_const_static.setter # type: ignore[no-redef]
      def non_const_static(cls, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Statics, "non_const_static").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "nonConstStatic", value)
  
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6475,10 +7034,13 @@
+@@ -6475,10 +7537,15 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
      @you_see_me.setter
      def you_see_me(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(StripInternal, "you_see_me").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "youSeeMe", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6501,10 +7063,15 @@
+@@ -6501,10 +7568,22 @@
  
          :param required_string: 
          :param optional_number: 
          :param optional_string: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructA.__init__)
++            def stub(
++                *,
++                required_string: builtins.str,
++                optional_number: typing.Optional[jsii.Number] = None,
++                optional_string: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_number", value=optional_number, expected_type=type_hints["optional_number"])
 +            check_type(argname="argument optional_string", value=optional_string, expected_type=type_hints["optional_string"])
@@ -16180,14 +16742,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6562,10 +7129,15 @@
+@@ -6562,10 +7641,22 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
          if isinstance(optional_struct_a, dict):
              optional_struct_a = StructA(**optional_struct_a)
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructB.__init__)
++            def stub(
++                *,
++                required_string: builtins.str,
++                optional_boolean: typing.Optional[builtins.bool] = None,
++                optional_struct_a: typing.Optional[typing.Union[StructA, typing.Dict[str, typing.Any]]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_boolean", value=optional_boolean, expected_type=type_hints["optional_boolean"])
 +            check_type(argname="argument optional_struct_a", value=optional_struct_a, expected_type=type_hints["optional_struct_a"])
@@ -16196,14 +16765,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6617,10 +7189,14 @@
+@@ -6617,10 +7708,20 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
          :param props: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructParameterType.__init__)
++            def stub(
++                *,
++                scope: builtins.str,
++                props: typing.Optional[builtins.bool] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
 +            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16211,14 +16786,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6663,10 +7239,14 @@
+@@ -6663,10 +7764,16 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
          :param inputs: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructPassing.how_many_var_args_did_i_pass)
++            def stub(_positional: jsii.Number, *inputs: "TopLevelStruct") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
 +            check_type(argname="argument inputs", value=inputs, expected_type=typing.Tuple[type_hints["inputs"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(jsii.Number, jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs]))
@@ -16226,42 +16803,58 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6681,10 +7261,13 @@
+@@ -6681,10 +7788,21 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructPassing.round_trip)
++            def stub(
++                _positional: jsii.Number,
++                *,
++                required: builtins.str,
++                second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
++                optional: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
          input = TopLevelStruct(
              required=required, second_level=second_level, optional=optional
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6701,10 +7284,13 @@
+@@ -6701,10 +7819,17 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
      ) -> builtins.bool:
          '''
          :param struct: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructUnionConsumer.is_struct_a)
++            def stub(
++                struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructA", [struct]))
  
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6712,18 +7298,24 @@
+@@ -6712,18 +7837,30 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
      ) -> builtins.bool:
          '''
          :param struct: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructUnionConsumer.is_struct_b)
++            def stub(
++                struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructB", [struct]))
  
@@ -16272,35 +16865,48 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructUnionConsumer.provide_struct)
++            def stub(which: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[StructA, StructB], jsii.sinvoke(cls, "provideStruct", [which]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6737,10 +7329,13 @@
+@@ -6737,10 +7874,18 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
      ) -> None:
          '''
          :param union_property: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructWithCollectionOfUnionts.__init__)
++            def stub(
++                *,
++                union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "union_property": union_property,
          }
  
      @builtins.property
-@@ -6777,10 +7372,14 @@
+@@ -6777,10 +7922,20 @@
      ) -> None:
          '''
          :param foo: An enum value.
          :param bar: Optional enum value (of type integer). Default: AllTypesEnum.YOUR_ENUM_VALUE
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructWithEnum.__init__)
++            def stub(
++                *,
++                foo: StringEnum,
++                bar: typing.Optional[AllTypesEnum] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16308,14 +16914,22 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -6836,10 +7435,16 @@
+@@ -6836,10 +7991,24 @@
          :param default: 
          :param assert_: 
          :param result: 
          :param that: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructWithJavaReservedWords.__init__)
++            def stub(
++                *,
++                default: builtins.str,
++                assert_: typing.Optional[builtins.str] = None,
++                result: typing.Optional[builtins.str] = None,
++                that: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument default", value=default, expected_type=type_hints["default"])
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
 +            check_type(argname="argument result", value=result, expected_type=type_hints["result"])
@@ -16325,28 +16939,36 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -6906,10 +7511,13 @@
+@@ -6906,10 +8075,15 @@
          '''The parts to sum.'''
          return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "parts"))
  
      @parts.setter
      def parts(self, value: typing.List[scope.jsii_calc_lib.NumericValue]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Sum, "parts").fset)
++            def stub(value: typing.List[scope.jsii_calc_lib.NumericValue]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "parts", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -6925,10 +7533,14 @@
+@@ -6925,10 +8099,20 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SupportsNiceJavaBuilderProps.__init__)
++            def stub(
++                *,
++                bar: jsii.Number,
++                id: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16354,28 +16976,37 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -6977,10 +7589,13 @@
+@@ -6977,10 +8161,20 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SupportsNiceJavaBuilderWithRequiredProps.__init__)
++            def stub(
++                id_: jsii.Number,
++                *,
++                bar: jsii.Number,
++                id: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument id_", value=id_, expected_type=type_hints["id_"])
          props = SupportsNiceJavaBuilderProps(bar=bar, id=id)
  
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7018,17 +7633,23 @@
+@@ -7018,17 +8212,27 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SyncVirtualMethods.modify_other_property)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyOtherProperty", [value]))
  
@@ -16385,21 +17016,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SyncVirtualMethods.modify_value_of_the_property)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyValueOfTheProperty", [value]))
  
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7048,17 +7669,23 @@
+@@ -7048,17 +8252,27 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
          :param n: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SyncVirtualMethods.virtual_method)
++            def stub(n: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument n", value=n, expected_type=type_hints["n"])
          return typing.cast(jsii.Number, jsii.invoke(self, "virtualMethod", [n]))
  
@@ -16409,21 +17044,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SyncVirtualMethods.write_a)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "writeA", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7069,46 +7696,61 @@
+@@ -7069,46 +8283,71 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(SyncVirtualMethods, "a").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -16435,7 +17074,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @caller_is_property.setter
      def caller_is_property(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(SyncVirtualMethods, "caller_is_property").fset)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "callerIsProperty", value)
  
@@ -16447,7 +17088,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @other_property.setter
      def other_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(SyncVirtualMethods, "other_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "otherProperty", value)
  
@@ -16459,7 +17102,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @the_property.setter
      def the_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(SyncVirtualMethods, "the_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "theProperty", value)
  
@@ -16471,21 +17116,30 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @value_of_other_property.setter
      def value_of_other_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(SyncVirtualMethods, "value_of_other_property").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueOfOtherProperty", value)
  
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7191,10 +7833,15 @@
+@@ -7191,10 +8430,22 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(TopLevelStruct.__init__)
++            def stub(
++                *,
++                required: builtins.str,
++                second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
++                optional: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument required", value=required, expected_type=type_hints["required"])
 +            check_type(argname="argument second_level", value=second_level, expected_type=type_hints["second_level"])
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
@@ -16494,28 +17148,36 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7285,10 +7932,13 @@
+@@ -7285,10 +8536,15 @@
  
      def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
          '''
          :param operand: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UnaryOperation.__init__)
++            def stub(operand: scope.jsii_calc_lib.NumericValue) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> scope.jsii_calc_lib.NumericValue:
-@@ -7319,10 +7969,14 @@
+@@ -7319,10 +8575,20 @@
      ) -> None:
          '''
          :param bar: 
          :param foo: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UnionProperties.__init__)
++            def stub(
++                *,
++                bar: typing.Union[builtins.str, jsii.Number, AllTypes],
++                foo: typing.Optional[typing.Union[builtins.str, jsii.Number]] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16523,42 +17185,48 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7359,10 +8013,13 @@
+@@ -7359,10 +8625,15 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UpcasingReflectable.__init__)
++            def stub(delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> scope.jsii_calc_lib.custom_submodule_name.Reflector:
-@@ -7405,10 +8062,13 @@
+@@ -7405,10 +8676,15 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UsesInterfaceWithProperties.__init__)
++            def stub(obj: IInterfaceWithProperties) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          jsii.create(self.__class__, self, [obj])
  
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7419,17 +8079,23 @@
+@@ -7419,17 +8695,27 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
          :param ext: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UsesInterfaceWithProperties.read_string_and_number)
++            def stub(ext: IInterfaceWithPropertiesExtension) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument ext", value=ext, expected_type=type_hints["ext"])
          return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
  
@@ -16568,21 +17236,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UsesInterfaceWithProperties.write_and_read)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.str, jsii.invoke(self, "writeAndRead", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7439,25 +8105,34 @@
+@@ -7439,25 +8725,40 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
          :param method: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VariadicInvoker.__init__)
++            def stub(method: "VariadicMethod") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument method", value=method, expected_type=type_hints["method"])
          jsii.create(self.__class__, self, [method])
  
@@ -16592,7 +17264,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param values: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VariadicInvoker.as_array)
++            def stub(*values: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument values", value=values, expected_type=typing.Tuple[type_hints["values"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [*values]))
  
@@ -16603,21 +17277,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param prefix: a prefix that will be use for all values returned by \`\`#asArray\`\`.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VariadicMethod.__init__)
++            def stub(*prefix: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument prefix", value=prefix, expected_type=typing.Tuple[type_hints["prefix"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*prefix])
  
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7466,10 +8141,14 @@
+@@ -7466,10 +8767,16 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
          :param others: other elements to be included in the array.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VariadicMethod.as_array)
++            def stub(first: jsii.Number, *others: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument first", value=first, expected_type=type_hints["first"])
 +            check_type(argname="argument others", value=others, expected_type=typing.Tuple[type_hints["others"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
@@ -16625,14 +17303,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7477,19 +8156,25 @@
+@@ -7477,19 +8784,29 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
          :param union: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VariadicTypeUnion.__init__)
++            def stub(*union: typing.Union[StructA, StructB]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument union", value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*union])
  
@@ -16644,21 +17324,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @union.setter
      def union(self, value: typing.List[typing.Union[StructA, StructB]]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(VariadicTypeUnion, "union").fset)
++            def stub(value: typing.List[typing.Union[StructA, StructB]]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "union", value)
  
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7501,38 +8186,53 @@
+@@ -7501,38 +8818,63 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
          :param index: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VirtualMethodPlayground.override_me_async)
++            def stub(index: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeAsync", [index]))
  
@@ -16668,7 +17352,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param index: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VirtualMethodPlayground.override_me_sync)
++            def stub(index: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.invoke(self, "overrideMeSync", [index]))
  
@@ -16678,7 +17364,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VirtualMethodPlayground.parallel_sum_async)
++            def stub(count: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "parallelSumAsync", [count]))
  
@@ -16688,7 +17376,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VirtualMethodPlayground.serial_sum_async)
++            def stub(count: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "serialSumAsync", [count]))
  
@@ -16698,49 +17388,60 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(VirtualMethodPlayground.sum_sync)
++            def stub(count: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumSync", [count]))
  
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7580,10 +8280,13 @@
+@@ -7580,10 +8922,15 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
          :param private_field: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(WithPrivatePropertyInConstructor.__init__)
++            def stub(private_field: typing.Optional[builtins.str] = None) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument private_field", value=private_field, expected_type=type_hints["private_field"])
          jsii.create(self.__class__, self, [private_field])
  
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7624,10 +8327,13 @@
+@@ -7624,10 +8971,15 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
          :param name: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(AbstractClass.abstract_method)
++            def stub(name: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.invoke(self, "abstractMethod", [name]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7643,10 +8349,14 @@
+@@ -7643,10 +8995,19 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Add.__init__)
++            def stub(
++                lhs: scope.jsii_calc_lib.NumericValue,
++                rhs: scope.jsii_calc_lib.NumericValue,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -16748,28 +17449,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7690,10 +8400,13 @@
+@@ -7690,10 +9051,15 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
      @rung.setter
      def rung(self, value: builtins.bool) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Bell, "rung").fset)
++            def stub(value: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "rung", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7704,10 +8417,14 @@
+@@ -7704,10 +9070,16 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
          :param bar: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ChildStruct982.__init__)
++            def stub(*, foo: builtins.str, bar: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16777,14 +17482,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7748,37 +8465,49 @@
+@@ -7748,37 +9120,57 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsTheInternalInterface, "a").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -16796,7 +17503,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsTheInternalInterface, "b").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -16808,7 +17517,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsTheInternalInterface, "c").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
@@ -16820,21 +17531,25 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @d.setter
      def d(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsTheInternalInterface, "d").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "d", value)
  
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -7793,37 +8522,49 @@
+@@ -7793,37 +9185,57 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsThePrivateInterface, "a").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -16846,7 +17561,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsThePrivateInterface, "b").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -16858,7 +17575,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsThePrivateInterface, "c").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
@@ -16870,21 +17589,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @e.setter
      def e(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassThatImplementsThePrivateInterface, "e").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "e", value)
  
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -7841,10 +8582,14 @@
+@@ -7841,10 +9253,19 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
          :param read_write_string: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithPrivateConstructorAndAutomaticProperties.create)
++            def stub(
++                read_only_string: builtins.str,
++                read_write_string: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument read_only_string", value=read_only_string, expected_type=type_hints["read_only_string"])
 +            check_type(argname="argument read_write_string", value=read_write_string, expected_type=type_hints["read_write_string"])
          return typing.cast("ClassWithPrivateConstructorAndAutomaticProperties", jsii.sinvoke(cls, "create", [read_only_string, read_write_string]))
@@ -16892,56 +17618,69 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -7855,10 +8600,13 @@
+@@ -7855,10 +9276,15 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(ClassWithPrivateConstructorAndAutomaticProperties, "read_write_string").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -7973,10 +8721,13 @@
+@@ -7973,10 +9399,15 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
          :param property: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(JSII417Derived.__init__)
++            def stub(property: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
          jsii.create(self.__class__, self, [property])
  
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -7997,10 +8748,13 @@
+@@ -7997,10 +9428,15 @@
  
      def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
          '''
          :param operand: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Negate.__init__)
++            def stub(operand: scope.jsii_calc_lib.NumericValue) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8060,10 +8814,16 @@
+@@ -8060,10 +9496,23 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
          :param rest: a variadic continuation.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SupportsNiceJavaBuilder.__init__)
++            def stub(
++                id: jsii.Number,
++                default_bar: typing.Optional[jsii.Number] = None,
++                props: typing.Optional[typing.Union[SupportsNiceJavaBuilderProps, typing.Dict[str, typing.Any]]] = None,
++                *rest: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
 +            check_type(argname="argument default_bar", value=default_bar, expected_type=type_hints["default_bar"])
 +            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
@@ -16956,14 +17695,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/anonymous/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/anonymous/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/anonymous/__init__.py	--runtime-type-checking
-@@ -54,26 +54,35 @@
+@@ -54,26 +54,41 @@
      @builtins.classmethod
      def consume(cls, option: typing.Union[IOptionA, IOptionB]) -> builtins.str:
          '''
          :param option: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UseOptions.consume)
++            def stub(option: typing.Union[IOptionA, IOptionB]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument option", value=option, expected_type=type_hints["option"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "consume", [option]))
  
@@ -16974,7 +17715,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UseOptions.privide_as_any)
++            def stub(which: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Any, jsii.sinvoke(cls, "privideAsAny", [which]))
  
@@ -16985,7 +17728,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UseOptions.provide)
++            def stub(which: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[IOptionA, IOptionB], jsii.sinvoke(cls, "provide", [which]))
  
@@ -16997,14 +17742,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/__init__.py	--runtime-type-checking
-@@ -42,10 +42,13 @@
+@@ -42,10 +42,15 @@
      def _unwrap(self, gen: _IRandomNumberGenerator_9643a8b9) -> jsii.Number:
          '''Implement this functin to return \`\`gen.next()\`\`. It is extremely important that the \`\`donotimport\`\` submodule is NEVER explicitly loaded in the testing application (otherwise this test is void).
  
          :param gen: a VERY pseudo random number generator.
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Cdk16625._unwrap)
++            def stub(gen: _IRandomNumberGenerator_9643a8b9) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(jsii.Number, jsii.invoke(self, "unwrap", [gen]))
  
@@ -17015,14 +17762,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/donotimport/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/donotimport/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/donotimport/__init__.py	--runtime-type-checking
-@@ -31,10 +31,13 @@
+@@ -31,10 +31,15 @@
  
      def __init__(self, value: jsii.Number) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(UnimportedSubmoduleType.__init__)
++            def stub(value: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
@@ -17034,14 +17783,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/composition/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/composition/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/composition/__init__.py	--runtime-type-checking
-@@ -52,30 +52,39 @@
+@@ -52,30 +52,45 @@
          '''A set of postfixes to include in a decorated .toString().'''
          return typing.cast(typing.List[builtins.str], jsii.get(self, "decorationPostfixes"))
  
      @decoration_postfixes.setter
      def decoration_postfixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(CompositeOperation, "decoration_postfixes").fset)
++            def stub(value: typing.List[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPostfixes", value)
  
@@ -17054,7 +17805,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @decoration_prefixes.setter
      def decoration_prefixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(CompositeOperation, "decoration_prefixes").fset)
++            def stub(value: typing.List[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPrefixes", value)
  
@@ -17067,7 +17820,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @string_style.setter
      def string_style(self, value: "CompositeOperation.CompositionStringStyle") -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(CompositeOperation, "string_style").fset)
++            def stub(value: "CompositeOperation.CompositionStringStyle") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringStyle", value)
  
@@ -17079,14 +17834,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/derived_class_has_no_properties/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/derived_class_has_no_properties/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/derived_class_has_no_properties/__init__.py	--runtime-type-checking
-@@ -25,10 +25,13 @@
+@@ -25,10 +25,15 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Base, "prop").fset)
++            def stub(value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
@@ -17098,28 +17855,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py	--runtime-type-checking
-@@ -25,10 +25,13 @@
+@@ -25,10 +25,15 @@
      def bar(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "bar"))
  
      @bar.setter
      def bar(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(Foo, "bar").fset)
++            def stub(value: typing.Optional[builtins.str]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "bar", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
-@@ -38,10 +41,13 @@
+@@ -38,10 +43,15 @@
  class Hello:
      def __init__(self, *, foo: jsii.Number) -> None:
          '''
          :param foo: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Hello.__init__)
++            def stub(*, foo: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
@@ -17131,14 +17892,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py	--runtime-type-checking
-@@ -21,10 +21,13 @@
+@@ -21,10 +21,15 @@
  class Hello:
      def __init__(self, *, foo: jsii.Number) -> None:
          '''
          :param foo: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Hello.__init__)
++            def stub(*, foo: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
@@ -17150,14 +17913,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/jsii3656/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/jsii3656/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/jsii3656/__init__.py	--runtime-type-checking
-@@ -27,10 +27,14 @@
+@@ -27,10 +27,20 @@
      ) -> None:
          '''
          :param name: 
          :param count: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ImplementMeOpts.__init__)
++            def stub(
++                *,
++                name: builtins.str,
++                count: typing.Optional[jsii.Number] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17165,14 +17934,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if count is not None:
              self._values["count"] = count
-@@ -69,10 +73,13 @@
+@@ -69,10 +79,15 @@
      @builtins.classmethod
      def call_abstract(cls, receiver: "OverrideMe") -> builtins.bool:
          '''
          :param receiver: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(OverrideMe.call_abstract)
++            def stub(receiver: "OverrideMe") -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument receiver", value=receiver, expected_type=type_hints["receiver"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "callAbstract", [receiver]))
  
@@ -17184,14 +17955,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2530/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2530/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2530/__init__.py	--runtime-type-checking
-@@ -21,25 +21,34 @@
+@@ -21,25 +21,40 @@
  
      def __init__(self, _: jsii.Number) -> None:
          '''
          :param _: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClass.__init__)
++            def stub(_: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          jsii.create(self.__class__, self, [_])
  
@@ -17202,7 +17975,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClass.bar)
++            def stub(_: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.sinvoke(cls, "bar", [_]))
  
@@ -17212,7 +17987,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClass.foo)
++            def stub(_: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.invoke(self, "foo", [_]))
  
@@ -17224,14 +18001,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2647/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2647/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2647/__init__.py	--runtime-type-checking
-@@ -31,10 +31,13 @@
+@@ -31,10 +31,15 @@
          '''
          :param very: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ExtendAndImplement.__init__)
++            def stub(very: scope.jsii_calc_base_of_base.Very) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
@@ -17243,14 +18022,18 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/methods/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/methods/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/methods/__init__.py	--runtime-type-checking
-@@ -29,17 +29,23 @@
+@@ -29,17 +29,29 @@
          _bar: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
      ) -> None:
          '''
          :param _bar: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClass.bar)
++            def stub(
++                _bar: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _bar", value=_bar, expected_type=type_hints["_bar"])
          return typing.cast(None, jsii.invoke(self, "bar", [_bar]))
  
@@ -17260,7 +18043,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _values: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClass.foo)
++            def stub(_values: typing.Sequence[scope.jsii_calc_lib.Number]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument _values", value=_values, expected_type=type_hints["_values"])
          return typing.cast(None, jsii.invoke(self, "foo", [_values]))
  
@@ -17272,14 +18057,20 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/structs/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/structs/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/structs/__init__.py	--runtime-type-checking
-@@ -30,10 +30,14 @@
+@@ -30,10 +30,20 @@
      ) -> None:
          '''
          :param base_map: 
          :param numbers: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyStruct.__init__)
++            def stub(
++                *,
++                base_map: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
++                numbers: typing.Sequence[scope.jsii_calc_lib.Number],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument base_map", value=base_map, expected_type=type_hints["base_map"])
 +            check_type(argname="argument numbers", value=numbers, expected_type=type_hints["numbers"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17291,14 +18082,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2692/submodule1/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2692/submodule1/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2692/submodule1/__init__.py	--runtime-type-checking
-@@ -21,10 +21,13 @@
+@@ -21,10 +21,15 @@
  class Bar:
      def __init__(self, *, bar1: builtins.str) -> None:
          '''
          :param bar1: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Bar.__init__)
++            def stub(*, bar1: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
          self._values: typing.Dict[str, typing.Any] = {
              "bar1": bar1,
@@ -17310,28 +18103,37 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2692/submodule2/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2692/submodule2/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2692/submodule2/__init__.py	--runtime-type-checking
-@@ -23,10 +23,13 @@
+@@ -23,10 +23,15 @@
  class Bar:
      def __init__(self, *, bar2: builtins.str) -> None:
          '''
          :param bar2: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Bar.__init__)
++            def stub(*, bar2: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
          self._values: typing.Dict[str, typing.Any] = {
              "bar2": bar2,
          }
  
      @builtins.property
-@@ -63,10 +66,15 @@
+@@ -63,10 +68,22 @@
          '''
          :param bar2: 
          :param bar1: 
          :param foo2: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Foo.__init__)
++            def stub(
++                *,
++                bar2: builtins.str,
++                bar1: builtins.str,
++                foo2: builtins.str,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
 +            check_type(argname="argument foo2", value=foo2, expected_type=type_hints["foo2"])
@@ -17345,14 +18147,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/python_self/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/python_self/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/python_self/__init__.py	--runtime-type-checking
-@@ -19,17 +19,23 @@
+@@ -19,17 +19,27 @@
  ):
      def __init__(self_, self: builtins.str) -> None:
          '''
          :param self: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithSelf.__init__)
++            def stub(self: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          jsii.create(self_.__class__, self_, [self])
  
@@ -17362,35 +18166,41 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param self: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ClassWithSelf.method)
++            def stub(self: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
      @builtins.property
      @jsii.member(jsii_name="self")
      def self(self) -> builtins.str:
-@@ -70,10 +76,13 @@
+@@ -70,10 +80,15 @@
      @jsii.member(jsii_name="method")
      def method(self_, self: jsii.Number) -> builtins.str:
          '''
          :param self: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(IInterfaceWithSelf.method)
++            def stub(self: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithSelf).__jsii_proxy_class__ = lambda : _IInterfaceWithSelfProxy
  
-@@ -86,10 +95,13 @@
+@@ -86,10 +101,15 @@
  class StructWithSelf:
      def __init__(self_, *, self: builtins.str) -> None:
          '''
          :param self: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(StructWithSelf.__init__)
++            def stub(*, self: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          self_._values: typing.Dict[str, typing.Any] = {
              "self": self,
@@ -17402,28 +18212,32 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/__init__.py	--runtime-type-checking
-@@ -39,10 +39,13 @@
+@@ -39,10 +39,15 @@
  
          :param foo: 
  
          :see: https://github.com/aws/jsii/issues/2637
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Default.__init__)
++            def stub(*, foo: jsii.Number) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -107,10 +110,13 @@
+@@ -107,10 +112,15 @@
      def all_types(self) -> typing.Optional[_AllTypes_b08307c5]:
          return typing.cast(typing.Optional[_AllTypes_b08307c5], jsii.get(self, "allTypes"))
  
      @all_types.setter
      def all_types(self, value: typing.Optional[_AllTypes_b08307c5]) -> None:
 +        if __debug__:
-+            type_hints = typing.get_type_hints(getattr(MyClass, "all_types").fset)
++            def stub(value: typing.Optional[_AllTypes_b08307c5]) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "allTypes", value)
  
@@ -17435,14 +18249,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/back_references/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/back_references/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/back_references/__init__.py	--runtime-type-checking
-@@ -23,10 +23,13 @@
+@@ -23,10 +23,15 @@
  class MyClassReference:
      def __init__(self, *, reference: _MyClass_a2fdc0b6) -> None:
          '''
          :param reference: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(MyClassReference.__init__)
++            def stub(*, reference: _MyClass_a2fdc0b6) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument reference", value=reference, expected_type=type_hints["reference"])
          self._values: typing.Dict[str, typing.Any] = {
              "reference": reference,
@@ -17454,42 +18270,52 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/child/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/child/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/child/__init__.py	--runtime-type-checking
-@@ -73,10 +73,13 @@
+@@ -73,10 +73,15 @@
  class SomeStruct:
      def __init__(self, *, prop: SomeEnum) -> None:
          '''
          :param prop: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SomeStruct.__init__)
++            def stub(*, prop: SomeEnum) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "prop": prop,
          }
  
      @builtins.property
-@@ -105,10 +108,13 @@
+@@ -105,10 +110,15 @@
  class Structure:
      def __init__(self, *, bool: builtins.bool) -> None:
          '''
          :param bool: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(Structure.__init__)
++            def stub(*, bool: builtins.bool) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument bool", value=bool, expected_type=type_hints["bool"])
          self._values: typing.Dict[str, typing.Any] = {
              "bool": bool,
          }
  
      @builtins.property
-@@ -143,10 +149,14 @@
+@@ -143,10 +153,20 @@
      ) -> None:
          '''
          :param prop: 
          :param extra: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(KwargsProps.__init__)
++            def stub(
++                *,
++                prop: SomeEnum,
++                extra: typing.Optional[builtins.str] = None,
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
 +            check_type(argname="argument extra", value=extra, expected_type=type_hints["extra"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17502,14 +18328,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/param/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/param/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/param/__init__.py	--runtime-type-checking
-@@ -21,10 +21,13 @@
+@@ -21,10 +21,15 @@
  class SpecialParameter:
      def __init__(self, *, value: builtins.str) -> None:
          '''
          :param value: 
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(SpecialParameter.__init__)
++            def stub(*, value: builtins.str) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[str, typing.Any] = {
              "value": value,
@@ -17521,14 +18349,18 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/union/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/union/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/union/__init__.py	--runtime-type-checking
-@@ -23,10 +23,13 @@
+@@ -23,10 +23,17 @@
          param: typing.Union["IResolvable", "Resolvable", scope.jsii_calc_lib.IFriendly],
      ) -> None:
          '''
          :param param: -
          '''
 +        if __debug__:
-+            type_hints = typing.get_type_hints(ConsumesUnion.union_type)
++            def stub(
++                param: typing.Union["IResolvable", "Resolvable", scope.jsii_calc_lib.IFriendly],
++            ) -> None:
++                ...
++            type_hints = typing.get_type_hints(stub)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))
  


### PR DESCRIPTION
When methods are decorated by users (e.g: replaced with an alternate function that delegates back to the original one), type annotations are not carried over to the new function.

Since type checking code relied on dynamically accessing the checked function for the purpose of getting type hints,this resulted in unexpected errors when executing type checking code.

In order to address this, the type checking code now declares a stub function locally with the relevant type information in order to have a reliable/stable source of type annotations (these cannot be constructed dynamically as Python does not expose the necessary constructors).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
