### PR TITLE
feat(superchain): add Amazon SSM agent

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -219,6 +219,17 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 RUN pip install aws-sam-cli                                                                                             \
   && sam --version
 
+# Install Amazon SSM agent (allows debugging of builds via `codebuild-breakpoint`, https://go.aws/3TVW7vL)
+RUN apt-get update                                                                                                      \
+  && apt-get -y install curl                                                                                            \
+  && curl -fSsL "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${TARGETPLATFORM#linux/}/amazon-ssm-agent.deb"      \
+  -o /tmp/amazon-ssm-agent.deb                                                                                          \
+  && dpkg -i /tmp/amazon-ssm-agent.deb                                                                                  \
+  && systemctl enable amazon-ssm-agent                                                                                  \
+  && rm -rf /var/lib/apt/lists/*
+COPY --chown=superchain:superchain superchain/amazon-ssm-agent.json /etc/amazon/ssm/amazon-ssm-agent.json
+
+
 # Install some configuration
 COPY superchain/ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config

--- a/superchain/amazon-ssm-agent.json
+++ b/superchain/amazon-ssm-agent.json
@@ -1,0 +1,45 @@
+{
+    "Profile":{
+        "ShareCreds" : true,
+        "ShareProfile" : ""
+    },
+    "Mds": {
+        "CommandWorkersLimit" : 5,
+        "StopTimeoutMillis" : 20000,
+        "Endpoint": "",
+        "CommandRetryLimit": 15
+    },
+    "Ssm": {
+        "Endpoint": "",
+        "HealthFrequencyMinutes": 5,
+        "CustomInventoryDefaultLocation" : "",
+        "AssociationLogsRetentionDurationHours" : 24,
+        "RunCommandLogsRetentionDurationHours" : 336,
+        "SessionLogsRetentionDurationHours" : 336
+    },
+    "Mgs": {
+        "Region": "",
+        "Endpoint": "",
+        "StopTimeoutMillis" : 20000,
+        "SessionWorkersLimit" : 1000
+    },
+    "Agent": {
+        "Region": "",
+        "OrchestrationRootDir": "",
+        "ContainerMode": true
+    },
+    "Os": {
+        "Lang": "en-US",
+        "Name": "",
+        "Version": "1"
+    },
+    "S3": {
+        "Endpoint": "",
+        "Region": "",
+        "LogBucket":"",
+        "LogKey":""
+    },
+    "Kms": {
+        "Endpoint": ""
+    }
+}


### PR DESCRIPTION
Add the Amazon SSM agent to our image, so that we will be able to debug builds using the CodeBuild `<->` SSM breakpoint feature.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
