### PR TITLE
fix(jsii-diff): does not check types in submodules

### DIFF
--- a/packages/jsii-diff/test/classes.test.ts
+++ b/packages/jsii-diff/test/classes.test.ts
@@ -749,3 +749,20 @@ test.each([
       `,
     ),
 );
+
+// ----------------------------------------------------------------------
+
+test('will find mismatches in submodules', () =>
+  expectError(
+    /number is not assignable to string/,
+    {
+      'index.ts': 'export * as submodule from "./subdir"',
+      'subdir/index.ts':
+        'export class Foo { public static readonly PROP = "abc"; }',
+    },
+    {
+      'index.ts': 'export * as submodule from "./subdir"',
+      'subdir/index.ts':
+        'export class Foo { public static readonly PROP = 42; }',
+    },
+  ));

--- a/packages/jsii-diff/test/util.ts
+++ b/packages/jsii-diff/test/util.ts
@@ -1,10 +1,13 @@
-import { sourceToAssemblyHelper } from 'jsii';
+import { MultipleSourceFiles, sourceToAssemblyHelper } from 'jsii';
 import * as reflect from 'jsii-reflect';
 
 import { compareAssemblies } from '../lib';
 import { Mismatches } from '../lib/types';
 
-export function expectNoError(original: string, updated: string) {
+export function expectNoError(
+  original: string | MultipleSourceFiles,
+  updated: string | MultipleSourceFiles,
+) {
   const mms = compare(original, updated);
   for (const msg of mms.messages()) {
     console.error(`- ${msg}`);
@@ -14,8 +17,8 @@ export function expectNoError(original: string, updated: string) {
 
 export function expectError(
   error: RegExp | undefined,
-  original: string,
-  updated: string,
+  original: string | MultipleSourceFiles,
+  updated: string | MultipleSourceFiles,
 ) {
   if (error == null) {
     expectNoError(original, updated);
@@ -32,7 +35,10 @@ export function expectError(
   }
 }
 
-export function compare(original: string, updated: string): Mismatches {
+export function compare(
+  original: string | MultipleSourceFiles,
+  updated: string | MultipleSourceFiles,
+): Mismatches {
   const ass1 = sourceToAssemblyHelper(original);
   const ts1 = new reflect.TypeSystem();
   const originalAssembly = ts1.addAssembly(new reflect.Assembly(ts1, ass1));

--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -168,17 +168,37 @@ export class Assembly extends ModuleLike {
   }
 
   /**
-   * All types, even those in submodules and nested submodules.
-   */
-  public get types(): readonly Type[] {
-    return Array.from(this.typeMap.values());
-  }
-
-  /**
-   * Return all types in the current assembly/submodule and all submodules underneath
+   * All types in the assembly and all of its submodules
    */
   public get allTypes(): readonly Type[] {
     return [...this.types, ...this.allSubmodules.flatMap((s) => s.types)];
+  }
+
+  /**
+   * All classes in the assembly and all of its submodules
+   */
+  public get allClasses(): readonly ClassType[] {
+    return this.allTypes
+      .filter((t) => t instanceof ClassType)
+      .map((t) => t as ClassType);
+  }
+
+  /**
+   * All interfaces in the assembly and all of its submodules
+   */
+  public get allInterfaces(): readonly InterfaceType[] {
+    return this.allTypes
+      .filter((t) => t instanceof InterfaceType)
+      .map((t) => t as InterfaceType);
+  }
+
+  /**
+   * All interfaces in the assembly and all of its submodules
+   */
+  public get allEnums(): readonly EnumType[] {
+    return this.allTypes
+      .filter((t) => t instanceof EnumType)
+      .map((t) => t as EnumType);
   }
 
   public findType(fqn: string) {

--- a/packages/jsii-reflect/lib/module-like.ts
+++ b/packages/jsii-reflect/lib/module-like.ts
@@ -34,22 +34,34 @@ export abstract class ModuleLike {
     return Array.from(this.submoduleMap.values());
   }
 
+  /**
+   * All types in this module/namespace (not submodules)
+   */
   public get types(): readonly Type[] {
     return Array.from(this.typeMap.values());
   }
 
+  /**
+   * All classes in this module/namespace (not submodules)
+   */
   public get classes(): readonly ClassType[] {
     return this.types
       .filter((t) => t instanceof ClassType)
       .map((t) => t as ClassType);
   }
 
+  /**
+   * All interfaces in this module/namespace (not submodules)
+   */
   public get interfaces(): readonly InterfaceType[] {
     return this.types
       .filter((t) => t instanceof InterfaceType)
       .map((t) => t as InterfaceType);
   }
 
+  /**
+   * All enums in this module/namespace (not submodules)
+   */
   public get enums(): readonly EnumType[] {
     return this.types
       .filter((t) => t instanceof EnumType)


### PR DESCRIPTION
`jsii-diff` was ignoring types in submodules, meaning no compatibility checks were being done on CDK v2 at all anymore.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
