### PR TITLE
feat: add error awareness to go deserialization

### DIFF
--- a/packages/@jsii/go-runtime-test/project/compliance_test.go
+++ b/packages/@jsii/go-runtime-test/project/compliance_test.go
@@ -1536,7 +1536,7 @@ func (i ImplementsStructReturningDelegate) ReturnStruct() *calc.StructB {
 }
 
 func (suite *ComplianceSuite) TestExceptions() {
-
+	// t := suite.T()
 	require := suite.Require()
 
 	calc3 := calc.NewCalculator(&calc.CalculatorProps{InitialValue: jsii.Number(20), MaximumValue: jsii.Number(30)})
@@ -1544,7 +1544,7 @@ func (suite *ComplianceSuite) TestExceptions() {
 	require.Equal(float64(23), *calc3.Value())
 
 	// TODO: should assert the actual error here - not working for some reasons
-	require.Panics(func() {
+	require.PanicsWithError("Error: Operation 33 exceeded maximum value 30", func() {
 		calc3.Add(jsii.Number(10))
 	})
 

--- a/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/process/process.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/process/process.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,6 +17,12 @@ import (
 )
 
 const JSII_RUNTIME string = "JSII_RUNTIME"
+
+type ErrorResponse struct {
+	Error string  `json:"error"`
+	Stack *string `json:"stack"`
+	Name  *string `json:"name"`
+}
 
 // Process is a simple interface over the child process hosting the
 // @jsii/kernel process. It only exposes a very straight-forward
@@ -197,7 +204,26 @@ func (p *Process) readResponse(into interface{}) error {
 	if !p.responses.More() {
 		return fmt.Errorf("no response received from child process")
 	}
-	return p.responses.Decode(into)
+
+	var raw json.RawMessage
+	var respmap map[string]interface{}
+	err := p.responses.Decode(&raw)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(raw, &respmap)
+	if err != nil {
+		return err
+	}
+
+	var errResp ErrorResponse
+	if _, ok := respmap["error"]; ok {
+		json.Unmarshal(raw, &errResp)
+		return errors.New(errResp.Error)
+	}
+
+	return json.Unmarshal(raw, &into)
 }
 
 func (p *Process) Close() {


### PR DESCRIPTION
Adds logic to detect when error responses are returned from the kernel within the go runtime library. This allows us to bubble up the correct error messaging from the kernel instead of just failed deserialization with unexpected response format.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
