### PR TITLE
fix(python): parameter names shadow imported modules

### DIFF
--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -2,6 +2,7 @@ import pytest
 import re
 
 from scope.jsii_calc_lib.custom_submodule_name import NestingClass
+from scope.jsii_calc_lib import Number
 import jsii_calc
 
 
@@ -187,3 +188,14 @@ class TestRuntimeTypeChecking:
         jsii_calc.homonymous_forward_references.bar.Consumer.consume(
             homonymous={"numeric_property": 1337}
         )
+
+    def test_shadowed_namespaces_are_not_a_problem(self):
+        """Verifies that a parameter shadowing a namespace does not cause errors
+
+        This has caused https://github.com/aws/aws-cdk/issues/22975.
+        """
+
+        subject = jsii_calc.ParamShadowsScope()
+        num = Number(1337)
+        # The parameter is named "scope" which shadows the "scope" module...
+        assert num == subject.use_scope(num)

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -3090,3 +3090,16 @@ export class VariadicTypeUnion {
     this.union = union;
   }
 }
+
+/**
+ * Validate that namespaces being shadowed by local variables does not cause
+ * type checking issues.
+ *
+ * @see https://github.com/aws/aws-cdk/issues/22975
+ */
+export class ParamShadowsScope {
+  // @scope/* packages are under the "scope." namespace in Python.
+  public useScope(scope: LibNumber) {
+    return scope;
+  }
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -11425,6 +11425,52 @@
       "name": "OverrideReturnsObject",
       "symbolId": "lib/compliance:OverrideReturnsObject"
     },
+    "jsii-calc.ParamShadowsScope": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "see": "https://github.com/aws/aws-cdk/issues/22975",
+        "stability": "stable",
+        "summary": "Validate that namespaces being shadowed by local variables does not cause type checking issues."
+      },
+      "fqn": "jsii-calc.ParamShadowsScope",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 3100
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 3102
+          },
+          "name": "useScope",
+          "parameters": [
+            {
+              "name": "scope",
+              "type": {
+                "fqn": "@scope/jsii-calc-lib.Number"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "fqn": "@scope/jsii-calc-lib.Number"
+            }
+          }
+        }
+      ],
+      "name": "ParamShadowsScope",
+      "symbolId": "lib/compliance:ParamShadowsScope"
+    },
     "jsii-calc.ParentStruct982": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -18565,5 +18611,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "b2P7abkCSB3ezfp46ujoSHTYSgRV0o7O1avtvIe5xX8="
+  "fingerprint": "qTr3P5AD9cBorxBMjHTT6y6sMYWUgGf/acN7eejGTgQ="
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -1344,9 +1344,7 @@ class Foo:
         :param foo: -
         '''
         if __debug__:
-            def stub(*, foo: jsii.Number) -> None:
-                ...
-            type_hints = typing.get_type_hints(stub)
+            type_hints = typing.get_type_hints(_typecheckingstub__bf2f596592c027f75261089e0a96611ccca28179a004c918d9b1057b4e390db5)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
         self._values: typing.Dict[str, typing.Any] = {
             "foo": foo,
@@ -1387,13 +1385,7 @@ class FooBar:
         :param bar: -
         '''
         if __debug__:
-            def stub(
-                *,
-                foo: jsii.Number,
-                bar: typing.Optional[builtins.str] = None,
-            ) -> None:
-                ...
-            type_hints = typing.get_type_hints(stub)
+            type_hints = typing.get_type_hints(_typecheckingstub__0cb0385f4239a994a5509c1ac8d143d10f8400893975d4519442a0d7baf1b5d4)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
         self._values: typing.Dict[str, typing.Any] = {
@@ -1444,14 +1436,7 @@ class Baz(Foo, FooBar):
         :param baz: -
         '''
         if __debug__:
-            def stub(
-                *,
-                foo: jsii.Number,
-                bar: typing.Optional[builtins.str] = None,
-                baz: builtins.bool,
-            ) -> None:
-                ...
-            type_hints = typing.get_type_hints(stub)
+            type_hints = typing.get_type_hints(_typecheckingstub__98e5f88ba6c94001e15cc6f3ce78d86bd3610eea1b79954536d33da0dee53b2d)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             check_type(argname="argument baz", value=baz, expected_type=type_hints["baz"])
@@ -1499,6 +1484,30 @@ __all__ = [
 ]
 
 publication.publish()
+
+def _typecheckingstub__bf2f596592c027f75261089e0a96611ccca28179a004c918d9b1057b4e390db5(
+    *,
+    foo: jsii.Number,
+) -> None:
+    """Type checking stubs"""
+    pass
+
+def _typecheckingstub__0cb0385f4239a994a5509c1ac8d143d10f8400893975d4519442a0d7baf1b5d4(
+    *,
+    foo: jsii.Number,
+    bar: typing.Optional[builtins.str] = None,
+) -> None:
+    """Type checking stubs"""
+    pass
+
+def _typecheckingstub__98e5f88ba6c94001e15cc6f3ce78d86bd3610eea1b79954536d33da0dee53b2d(
+    *,
+    foo: jsii.Number,
+    bar: typing.Optional[builtins.str] = None,
+    baz: builtins.bool,
+) -> None:
+    """Type checking stubs"""
+    pass
 
 `;
 
@@ -2744,9 +2753,7 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
             :param bar: -
             '''
             if __debug__:
-                def stub(*, bar: builtins.str) -> None:
-                    ...
-                type_hints = typing.get_type_hints(stub)
+                type_hints = typing.get_type_hints(_typecheckingstub__2a8df629360a764124e23427f4b4bb1422fef01e5b6dcd040a2f64d477f476d9)
                 check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             self._values: typing.Dict[str, typing.Any] = {
                 "bar": bar,
@@ -2825,6 +2832,13 @@ __all__ = [
 ]
 
 publication.publish()
+
+def _typecheckingstub__2a8df629360a764124e23427f4b4bb1422fef01e5b6dcd040a2f64d477f476d9(
+    *,
+    bar: builtins.str,
+) -> None:
+    """Type checking stubs"""
+    pass
 
 `;
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -3187,6 +3187,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 OptionalStructConsumer.cs
        ┃           ┣━ 📄 OverridableProtectedMember.cs
        ┃           ┣━ 📄 OverrideReturnsObject.cs
+       ┃           ┣━ 📄 ParamShadowsScope.cs
        ┃           ┣━ 📄 ParentStruct982.cs
        ┃           ┣━ 📄 PartiallyInitializedThisConsumer.cs
        ┃           ┣━ 📄 Polymorphism.cs
@@ -16716,6 +16717,54 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         public virtual double Test(Amazon.JSII.Tests.CalculatorNamespace.IReturnsNumber obj)
         {
             return InvokeInstanceMethod<double>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.IReturnsNumber)}, new object[]{obj})!;
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/ParamShadowsScope.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    /// <summary>Validate that namespaces being shadowed by local variables does not cause type checking issues.</summary>
+    /// <remarks>
+    /// <strong>See</strong>: https://github.com/aws/aws-cdk/issues/22975
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.ParamShadowsScope), fullyQualifiedName: "jsii-calc.ParamShadowsScope")]
+    public class ParamShadowsScope : DeputyBase
+    {
+        public ParamShadowsScope(): base(_MakeDeputyProps())
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps()
+        {
+            return new DeputyProps(System.Array.Empty<object?>());
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected ParamShadowsScope(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected ParamShadowsScope(DeputyProps props): base(props)
+        {
+        }
+
+        [JsiiMethod(name: "useScope", returnsJson: "{\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"}}", parametersJson: "[{\\"name\\":\\"scope\\",\\"type\\":{\\"fqn\\":\\"@scope/jsii-calc-lib.Number\\"}}]")]
+        public virtual Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number UseScope(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number scope)
+        {
+            return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.LibNamespace.Number)}, new object[]{scope})!;
         }
     }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -2745,6 +2745,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┣━ 📄 jsiicalc_OptionalStructConsumer.go
        ┣━ 📄 jsiicalc_OverridableProtectedMember.go
        ┣━ 📄 jsiicalc_OverrideReturnsObject.go
+       ┣━ 📄 jsiicalc_ParamShadowsScope.go
        ┣━ 📄 jsiicalc_ParentStruct982.go
        ┣━ 📄 jsiicalc_PartiallyInitializedThisConsumer.go
        ┣━ 📄 jsiicalc_Polymorphism.go
@@ -6122,6 +6123,16 @@ func init() {
 		},
 		func() interface{} {
 			return &jsiiProxy_OverrideReturnsObject{}
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.ParamShadowsScope",
+		reflect.TypeOf((*ParamShadowsScope)(nil)).Elem(),
+		[]_jsii_.Member{
+			_jsii_.MemberMethod{JsiiMethod: "useScope", GoMethod: "UseScope"},
+		},
+		func() interface{} {
+			return &jsiiProxy_ParamShadowsScope{}
 		},
 	)
 	_jsii_.RegisterStruct(
@@ -17558,6 +17569,69 @@ func (o *jsiiProxy_OverrideReturnsObject) Test(obj IReturnsNumber) *float64 {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ParamShadowsScope.go 1`] = `
+// A simple calcuator built on JSII.
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+
+	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
+)
+
+// Validate that namespaces being shadowed by local variables does not cause type checking issues.
+// See: https://github.com/aws/aws-cdk/issues/22975
+//
+type ParamShadowsScope interface {
+	UseScope(scope scopejsiicalclib.Number) scopejsiicalclib.Number
+}
+
+// The jsii proxy struct for ParamShadowsScope
+type jsiiProxy_ParamShadowsScope struct {
+	_ byte // padding
+}
+
+func NewParamShadowsScope() ParamShadowsScope {
+	_init_.Initialize()
+
+	j := jsiiProxy_ParamShadowsScope{}
+
+	_jsii_.Create(
+		"jsii-calc.ParamShadowsScope",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewParamShadowsScope_Override(p ParamShadowsScope) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.ParamShadowsScope",
+		nil, // no parameters
+		p,
+	)
+}
+
+func (p *jsiiProxy_ParamShadowsScope) UseScope(scope scopejsiicalclib.Number) scopejsiicalclib.Number {
+	var returns scopejsiicalclib.Number
+
+	_jsii_.Invoke(
+		p,
+		"useScope",
+		[]interface{}{scope},
+		&returns,
+	)
+
+	return returns
+}
+
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsiicalc_ParentStruct982.go 1`] = `
 // A simple calcuator built on JSII.
 package jsiicalc
@@ -24831,6 +24905,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
        ┣━ 🆕 jsiicalc_OverrideReturnsObject__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_OverrideReturnsObject__runtime_type_checks.go
        ┣━ 📄 jsiicalc_OverrideReturnsObject.go.diff
+       ┣━ 🆕 jsiicalc_ParamShadowsScope__no_runtime_type_checking.go
+       ┣━ 🆕 jsiicalc_ParamShadowsScope__runtime_type_checks.go
+       ┣━ 📄 jsiicalc_ParamShadowsScope.go.diff
        ┣━ 🆕 jsiicalc_PartiallyInitializedThisConsumer__no_runtime_type_checking.go
        ┣━ 🆕 jsiicalc_PartiallyInitializedThisConsumer__runtime_type_checks.go
        ┣━ 📄 jsiicalc_PartiallyInitializedThisConsumer.go.diff
@@ -31843,6 +31920,67 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/j
 +func (o *jsiiProxy_OverrideReturnsObject) validateTestParameters(obj IReturnsNumber) error {
 +	if obj == nil {
 +		return fmt.Errorf("parameter obj is required, but nil was provided")
++	}
++
++	return nil
++}
++
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_ParamShadowsScope.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_ParamShadowsScope.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_ParamShadowsScope.go	--runtime-type-checking
+@@ -43,10 +43,13 @@
+ 		p,
+ 	)
+ }
+ 
+ func (p *jsiiProxy_ParamShadowsScope) UseScope(scope scopejsiicalclib.Number) scopejsiicalclib.Number {
++	if err := p.validateUseScopeParameters(scope); err != nil {
++		panic(err)
++	}
+ 	var returns scopejsiicalclib.Number
+ 
+ 	_jsii_.Invoke(
+ 		p,
+ 		"useScope",
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_ParamShadowsScope__no_runtime_type_checking.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_ParamShadowsScope__no_runtime_type_checking.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_ParamShadowsScope__no_runtime_type_checking.go	--runtime-type-checking
+@@ -0,0 +1,11 @@
++//go:build no_runtime_type_checking
++
++// A simple calcuator built on JSII.
++package jsiicalc
++
++// Building without runtime type checking enabled, so all the below just return nil
++
++func (p *jsiiProxy_ParamShadowsScope) validateUseScopeParameters(scope scopejsiicalclib.Number) error {
++	return nil
++}
++
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/jsiicalc_ParamShadowsScope__runtime_type_checks.go.diff 1`] = `
+--- go/jsiicalc/jsiicalc_ParamShadowsScope__runtime_type_checks.go	--no-runtime-type-checking
++++ go/jsiicalc/jsiicalc_ParamShadowsScope__runtime_type_checks.go	--runtime-type-checking
+@@ -0,0 +1,19 @@
++//go:build !no_runtime_type_checking
++
++// A simple calcuator built on JSII.
++package jsiicalc
++
++import (
++	"fmt"
++
++	"github.com/aws/jsii/jsii-calc/go/scopejsiicalclib"
++)
++
++func (p *jsiiProxy_ParamShadowsScope) validateUseScopeParameters(scope scopejsiicalclib.Number) error {
++	if scope == nil {
++		return fmt.Errorf("parameter scope is required, but nil was provided")
 +	}
 +
 +	return nil

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -3920,6 +3920,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 OverridableProtectedMember.java
           ┃                 ┣━ 📄 OverrideReturnsObject.java
           ┃                 ┣━ 📄 package-info.java
+          ┃                 ┣━ 📄 ParamShadowsScope.java
           ┃                 ┣━ 📄 ParentStruct982.java
           ┃                 ┣━ 📄 PartiallyInitializedThisConsumer.java
           ┃                 ┣━ 📄 Polymorphism.java
@@ -18544,6 +18545,46 @@ public class OverrideReturnsObject extends software.amazon.jsii.JsiiObject {
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/ParamShadowsScope.java 1`] = `
+package software.amazon.jsii.tests.calculator;
+
+/**
+ * Validate that namespaces being shadowed by local variables does not cause type checking issues.
+ * <p>
+ * @see <a href="https://github.com/aws/aws-cdk/issues/22975">https://github.com/aws/aws-cdk/issues/22975</a>
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.ParamShadowsScope")
+public class ParamShadowsScope extends software.amazon.jsii.JsiiObject {
+
+    protected ParamShadowsScope(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected ParamShadowsScope(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public ParamShadowsScope() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+
+    /**
+     * @param scope This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Number useScope(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.lib.Number scope) {
+        return software.amazon.jsii.Kernel.call(this, "useScope", software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.lib.Number.class), new Object[] { java.util.Objects.requireNonNull(scope, "scope is required") });
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/ParentStruct982.java 1`] = `
 package software.amazon.jsii.tests.calculator;
 
@@ -28522,6 +28563,7 @@ jsii-calc.OptionalStruct=software.amazon.jsii.tests.calculator.OptionalStruct
 jsii-calc.OptionalStructConsumer=software.amazon.jsii.tests.calculator.OptionalStructConsumer
 jsii-calc.OverridableProtectedMember=software.amazon.jsii.tests.calculator.OverridableProtectedMember
 jsii-calc.OverrideReturnsObject=software.amazon.jsii.tests.calculator.OverrideReturnsObject
+jsii-calc.ParamShadowsScope=software.amazon.jsii.tests.calculator.ParamShadowsScope
 jsii-calc.ParentStruct982=software.amazon.jsii.tests.calculator.ParentStruct982
 jsii-calc.PartiallyInitializedThisConsumer=software.amazon.jsii.tests.calculator.PartiallyInitializedThisConsumer
 jsii-calc.Polymorphism=software.amazon.jsii.tests.calculator.Polymorphism

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -336,7 +336,7 @@ from typeguard import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base_of_base
+import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
 
 
 class Base(metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-base.Base"):
@@ -362,14 +362,14 @@ typing.cast(typing.Any, Base).__jsii_proxy_class__ = lambda : _BaseProxy
 
 @jsii.data_type(
     jsii_type="@scope/jsii-calc-base.BaseProps",
-    jsii_struct_bases=[scope.jsii_calc_base_of_base.VeryBaseProps],
+    jsii_struct_bases=[_scope_jsii_calc_base_of_base_49fa37fe.VeryBaseProps],
     name_mapping={"foo": "foo", "bar": "bar"},
 )
-class BaseProps(scope.jsii_calc_base_of_base.VeryBaseProps):
+class BaseProps(_scope_jsii_calc_base_of_base_49fa37fe.VeryBaseProps):
     def __init__(
         self,
         *,
-        foo: scope.jsii_calc_base_of_base.Very,
+        foo: _scope_jsii_calc_base_of_base_49fa37fe.Very,
         bar: builtins.str,
     ) -> None:
         '''
@@ -382,10 +382,10 @@ class BaseProps(scope.jsii_calc_base_of_base.VeryBaseProps):
         }
 
     @builtins.property
-    def foo(self) -> scope.jsii_calc_base_of_base.Very:
+    def foo(self) -> _scope_jsii_calc_base_of_base_49fa37fe.Very:
         result = self._values.get("foo")
         assert result is not None, "Required property 'foo' is missing"
-        return typing.cast(scope.jsii_calc_base_of_base.Very, result)
+        return typing.cast(_scope_jsii_calc_base_of_base_49fa37fe.Very, result)
 
     @builtins.property
     def bar(self) -> builtins.str:
@@ -407,7 +407,7 @@ class BaseProps(scope.jsii_calc_base_of_base.VeryBaseProps):
 
 @jsii.interface(jsii_type="@scope/jsii-calc-base.IBaseInterface")
 class IBaseInterface(
-    scope.jsii_calc_base_of_base.IVeryBaseInterface,
+    _scope_jsii_calc_base_of_base_49fa37fe.IVeryBaseInterface,
     typing_extensions.Protocol,
 ):
     @jsii.member(jsii_name="bar")
@@ -416,7 +416,7 @@ class IBaseInterface(
 
 
 class _IBaseInterfaceProxy(
-    jsii.proxy_for(scope.jsii_calc_base_of_base.IVeryBaseInterface), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_base_of_base_49fa37fe.IVeryBaseInterface), # type: ignore[misc]
 ):
     __jsii_type__: typing.ClassVar[str] = "@scope/jsii-calc-base.IBaseInterface"
 
@@ -503,20 +503,14 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/ 
 exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base/__init__.py	--runtime-type-checking
-@@ -50,10 +50,20 @@
+@@ -50,10 +50,14 @@
      ) -> None:
          '''
          :param foo: -
          :param bar: -
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                foo: scope.jsii_calc_base_of_base.Very,
-+                bar: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e2d8a566db7d86eb1cb511cb869273dae39a21b3ad7041359aabb7bd283dcfef)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -524,22 +518,40 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
              "bar": bar,
          }
  
-@@ -117,10 +127,15 @@
+@@ -117,10 +121,13 @@
      @builtins.classmethod
      def consume(cls, *args: typing.Any) -> None:
          '''
          :param args: -
          '''
 +        if __debug__:
-+            def stub(*args: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__66400f6ebe2f9a3fbb550342b894bebf4f5368890843f3917e2b903f62d48b38)
 +            check_type(argname="argument args", value=args, expected_type=typing.Tuple[type_hints["args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*args]))
  
  
  __all__ = [
      "Base",
+@@ -128,5 +135,19 @@
+     "IBaseInterface",
+     "StaticConsumer",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__e2d8a566db7d86eb1cb511cb869273dae39a21b3ad7041359aabb7bd283dcfef(
++    *,
++    foo: _scope_jsii_calc_base_of_base_49fa37fe.Very,
++    bar: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__66400f6ebe2f9a3fbb550342b894bebf4f5368890843f3917e2b903f62d48b38(
++    *args: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
@@ -1016,38 +1028,53 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base_of_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base_of_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base_of_base/__init__.py	--runtime-type-checking
-@@ -39,10 +39,15 @@
+@@ -39,10 +39,13 @@
      @builtins.classmethod
      def consume(cls, *_args: typing.Any) -> None:
          '''
          :param _args: -
          '''
 +        if __debug__:
-+            def stub(*_args: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__740535cda6ecbc578919a2921dd1fa0b87c5dd735a2acd391963310cdf59f47c)
 +            check_type(argname="argument _args", value=_args, expected_type=typing.Tuple[type_hints["_args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*_args]))
  
  
  class Very(metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-base-of-base.Very"):
      '''(experimental) Something here.
-@@ -69,10 +74,15 @@
+@@ -69,10 +72,13 @@
  class VeryBaseProps:
      def __init__(self, *, foo: Very) -> None:
          '''
          :param foo: -
          '''
 +        if __debug__:
-+            def stub(*, foo: Very) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c314d9d6951cb6f41a208c5feb55cc9d30da774b67f6d47cb4fa13215b96f2b9)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
+@@ -99,5 +105,18 @@
+     "Very",
+     "VeryBaseProps",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__740535cda6ecbc578919a2921dd1fa0b87c5dd735a2acd391963310cdf59f47c(
++    *_args: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c314d9d6951cb6f41a208c5feb55cc9d30da774b67f6d47cb4fa13215b96f2b9(
++    *,
++    foo: Very,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
@@ -1394,8 +1421,8 @@ from typeguard import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_base_of_base
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
 
 
 class BaseFor2647(
@@ -1412,7 +1439,7 @@ class BaseFor2647(
     :stability: deprecated
     '''
 
-    def __init__(self, very: scope.jsii_calc_base_of_base.Very) -> None:
+    def __init__(self, very: _scope_jsii_calc_base_of_base_49fa37fe.Very) -> None:
         '''
         :param very: -
 
@@ -1421,7 +1448,7 @@ class BaseFor2647(
         jsii.create(self.__class__, self, [very])
 
     @jsii.member(jsii_name="foo")
-    def foo(self, obj: scope.jsii_calc_base.IBaseInterface) -> None:
+    def foo(self, obj: _scope_jsii_calc_base_734f0262.IBaseInterface) -> None:
         '''
         :param obj: -
 
@@ -1633,7 +1660,7 @@ typing.cast(typing.Any, IFriendly).__jsii_proxy_class__ = lambda : _IFriendlyPro
 
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IThreeLevelsInterface")
 class IThreeLevelsInterface(
-    scope.jsii_calc_base.IBaseInterface,
+    _scope_jsii_calc_base_734f0262.IBaseInterface,
     typing_extensions.Protocol,
 ):
     '''(deprecated) Interface that inherits from packages 2 levels up the tree.
@@ -1653,7 +1680,7 @@ class IThreeLevelsInterface(
 
 
 class _IThreeLevelsInterfaceProxy(
-    jsii.proxy_for(scope.jsii_calc_base.IBaseInterface), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_base_734f0262.IBaseInterface), # type: ignore[misc]
 ):
     '''(deprecated) Interface that inherits from packages 2 levels up the tree.
 
@@ -1749,7 +1776,7 @@ class MyFirstStruct:
 
 
 class NumericValue(
-    scope.jsii_calc_base.Base,
+    _scope_jsii_calc_base_734f0262.Base,
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="@scope/jsii-calc-lib.NumericValue",
 ):
@@ -1782,7 +1809,7 @@ class NumericValue(
 
 class _NumericValueProxy(
     NumericValue,
-    jsii.proxy_for(scope.jsii_calc_base.Base), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_base_734f0262.Base), # type: ignore[misc]
 ):
     @builtins.property
     @jsii.member(jsii_name="value")
@@ -2306,50 +2333,40 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/ 1
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/__init__.py	--runtime-type-checking
-@@ -34,19 +34,29 @@
+@@ -34,19 +34,25 @@
          '''
          :param very: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(very: scope.jsii_calc_base_of_base.Very) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__46512218b53da06690990919b41a88d6c2379b11ef0a3243cf6d60add5197ae2)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
      @jsii.member(jsii_name="foo")
-     def foo(self, obj: scope.jsii_calc_base.IBaseInterface) -> None:
+     def foo(self, obj: _scope_jsii_calc_base_734f0262.IBaseInterface) -> None:
          '''
          :param obj: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(obj: scope.jsii_calc_base.IBaseInterface) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e721760a6f0cb2ba909986665323a1f1f880769c379ae1f2ad0dbadf80ee9016)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(None, jsii.invoke(self, "foo", [obj]))
  
  
  @jsii.data_type(
      jsii_type="@scope/jsii-calc-lib.DiamondLeft",
-@@ -64,10 +74,20 @@
+@@ -64,10 +70,14 @@
          :param hoisted_top: 
          :param left: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                hoisted_top: typing.Optional[builtins.str] = None,
-+                left: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__969bc4b33aa2d0684b20d440803d81dfda55aa9fa6398ac40f1afafc2114db5a)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -2357,20 +2374,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -116,10 +136,20 @@
+@@ -116,10 +126,14 @@
          :param hoisted_top: 
          :param right: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                hoisted_top: typing.Optional[builtins.str] = None,
-+                right: typing.Optional[builtins.bool] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__31f7eac552107efa0a4275f6798b003fcc3b6e74e0a463ae709af8b660b91dc4)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -2378,21 +2389,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if right is not None:
              self._values["right"] = right
-@@ -317,10 +347,22 @@
+@@ -317,10 +331,15 @@
          :param astring: (deprecated) A string value.
          :param first_optional: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                anumber: jsii.Number,
-+                astring: builtins.str,
-+                first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__de81edc65427ea9129fd035388008307a6cae942eefc63cb3d9fd8b42956da06)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
 +            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
@@ -2401,21 +2405,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              "astring": astring,
          }
          if first_optional is not None:
-@@ -477,10 +519,22 @@
+@@ -477,10 +496,15 @@
          :param optional2: 
          :param optional3: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                optional1: typing.Optional[builtins.str] = None,
-+                optional2: typing.Optional[jsii.Number] = None,
-+                optional3: typing.Optional[builtins.bool] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__82b4e5e8f3b46996124a87aac13a874f61bf9660a45a062bafa08046c027da63)
 +            check_type(argname="argument optional1", value=optional1, expected_type=type_hints["optional1"])
 +            check_type(argname="argument optional2", value=optional2, expected_type=type_hints["optional2"])
 +            check_type(argname="argument optional3", value=optional3, expected_type=type_hints["optional3"])
@@ -2424,53 +2421,105 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["optional1"] = optional1
          if optional2 is not None:
              self._values["optional2"] = optional2
-@@ -540,10 +594,15 @@
+@@ -540,10 +564,13 @@
  
          :param value: The number.
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__adff4f4d0383c32ffdeb0bca92ae1ea2ebe0b2ea8d9bf5f5433287cc06e55e07)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
      @builtins.property
      @jsii.member(jsii_name="doubleValue")
      def double_value(self) -> jsii.Number:
+@@ -583,5 +610,57 @@
+ publication.publish()
+ 
+ # Loading modules to ensure their types are registered with the jsii runtime library
+ from . import custom_submodule_name
+ from . import deprecation_removal
++
++def _typecheckingstub__46512218b53da06690990919b41a88d6c2379b11ef0a3243cf6d60add5197ae2(
++    very: _scope_jsii_calc_base_of_base_49fa37fe.Very,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e721760a6f0cb2ba909986665323a1f1f880769c379ae1f2ad0dbadf80ee9016(
++    obj: _scope_jsii_calc_base_734f0262.IBaseInterface,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__969bc4b33aa2d0684b20d440803d81dfda55aa9fa6398ac40f1afafc2114db5a(
++    *,
++    hoisted_top: typing.Optional[builtins.str] = None,
++    left: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__31f7eac552107efa0a4275f6798b003fcc3b6e74e0a463ae709af8b660b91dc4(
++    *,
++    hoisted_top: typing.Optional[builtins.str] = None,
++    right: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__de81edc65427ea9129fd035388008307a6cae942eefc63cb3d9fd8b42956da06(
++    *,
++    anumber: jsii.Number,
++    astring: builtins.str,
++    first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__82b4e5e8f3b46996124a87aac13a874f61bf9660a45a062bafa08046c027da63(
++    *,
++    optional1: typing.Optional[builtins.str] = None,
++    optional2: typing.Optional[jsii.Number] = None,
++    optional3: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__adff4f4d0383c32ffdeb0bca92ae1ea2ebe0b2ea8d9bf5f5433287cc06e55e07(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--runtime-type-checking
-@@ -97,10 +97,15 @@
+@@ -97,10 +97,13 @@
  
              :param name: 
  
              :stability: deprecated
              '''
 +            if __debug__:
-+                def stub(*, name: builtins.str) -> None:
-+                    ...
-+                type_hints = typing.get_type_hints(stub)
++                type_hints = typing.get_type_hints(_typecheckingstub__5c03ed6e0d395f6fa262d12c7831dd2893af2098bf580a0c602a20f92c1ad24b)
 +                check_type(argname="argument name", value=name, expected_type=type_hints["name"])
              self._values: typing.Dict[str, typing.Any] = {
                  "name": name,
              }
  
          @builtins.property
-@@ -135,10 +140,16 @@
+@@ -135,10 +138,14 @@
          :param key: 
          :param value: 
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(*, key: builtins.str, value: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__301126f287c0bfbbd3cb015833c5e0b2ced77e73d25597215c917612b67c3331)
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -2478,22 +2527,47 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              "value": value,
          }
  
-@@ -194,10 +205,15 @@
+@@ -194,10 +201,13 @@
          '''
          :param reflectable: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(reflectable: IReflectable) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__bed3b5b08c611933987ef5d9dfc131289e09ebcd26286417337c3708ca054e9f)
 +            check_type(argname="argument reflectable", value=reflectable, expected_type=type_hints["reflectable"])
          return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
  
  
  __all__ = [
      "IReflectable",
+@@ -205,5 +215,26 @@
+     "ReflectableEntry",
+     "Reflector",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__5c03ed6e0d395f6fa262d12c7831dd2893af2098bf580a0c602a20f92c1ad24b(
++    *,
++    name: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__301126f287c0bfbbd3cb015833c5e0b2ced77e73d25597215c917612b67c3331(
++    *,
++    key: builtins.str,
++    value: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__bed3b5b08c611933987ef5d9dfc131289e09ebcd26286417337c3708ca054e9f(
++    reflectable: IReflectable,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
@@ -3000,10 +3074,10 @@ from typeguard import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_base_of_base
-import scope.jsii_calc_lib
-import scope.jsii_calc_lib.custom_submodule_name
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+import scope.jsii_calc_lib.custom_submodule_name as _scope_jsii_calc_lib_custom_submodule_name_c61f082f
 from .composition import CompositeOperation as _CompositeOperation_1c4d123b
 
 
@@ -3217,13 +3291,15 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
 
     @builtins.property
     @jsii.member(jsii_name="mapProperty")
-    def map_property(self) -> typing.Mapping[builtins.str, scope.jsii_calc_lib.Number]:
-        return typing.cast(typing.Mapping[builtins.str, scope.jsii_calc_lib.Number], jsii.get(self, "mapProperty"))
+    def map_property(
+        self,
+    ) -> typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.Number]:
+        return typing.cast(typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.Number], jsii.get(self, "mapProperty"))
 
     @map_property.setter
     def map_property(
         self,
-        value: typing.Mapping[builtins.str, scope.jsii_calc_lib.Number],
+        value: typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.Number],
     ) -> None:
         jsii.set(self, "mapProperty", value)
 
@@ -3249,13 +3325,13 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @jsii.member(jsii_name="unionArrayProperty")
     def union_array_property(
         self,
-    ) -> typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]]:
-        return typing.cast(typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]], jsii.get(self, "unionArrayProperty"))
+    ) -> typing.List[typing.Union[jsii.Number, _scope_jsii_calc_lib_c61f082f.NumericValue]]:
+        return typing.cast(typing.List[typing.Union[jsii.Number, _scope_jsii_calc_lib_c61f082f.NumericValue]], jsii.get(self, "unionArrayProperty"))
 
     @union_array_property.setter
     def union_array_property(
         self,
-        value: typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]],
+        value: typing.List[typing.Union[jsii.Number, _scope_jsii_calc_lib_c61f082f.NumericValue]],
     ) -> None:
         jsii.set(self, "unionArrayProperty", value)
 
@@ -3263,13 +3339,13 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @jsii.member(jsii_name="unionMapProperty")
     def union_map_property(
         self,
-    ) -> typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]]:
-        return typing.cast(typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]], jsii.get(self, "unionMapProperty"))
+    ) -> typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number]]:
+        return typing.cast(typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number]], jsii.get(self, "unionMapProperty"))
 
     @union_map_property.setter
     def union_map_property(
         self,
-        value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]],
+        value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number]],
     ) -> None:
         jsii.set(self, "unionMapProperty", value)
 
@@ -3277,13 +3353,13 @@ class AllTypes(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.AllTypes"):
     @jsii.member(jsii_name="unionProperty")
     def union_property(
         self,
-    ) -> typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"]:
-        return typing.cast(typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"], jsii.get(self, "unionProperty"))
+    ) -> typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number, "Multiply"]:
+        return typing.cast(typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number, "Multiply"], jsii.get(self, "unionProperty"))
 
     @union_property.setter
     def union_property(
         self,
-        value: typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"],
+        value: typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number, "Multiply"],
     ) -> None:
         jsii.set(self, "unionProperty", value)
 
@@ -3488,9 +3564,9 @@ class BaseJsii976(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.BaseJsii976"):
         jsii.create(self.__class__, self, [])
 
 
-@jsii.implements(scope.jsii_calc_lib.IFriendly)
+@jsii.implements(_scope_jsii_calc_lib_c61f082f.IFriendly)
 class BinaryOperation(
-    scope.jsii_calc_lib.Operation,
+    _scope_jsii_calc_lib_c61f082f.Operation,
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.BinaryOperation",
 ):
@@ -3498,8 +3574,8 @@ class BinaryOperation(
 
     def __init__(
         self,
-        lhs: scope.jsii_calc_lib.NumericValue,
-        rhs: scope.jsii_calc_lib.NumericValue,
+        lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
+        rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
     ) -> None:
         '''Creates a BinaryOperation.
 
@@ -3515,20 +3591,20 @@ class BinaryOperation(
 
     @builtins.property
     @jsii.member(jsii_name="lhs")
-    def lhs(self) -> scope.jsii_calc_lib.NumericValue:
+    def lhs(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''Left-hand side operand.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "lhs"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "lhs"))
 
     @builtins.property
     @jsii.member(jsii_name="rhs")
-    def rhs(self) -> scope.jsii_calc_lib.NumericValue:
+    def rhs(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''Right-hand side operand.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "rhs"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "rhs"))
 
 
 class _BinaryOperationProxy(
     BinaryOperation,
-    jsii.proxy_for(scope.jsii_calc_lib.Operation), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_lib_c61f082f.Operation), # type: ignore[misc]
 ):
     pass
 
@@ -3653,32 +3729,32 @@ class Calculator(
 
     @builtins.property
     @jsii.member(jsii_name="expression")
-    def expression(self) -> scope.jsii_calc_lib.NumericValue:
+    def expression(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''Returns the expression.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property
     @jsii.member(jsii_name="operationsLog")
-    def operations_log(self) -> typing.List[scope.jsii_calc_lib.NumericValue]:
+    def operations_log(self) -> typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue]:
         '''A log of all operations.'''
-        return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "operationsLog"))
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue], jsii.get(self, "operationsLog"))
 
     @builtins.property
     @jsii.member(jsii_name="operationsMap")
     def operations_map(
         self,
-    ) -> typing.Mapping[builtins.str, typing.List[scope.jsii_calc_lib.NumericValue]]:
+    ) -> typing.Mapping[builtins.str, typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue]]:
         '''A map of per operation name of all operations performed.'''
-        return typing.cast(typing.Mapping[builtins.str, typing.List[scope.jsii_calc_lib.NumericValue]], jsii.get(self, "operationsMap"))
+        return typing.cast(typing.Mapping[builtins.str, typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue]], jsii.get(self, "operationsMap"))
 
     @builtins.property
     @jsii.member(jsii_name="curr")
-    def curr(self) -> scope.jsii_calc_lib.NumericValue:
+    def curr(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The current value.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "curr"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "curr"))
 
     @curr.setter
-    def curr(self, value: scope.jsii_calc_lib.NumericValue) -> None:
+    def curr(self, value: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
         jsii.set(self, "curr", value)
 
     @builtins.property
@@ -4010,13 +4086,13 @@ class ConfusingToJackson(
     @jsii.member(jsii_name="unionProperty")
     def union_property(
         self,
-    ) -> typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]]:
-        return typing.cast(typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]], jsii.get(self, "unionProperty"))
+    ) -> typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]]:
+        return typing.cast(typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]], jsii.get(self, "unionProperty"))
 
     @union_property.setter
     def union_property(
         self,
-        value: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]],
+        value: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]],
     ) -> None:
         jsii.set(self, "unionProperty", value)
 
@@ -4030,7 +4106,7 @@ class ConfusingToJacksonStruct:
     def __init__(
         self,
         *,
-        union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.Sequence[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]] = None,
+        union_property: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.Sequence[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]] = None,
     ) -> None:
         '''
         :param union_property: 
@@ -4042,9 +4118,9 @@ class ConfusingToJacksonStruct:
     @builtins.property
     def union_property(
         self,
-    ) -> typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]]:
+    ) -> typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]]:
         result = self._values.get("union_property")
-        return typing.cast(typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]], result)
+        return typing.cast(typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]], result)
 
     def __eq__(self, rhs: typing.Any) -> builtins.bool:
         return isinstance(rhs, self.__class__) and rhs._values == self._values
@@ -4333,7 +4409,7 @@ class DataRenderer(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DataRenderer"):
         :param astring: (deprecated) A string value.
         :param first_optional: 
         '''
-        data = scope.jsii_calc_lib.MyFirstStruct(
+        data = _scope_jsii_calc_lib_c61f082f.MyFirstStruct(
             anumber=anumber, astring=astring, first_optional=first_optional
         )
 
@@ -4548,7 +4624,7 @@ class DeprecatedStruct:
 
 @jsii.data_type(
     jsii_type="jsii-calc.DerivedStruct",
-    jsii_struct_bases=[scope.jsii_calc_lib.MyFirstStruct],
+    jsii_struct_bases=[_scope_jsii_calc_lib_c61f082f.MyFirstStruct],
     name_mapping={
         "anumber": "anumber",
         "astring": "astring",
@@ -4561,7 +4637,7 @@ class DeprecatedStruct:
         "optional_array": "optionalArray",
     },
 )
-class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
+class DerivedStruct(_scope_jsii_calc_lib_c61f082f.MyFirstStruct):
     def __init__(
         self,
         *,
@@ -4571,7 +4647,7 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
         another_required: datetime.datetime,
         bool: builtins.bool,
         non_primitive: "DoubleTrouble",
-        another_optional: typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]] = None,
+        another_optional: typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]] = None,
         optional_any: typing.Any = None,
         optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
     ) -> None:
@@ -4653,10 +4729,10 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
     @builtins.property
     def another_optional(
         self,
-    ) -> typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]]:
+    ) -> typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]]:
         '''This is optional.'''
         result = self._values.get("another_optional")
-        return typing.cast(typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]], result)
+        return typing.cast(typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]], result)
 
     @builtins.property
     def optional_any(self) -> typing.Any:
@@ -4683,7 +4759,8 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
 @jsii.data_type(
     jsii_type="jsii-calc.DiamondBottom",
     jsii_struct_bases=[
-        scope.jsii_calc_lib.DiamondLeft, scope.jsii_calc_lib.DiamondRight
+        _scope_jsii_calc_lib_c61f082f.DiamondLeft,
+        _scope_jsii_calc_lib_c61f082f.DiamondRight,
     ],
     name_mapping={
         "hoisted_top": "hoistedTop",
@@ -4692,7 +4769,10 @@ class DerivedStruct(scope.jsii_calc_lib.MyFirstStruct):
         "bottom": "bottom",
     },
 )
-class DiamondBottom(scope.jsii_calc_lib.DiamondLeft, scope.jsii_calc_lib.DiamondRight):
+class DiamondBottom(
+    _scope_jsii_calc_lib_c61f082f.DiamondLeft,
+    _scope_jsii_calc_lib_c61f082f.DiamondRight,
+):
     def __init__(
         self,
         *,
@@ -5597,13 +5677,13 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         another_required: datetime.datetime,
         bool: builtins.bool,
         non_primitive: "DoubleTrouble",
-        another_optional: typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]] = None,
+        another_optional: typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]] = None,
         optional_any: typing.Any = None,
         optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
         anumber: jsii.Number,
         astring: builtins.str,
         first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
-    ) -> scope.jsii_calc_lib.MyFirstStruct:
+    ) -> _scope_jsii_calc_lib_c61f082f.MyFirstStruct:
         '''Accepts a struct of type DerivedStruct and returns a struct of type FirstStruct.
 
         :param another_required: 
@@ -5628,7 +5708,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
             first_optional=first_optional,
         )
 
-        return typing.cast(scope.jsii_calc_lib.MyFirstStruct, jsii.invoke(self, "derivedToFirst", [derived]))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.MyFirstStruct, jsii.invoke(self, "derivedToFirst", [derived]))
 
     @jsii.member(jsii_name="readDerivedNonPrimitive")
     def read_derived_non_primitive(
@@ -5637,7 +5717,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         another_required: datetime.datetime,
         bool: builtins.bool,
         non_primitive: "DoubleTrouble",
-        another_optional: typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]] = None,
+        another_optional: typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]] = None,
         optional_any: typing.Any = None,
         optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
         anumber: jsii.Number,
@@ -5684,7 +5764,7 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
         :param astring: (deprecated) A string value.
         :param first_optional: 
         '''
-        first = scope.jsii_calc_lib.MyFirstStruct(
+        first = _scope_jsii_calc_lib_c61f082f.MyFirstStruct(
             anumber=anumber, astring=astring, first_optional=first_optional
         )
 
@@ -5692,8 +5772,8 @@ class GiveMeStructs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.GiveMeStructs"
 
     @builtins.property
     @jsii.member(jsii_name="structLiteral")
-    def struct_literal(self) -> scope.jsii_calc_lib.StructWithOnlyOptionals:
-        return typing.cast(scope.jsii_calc_lib.StructWithOnlyOptionals, jsii.get(self, "structLiteral"))
+    def struct_literal(self) -> _scope_jsii_calc_lib_c61f082f.StructWithOnlyOptionals:
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.StructWithOnlyOptionals, jsii.get(self, "structLiteral"))
 
 
 @jsii.data_type(
@@ -5740,7 +5820,10 @@ class GreetingAugmenter(
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="betterGreeting")
-    def better_greeting(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
+    def better_greeting(
+        self,
+        friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
+    ) -> builtins.str:
         '''
         :param friendly: -
         '''
@@ -6126,7 +6209,7 @@ typing.cast(typing.Any, IExternalInterface).__jsii_proxy_class__ = lambda : _IEx
 
 
 @jsii.interface(jsii_type="jsii-calc.IFriendlier")
-class IFriendlier(scope.jsii_calc_lib.IFriendly, typing_extensions.Protocol):
+class IFriendlier(_scope_jsii_calc_lib_c61f082f.IFriendly, typing_extensions.Protocol):
     '''Even friendlier classes can implement this interface.'''
 
     @jsii.member(jsii_name="farewell")
@@ -6144,7 +6227,7 @@ class IFriendlier(scope.jsii_calc_lib.IFriendly, typing_extensions.Protocol):
 
 
 class _IFriendlierProxy(
-    jsii.proxy_for(scope.jsii_calc_lib.IFriendly), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_lib_c61f082f.IFriendly), # type: ignore[misc]
 ):
     '''Even friendlier classes can implement this interface.'''
 
@@ -7121,11 +7204,11 @@ typing.cast(typing.Any, IReturnJsii976).__jsii_proxy_class__ = lambda : _IReturn
 class IReturnsNumber(typing_extensions.Protocol):
     @builtins.property
     @jsii.member(jsii_name="numberProp")
-    def number_prop(self) -> scope.jsii_calc_lib.Number:
+    def number_prop(self) -> _scope_jsii_calc_lib_c61f082f.Number:
         ...
 
     @jsii.member(jsii_name="obtainNumber")
-    def obtain_number(self) -> scope.jsii_calc_lib.IDoublable:
+    def obtain_number(self) -> _scope_jsii_calc_lib_c61f082f.IDoublable:
         ...
 
 
@@ -7134,12 +7217,12 @@ class _IReturnsNumberProxy:
 
     @builtins.property
     @jsii.member(jsii_name="numberProp")
-    def number_prop(self) -> scope.jsii_calc_lib.Number:
-        return typing.cast(scope.jsii_calc_lib.Number, jsii.get(self, "numberProp"))
+    def number_prop(self) -> _scope_jsii_calc_lib_c61f082f.Number:
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.Number, jsii.get(self, "numberProp"))
 
     @jsii.member(jsii_name="obtainNumber")
-    def obtain_number(self) -> scope.jsii_calc_lib.IDoublable:
-        return typing.cast(scope.jsii_calc_lib.IDoublable, jsii.invoke(self, "obtainNumber", []))
+    def obtain_number(self) -> _scope_jsii_calc_lib_c61f082f.IDoublable:
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.IDoublable, jsii.invoke(self, "obtainNumber", []))
 
 # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
 typing.cast(typing.Any, IReturnsNumber).__jsii_proxy_class__ = lambda : _IReturnsNumberProxy
@@ -7295,14 +7378,14 @@ class ImplementsPrivateInterface(
 
 @jsii.data_type(
     jsii_type="jsii-calc.ImplictBaseOfBase",
-    jsii_struct_bases=[scope.jsii_calc_base.BaseProps],
+    jsii_struct_bases=[_scope_jsii_calc_base_734f0262.BaseProps],
     name_mapping={"foo": "foo", "bar": "bar", "goo": "goo"},
 )
-class ImplictBaseOfBase(scope.jsii_calc_base.BaseProps):
+class ImplictBaseOfBase(_scope_jsii_calc_base_734f0262.BaseProps):
     def __init__(
         self,
         *,
-        foo: scope.jsii_calc_base_of_base.Very,
+        foo: _scope_jsii_calc_base_of_base_49fa37fe.Very,
         bar: builtins.str,
         goo: datetime.datetime,
     ) -> None:
@@ -7318,10 +7401,10 @@ class ImplictBaseOfBase(scope.jsii_calc_base.BaseProps):
         }
 
     @builtins.property
-    def foo(self) -> scope.jsii_calc_base_of_base.Very:
+    def foo(self) -> _scope_jsii_calc_base_of_base_49fa37fe.Very:
         result = self._values.get("foo")
         assert result is not None, "Required property 'foo' is missing"
-        return typing.cast(scope.jsii_calc_base_of_base.Very, result)
+        return typing.cast(_scope_jsii_calc_base_of_base_49fa37fe.Very, result)
 
     @builtins.property
     def bar(self) -> builtins.str:
@@ -7385,11 +7468,11 @@ class InterfacesMaker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.InterfacesMa
     def make_interfaces(
         cls,
         count: jsii.Number,
-    ) -> typing.List[scope.jsii_calc_lib.IDoublable]:
+    ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
         '''
         :param count: -
         '''
-        return typing.cast(typing.List[scope.jsii_calc_lib.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
 
 
 class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
@@ -7463,8 +7546,8 @@ class JSObjectLiteralForInterface(
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="giveMeFriendly")
-    def give_me_friendly(self) -> scope.jsii_calc_lib.IFriendly:
-        return typing.cast(scope.jsii_calc_lib.IFriendly, jsii.invoke(self, "giveMeFriendly", []))
+    def give_me_friendly(self) -> _scope_jsii_calc_lib_c61f082f.IFriendly:
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.IFriendly, jsii.invoke(self, "giveMeFriendly", []))
 
     @jsii.member(jsii_name="giveMeFriendlyGenerator")
     def give_me_friendly_generator(self) -> "IFriendlyRandomGenerator":
@@ -8117,8 +8200,8 @@ class Multiply(
 
     def __init__(
         self,
-        lhs: scope.jsii_calc_lib.NumericValue,
-        rhs: scope.jsii_calc_lib.NumericValue,
+        lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
+        rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
     ) -> None:
         '''Creates a BinaryOperation.
 
@@ -8162,8 +8245,8 @@ class NestedClassInstance(
     @builtins.classmethod
     def make_instance(
         cls,
-    ) -> scope.jsii_calc_lib.custom_submodule_name.NestingClass.NestedClass:
-        return typing.cast(scope.jsii_calc_lib.custom_submodule_name.NestingClass.NestedClass, jsii.sinvoke(cls, "makeInstance", []))
+    ) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.NestingClass.NestedClass:
+        return typing.cast(_scope_jsii_calc_lib_custom_submodule_name_c61f082f.NestingClass.NestedClass, jsii.sinvoke(cls, "makeInstance", []))
 
 
 @jsii.data_type(
@@ -8383,7 +8466,7 @@ class ObjectRefsInCollections(
     @jsii.member(jsii_name="sumFromArray")
     def sum_from_array(
         self,
-        values: typing.Sequence[scope.jsii_calc_lib.NumericValue],
+        values: typing.Sequence[_scope_jsii_calc_lib_c61f082f.NumericValue],
     ) -> jsii.Number:
         '''Returns the sum of all values.
 
@@ -8394,7 +8477,7 @@ class ObjectRefsInCollections(
     @jsii.member(jsii_name="sumFromMap")
     def sum_from_map(
         self,
-        values: typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue],
+        values: typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue],
     ) -> jsii.Number:
         '''Returns the sum of all values in a map.
 
@@ -8595,6 +8678,29 @@ class OverrideReturnsObject(
         return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
 
 
+class ParamShadowsScope(
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.ParamShadowsScope",
+):
+    '''Validate that namespaces being shadowed by local variables does not cause type checking issues.
+
+    :see: https://github.com/aws/aws-cdk/issues/22975
+    '''
+
+    def __init__(self) -> None:
+        jsii.create(self.__class__, self, [])
+
+    @jsii.member(jsii_name="useScope")
+    def use_scope(
+        self,
+        scope: _scope_jsii_calc_lib_c61f082f.Number,
+    ) -> _scope_jsii_calc_lib_c61f082f.Number:
+        '''
+        :param scope: -
+        '''
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.Number, jsii.invoke(self, "useScope", [scope]))
+
+
 @jsii.data_type(
     jsii_type="jsii-calc.ParentStruct982",
     jsii_struct_bases=[],
@@ -8675,7 +8781,10 @@ class Polymorphism(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Polymorphism"):
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="sayHello")
-    def say_hello(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
+    def say_hello(
+        self,
+        friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
+    ) -> builtins.str:
         '''
         :param friendly: -
         '''
@@ -8691,8 +8800,8 @@ class Power(
 
     def __init__(
         self,
-        base: scope.jsii_calc_lib.NumericValue,
-        pow: scope.jsii_calc_lib.NumericValue,
+        base: _scope_jsii_calc_lib_c61f082f.NumericValue,
+        pow: _scope_jsii_calc_lib_c61f082f.NumericValue,
     ) -> None:
         '''Creates a Power operation.
 
@@ -8703,24 +8812,24 @@ class Power(
 
     @builtins.property
     @jsii.member(jsii_name="base")
-    def base(self) -> scope.jsii_calc_lib.NumericValue:
+    def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The base of the power.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "base"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "base"))
 
     @builtins.property
     @jsii.member(jsii_name="expression")
-    def expression(self) -> scope.jsii_calc_lib.NumericValue:
+    def expression(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
         '''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property
     @jsii.member(jsii_name="pow")
-    def pow(self) -> scope.jsii_calc_lib.NumericValue:
+    def pow(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The number of times to multiply.'''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "pow"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "pow"))
 
 
 class PropertyNamedProperty(
@@ -8898,11 +9007,16 @@ class ReferenceEnumFromScopedPackage(
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="loadFoo")
-    def load_foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
-        return typing.cast(typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule], jsii.invoke(self, "loadFoo", []))
+    def load_foo(
+        self,
+    ) -> typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule]:
+        return typing.cast(typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule], jsii.invoke(self, "loadFoo", []))
 
     @jsii.member(jsii_name="saveFoo")
-    def save_foo(self, value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
+    def save_foo(
+        self,
+        value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
+    ) -> None:
         '''
         :param value: -
         '''
@@ -8910,13 +9024,15 @@ class ReferenceEnumFromScopedPackage(
 
     @builtins.property
     @jsii.member(jsii_name="foo")
-    def foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
-        return typing.cast(typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule], jsii.get(self, "foo"))
+    def foo(
+        self,
+    ) -> typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule]:
+        return typing.cast(typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule], jsii.get(self, "foo"))
 
     @foo.setter
     def foo(
         self,
-        value: typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule],
+        value: typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule],
     ) -> None:
         jsii.set(self, "foo", value)
 
@@ -9855,21 +9971,24 @@ class Sum(
 
     @builtins.property
     @jsii.member(jsii_name="expression")
-    def expression(self) -> scope.jsii_calc_lib.NumericValue:
+    def expression(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
         '''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "expression"))
 
     @builtins.property
     @jsii.member(jsii_name="parts")
-    def parts(self) -> typing.List[scope.jsii_calc_lib.NumericValue]:
+    def parts(self) -> typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue]:
         '''The parts to sum.'''
-        return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "parts"))
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue], jsii.get(self, "parts"))
 
     @parts.setter
-    def parts(self, value: typing.List[scope.jsii_calc_lib.NumericValue]) -> None:
+    def parts(
+        self,
+        value: typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue],
+    ) -> None:
         jsii.set(self, "parts", value)
 
 
@@ -10239,13 +10358,13 @@ class UmaskCheck(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UmaskCheck"):
 
 
 class UnaryOperation(
-    scope.jsii_calc_lib.Operation,
+    _scope_jsii_calc_lib_c61f082f.Operation,
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.UnaryOperation",
 ):
     '''An operation on a single operand.'''
 
-    def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
+    def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
         '''
         :param operand: -
         '''
@@ -10253,13 +10372,13 @@ class UnaryOperation(
 
     @builtins.property
     @jsii.member(jsii_name="operand")
-    def operand(self) -> scope.jsii_calc_lib.NumericValue:
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "operand"))
+    def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "operand"))
 
 
 class _UnaryOperationProxy(
     UnaryOperation,
-    jsii.proxy_for(scope.jsii_calc_lib.Operation), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_lib_c61f082f.Operation), # type: ignore[misc]
 ):
     pass
 
@@ -10312,7 +10431,7 @@ class UnionProperties:
         )
 
 
-@jsii.implements(scope.jsii_calc_lib.custom_submodule_name.IReflectable)
+@jsii.implements(_scope_jsii_calc_lib_custom_submodule_name_c61f082f.IReflectable)
 class UpcasingReflectable(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.UpcasingReflectable",
@@ -10327,15 +10446,15 @@ class UpcasingReflectable(
 
     @jsii.python.classproperty
     @jsii.member(jsii_name="reflector")
-    def REFLECTOR(cls) -> scope.jsii_calc_lib.custom_submodule_name.Reflector:
-        return typing.cast(scope.jsii_calc_lib.custom_submodule_name.Reflector, jsii.sget(cls, "reflector"))
+    def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
+        return typing.cast(_scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector, jsii.sget(cls, "reflector"))
 
     @builtins.property
     @jsii.member(jsii_name="entries")
     def entries(
         self,
-    ) -> typing.List[scope.jsii_calc_lib.custom_submodule_name.ReflectableEntry]:
-        return typing.cast(typing.List[scope.jsii_calc_lib.custom_submodule_name.ReflectableEntry], jsii.get(self, "entries"))
+    ) -> typing.List[_scope_jsii_calc_lib_custom_submodule_name_c61f082f.ReflectableEntry]:
+        return typing.cast(typing.List[_scope_jsii_calc_lib_custom_submodule_name_c61f082f.ReflectableEntry], jsii.get(self, "entries"))
 
 
 class UseBundledDependency(
@@ -10357,8 +10476,8 @@ class UseCalcBase(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.UseCalcBase"):
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="hello")
-    def hello(self) -> scope.jsii_calc_base.Base:
-        return typing.cast(scope.jsii_calc_base.Base, jsii.invoke(self, "hello", []))
+    def hello(self) -> _scope_jsii_calc_base_734f0262.Base:
+        return typing.cast(_scope_jsii_calc_base_734f0262.Base, jsii.invoke(self, "hello", []))
 
 
 class UsesInterfaceWithProperties(
@@ -10599,8 +10718,8 @@ class Add(BinaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Add"):
 
     def __init__(
         self,
-        lhs: scope.jsii_calc_lib.NumericValue,
-        rhs: scope.jsii_calc_lib.NumericValue,
+        lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
+        rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
     ) -> None:
         '''Creates a BinaryOperation.
 
@@ -10830,7 +10949,7 @@ class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCom
 @jsii.interface(jsii_type="jsii-calc.IFriendlyRandomGenerator")
 class IFriendlyRandomGenerator(
     IRandomNumberGenerator,
-    scope.jsii_calc_lib.IFriendly,
+    _scope_jsii_calc_lib_c61f082f.IFriendly,
     typing_extensions.Protocol,
 ):
     pass
@@ -10838,7 +10957,7 @@ class IFriendlyRandomGenerator(
 
 class _IFriendlyRandomGeneratorProxy(
     jsii.proxy_for(IRandomNumberGenerator), # type: ignore[misc]
-    jsii.proxy_for(scope.jsii_calc_lib.IFriendly), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_lib_c61f082f.IFriendly), # type: ignore[misc]
 ):
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.IFriendlyRandomGenerator"
     pass
@@ -10957,7 +11076,7 @@ class JSII417Derived(
 class Negate(UnaryOperation, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Negate"):
     '''The negation operation ("-value").'''
 
-    def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
+    def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
         '''
         :param operand: -
         '''
@@ -11213,6 +11332,7 @@ __all__ = [
     "OptionalStructConsumer",
     "OverridableProtectedMember",
     "OverrideReturnsObject",
+    "ParamShadowsScope",
     "ParentStruct982",
     "PartiallyInitializedThisConsumer",
     "Polymorphism",
@@ -11588,11 +11708,11 @@ from typeguard import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 class CompositeOperation(
-    scope.jsii_calc_lib.Operation,
+    _scope_jsii_calc_lib_c61f082f.Operation,
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.composition.CompositeOperation",
 ):
@@ -11609,7 +11729,7 @@ class CompositeOperation(
     @builtins.property
     @jsii.member(jsii_name="expression")
     @abc.abstractmethod
-    def expression(self) -> scope.jsii_calc_lib.NumericValue:
+    def expression(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
@@ -11666,16 +11786,16 @@ class CompositeOperation(
 
 class _CompositeOperationProxy(
     CompositeOperation,
-    jsii.proxy_for(scope.jsii_calc_lib.Operation), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_lib_c61f082f.Operation), # type: ignore[misc]
 ):
     @builtins.property
     @jsii.member(jsii_name="expression")
-    def expression(self) -> scope.jsii_calc_lib.NumericValue:
+    def expression(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
         '''The expression that this operation consists of.
 
         Must be implemented by derived classes.
         '''
-        return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "expression"))
+        return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "expression"))
 
 # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
 typing.cast(typing.Any, CompositeOperation).__jsii_proxy_class__ = lambda : _CompositeOperationProxy
@@ -12360,13 +12480,13 @@ from typeguard import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_base_of_base
-import scope.jsii_calc_lib
+import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
-@jsii.implements(scope.jsii_calc_lib.IFriendly)
+@jsii.implements(_scope_jsii_calc_lib_c61f082f.IFriendly)
 class ExtendAndImplement(
-    scope.jsii_calc_lib.BaseFor2647,
+    _scope_jsii_calc_lib_c61f082f.BaseFor2647,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.module2647.ExtendAndImplement",
 ):
@@ -12375,7 +12495,7 @@ class ExtendAndImplement(
     :see: https://github.com/aws/jsii/issues/2647
     '''
 
-    def __init__(self, very: scope.jsii_calc_base_of_base.Very) -> None:
+    def __init__(self, very: _scope_jsii_calc_base_of_base_49fa37fe.Very) -> None:
         '''
         :param very: -
 
@@ -12448,8 +12568,8 @@ from typeguard import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_lib
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 class MyClass(
@@ -12462,7 +12582,7 @@ class MyClass(
     @jsii.member(jsii_name="bar")
     def bar(
         self,
-        _bar: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
+        _bar: typing.Mapping[builtins.str, typing.Union[_scope_jsii_calc_base_734f0262.BaseProps, typing.Dict[str, typing.Any]]],
     ) -> None:
         '''
         :param _bar: -
@@ -12470,7 +12590,10 @@ class MyClass(
         return typing.cast(None, jsii.invoke(self, "bar", [_bar]))
 
     @jsii.member(jsii_name="foo")
-    def foo(self, _values: typing.Sequence[scope.jsii_calc_lib.Number]) -> None:
+    def foo(
+        self,
+        _values: typing.Sequence[_scope_jsii_calc_lib_c61f082f.Number],
+    ) -> None:
         '''
         :param _values: -
         '''
@@ -12500,8 +12623,8 @@ from typeguard import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_lib
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.props.MyClass"):
@@ -12510,13 +12633,15 @@ class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.props.MyC
 
     @builtins.property
     @jsii.member(jsii_name="bar")
-    def bar(self) -> typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps]:
-        return typing.cast(typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps], jsii.get(self, "bar"))
+    def bar(
+        self,
+    ) -> typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps]:
+        return typing.cast(typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps], jsii.get(self, "bar"))
 
     @builtins.property
     @jsii.member(jsii_name="foo")
-    def foo(self) -> typing.List[scope.jsii_calc_lib.Number]:
-        return typing.cast(typing.List[scope.jsii_calc_lib.Number], jsii.get(self, "foo"))
+    def foo(self) -> typing.List[_scope_jsii_calc_lib_c61f082f.Number]:
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.Number], jsii.get(self, "foo"))
 
 
 __all__ = [
@@ -12542,8 +12667,8 @@ from typeguard import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_lib
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.retval.MyClass"):
@@ -12551,12 +12676,14 @@ class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.retval.My
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="bar")
-    def bar(self) -> typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps]:
-        return typing.cast(typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps], jsii.invoke(self, "bar", []))
+    def bar(
+        self,
+    ) -> typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps]:
+        return typing.cast(typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps], jsii.invoke(self, "bar", []))
 
     @jsii.member(jsii_name="foo")
-    def foo(self) -> typing.List[scope.jsii_calc_lib.Number]:
-        return typing.cast(typing.List[scope.jsii_calc_lib.Number], jsii.invoke(self, "foo", []))
+    def foo(self) -> typing.List[_scope_jsii_calc_lib_c61f082f.Number]:
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.Number], jsii.invoke(self, "foo", []))
 
 
 __all__ = [
@@ -12582,8 +12709,8 @@ from typeguard import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base
-import scope.jsii_calc_lib
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 @jsii.data_type(
@@ -12595,8 +12722,8 @@ class MyStruct:
     def __init__(
         self,
         *,
-        base_map: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
-        numbers: typing.Sequence[scope.jsii_calc_lib.Number],
+        base_map: typing.Mapping[builtins.str, typing.Union[_scope_jsii_calc_base_734f0262.BaseProps, typing.Dict[str, typing.Any]]],
+        numbers: typing.Sequence[_scope_jsii_calc_lib_c61f082f.Number],
     ) -> None:
         '''
         :param base_map: 
@@ -12608,16 +12735,18 @@ class MyStruct:
         }
 
     @builtins.property
-    def base_map(self) -> typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps]:
+    def base_map(
+        self,
+    ) -> typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps]:
         result = self._values.get("base_map")
         assert result is not None, "Required property 'base_map' is missing"
-        return typing.cast(typing.Mapping[builtins.str, scope.jsii_calc_base.BaseProps], result)
+        return typing.cast(typing.Mapping[builtins.str, _scope_jsii_calc_base_734f0262.BaseProps], result)
 
     @builtins.property
-    def numbers(self) -> typing.List[scope.jsii_calc_lib.Number]:
+    def numbers(self) -> typing.List[_scope_jsii_calc_lib_c61f082f.Number]:
         result = self._values.get("numbers")
         assert result is not None, "Required property 'numbers' is missing"
-        return typing.cast(typing.List[scope.jsii_calc_lib.Number], result)
+        return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.Number], result)
 
     def __eq__(self, rhs: typing.Any) -> builtins.bool:
         return isinstance(rhs, self.__class__) and rhs._values == self._values
@@ -12930,11 +13059,11 @@ from typeguard import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_base
+import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
 
 
 class Class1(
-    scope.jsii_calc_base.Base,
+    _scope_jsii_calc_base_734f0262.Base,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.module2702.Class1",
 ):
@@ -12947,7 +13076,7 @@ class Class1(
 
 
 class Class2(
-    scope.jsii_calc_base.Base,
+    _scope_jsii_calc_base_734f0262.Base,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.module2702.Class2",
 ):
@@ -12960,7 +13089,7 @@ class Class2(
         return typing.cast(builtins.str, jsii.get(self, "base"))
 
 
-@jsii.implements(scope.jsii_calc_base.IBaseInterface)
+@jsii.implements(_scope_jsii_calc_base_734f0262.IBaseInterface)
 class Class3(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2702.Class3"):
     def __init__(self) -> None:
         jsii.create(self.__class__, self, [])
@@ -12979,14 +13108,14 @@ class Class3(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2702.Class3"):
 
 
 @jsii.interface(jsii_type="jsii-calc.module2702.IBaz")
-class IBaz(scope.jsii_calc_base.IBaseInterface, typing_extensions.Protocol):
+class IBaz(_scope_jsii_calc_base_734f0262.IBaseInterface, typing_extensions.Protocol):
     @jsii.member(jsii_name="bazMethod")
     def baz_method(self) -> None:
         ...
 
 
 class _IBazProxy(
-    jsii.proxy_for(scope.jsii_calc_base.IBaseInterface), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_base_734f0262.IBaseInterface), # type: ignore[misc]
 ):
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.module2702.IBaz"
 
@@ -13017,7 +13146,7 @@ typing.cast(typing.Any, IConstruct).__jsii_proxy_class__ = lambda : _IConstructP
 
 
 @jsii.interface(jsii_type="jsii-calc.module2702.IFoo")
-class IFoo(scope.jsii_calc_base.IBaseInterface, typing_extensions.Protocol):
+class IFoo(_scope_jsii_calc_base_734f0262.IBaseInterface, typing_extensions.Protocol):
     @builtins.property
     @jsii.member(jsii_name="iBaseInterface")
     def i_base_interface(self) -> builtins.str:
@@ -13025,7 +13154,7 @@ class IFoo(scope.jsii_calc_base.IBaseInterface, typing_extensions.Protocol):
 
 
 class _IFooProxy(
-    jsii.proxy_for(scope.jsii_calc_base.IBaseInterface), # type: ignore[misc]
+    jsii.proxy_for(_scope_jsii_calc_base_734f0262.IBaseInterface), # type: ignore[misc]
 ):
     __jsii_type__: typing.ClassVar[str] = "jsii-calc.module2702.IFoo"
 
@@ -14067,7 +14196,7 @@ from typeguard import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib
+import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
 
 
 class ConsumesUnion(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.union.ConsumesUnion"):
@@ -14075,7 +14204,7 @@ class ConsumesUnion(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.union.Consumes
     @builtins.classmethod
     def union_type(
         cls,
-        param: typing.Union["IResolvable", "Resolvable", scope.jsii_calc_lib.IFriendly],
+        param: typing.Union["IResolvable", "Resolvable", _scope_jsii_calc_lib_c61f082f.IFriendly],
     ) -> None:
         '''
         :param param: -
@@ -14176,32 +14305,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/__init__.py	--runtime-type-checking
-@@ -111,10 +111,15 @@
+@@ -111,10 +111,13 @@
      def work_it_all(self, seed: builtins.str) -> builtins.str:
          '''Sets \`\`seed\`\` to \`\`this.property\`\`, then calls \`\`someMethod\`\` with \`\`this.property\`\` and returns the result.
  
          :param seed: a \`\`string\`\`.
          '''
 +        if __debug__:
-+            def stub(seed: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8348af6419fc01178f78ba59cea59d0c7437626169866d772f4e957d09e6e13a)
 +            check_type(argname="argument seed", value=seed, expected_type=type_hints["seed"])
          return typing.cast(builtins.str, jsii.invoke(self, "workItAll", [seed]))
  
      @builtins.property
      @jsii.member(jsii_name="property")
      @abc.abstractmethod
-@@ -131,19 +136,29 @@
+@@ -131,19 +134,25 @@
      @jsii.member(jsii_name="someMethod")
      def _some_method(self, str: builtins.str) -> builtins.str:
          '''
          :param str: -
          '''
 +        if __debug__:
-+            def stub(str: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__06c06b97e36be962012901c4c1f542b3f51b377154f91bf1154d1bd475221829)
 +            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
          return typing.cast(builtins.str, jsii.invoke(self, "someMethod", [str]))
  
@@ -14213,57 +14338,49 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @_property.setter
      def _property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__0f076015f51de68c2d0e6902c0d199c9058ad0bff9c11f58b2aae99578ece6ae)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractSuite).__jsii_proxy_class__ = lambda : _AbstractSuiteProxy
  
-@@ -161,10 +176,15 @@
+@@ -161,10 +170,13 @@
      @jsii.member(jsii_name="anyIn")
      def any_in(self, inp: typing.Any) -> None:
          '''
          :param inp: -
          '''
 +        if __debug__:
-+            def stub(inp: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__81a2d86a9598fa10dde4af8bd70d369967edc6febb332dc788702f6aea07f33c)
 +            check_type(argname="argument inp", value=inp, expected_type=type_hints["inp"])
          return typing.cast(None, jsii.invoke(self, "anyIn", [inp]))
  
      @jsii.member(jsii_name="anyOut")
      def any_out(self) -> typing.Any:
          return typing.cast(typing.Any, jsii.invoke(self, "anyOut", []))
-@@ -172,10 +192,15 @@
+@@ -172,10 +184,13 @@
      @jsii.member(jsii_name="enumMethod")
      def enum_method(self, value: "StringEnum") -> "StringEnum":
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: StringEnum) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__56056c33132184bd4ad46f69c534777112c49b9a987cc7b962d4026cf550998c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast("StringEnum", jsii.invoke(self, "enumMethod", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="enumPropertyValue")
      def enum_property_value(self) -> jsii.Number:
-@@ -186,73 +211,113 @@
+@@ -186,73 +201,97 @@
      def any_array_property(self) -> typing.List[typing.Any]:
          return typing.cast(typing.List[typing.Any], jsii.get(self, "anyArrayProperty"))
  
      @any_array_property.setter
      def any_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1ab9ae75c746f751d2bf2ac254bcd1bee8eae7281ec936e222c9f29765fdcfa4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyArrayProperty", value)
  
@@ -14275,9 +14392,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @any_map_property.setter
      def any_map_property(self, value: typing.Mapping[builtins.str, typing.Any]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Mapping[builtins.str, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f88e356a91a703923e622c02850435cc7f632a66f49ca79f00d42590d2928a5e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyMapProperty", value)
  
@@ -14289,9 +14404,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @any_property.setter
      def any_property(self, value: typing.Any) -> None:
 +        if __debug__:
-+            def stub(value: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d81f1a89ccd850ccdb0b96a43000dfcde30f3542bf797051c754610d641f2316)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyProperty", value)
  
@@ -14303,9 +14416,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @array_property.setter
      def array_property(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__0c663902e9a8a1db9aff59eb8642a68c944dc2e3385744098d2b51ecf2e2e11f)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "arrayProperty", value)
  
@@ -14317,9 +14428,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @boolean_property.setter
      def boolean_property(self, value: builtins.bool) -> None:
 +        if __debug__:
-+            def stub(value: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__106a83d3c77dbb6dbc6fcd706bca888d57ec37cd4beedf7dcc9d7d4428f44845)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "booleanProperty", value)
  
@@ -14331,9 +14440,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @date_property.setter
      def date_property(self, value: datetime.datetime) -> None:
 +        if __debug__:
-+            def stub(value: datetime.datetime) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5e62ea2f9629943c1138cad77629f47906644279c178b9436e4303e5a5f74c8a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dateProperty", value)
  
@@ -14345,9 +14452,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @enum_property.setter
      def enum_property(self, value: "AllTypesEnum") -> None:
 +        if __debug__:
-+            def stub(value: AllTypesEnum) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f0d83d5dde352e12690bd34359b2272194b20ad0d4585d4cd235a62a68413cc7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "enumProperty", value)
  
@@ -14359,27 +14464,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @json_property.setter
      def json_property(self, value: typing.Mapping[typing.Any, typing.Any]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Mapping[typing.Any, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8cddc5c03b0b87366a7bf274aedf92ced502b23fe811780c7f8c3da532cba3fc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "jsonProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="mapProperty")
-     def map_property(self) -> typing.Mapping[builtins.str, scope.jsii_calc_lib.Number]:
-@@ -261,28 +326,45 @@
+     def map_property(
+@@ -263,28 +302,37 @@
      @map_property.setter
      def map_property(
          self,
-         value: typing.Mapping[builtins.str, scope.jsii_calc_lib.Number],
+         value: typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.Number],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Mapping[builtins.str, scope.jsii_calc_lib.Number],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ce34799b1443789feb28cffe434f5bcbb9cb940065992aa75dbb30eb89cd78e6)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mapProperty", value)
  
@@ -14391,9 +14490,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @number_property.setter
      def number_property(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c8fb4d044e2e7432d7e661aafdb286ebf21dfe5a82b9908dee57945f6892a63e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "numberProperty", value)
  
@@ -14405,63 +14502,49 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @string_property.setter
      def string_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4e3dc199e54a9fbd40ceb20cecf887aa2aeca670e9ba223707466d9670eec9b9)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionArrayProperty")
      def union_array_property(
-@@ -293,10 +375,17 @@
+@@ -295,10 +343,13 @@
      @union_array_property.setter
      def union_array_property(
          self,
-         value: typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]],
+         value: typing.List[typing.Union[jsii.Number, _scope_jsii_calc_lib_c61f082f.NumericValue]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.List[typing.Union[jsii.Number, scope.jsii_calc_lib.NumericValue]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4a9e87035008a2c1b649b911c8cfc02f2723230d8ced957948b2948c76caf61a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionArrayProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionMapProperty")
      def union_map_property(
-@@ -307,10 +396,17 @@
+@@ -309,10 +360,13 @@
      @union_map_property.setter
      def union_map_property(
          self,
-         value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]],
+         value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__62ebee42e1871545bc2e82cfb9c7fe43b5a607c8f662caff89dda0f0ed99a3df)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionMapProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -321,19 +417,31 @@
+@@ -323,19 +377,25 @@
      @union_property.setter
      def union_property(
          self,
-         value: typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, "Multiply"],
+         value: typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number, "Multiply"],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Union[builtins.str, jsii.Number, scope.jsii_calc_lib.Number, Multiply],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c9be2756a18e8a40eb03cf55231201574f76abf02996a73d0d75fefd1393473d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
@@ -14473,25 +14556,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @unknown_array_property.setter
      def unknown_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e49729a44c21aef8c75584ff0991ddba3ee45184cacf816eb1a6a13b99e99ecc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownArrayProperty", value)
  
      @builtins.property
      @jsii.member(jsii_name="unknownMapProperty")
      def unknown_map_property(self) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -342,28 +450,43 @@
+@@ -344,28 +404,37 @@
      @unknown_map_property.setter
      def unknown_map_property(
          self,
          value: typing.Mapping[builtins.str, typing.Any],
      ) -> None:
 +        if __debug__:
-+            def stub(value: typing.Mapping[builtins.str, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f8de6b30de9bfa884f9de02e2abe57e9394fb7a387b5691f858b7b98817b1db7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownMapProperty", value)
  
@@ -14503,9 +14582,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @unknown_property.setter
      def unknown_property(self, value: typing.Any) -> None:
 +        if __debug__:
-+            def stub(value: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__901c3574a81e006fdf36f73e34f66b34f65ada4bddcb11cd15a51d6e3d9b59e4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownProperty", value)
  
@@ -14517,25 +14594,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @optional_enum_value.setter
      def optional_enum_value(self, value: typing.Optional["StringEnum"]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[StringEnum]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__705bed55c0dbc20a3a1bad9a21931270f0c285e5b3b276e13bca645ffa7ccb0f)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "optionalEnumValue", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.AllTypesEnum")
  class AllTypesEnum(enum.Enum):
-@@ -383,36 +506,60 @@
+@@ -385,36 +454,52 @@
      def get_bar(self, _p1: builtins.str, _p2: jsii.Number) -> None:
          '''
          :param _p1: -
          :param _p2: -
          '''
 +        if __debug__:
-+            def stub(_p1: builtins.str, _p2: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__99730dd857f01c8e93755d3e4f1e04f44efd2e63487e37db32f0fae8d36c618e)
 +            check_type(argname="argument _p1", value=_p1, expected_type=type_hints["_p1"])
 +            check_type(argname="argument _p2", value=_p2, expected_type=type_hints["_p2"])
          return typing.cast(None, jsii.invoke(self, "getBar", [_p1, _p2]))
@@ -14547,9 +14620,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param with_param: -
          '''
 +        if __debug__:
-+            def stub(with_param: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7f25304a2274ca1691dbe05a223f32126250948b15187c5095780e5c9af08c2a)
 +            check_type(argname="argument with_param", value=with_param, expected_type=type_hints["with_param"])
          return typing.cast(builtins.str, jsii.invoke(self, "getFoo", [with_param]))
  
@@ -14561,9 +14632,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _z: -
          '''
 +        if __debug__:
-+            def stub(_x: builtins.str, _y: jsii.Number, _z: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__12f6979e6d88948e4aebfe8c25ed814c21d19b4b549d6bc2db4620794e706238)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
 +            check_type(argname="argument _z", value=_z, expected_type=type_hints["_z"])
@@ -14577,9 +14646,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _y: -
          '''
 +        if __debug__:
-+            def stub(_x: builtins.str, _y: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ca978ab380897c8607252c370202d45bc72e8b5cdc52549bb53b870299333d52)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
          return typing.cast(None, jsii.invoke(self, "setFoo", [_x, _y]))
@@ -14587,56 +14654,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class AmbiguousParameters(
      metaclass=jsii.JSIIMeta,
-@@ -428,10 +575,20 @@
+@@ -430,10 +515,13 @@
          '''
          :param scope_: -
          :param scope: 
          :param props: 
          '''
 +        if __debug__:
-+            def stub(
-+                scope_: Bell,
-+                *,
-+                scope: builtins.str,
-+                props: typing.Optional[builtins.bool] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__35fb7428c2ad70583f7b280c07cec184905b51e8e896efe6cc88eaf83a6f65c3)
 +            check_type(argname="argument scope_", value=scope_, expected_type=type_hints["scope_"])
          props_ = StructParameterType(scope=scope, props=props)
  
          jsii.create(self.__class__, self, [scope_, props_])
  
      @builtins.property
-@@ -478,10 +635,15 @@
+@@ -480,10 +568,13 @@
      @jsii.member(jsii_name="overrideMe")
      def override_me(self, mult: jsii.Number) -> jsii.Number:
          '''
          :param mult: -
          '''
 +        if __debug__:
-+            def stub(mult: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__49537950cbbeb6e2c62cb1b8a079cc9bb5cc6d06d95cf2229128539d2be886a3)
 +            check_type(argname="argument mult", value=mult, expected_type=type_hints["mult"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMe", [mult]))
  
      @jsii.member(jsii_name="overrideMeToo")
      def override_me_too(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeToo", []))
-@@ -542,10 +704,19 @@
+@@ -544,10 +635,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            def stub(
-+                lhs: scope.jsii_calc_lib.NumericValue,
-+                rhs: scope.jsii_calc_lib.NumericValue,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__408890be1949f7684db536e79081b85d00d72250ca9eb19c74db6ad226564784)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -14644,32 +14697,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
-@@ -606,10 +777,15 @@
+@@ -608,10 +703,13 @@
  
          :param value: the value that should be returned.
  
          :return: \`\`value\`\`
          '''
 +        if __debug__:
-+            def stub(value: typing.Any) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__67894f861ef38d2769b440d2fe71f549cb9e333247b385c5d6ae862b2eb04fc5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Any, jsii.invoke(self, "giveItBack", [value]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, BurriedAnonymousObject).__jsii_proxy_class__ = lambda : _BurriedAnonymousObjectProxy
  
-@@ -659,18 +835,28 @@
+@@ -661,18 +759,24 @@
      def add(self, value: jsii.Number) -> None:
          '''Adds a number to the current value.
  
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__106b87a3d0b194bda7cee057654f752c82d9a92a3775bcc3b2dc5cf7814ba84d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "add", [value]))
  
@@ -14680,41 +14729,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b0e9a9c8546dd024e1568b2e6d11bd847e53548d624f33afffdffacc77fe01ef)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "mul", [value]))
  
      @jsii.member(jsii_name="neg")
      def neg(self) -> None:
          '''Negates the current value.'''
-@@ -680,10 +866,15 @@
+@@ -682,10 +786,13 @@
      def pow(self, value: jsii.Number) -> None:
          '''Raises the current value by a power.
  
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c62707f1a80d6bc26c0b74205f8892c1777e6ed97359263df05628018d8ef6fc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "pow", [value]))
  
      @jsii.member(jsii_name="readUnionValue")
      def read_union_value(self) -> jsii.Number:
          '''Returns teh value of the union property (if defined).'''
-@@ -715,20 +906,30 @@
+@@ -717,20 +824,26 @@
          '''The current value.'''
-         return typing.cast(scope.jsii_calc_lib.NumericValue, jsii.get(self, "curr"))
+         return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "curr"))
  
      @curr.setter
-     def curr(self, value: scope.jsii_calc_lib.NumericValue) -> None:
+     def curr(self, value: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
 +        if __debug__:
-+            def stub(value: scope.jsii_calc_lib.NumericValue) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c74abb191c66f86aed2c139ec3e50b0442b6d3bdcd41beb06db17c9b3c5d93d0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "curr", value)
  
@@ -14727,47 +14770,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @max_value.setter
      def max_value(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1af5d9bb897bd9bfc2029e92d33fc306fc090e2d0a9bc0bd70fb01762e798fe6)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "maxValue", value)
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -740,10 +941,17 @@
+@@ -742,10 +855,13 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.Optional[typing.Union["Add", "Multiply", "Power"]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Optional[typing.Union[Add, Multiply, Power]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__349b2a1dce95cb7ff4c5a7772d81772697767c5f4e7e5fd709847ff5e526c3c1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.CalculatorProps",
-@@ -760,10 +968,20 @@
+@@ -762,10 +878,14 @@
          '''Properties for Calculator.
  
          :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
          :param maximum_value: The maximum value the calculator can store. Default: none
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                initial_value: typing.Optional[jsii.Number] = None,
-+                maximum_value: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__21033948ed66f89716ed818c4cf9e5a38a9252e042231e1e8e1672356d403bef)
 +            check_type(argname="argument initial_value", value=initial_value, expected_type=type_hints["initial_value"])
 +            check_type(argname="argument maximum_value", value=maximum_value, expected_type=type_hints["maximum_value"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -14775,55 +14806,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["initial_value"] = initial_value
          if maximum_value is not None:
              self._values["maximum_value"] = maximum_value
-@@ -809,10 +1027,17 @@
+@@ -811,10 +931,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]],
      ) -> None:
          '''
          :param union_property: -
          '''
 +        if __debug__:
-+            def stub(
-+                union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9e749834c2e46eee6370de7b60daabbff6e5c16febe9775b98a2b961b0d4e335)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -823,10 +1048,17 @@
+@@ -825,10 +948,13 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.List[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.List[typing.Mapping[builtins.str, typing.Union[StructA, StructB]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__80b80f78c4ac7fda46ac2aec7ab826a87bef3eaaba64661c90f346972800baf5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  class ClassWithCollections(
      metaclass=jsii.JSIIMeta,
-@@ -839,10 +1071,19 @@
+@@ -841,10 +967,14 @@
      ) -> None:
          '''
          :param map: -
          :param array: -
          '''
 +        if __debug__:
-+            def stub(
-+                map: typing.Mapping[builtins.str, builtins.str],
-+                array: typing.Sequence[builtins.str],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7eb49cfb1282d7f1bd28096ff0407c0806693194f02f5c053936f99756a2a8fd)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
          jsii.create(self.__class__, self, [map, array])
@@ -14831,16 +14849,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="createAList")
      @builtins.classmethod
      def create_a_list(cls) -> typing.List[builtins.str]:
-@@ -858,37 +1099,57 @@
+@@ -860,37 +990,49 @@
      def static_array(cls) -> typing.List[builtins.str]:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[builtins.str], jsii.sget(cls, "staticArray"))
  
      @static_array.setter # type: ignore[no-redef]
      def static_array(cls, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__964903eb68623806c91fc9026cacfdc726cfbb287698530724c5a9938a7bb2ca)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticArray", value)
  
@@ -14852,9 +14868,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @static_map.setter # type: ignore[no-redef]
      def static_map(cls, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Mapping[builtins.str, builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8dd7203701e4915203e4778820ee40fe6bdd6f0bb2855c200f375606277e06c8)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticMap", value)
  
@@ -14866,9 +14880,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @array.setter
      def array(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c0c76fec28076841e36c26581c26385de1e984d96e91ea434a61c4bf36c9b4d9)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "array", value)
  
@@ -14880,33 +14892,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @map.setter
      def map(self, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Mapping[builtins.str, builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5461a3c7bb81040765e4ca2e9effb12cc7f5fb018e5e1b8b21501a3f9cd6a8b3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "map", value)
  
  
  class ClassWithContainerTypes(
      metaclass=jsii.JSIIMeta,
-@@ -910,10 +1171,25 @@
+@@ -912,10 +1054,15 @@
          :param obj: -
          :param array_prop: 
          :param obj_prop: 
          :param record_prop: 
          '''
 +        if __debug__:
-+            def stub(
-+                array: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                record: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                obj: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                *,
-+                array_prop: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                obj_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                record_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__11d94174b1d488125abef65967a384ceb599f4948eca6cb9be3d55e1979fb64f)
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
 +            check_type(argname="argument record", value=record, expected_type=type_hints["record"])
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
@@ -14915,16 +14915,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          jsii.create(self.__class__, self, [array, record, obj, props])
-@@ -963,17 +1239,27 @@
+@@ -965,17 +1112,23 @@
  ):
      def __init__(self, int: builtins.str) -> None:
          '''
          :param int: -
          '''
 +        if __debug__:
-+            def stub(int: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c017a39e0da5d21f3a9acbfd00f6a5c84eb4cad306148504e7c835359d35537e)
 +            check_type(argname="argument int", value=int, expected_type=type_hints["int"])
          jsii.create(self.__class__, self, [int])
  
@@ -14934,194 +14932,161 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param assert_: -
          '''
 +        if __debug__:
-+            def stub(assert_: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7a756cab89b47a2ae4c08f36162482b60fdf963b8ba638917a63c5e110b4d33e)
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
          return typing.cast(builtins.str, jsii.invoke(self, "import", [assert_]))
  
      @builtins.property
      @jsii.member(jsii_name="int")
      def int(self) -> builtins.str:
-@@ -992,10 +1278,15 @@
+@@ -994,10 +1147,13 @@
      def mutable_object(self) -> "IMutableObjectLiteral":
          return typing.cast("IMutableObjectLiteral", jsii.get(self, "mutableObject"))
  
      @mutable_object.setter
      def mutable_object(self, value: "IMutableObjectLiteral") -> None:
 +        if __debug__:
-+            def stub(value: IMutableObjectLiteral) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3afbef7e05ef43a18b9260b86660c09b15be66fabeae128c9a9f99b729da7143)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableObject", value)
  
  
  class ClassWithNestedUnion(
      metaclass=jsii.JSIIMeta,
-@@ -1006,10 +1297,17 @@
+@@ -1008,10 +1164,13 @@
          union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union["StructA", typing.Dict[str, typing.Any]], typing.Union["StructB", typing.Dict[str, typing.Any]]]]]],
      ) -> None:
          '''
          :param union_property: -
          '''
 +        if __debug__:
-+            def stub(
-+                union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__0b8f0f729686dad01c8555a3b1bc47509e495bd18f1560ef045b558884b2a1fb)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -1020,10 +1318,17 @@
+@@ -1022,10 +1181,13 @@
      @union_property.setter
      def union_property(
          self,
          value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]], typing.List[typing.Union["StructA", "StructB"]]]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union[StructA, StructB]], typing.List[typing.Union[StructA, StructB]]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a8a15eb37393d5188c71779e29278367f7b3600c6dd48bdbcd502cdf510c3c15)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  class ConfusingToJackson(
      metaclass=jsii.JSIIMeta,
-@@ -1054,10 +1359,17 @@
+@@ -1056,10 +1218,13 @@
      @union_property.setter
      def union_property(
          self,
-         value: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]],
+         value: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.List[typing.Union[scope.jsii_calc_lib.IFriendly, AbstractClass]]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ec229cc92e04670f4dca9546759b3b39ee813eb1aa18057135bb155d08971e6a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ConfusingToJacksonStruct",
-@@ -1071,10 +1383,18 @@
-         union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.Sequence[typing.Union[scope.jsii_calc_lib.IFriendly, "AbstractClass"]]]] = None,
+@@ -1073,10 +1238,13 @@
+         union_property: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.Sequence[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]] = None,
      ) -> None:
          '''
          :param union_property: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                union_property: typing.Optional[typing.Union[scope.jsii_calc_lib.IFriendly, typing.Sequence[typing.Union[scope.jsii_calc_lib.IFriendly, AbstractClass]]]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__481b1113b85e6dc9d7ba31c3ef5654e3550abac1edef9204348ab0f9554f61c1)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[str, typing.Any] = {}
          if union_property is not None:
              self._values["union_property"] = union_property
  
      @builtins.property
-@@ -1102,10 +1422,15 @@
+@@ -1104,10 +1272,13 @@
  ):
      def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
          '''
          :param consumer: -
          '''
 +        if __debug__:
-+            def stub(consumer: PartiallyInitializedThisConsumer) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5676fcb3395f1db1a013537fa52220553e5e418c2a9d97aa2f9541c00ffe259e)
 +            check_type(argname="argument consumer", value=consumer, expected_type=type_hints["consumer"])
          jsii.create(self.__class__, self, [consumer])
  
  
  class Constructors(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Constructors"):
      def __init__(self) -> None:
-@@ -1153,10 +1478,15 @@
+@@ -1155,10 +1326,13 @@
  ):
      def __init__(self, delegate: "IStructReturningDelegate") -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            def stub(delegate: IStructReturningDelegate) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5c5defc6d683ee91707f8b7770d8d2fb11d381b9c928d7e5d6e2c5c495395f38)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="workItBaby")
      def work_it_baby(self) -> "StructB":
          return typing.cast("StructB", jsii.invoke(self, "workItBaby", []))
-@@ -1185,10 +1515,15 @@
+@@ -1187,10 +1361,13 @@
  
          Returns whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1df814299f3f9720be108d84bdfd61bc591699a79a3c8ac6d450bfb0a9610278)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPrivateClass")
      @builtins.classmethod
      def static_implemented_by_private_class(
-@@ -1199,10 +1534,15 @@
+@@ -1201,10 +1378,13 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2f08bd2d56e856071db5f777b63fe2577f9e96dbfcd91e4044d0eda2d26f9017)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPublicClass")
      @builtins.classmethod
      def static_implemented_by_public_class(cls, ringer: "IBellRinger") -> builtins.bool:
-@@ -1210,10 +1550,15 @@
+@@ -1212,10 +1392,13 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4a2b7f0a05298ddaec112cb088cc71cfa2856aaa1d8414a5157d581b6d5a7293)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
  
      @jsii.member(jsii_name="staticWhenTypedAsClass")
      @builtins.classmethod
      def static_when_typed_as_class(cls, ringer: "IConcreteBellRinger") -> builtins.bool:
-@@ -1221,50 +1566,75 @@
+@@ -1223,50 +1406,65 @@
  
          Return whether the bell was rung.
  
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IConcreteBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f751da3f5766ea4973eb2d89086565259f0a3cd626425a7eec723afd7b64f392)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
  
@@ -15134,9 +15099,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cca04fe4a4c41a0034087ab0c574d1d2f1d0427d87a806fc660446b6a7e5290a)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
  
@@ -15149,9 +15112,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7bde53b867de290d21a419baa46b8e833a0d394835a1ce2be3b429179b2ddce5)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
  
@@ -15164,9 +15125,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__988e53d92b16fb4b7224c654f985a074cbfa7dd5f567df005b41522641ad92ac)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
  
@@ -15179,25 +15138,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param ringer: -
          '''
 +        if __debug__:
-+            def stub(ringer: IConcreteBellRinger) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1d786308546ae61deacb465c6f501fe7e0be028973494548b57e0480759ed460)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
  
  
  class ConsumersOfThisCrazyTypeSystem(
      metaclass=jsii.JSIIMeta,
-@@ -1279,20 +1649,30 @@
+@@ -1281,20 +1479,26 @@
          obj: "IAnotherPublicInterface",
      ) -> builtins.str:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            def stub(obj: IAnotherPublicInterface) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__83037a3f429b90a38d2d9532a347144030578d83f68817b1a5677ebcd1b38e12)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
  
@@ -15210,30 +15165,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param obj: -
          '''
 +        if __debug__:
-+            def stub(obj: INonInternalInterface) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__139bf4e63e56bef32e364c5972e055de5cba153d49cc821740fba1d51f73ef70)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ContainerProps",
-@@ -1314,10 +1694,22 @@
+@@ -1316,10 +1520,15 @@
          '''
          :param array_prop: 
          :param obj_prop: 
          :param record_prop: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                array_prop: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                obj_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+                record_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2be181b08e5a2c0e1e3f3a84732a423af31039117701d35431ee251d343ca9d5)
 +            check_type(argname="argument array_prop", value=array_prop, expected_type=type_hints["array_prop"])
 +            check_type(argname="argument obj_prop", value=obj_prop, expected_type=type_hints["obj_prop"])
 +            check_type(argname="argument record_prop", value=record_prop, expected_type=type_hints["record_prop"])
@@ -15242,16 +15188,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "obj_prop": obj_prop,
              "record_prop": record_prop,
          }
-@@ -1383,17 +1775,27 @@
+@@ -1385,17 +1594,23 @@
          data: typing.Mapping[builtins.str, typing.Any],
      ) -> builtins.str:
          '''
          :param data: -
          '''
 +        if __debug__:
-+            def stub(data: typing.Mapping[builtins.str, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__dd941dcba8415b4b4dbb95bc3f55ac3404bdaf303822dfc7093fb615dc66b2cf)
 +            check_type(argname="argument data", value=data, expected_type=type_hints["data"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderArbitrary", [data]))
  
@@ -15261,29 +15205,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param map: -
          '''
 +        if __debug__:
-+            def stub(map: typing.Mapping[builtins.str, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9008dfc97234c0f2895caaa88d20a94de081c3cd97c38f9a012f13cdae75fbd6)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderMap", [map]))
  
  
  class Default(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Default"):
      '''A class named "Default".
-@@ -1422,10 +1824,21 @@
+@@ -1424,10 +1639,15 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            def stub(
-+                arg1: typing.Optional[jsii.Number] = None,
-+                arg2: typing.Optional[builtins.str] = None,
-+                arg3: typing.Optional[datetime.datetime] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__019e6ec86ae7ee325dc404a7025eaf0edcb164e166535a831bccf6658adfbb10)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -15292,19 +15228,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -1483,10 +1896,19 @@
+@@ -1485,10 +1705,14 @@
  
          :deprecated: this constructor is "just" okay
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(
-+                readonly_string: builtins.str,
-+                mutable_number: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f64945b01dd806fcd872f369983e1fa6b3db8811cb0682ac6adf88aebb0aabda)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -15312,59 +15243,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -1516,10 +1938,15 @@
+@@ -1518,10 +1742,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3aef3220b38be7daf4208453b1766d9eafb6a74bd51dfb351d21235a205afa34)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.DeprecatedEnum")
  class DeprecatedEnum(enum.Enum):
-@@ -1555,10 +1982,15 @@
+@@ -1557,10 +1784,13 @@
  
          :deprecated: it just wraps a string
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(*, readonly_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cdee1d6893b4921a8d7cf0a9c957a543b69f7a98eb3cedd7ece84871fc81c767)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -1623,10 +2055,34 @@
+@@ -1625,10 +1855,21 @@
          :param non_primitive: An example of a non primitive property.
          :param another_optional: This is optional.
          :param optional_any: 
          :param optional_array: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                anumber: jsii.Number,
-+                astring: builtins.str,
-+                first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
-+                another_required: datetime.datetime,
-+                bool: builtins.bool,
-+                non_primitive: DoubleTrouble,
-+                another_optional: typing.Optional[typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue]] = None,
-+                optional_any: typing.Any = None,
-+                optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c544311353634d5a2f08144f0c184afbcb700d8304b9f49deae99f19e1e7b0af)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
 +            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
@@ -15379,22 +15293,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "astring": astring,
              "another_required": another_required,
              "bool": bool,
-@@ -1743,10 +2199,24 @@
+@@ -1749,10 +1990,16 @@
          :param hoisted_top: 
          :param left: 
          :param right: 
          :param bottom: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                hoisted_top: typing.Optional[builtins.str] = None,
-+                left: typing.Optional[jsii.Number] = None,
-+                right: typing.Optional[builtins.bool] = None,
-+                bottom: typing.Optional[datetime.datetime] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__865cdfdd094ca753189170221ee7d6a0e59c2c0bcfdeff3dc37bb87dd39515ca)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
 +            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
@@ -15404,36 +15310,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -1804,10 +2274,15 @@
+@@ -1810,10 +2057,13 @@
  class DiamondInheritanceBaseLevelStruct:
      def __init__(self, *, base_level_property: builtins.str) -> None:
          '''
          :param base_level_property: 
          '''
 +        if __debug__:
-+            def stub(*, base_level_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cfa52ba952c3d4a7e6df7fba3f619bf3ac14c52e829cce862a5fa495e45d0e70)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "base_level_property": base_level_property,
          }
  
      @builtins.property
-@@ -1845,10 +2320,20 @@
+@@ -1851,10 +2101,14 @@
      ) -> None:
          '''
          :param base_level_property: 
          :param first_mid_level_property: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                base_level_property: builtins.str,
-+                first_mid_level_property: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__354311bd3d60d2b3b4ea927d6a96bdf66aa6d1109c29bfcd96266051c7c30a5e)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15441,20 +15339,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
          }
  
-@@ -1893,10 +2378,20 @@
+@@ -1899,10 +2153,14 @@
      ) -> None:
          '''
          :param base_level_property: 
          :param second_mid_level_property: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                base_level_property: builtins.str,
-+                second_mid_level_property: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8074c5f38699399b9e6f8708c125bef5d7c89118c36ffcce8582d66cac2197da)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15462,22 +15354,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_mid_level_property": second_mid_level_property,
          }
  
-@@ -1952,10 +2447,24 @@
+@@ -1958,10 +2216,16 @@
          :param base_level_property: 
          :param first_mid_level_property: 
          :param second_mid_level_property: 
          :param top_level_property: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                base_level_property: builtins.str,
-+                first_mid_level_property: builtins.str,
-+                second_mid_level_property: builtins.str,
-+                top_level_property: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9384691e88dd3ab7e55516762b2076445d94bd6d9348db1b93f79de9f4ae0ea1)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
 +            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
@@ -15487,36 +15371,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
              "second_mid_level_property": second_mid_level_property,
              "top_level_property": top_level_property,
-@@ -2035,10 +2544,15 @@
+@@ -2041,10 +2305,13 @@
      @jsii.member(jsii_name="changePrivatePropertyValue")
      def change_private_property_value(self, new_value: builtins.str) -> None:
          '''
          :param new_value: -
          '''
 +        if __debug__:
-+            def stub(new_value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5ae2124576c295a0c88fc75be0e57258f0f72e63c733e7493367b8558266510e)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(None, jsii.invoke(self, "changePrivatePropertyValue", [new_value]))
  
      @jsii.member(jsii_name="privateMethodValue")
      def private_method_value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "privateMethodValue", []))
-@@ -2067,10 +2581,21 @@
+@@ -2073,10 +2340,15 @@
          '''
          :param _required_any: -
          :param _optional_any: -
          :param _optional_string: -
          '''
 +        if __debug__:
-+            def stub(
-+                _required_any: typing.Any,
-+                _optional_any: typing.Any = None,
-+                _optional_string: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8ffaadb351f5c2c48a7368068d5c88e0c7836deefe0e13aa9fe53ac104052fd5)
 +            check_type(argname="argument _required_any", value=_required_any, expected_type=type_hints["_required_any"])
 +            check_type(argname="argument _optional_any", value=_optional_any, expected_type=type_hints["_optional_any"])
 +            check_type(argname="argument _optional_string", value=_optional_string, expected_type=type_hints["_optional_string"])
@@ -15525,19 +15401,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2134,10 +2659,19 @@
+@@ -2140,10 +2412,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
          :param things: -
          '''
 +        if __debug__:
-+            def stub(
-+                optional: typing.Optional[builtins.str] = None,
-+                *things: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5af7b38b9b5c170ebd3e05c215e05f10e6843b03868850dad87a5a149b90e790)
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
 +            check_type(argname="argument things", value=things, expected_type=typing.Tuple[type_hints["things"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.str, jsii.invoke(self, "optionalAndVariadic", [optional, *things]))
@@ -15545,32 +15416,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DummyObj",
-@@ -2147,10 +2681,15 @@
+@@ -2153,10 +2429,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
          :param example: 
          '''
 +        if __debug__:
-+            def stub(*, example: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ae5d543014149876cec8b005abbb94c112981cccaf318870c7fe4e8353c2c675)
 +            check_type(argname="argument example", value=example, expected_type=type_hints["example"])
          self._values: typing.Dict[str, typing.Any] = {
              "example": example,
          }
  
      @builtins.property
-@@ -2179,28 +2718,43 @@
+@@ -2185,28 +2464,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
          :param value_store: -
          '''
 +        if __debug__:
-+            def stub(value_store: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c0d457497f870b36d210f01af9890c6624684d1e53da833858e801c18baf9fbb)
 +            check_type(argname="argument value_store", value=value_store, expected_type=type_hints["value_store"])
          jsii.create(self.__class__, self, [value_store])
  
@@ -15582,9 +15449,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @dynamic_property.setter
      def dynamic_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4f40c12fae2ef2673f3f324c0c452f65c187c1b3e6552b86768465a2d20de051)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dynamicProperty", value)
  
@@ -15596,25 +15461,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @value_store.setter
      def value_store(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9106fb2a86e944ce0c61537852ab2d310a8a53448c6946af051de0325a67fa1a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueStore", value)
  
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2209,20 +2763,30 @@
+@@ -2215,20 +2503,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
          :param original_value: -
          '''
 +        if __debug__:
-+            def stub(original_value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ad557fbd0532aa4220227645f5aae3e73ebae6b529cfe074430abf30d18cd5e9)
 +            check_type(argname="argument original_value", value=original_value, expected_type=type_hints["original_value"])
          jsii.create(self.__class__, self, [original_value])
  
@@ -15627,60 +15488,49 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :return: the old value that was set.
          '''
 +        if __debug__:
-+            def stub(new_value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a4026611d197b83d9a37b973ba97c69254e674921a7d89d0eb57ac41a19b636e)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(builtins.str, jsii.invoke(self, "overrideValue", [new_value]))
  
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2235,10 +2799,15 @@
+@@ -2241,10 +2535,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
          :param clock: your implementation of \`\`WallClock\`\`.
          '''
 +        if __debug__:
-+            def stub(clock: IWallClock) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2a7f203302b2610301f1b36f34453db0f5572f2e02b0bc4c9933fd670e594222)
 +            check_type(argname="argument clock", value=clock, expected_type=type_hints["clock"])
          jsii.create(self.__class__, self, [clock])
  
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2266,10 +2835,15 @@
+@@ -2272,10 +2569,13 @@
  
          :param word: the value to return.
  
          :return: \`\`word\`\`.
          '''
 +        if __debug__:
-+            def stub(word: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a90d161fb7d47a195a192cf987ac6968fc2c6fbe27005bdd7684478a3d956e66)
 +            check_type(argname="argument word", value=word, expected_type=type_hints["word"])
          return typing.cast(builtins.str, jsii.invoke(self, "repeat", [word]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2306,10 +2880,19 @@
+@@ -2312,10 +2612,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
          :param key: -
          '''
 +        if __debug__:
-+            def stub(
-+                opts: typing.Union[EraseUndefinedHashValuesOptions, typing.Dict[str, typing.Any]],
-+                key: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b87cc89f87e9b1c180227625f3aba9395da5a8b258a88e605d466edb9004d709)
 +            check_type(argname="argument opts", value=opts, expected_type=type_hints["opts"])
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "doesKeyExist", [opts, key]))
@@ -15688,20 +15538,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2337,10 +2920,20 @@
+@@ -2343,10 +2647,14 @@
      ) -> None:
          '''
          :param option1: 
          :param option2: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                option1: typing.Optional[builtins.str] = None,
-+                option2: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d34e4f5dab670ec3ea298ec2cda50be32700f7f52dcef6a618ca9cb3706062ee)
 +            check_type(argname="argument option1", value=option1, expected_type=type_hints["option1"])
 +            check_type(argname="argument option2", value=option2, expected_type=type_hints["option2"])
          self._values: typing.Dict[str, typing.Any] = {}
@@ -15709,19 +15553,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2384,10 +2977,19 @@
+@@ -2390,10 +2698,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
          :stability: experimental
          '''
 +        if __debug__:
-+            def stub(
-+                readonly_string: builtins.str,
-+                mutable_number: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6a92c7223d00e7a0a2f0611cbb689671885b835bb26eedc8eb4a4d12e4ed5021)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -15729,64 +15568,56 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2411,10 +3013,15 @@
+@@ -2417,10 +2729,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__52559292c6e04ad49e53e443b1a4c56149833b8f12876d779bb8860fcb231b41)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2442,10 +3049,15 @@
+@@ -2448,10 +2763,13 @@
          '''
          :param readonly_property: 
  
          :stability: experimental
          '''
 +        if __debug__:
-+            def stub(*, readonly_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b0c8f4c6eca5af7072a4a7c737950b39e75c61a56c505deb94edc5cd0995ed7d)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -2475,10 +3087,15 @@
+@@ -2481,10 +2799,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
          :param success: -
          '''
 +        if __debug__:
-+            def stub(success: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__dad018fa707514e8023df185b5e6e0a4b611bec563fe57abd9b81939b8833ebb)
 +            check_type(argname="argument success", value=success, expected_type=type_hints["success"])
          jsii.create(self.__class__, self, [success])
  
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2494,10 +3111,16 @@
+@@ -2500,10 +2821,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
          :param prop: 
          '''
 +        if __debug__:
-+            def stub(*, boom: builtins.bool, prop: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__861a5ec03219f6c9fecd1b039faa2e53075227ff0d28f8eb66929909bc0c3096)
 +            check_type(argname="argument boom", value=boom, expected_type=type_hints["boom"])
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -15794,19 +15625,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2539,10 +3162,19 @@
+@@ -2545,10 +2870,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
          :external: true
          '''
 +        if __debug__:
-+            def stub(
-+                readonly_string: builtins.str,
-+                mutable_number: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__82149b1f61aca58419f6ba4c74c8bb1c5c241433707e64ea4626937b294d8fe5)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -15814,195 +15640,168 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2566,10 +3198,15 @@
+@@ -2572,10 +2901,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8380ec30b1f8773df7b5b27be8811be79b04f1d17c8eca83f83927eb56cdfd34)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2597,10 +3234,15 @@
+@@ -2603,10 +2935,13 @@
          '''
          :param readonly_property: 
  
          :external: true
          '''
 +        if __debug__:
-+            def stub(*, readonly_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8e8843a5fc914ec2c1e3baccdad526ea4d48eee37296f6812f3c0673ef86794f)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -2743,10 +3385,15 @@
+@@ -2749,10 +3084,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
          :param name: The name of the greetee. Default: world
          '''
 +        if __debug__:
-+            def stub(*, name: typing.Optional[builtins.str] = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3dce87825e36304d54521ce5524aa7e230fa5d505b0abbc79101fd9014f2cbd9)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          self._values: typing.Dict[str, typing.Any] = {}
          if name is not None:
              self._values["name"] = name
  
      @builtins.property
-@@ -2780,10 +3427,15 @@
-     @jsii.member(jsii_name="betterGreeting")
-     def better_greeting(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
+@@ -2789,10 +3127,13 @@
+         friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
+     ) -> builtins.str:
          '''
          :param friendly: -
          '''
 +        if __debug__:
-+            def stub(friendly: scope.jsii_calc_lib.IFriendly) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d17f0544be961cba6cabfbb40f28c196963de107fcaef9c56d8227bdcb359431)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
  
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2863,10 +3515,15 @@
+@@ -2872,10 +3213,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3eabfcad9a21b26024f4c1480ca127a3d6c6888067f0ae991d5922a49bfe81d4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2909,10 +3566,15 @@
+@@ -2918,10 +3262,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
          :param bell: -
          '''
 +        if __debug__:
-+            def stub(bell: IBell) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d127476ce3b6e59ff9f375f547c1b6e1826d7a3969612c0605ebd0017d2b985d)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -2937,10 +3599,15 @@
+@@ -2946,10 +3293,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
          :param bell: -
          '''
 +        if __debug__:
-+            def stub(bell: Bell) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2c34aaac5945bdc61c4f56492dee5608e1852940835d94d3e991fed377db66f2)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -2996,10 +3663,15 @@
+@@ -3005,10 +3355,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e4d76200a6c5bdbdd51f208229da8bfd8f6f4c967af28e1e733579780e9d4a0e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3054,10 +3726,15 @@
+@@ -3063,10 +3416,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6e68d313f3254be7145220b211c66f45749aa8efc15aaf93d96330eb3cb7c6c7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3099,10 +3776,15 @@
+@@ -3108,10 +3464,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
      @private.setter
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8199a83e86f8a4cf29ddc53d2b2151c37c7fa10d29562b454127376d1867d6da)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3148,10 +3830,15 @@
+@@ -3157,10 +3516,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a904d745cb9f037de717ed7a2b1d3a207493564662fdbe1d7c63e60a24f9bace)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3333,10 +4020,19 @@
+@@ -3342,10 +3704,14 @@
      ) -> None:
          '''
          :param arg1: -
          :param arg2: -
          '''
 +        if __debug__:
-+            def stub(
-+                arg1: builtins.str,
-+                arg2: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5568c72c746dd5221cb6fb7b741ed7a3346c346d7a30863c5abe3d99ada53098)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
          return typing.cast(None, jsii.invoke(self, "hello", [arg1, arg2]))
@@ -16010,64 +15809,56 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3371,10 +4067,15 @@
+@@ -3380,10 +3746,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__858de6e8785f18ad264a158ca83a0fc1e0a6299efa9f77a0b31eaaffaa5b086c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3404,10 +4105,15 @@
+@@ -3413,10 +3782,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
      @foo.setter
      def foo(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c571c6749392bc04e123a99b926edaf10b88be6b6d6b6a3937cae9893af5119e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -3927,10 +4633,15 @@
+@@ -3936,10 +4308,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
      @value.setter
      def value(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e0395944061fad9d5156b633dc20682ff9759ae0acb88df574b159f4919ab3a5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "value", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -3966,19 +4677,29 @@
+@@ -3975,19 +4350,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9d1e4198ba3f4e6b6a6f4ce0a4a185223ec216368c0c3304c69b029aba13ca49)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -16079,94 +15870,77 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6774e195ab25dab5790e1d187eb30be56997804d5186753a9928f2575f81977b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4011,10 +4732,15 @@
+@@ -4020,10 +4401,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
      @property.setter
      def property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__831f664cd567fd4e707fd175e9c9e13519f3ca587b792d7d5bc79f427589a802)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4207,10 +4933,15 @@
+@@ -4216,10 +4600,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__254a58386276f7b7d5a41dddd674375b8942c2cad4deb6c2d24b55d240d14350)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4277,10 +5008,15 @@
+@@ -4286,10 +4673,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__10bb8b026d6c8368d479cf0da8b27c049c5f9088f173a63624e515dd36607439)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4326,10 +5062,15 @@
+@@ -4335,10 +4725,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
      @private.setter
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2df4d055b033cdfdf7ad915b451ddc787ad68fb64b7e02386a9d8e591c1657af)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4347,10 +5088,22 @@
+@@ -4356,10 +4749,15 @@
          '''
          :param foo: -
          :param bar: -
          :param goo: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                foo: scope.jsii_calc_base_of_base.Very,
-+                bar: builtins.str,
-+                goo: datetime.datetime,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b70592e4d080897239bf5f8b0de5b6b464cd9e888e39fca1082c04b5cbeca890)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument goo", value=goo, expected_type=type_hints["goo"])
@@ -16175,32 +15949,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4425,10 +5178,15 @@
+@@ -4434,10 +4832,13 @@
          count: jsii.Number,
-     ) -> typing.List[scope.jsii_calc_lib.IDoublable]:
+     ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
          :param count: -
          '''
 +        if __debug__:
-+            def stub(count: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1d6e348a61ed27bfc8b7928365798b43e0130ca2b720c1105baca04fa093d194)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
-         return typing.cast(typing.List[scope.jsii_calc_lib.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
+         return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
  
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4533,19 +5291,29 @@
+@@ -4542,19 +4943,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
      @prop_a.setter
      def prop_a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__30ce308abdc1d2462c00bf7a4acc194ec05d61ddee24b2e79c674aa7034e5ffa)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propA", value)
  
@@ -16212,118 +15982,91 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @prop_b.setter
      def prop_b(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__eef7c487e6f0c4d81dd633cf70121104ff8f3458fa52a418df64bcab9fe4bd3e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propB", value)
  
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4767,10 +5535,15 @@
+@@ -4776,10 +5183,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
      @while_.setter
      def while_(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a7654af9a241e67ad498c3eb33b98e6cdb1558487bb9b02dcce41f75334b76ad)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "while", value)
  
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4872,10 +5645,15 @@
+@@ -4881,10 +5291,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: typing.Any = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__43f45c49ecee3d08351b82aa5cdc3548d9dafa534cd2d99da8b5c5c9188e9a54)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Optional[builtins.str], jsii.sinvoke(cls, "stringify", [value]))
  
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4905,10 +5683,15 @@
+@@ -4914,10 +5327,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
              :param value: 
              '''
 +            if __debug__:
-+                def stub(*, value: builtins.bool) -> None:
-+                    ...
-+                type_hints = typing.get_type_hints(stub)
++                type_hints = typing.get_type_hints(_typecheckingstub__ef705a05998260349d35c748c557e65cf539d53e136eb9191250080bdce852c3)
 +                check_type(argname="argument value", value=value, expected_type=type_hints["value"])
              self._values: typing.Dict[str, typing.Any] = {
                  "value": value,
              }
  
          @builtins.property
-@@ -4942,10 +5725,18 @@
+@@ -4951,10 +5367,13 @@
              '''
              :param prop: 
              '''
              if isinstance(prop, dict):
                  prop = LevelOne.PropBooleanValue(**prop)
 +            if __debug__:
-+                def stub(
-+                    *,
-+                    prop: typing.Union[LevelOne.PropBooleanValue, typing.Dict[str, typing.Any]],
-+                ) -> None:
-+                    ...
-+                type_hints = typing.get_type_hints(stub)
++                type_hints = typing.get_type_hints(_typecheckingstub__2a9e65060bf85c3d49b79ada1f9394ae146c380a4212c190065e031098d570b8)
 +                check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
              self._values: typing.Dict[str, typing.Any] = {
                  "prop": prop,
              }
  
          @builtins.property
-@@ -4980,10 +5771,18 @@
+@@ -4989,10 +5408,13 @@
          '''
          :param prop: 
          '''
          if isinstance(prop, dict):
              prop = LevelOne.PropProperty(**prop)
 +        if __debug__:
-+            def stub(
-+                *,
-+                prop: typing.Union[LevelOne.PropProperty, typing.Dict[str, typing.Any]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__479be5d5625f656c28cf12ffdc2cef9d6d74aae555551630f440fcb05351d261)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "prop": prop,
          }
  
      @builtins.property
-@@ -5031,10 +5830,26 @@
+@@ -5040,10 +5462,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
          :param public_tasks: Determines whether your Fargate Service will be assigned a public IP address. Default: false
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                container_port: typing.Optional[jsii.Number] = None,
-+                cpu: typing.Optional[builtins.str] = None,
-+                memory_mib: typing.Optional[builtins.str] = None,
-+                public_load_balancer: typing.Optional[builtins.bool] = None,
-+                public_tasks: typing.Optional[builtins.bool] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b3d89a25beb0ebd10c196d941aa924197ae9a2def08f1f414c190a2a6d943d9c)
 +            check_type(argname="argument container_port", value=container_port, expected_type=type_hints["container_port"])
 +            check_type(argname="argument cpu", value=cpu, expected_type=type_hints["cpu"])
 +            check_type(argname="argument memory_mib", value=memory_mib, expected_type=type_hints["memory_mib"])
@@ -16334,19 +16077,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5161,10 +5976,19 @@
+@@ -5170,10 +5599,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            def stub(
-+                lhs: scope.jsii_calc_lib.NumericValue,
-+                rhs: scope.jsii_calc_lib.NumericValue,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7e73465ea858e34d4df8697d34f29a53ca3c3a41c47946382e5d49f498e3747d)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -16354,32 +16092,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5212,10 +6036,15 @@
+@@ -5221,10 +5654,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
          :param number_prop: When provided, must be > 0.
          '''
 +        if __debug__:
-+            def stub(*, number_prop: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__04dae031a5097183ccda93eb91ec51a8a6fa1133134a6a398f1f05c581bc0091)
 +            check_type(argname="argument number_prop", value=number_prop, expected_type=type_hints["number_prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "number_prop": number_prop,
          }
  
      @builtins.property
-@@ -5286,17 +6115,28 @@
+@@ -5295,17 +5731,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
          :param optional: -
          '''
 +        if __debug__:
-+            def stub(_param1: builtins.str, optional: typing.Any = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__218107d38285901ff40e08163f0de0bac5d835bd64c21c0a735e8d72399ebe35)
 +            check_type(argname="argument _param1", value=_param1, expected_type=type_hints["_param1"])
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
          jsii.create(self.__class__, self, [_param1, optional])
@@ -16390,45 +16124,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: typing.Any = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a109cd8429db09172895a3eb04ca7e9d5c92129c7ca7a50f85fa89b6f6ab366b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "giveMeUndefined", [value]))
  
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5324,10 +6164,15 @@
+@@ -5333,10 +5776,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
      @change_me_to_undefined.setter
      def change_me_to_undefined(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7102c29a709c4297fb88615c74a3e42a584364ac4ccba5c1db42a65e05184d1b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "changeMeToUndefined", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5346,10 +6191,20 @@
+@@ -5355,10 +5801,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
          :param this_should_be_undefined: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                array_with_three_elements_and_undefined_as_second_argument: typing.Sequence[typing.Any],
-+                this_should_be_undefined: typing.Any = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ae8d47cabe4d36f88c891d250d7e792432b0d153223789ec3687e714ba92a5f3)
 +            check_type(argname="argument array_with_three_elements_and_undefined_as_second_argument", value=array_with_three_elements_and_undefined_as_second_argument, expected_type=type_hints["array_with_three_elements_and_undefined_as_second_argument"])
 +            check_type(argname="argument this_should_be_undefined", value=this_should_be_undefined, expected_type=type_hints["this_should_be_undefined"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16436,16 +16160,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5384,17 +6239,27 @@
+@@ -5393,17 +5843,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
          :param generator: -
          '''
 +        if __debug__:
-+            def stub(generator: IRandomNumberGenerator) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3c1812783ba0b3b2146a3dd9609a6e12af404502ff5fbb9b9a9be49bf576122b)
 +            check_type(argname="argument generator", value=generator, expected_type=type_hints["generator"])
          jsii.create(self.__class__, self, [generator])
  
@@ -16455,95 +16177,77 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param gen: -
          '''
 +        if __debug__:
-+            def stub(gen: IRandomNumberGenerator) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__151b90e9765ce9a05ae13e568f4ba7c9e36e34c1cd991c5c1ee0249869fd4cce)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
  
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5404,10 +6269,15 @@
+@@ -5413,10 +5869,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
      @generator.setter
      def generator(self, value: IRandomNumberGenerator) -> None:
 +        if __debug__:
-+            def stub(value: IRandomNumberGenerator) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__0f5a1cc548d3db6e156cec5671bc04b980132e529c77f3bb5aaa58427db35e7c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "generator", value)
  
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5425,10 +6295,15 @@
+@@ -5434,10 +5893,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
          :param values: -
          '''
 +        if __debug__:
-+            def stub(values: typing.Sequence[scope.jsii_calc_lib.NumericValue]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f5cb9f9511b0248cd4c0c4bec4eed9e75e7690012237fdb1b39b3f7b3bb0392e)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromArray", [values]))
  
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5436,10 +6311,17 @@
+@@ -5445,10 +5907,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
          :param values: -
          '''
 +        if __debug__:
-+            def stub(
-+                values: typing.Mapping[builtins.str, scope.jsii_calc_lib.NumericValue],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ca5199647728e53a1ec89d4fd7dad9aeb7239f8c1213c51b4e2eda734daa4cf4)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromMap", [values]))
  
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5480,10 +6362,15 @@
+@@ -5489,10 +5954,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            def stub(delegate: IInterfaceWithOptionalMethodArguments) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__da93d15e57e6e2a1857cd7df156fb2a55ec91715c97323f20268def40f72137c)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5506,10 +6393,21 @@
+@@ -5515,10 +5983,15 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            def stub(
-+                arg1: jsii.Number,
-+                arg2: builtins.str,
-+                arg3: typing.Optional[datetime.datetime] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5f6c5e5b55379123a8bd2bc457d9a5e9a0d34dd512b2bd2f59c6a5bec2a95f14)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -16552,84 +16256,84 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5534,10 +6432,15 @@
+@@ -5543,10 +6016,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
          :param field: 
          '''
 +        if __debug__:
-+            def stub(*, field: typing.Optional[builtins.str] = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__26ecd0d4ea200acf388a8b91f17bfd3c09b6c7f8e0a84228b89c27ace672d0b1)
 +            check_type(argname="argument field", value=field, expected_type=type_hints["field"])
          self._values: typing.Dict[str, typing.Any] = {}
          if field is not None:
              self._values["field"] = field
  
      @builtins.property
-@@ -5613,10 +6516,15 @@
+@@ -5622,10 +6098,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
      @_override_read_write.setter
      def _override_read_write(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__72ca8c3c148afe2b76dc14b63b8e2baf0bbf28802add3f88490cb5d3792825fb)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "overrideReadWrite", value)
  
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5628,10 +6536,15 @@
+@@ -5637,10 +6116,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            def stub(obj: IReturnsNumber) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ca8d417ddf787890441d6903718eebaf7fde3508b3466202724fdac3a17ba79b)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
  
  
+ class ParamShadowsScope(
+     metaclass=jsii.JSIIMeta,
+@@ -5660,10 +6142,13 @@
+         scope: _scope_jsii_calc_lib_c61f082f.Number,
+     ) -> _scope_jsii_calc_lib_c61f082f.Number:
+         '''
+         :param scope: -
+         '''
++        if __debug__:
++            type_hints = typing.get_type_hints(_typecheckingstub__ae63c91319764cabd02536ac5b03026eb3f4071497b2a04adf93ca02985507ae)
++            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
+         return typing.cast(_scope_jsii_calc_lib_c61f082f.Number, jsii.invoke(self, "useScope", [scope]))
+ 
+ 
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5642,10 +6555,15 @@
+@@ -5674,10 +6159,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
          :param foo: 
          '''
 +        if __debug__:
-+            def stub(*, foo: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f6db465208dd616dc4f171643676a159b21fe5963ec9a3d1fd752e5cb291868d)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -5700,10 +6618,21 @@
+@@ -5732,10 +6220,15 @@
          '''
          :param obj: -
          :param dt: -
          :param ev: -
          '''
 +        if __debug__:
-+            def stub(
-+                obj: ConstructorPassesThisOut,
-+                dt: datetime.datetime,
-+                ev: AllTypesEnum,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__85c3ad65f24d8d5af99d7777a0379b793f45ac0e0e39714f279b8f2d58dbcfdb)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
 +            check_type(argname="argument dt", value=dt, expected_type=type_hints["dt"])
 +            check_type(argname="argument ev", value=ev, expected_type=type_hints["ev"])
@@ -16638,90 +16342,71 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5715,10 +6644,15 @@
-     @jsii.member(jsii_name="sayHello")
-     def say_hello(self, friendly: scope.jsii_calc_lib.IFriendly) -> builtins.str:
+@@ -5750,10 +6243,13 @@
+         friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
+     ) -> builtins.str:
          '''
          :param friendly: -
          '''
 +        if __debug__:
-+            def stub(friendly: scope.jsii_calc_lib.IFriendly) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__edbbf85a7c4217635da7418d28aa61c4e11f7a0c1e9c960528ed4e7bee1ad541)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
  
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5735,10 +6669,19 @@
+@@ -5770,10 +6266,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
          :param pow: The number of times to multiply.
          '''
 +        if __debug__:
-+            def stub(
-+                base: scope.jsii_calc_lib.NumericValue,
-+                pow: scope.jsii_calc_lib.NumericValue,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__df4f41b4c003b9ba61f07f4d41a4059f167ea41c03ea29933966d2caeb831d8c)
 +            check_type(argname="argument base", value=base, expected_type=type_hints["base"])
 +            check_type(argname="argument pow", value=pow, expected_type=type_hints["pow"])
          jsii.create(self.__class__, self, [base, pow])
  
      @builtins.property
      @jsii.member(jsii_name="base")
-     def base(self) -> scope.jsii_calc_lib.NumericValue:
-@@ -5942,10 +6885,15 @@
-     @jsii.member(jsii_name="saveFoo")
-     def save_foo(self, value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
+     def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
+@@ -5982,10 +6482,13 @@
+         value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
+     ) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: scope.jsii_calc_lib.EnumFromScopedModule) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__235768085718ab33214221cff3145bb2a82c28916350f273995760a428a1aba3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "saveFoo", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="foo")
-     def foo(self) -> typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule]:
-@@ -5954,10 +6902,17 @@
+     def foo(
+@@ -5996,10 +6499,13 @@
      @foo.setter
      def foo(
          self,
-         value: typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule],
+         value: typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule],
      ) -> None:
 +        if __debug__:
-+            def stub(
-+                value: typing.Optional[scope.jsii_calc_lib.EnumFromScopedModule],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__100c679fa10c1938fc087475a1e5fcdf7c2cbff383b1c02b1d09471cb4f23123)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -5999,10 +6954,20 @@
+@@ -6041,10 +6547,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
          if isinstance(nested_struct, dict):
              nested_struct = NestedStruct(**nested_struct)
 +        if __debug__:
-+            def stub(
-+                *,
-+                string_prop: builtins.str,
-+                nested_struct: typing.Optional[typing.Union[NestedStruct, typing.Dict[str, typing.Any]]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cf66d7b4f4a567aefacbafc24f61d33a942afde3d167676ed65ea82da95cd36e)
 +            check_type(argname="argument string_prop", value=string_prop, expected_type=type_hints["string_prop"])
 +            check_type(argname="argument nested_struct", value=nested_struct, expected_type=type_hints["nested_struct"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16729,20 +16414,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6069,17 +7034,33 @@
+@@ -6111,17 +6621,25 @@
          '''
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            def stub(
-+                arg1: typing.Optional[jsii.Number] = None,
-+                arg2: typing.Optional[builtins.str] = None,
-+                arg3: typing.Optional[datetime.datetime] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6db501e892de783af62ff728e59cc3155afc51ddc2dff77cce61ffe698e2e1f3)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -16754,29 +16433,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg: -
          '''
 +        if __debug__:
-+            def stub(arg: typing.Any = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5978f09aaa3317742377437d5735571f672119325c2b5d69f26153bae6764c85)
 +            check_type(argname="argument arg", value=arg, expected_type=type_hints["arg"])
          return typing.cast(None, jsii.invoke(self, "methodWithOptionalAnyArgument", [arg]))
  
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6091,10 +7072,21 @@
+@@ -6133,10 +6651,15 @@
  
          :param arg1: -
          :param arg2: -
          :param arg3: -
          '''
 +        if __debug__:
-+            def stub(
-+                arg1: jsii.Number,
-+                arg2: builtins.str,
-+                arg3: typing.Optional[datetime.datetime] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c894904fd4904d7e110da91df846a8ec0970051a274bba5ad95c2b7dc1125cc2)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
 +            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
@@ -16785,20 +16456,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6113,10 +7105,20 @@
+@@ -6155,10 +6678,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
          :param deeper_optional_prop: It's long, but you'll almost never pass it.
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                deeper_required_prop: builtins.str,
-+                deeper_optional_prop: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e7383b9a36a10b88815e6c310c7b13c611260f5ccb143b75dac114873643350d)
 +            check_type(argname="argument deeper_required_prop", value=deeper_required_prop, expected_type=type_hints["deeper_required_prop"])
 +            check_type(argname="argument deeper_optional_prop", value=deeper_optional_prop, expected_type=type_hints["deeper_optional_prop"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16806,48 +16471,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6178,10 +7180,15 @@
+@@ -6220,10 +6747,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2ccde09a2986c421795069d44c46d9e2d7470609094b8b7177c6b154360f7435)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonInt", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6200,10 +7207,15 @@
+@@ -6242,10 +6772,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__76cbdc0bba36d674ab013a40d091c1f3ccb139f10e78844ebc868bfa5d707ef8)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonString", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6227,10 +7239,16 @@
+@@ -6269,10 +6802,14 @@
      ) -> None:
          '''
          :param property: 
          :param yet_anoter_one: 
          '''
 +        if __debug__:
-+            def stub(*, property: builtins.str, yet_anoter_one: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1b795ca2a3052da38144d10d87f230e74bcfa497af1262580f53908be48f6710)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
 +            check_type(argname="argument yet_anoter_one", value=yet_anoter_one, expected_type=type_hints["yet_anoter_one"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -16855,19 +16514,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6281,10 +7299,19 @@
+@@ -6323,10 +6860,14 @@
      ) -> None:
          '''
          :param readonly_string: -
          :param mutable_number: -
          '''
 +        if __debug__:
-+            def stub(
-+                readonly_string: builtins.str,
-+                mutable_number: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8c577a76d55e32f4b62a2a005d0c321bf9d0784b2f6cea5f10e297f3f79fc4bb)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
@@ -16875,64 +16529,56 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6299,10 +7326,15 @@
+@@ -6341,10 +6882,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[jsii.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__737be2f0376e64bd8c0980aee9fc6afd796bb4d0cb3415eab28d054f15881752)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6318,10 +7350,15 @@
+@@ -6360,10 +6904,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
          :param readonly_property: 
          '''
 +        if __debug__:
-+            def stub(*, readonly_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4bbf1eebbce12768b1d2ef90968ffdbe749e42ce8bcdaf4c8750314d2160c5ea)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -6358,10 +7395,15 @@
+@@ -6400,10 +6947,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
      @static_variable.setter # type: ignore[no-redef]
      def static_variable(cls, value: builtins.bool) -> None:
 +        if __debug__:
-+            def stub(value: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cf00e16ec45ebcadc1f7003eb344ecf452096a12a1a76ff0e15fce1066d716d2)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticVariable", value)
  
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6391,19 +7433,29 @@
+@@ -6433,19 +6983,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__69df39c5fc3367bba974a46518d9122ce067721f56037ef6e1faedf479222822)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
@@ -16944,25 +16590,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param name: The name of the person to say hello to.
          '''
 +        if __debug__:
-+            def stub(name: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c4597464b7867e98bf0052f7808e080b75874d088aeac980865a4fc19e47a6d1)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "staticMethod", [name]))
  
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6440,19 +7492,29 @@
+@@ -6482,19 +7038,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
      @instance.setter # type: ignore[no-redef]
      def instance(cls, value: "Statics") -> None:
 +        if __debug__:
-+            def stub(value: Statics) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__748a4d0813e4a3ab750bd52215b9ff4dee315d39b160d47884780ea7c4b10daf)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "instance", value)
  
@@ -16974,46 +16616,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @non_const_static.setter # type: ignore[no-redef]
      def non_const_static(cls, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5d0ed37ae4b7f5bd294a768da342f4735c6636e0197883a5727e46ed81deec69)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "nonConstStatic", value)
  
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6475,10 +7537,15 @@
+@@ -6517,10 +7079,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
      @you_see_me.setter
      def you_see_me(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__aa3b9a5342b6fe1366fac3279219c5bae15389881ddd050c544c1d0001853482)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "youSeeMe", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6501,10 +7568,22 @@
+@@ -6543,10 +7108,15 @@
  
          :param required_string: 
          :param optional_number: 
          :param optional_string: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                required_string: builtins.str,
-+                optional_number: typing.Optional[jsii.Number] = None,
-+                optional_string: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c9e4f6413d6ce49f4a289256d84d0fa97f7abac1877fc8d49f80f4a7d83a4972)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_number", value=optional_number, expected_type=type_hints["optional_number"])
 +            check_type(argname="argument optional_string", value=optional_string, expected_type=type_hints["optional_string"])
@@ -17022,21 +16653,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6562,10 +7641,22 @@
+@@ -6604,10 +7174,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
          if isinstance(optional_struct_a, dict):
              optional_struct_a = StructA(**optional_struct_a)
 +        if __debug__:
-+            def stub(
-+                *,
-+                required_string: builtins.str,
-+                optional_boolean: typing.Optional[builtins.bool] = None,
-+                optional_struct_a: typing.Optional[typing.Union[StructA, typing.Dict[str, typing.Any]]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4d335a3a7bbc35ed76509a5e85466d6d29221efebdd6dd4de639ef040628f332)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_boolean", value=optional_boolean, expected_type=type_hints["optional_boolean"])
 +            check_type(argname="argument optional_struct_a", value=optional_struct_a, expected_type=type_hints["optional_struct_a"])
@@ -17045,20 +16669,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6617,10 +7708,20 @@
+@@ -6659,10 +7234,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
          :param props: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                scope: builtins.str,
-+                props: typing.Optional[builtins.bool] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7eb7b6caeb33bbd3740ca0fc027022df9d4fade4a7d1943a334f2869ab44bd98)
 +            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
 +            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17066,16 +16684,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6663,10 +7764,16 @@
+@@ -6705,10 +7284,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
          :param inputs: -
          '''
 +        if __debug__:
-+            def stub(_positional: jsii.Number, *inputs: TopLevelStruct) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e3587fc6359e7cd1adf0bb70ed66e1cd69faa462a530e07c8d25a96b942cb943)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
 +            check_type(argname="argument inputs", value=inputs, expected_type=typing.Tuple[type_hints["inputs"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(jsii.Number, jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs]))
@@ -17083,58 +16699,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6681,10 +7788,21 @@
+@@ -6723,10 +7306,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
 +        if __debug__:
-+            def stub(
-+                _positional: jsii.Number,
-+                *,
-+                required: builtins.str,
-+                second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
-+                optional: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b60fd8dad9496da93546e0555f2f8a7a34711e7160c06dc64a47f095f1539d02)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
          input = TopLevelStruct(
              required=required, second_level=second_level, optional=optional
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6701,10 +7819,17 @@
+@@ -6743,10 +7329,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
      ) -> builtins.bool:
          '''
          :param struct: -
          '''
 +        if __debug__:
-+            def stub(
-+                struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1c22dd35a08877498e4c2c0ed61e220c19d83da3b6a1e278dfcb7af4d76d2df8)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructA", [struct]))
  
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6712,18 +7837,30 @@
+@@ -6754,18 +7343,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
      ) -> builtins.bool:
          '''
          :param struct: -
          '''
 +        if __debug__:
-+            def stub(
-+                struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__bfb5d0235b42940b9a17c7bb3182f454c7652fdb031f8993719a701d42833623)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructB", [struct]))
  
@@ -17145,48 +16745,35 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            def stub(which: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e3e3d0b072ef214d95806fb0366dd1f4a92b97932f845c9364616c9348bce502)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[StructA, StructB], jsii.sinvoke(cls, "provideStruct", [which]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6737,10 +7874,18 @@
+@@ -6779,10 +7374,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
      ) -> None:
          '''
          :param union_property: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__06173422e8b2a410ef992bee26115592516245e72f1a99397919d18bfebc1259)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "union_property": union_property,
          }
  
      @builtins.property
-@@ -6777,10 +7922,20 @@
+@@ -6819,10 +7417,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
          :param bar: Optional enum value (of type integer). Default: AllTypesEnum.YOUR_ENUM_VALUE
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                foo: StringEnum,
-+                bar: typing.Optional[AllTypesEnum] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9fac60639e71eb35a422d891e6b571b3ba2118da50de35e8ba784bbb73928be9)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17194,22 +16781,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -6836,10 +7991,24 @@
+@@ -6878,10 +7480,16 @@
          :param default: 
          :param assert_: 
          :param result: 
          :param that: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                default: builtins.str,
-+                assert_: typing.Optional[builtins.str] = None,
-+                result: typing.Optional[builtins.str] = None,
-+                that: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__21b11cdfe2d95237cdddef417a67936ff8529ea3cef4bd7e80fe498f1e27527d)
 +            check_type(argname="argument default", value=default, expected_type=type_hints["default"])
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
 +            check_type(argname="argument result", value=result, expected_type=type_hints["result"])
@@ -17219,36 +16798,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -6906,10 +8075,15 @@
-         '''The parts to sum.'''
-         return typing.cast(typing.List[scope.jsii_calc_lib.NumericValue], jsii.get(self, "parts"))
- 
+@@ -6951,10 +7559,13 @@
      @parts.setter
-     def parts(self, value: typing.List[scope.jsii_calc_lib.NumericValue]) -> None:
+     def parts(
+         self,
+         value: typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue],
+     ) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[scope.jsii_calc_lib.NumericValue]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e2e14d04b1a68f16d9aef0965aa4ffbc51af3cbd2d201ac6e236d861b10c2fbf)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "parts", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -6925,10 +8099,20 @@
+@@ -6970,10 +7581,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                bar: jsii.Number,
-+                id: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__11e78aa6557af36be636eea7a1a9b1d6ebf38d63d876b270de65a5f23152b605)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17256,37 +16827,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -6977,10 +8161,20 @@
+@@ -7022,10 +7637,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
 +        if __debug__:
-+            def stub(
-+                id_: jsii.Number,
-+                *,
-+                bar: jsii.Number,
-+                id: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__46b91a4f1b85f01437aa8a6dda82c7c9e02f0b2ae5324f8c1591fa7ff74feaa0)
 +            check_type(argname="argument id_", value=id_, expected_type=type_hints["id_"])
          props = SupportsNiceJavaBuilderProps(bar=bar, id=id)
  
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7018,17 +8212,27 @@
+@@ -7063,17 +7681,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a961c6dee96c75a70470863d82c09136094c1d72d47aafe7f105c7733536dd4d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyOtherProperty", [value]))
  
@@ -17296,25 +16858,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f3d4d3109122672e8fa17c64fb60787d84a098ee0ee0857d4a10ffe5345a1908)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyValueOfTheProperty", [value]))
  
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7048,17 +8252,27 @@
+@@ -7093,17 +7717,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
          :param n: -
          '''
 +        if __debug__:
-+            def stub(n: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ba36c4cb32b9551fe1c3e91bd834b2e97f7ee93d0b5919acfb1c4fd3d6161295)
 +            check_type(argname="argument n", value=n, expected_type=type_hints["n"])
          return typing.cast(jsii.Number, jsii.invoke(self, "virtualMethod", [n]))
  
@@ -17324,25 +16882,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7118412729d7ec6272cded791897b09f12ee70e1ca550853121f98ceb30ee0e7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "writeA", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7069,46 +8283,71 @@
+@@ -7114,46 +7744,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c361a6694d6564ff5c16af012cfaf94cac0a971928a1d0fb014c27f971287836)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -17354,9 +16908,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @caller_is_property.setter
      def caller_is_property(self, value: jsii.Number) -> None:
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d5d44f6e3395b0db421bab95a6dd7d1560538c63f136025c6b216ffb01eae179)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "callerIsProperty", value)
  
@@ -17368,9 +16920,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @other_property.setter
      def other_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__64c8c65ae76fcafb4b6d28e75f8fd31efad60ab9e71d11cbd5877c28c45d8f70)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "otherProperty", value)
  
@@ -17382,9 +16932,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @the_property.setter
      def the_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__52ea95020be0094da769c873214a182768aa2de47b1c4c3dff43f1226edfe281)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "theProperty", value)
  
@@ -17396,30 +16944,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @value_of_other_property.setter
      def value_of_other_property(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__21d6ffe465a7e42c257c8318bf2bee38ecbc6b1959e6e945e769e365afb3e55d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueOfOtherProperty", value)
  
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7191,10 +8430,22 @@
+@@ -7236,10 +7881,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                required: builtins.str,
-+                second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
-+                optional: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__74359fdf4e6a6505a1c0bc4c2c687826dde0a7696de75fc39f9ed57d89137f96)
 +            check_type(argname="argument required", value=required, expected_type=type_hints["required"])
 +            check_type(argname="argument second_level", value=second_level, expected_type=type_hints["second_level"])
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
@@ -17428,36 +16967,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7285,10 +8536,15 @@
+@@ -7330,10 +7980,13 @@
  
-     def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
+     def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
          :param operand: -
          '''
 +        if __debug__:
-+            def stub(operand: scope.jsii_calc_lib.NumericValue) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e31f878fe14747887a58683a15ca9c8ab54ec35cd6e3a665ad70dd53deadb573)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @builtins.property
      @jsii.member(jsii_name="operand")
-     def operand(self) -> scope.jsii_calc_lib.NumericValue:
-@@ -7319,10 +8575,20 @@
+     def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
+@@ -7364,10 +8017,14 @@
      ) -> None:
          '''
          :param bar: 
          :param foo: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                bar: typing.Union[builtins.str, jsii.Number, AllTypes],
-+                foo: typing.Optional[typing.Union[builtins.str, jsii.Number]] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__223de5294ccc50da976adb8794cb8556981e31d63a2c8b249f7dfbd9e2d99eac)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17465,48 +16996,42 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7359,10 +8625,15 @@
+@@ -7404,10 +8061,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
          :param delegate: -
          '''
 +        if __debug__:
-+            def stub(delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__aaaf822e80c6473bff9b1da58151a278cd846ae0614db9af97bc57ea6f899ce2)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
-     def REFLECTOR(cls) -> scope.jsii_calc_lib.custom_submodule_name.Reflector:
-@@ -7405,10 +8676,15 @@
+     def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
+@@ -7450,10 +8110,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
          :param obj: -
          '''
 +        if __debug__:
-+            def stub(obj: IInterfaceWithProperties) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__73d1545891c65d400938add489402441cb083c61d214ad7a922b6417d3984732)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          jsii.create(self.__class__, self, [obj])
  
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7419,17 +8695,27 @@
+@@ -7464,17 +8127,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
          :param ext: -
          '''
 +        if __debug__:
-+            def stub(ext: IInterfaceWithPropertiesExtension) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__60f3870a6dceb3773397b75ec3f3b664f38c2cc3d2f37dc055262663d12f41a8)
 +            check_type(argname="argument ext", value=ext, expected_type=type_hints["ext"])
          return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
  
@@ -17516,25 +17041,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__42edcb376aed0b6e6fec7d7df016bda9e3a31df0e47ecabb5465d1c84d16a414)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.str, jsii.invoke(self, "writeAndRead", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7439,25 +8725,40 @@
+@@ -7484,25 +8153,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
          :param method: -
          '''
 +        if __debug__:
-+            def stub(method: VariadicMethod) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6d238d6a2f6e464c570c3176db3d78d62e0be9908b705705c8f6d7b6b2385c54)
 +            check_type(argname="argument method", value=method, expected_type=type_hints["method"])
          jsii.create(self.__class__, self, [method])
  
@@ -17544,9 +17065,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param values: -
          '''
 +        if __debug__:
-+            def stub(*values: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__43f32dfb73f1a7fe9c86c00bbc381391db4812c13b5b72363ddcfcd57638c368)
 +            check_type(argname="argument values", value=values, expected_type=typing.Tuple[type_hints["values"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [*values]))
  
@@ -17557,25 +17076,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param prefix: a prefix that will be use for all values returned by \`\`#asArray\`\`.
          '''
 +        if __debug__:
-+            def stub(*prefix: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a33769c23320f9f6bce3e3a70c594135cf44ca5c9c6d1de1cae8cc62a99d49e9)
 +            check_type(argname="argument prefix", value=prefix, expected_type=typing.Tuple[type_hints["prefix"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*prefix])
  
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7466,10 +8767,16 @@
+@@ -7511,10 +8189,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
          :param others: other elements to be included in the array.
          '''
 +        if __debug__:
-+            def stub(first: jsii.Number, *others: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1c18f2c7d91dcdc13843ff1637ed95a1f1c1ed99384d6276ee493b0ca579b4a4)
 +            check_type(argname="argument first", value=first, expected_type=type_hints["first"])
 +            check_type(argname="argument others", value=others, expected_type=typing.Tuple[type_hints["others"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
@@ -17583,16 +17098,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7477,19 +8784,29 @@
+@@ -7522,19 +8204,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
          :param union: -
          '''
 +        if __debug__:
-+            def stub(*union: typing.Union[StructA, StructB]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f18ff2aa5c744d99cc2b37e705d6ed44823660f714c20539c148c9e34e123752)
 +            check_type(argname="argument union", value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*union])
  
@@ -17604,25 +17117,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @union.setter
      def union(self, value: typing.List[typing.Union[StructA, StructB]]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[typing.Union[StructA, StructB]]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__01944feab2feb5a9fdf3d356f62de139685f520d3bb3a38ddc5c42d0b03963fe)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "union", value)
  
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7501,38 +8818,63 @@
+@@ -7546,38 +8234,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
          :param index: -
          '''
 +        if __debug__:
-+            def stub(index: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5efa2ef42e261d5c38c59d5e216e587cb3005bbbb5b4a62e926087ee58478a36)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeAsync", [index]))
  
@@ -17632,9 +17141,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param index: -
          '''
 +        if __debug__:
-+            def stub(index: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ca8f2360b0292d0b5329ac52818673aece7fb01cf2f09567e60ff65b7728c9cc)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.invoke(self, "overrideMeSync", [index]))
  
@@ -17644,9 +17151,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            def stub(count: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5bc99fd66b59152ee7799cf716c91bec428d7091eb33ece69057f9ca9b9fdb19)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "parallelSumAsync", [count]))
  
@@ -17656,9 +17161,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            def stub(count: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__58451fb4813d1aa8877a55de41f1ef8bd30300048337edb2bcf16985abbb6f45)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "serialSumAsync", [count]))
  
@@ -17668,60 +17171,49 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param count: -
          '''
 +        if __debug__:
-+            def stub(count: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7ac4c09636b11fefb0a54fbd52b88fc2b4c5c356eb07189a0d2545601f3bef9c)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumSync", [count]))
  
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7580,10 +8922,15 @@
+@@ -7625,10 +8328,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
          :param private_field: -
          '''
 +        if __debug__:
-+            def stub(private_field: typing.Optional[builtins.str] = None) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__01fcbc911a24b1fa352275e1273526114db562d2c278b742181eba6e8cb11ad4)
 +            check_type(argname="argument private_field", value=private_field, expected_type=type_hints["private_field"])
          jsii.create(self.__class__, self, [private_field])
  
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7624,10 +8971,15 @@
+@@ -7669,10 +8375,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
          :param name: -
          '''
 +        if __debug__:
-+            def stub(name: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__af1f574dee5c4eb581961518ccf32b4060094ed2f9b7e60bece1ed48e3fc45a1)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.invoke(self, "abstractMethod", [name]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7643,10 +8995,19 @@
+@@ -7688,10 +8397,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
 +        if __debug__:
-+            def stub(
-+                lhs: scope.jsii_calc_lib.NumericValue,
-+                rhs: scope.jsii_calc_lib.NumericValue,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__c0e59e6ea7e78215051bf4fe6b69de179aefb4116a344decdfaab4b6b15189b8)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
@@ -17729,32 +17221,28 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7690,10 +9051,15 @@
+@@ -7735,10 +8448,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
      @rung.setter
      def rung(self, value: builtins.bool) -> None:
 +        if __debug__:
-+            def stub(value: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__fa23831ecd0b539d7689616a0557240dc1a45f924fafe58c0d5f0ac464eecf94)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "rung", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7704,10 +9070,16 @@
+@@ -7749,10 +8465,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
          :param bar: 
          '''
 +        if __debug__:
-+            def stub(*, foo: builtins.str, bar: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__84a0b7e93c52a4977e9726c1186b64f57ff35c59c5bc0e7250da1d3236e70208)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -17762,16 +17250,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7748,37 +9120,57 @@
+@@ -7793,37 +8513,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__720d53a768711730e792d129fcff6272627608d1d3942f42e3010e61a3463b31)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -17783,9 +17269,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5236e267a6763b672404dac13a3d5e50c03eb03d35fe2c18cbe7f649933301f1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -17797,9 +17281,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__1bd3b16d1aaf127e7610a230095bced32c4c3ef1cadc73f6b24c76b3ebffdd8e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
@@ -17811,25 +17293,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @d.setter
      def d(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4e685d8185af60a2f5c9bcffe812224568fe893228304e510b4d989f92c19b90)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "d", value)
  
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -7793,37 +9185,57 @@
+@@ -7838,37 +8570,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
      @a.setter
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6499a25aa5ac6723e26c4c716dd2d62a1f9ecd75ae2a476d3213fa5fe8792a1d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
@@ -17841,9 +17319,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @b.setter
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5da75e226d085b0daac7742a86525ea697c77a044896ce80d48677f5fadb2d57)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
@@ -17855,9 +17331,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @c.setter
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__538f9410afd2d028ca599a233896016121b326bd90d69693e949aff75d72caf3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
@@ -17869,28 +17343,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @e.setter
      def e(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ba8bf3471001981f03d1ad5b84a1b0a4a4d7d556c72734d25d96637a60ad2477)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "e", value)
  
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -7841,10 +9253,19 @@
+@@ -7886,10 +8630,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
          :param read_write_string: -
          '''
 +        if __debug__:
-+            def stub(
-+                read_only_string: builtins.str,
-+                read_write_string: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__71399b17d07223b2b83f0d7b33d5172c49eb3d0cf3fe38d6059d4c9b7f471113)
 +            check_type(argname="argument read_only_string", value=read_only_string, expected_type=type_hints["read_only_string"])
 +            check_type(argname="argument read_write_string", value=read_write_string, expected_type=type_hints["read_write_string"])
          return typing.cast("ClassWithPrivateConstructorAndAutomaticProperties", jsii.sinvoke(cls, "create", [read_only_string, read_write_string]))
@@ -17898,69 +17365,56 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -7855,10 +9276,15 @@
+@@ -7900,10 +8648,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e308499c7b9268c91ee3dc9e4a9c975efdfaa0cd72bd877383c6c64e8f2768d0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -7973,10 +9399,15 @@
+@@ -8018,10 +8769,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
          :param property: -
          '''
 +        if __debug__:
-+            def stub(property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__148cd823b5de47723c8a76d0553f3ff6c880ba8ecec14b9a86bd89025a18f4d3)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
          jsii.create(self.__class__, self, [property])
  
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -7997,10 +9428,15 @@
+@@ -8042,10 +8796,13 @@
  
-     def __init__(self, operand: scope.jsii_calc_lib.NumericValue) -> None:
+     def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
          :param operand: -
          '''
 +        if __debug__:
-+            def stub(operand: scope.jsii_calc_lib.NumericValue) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e7aa949631662ae6f6ab2804e4a231fa264a1c879d86efa8267e53158c50e647)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8060,10 +9496,23 @@
+@@ -8105,10 +8862,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
          :param rest: a variadic continuation.
          '''
 +        if __debug__:
-+            def stub(
-+                id: jsii.Number,
-+                default_bar: typing.Optional[jsii.Number] = None,
-+                props: typing.Optional[typing.Union[SupportsNiceJavaBuilderProps, typing.Dict[str, typing.Any]]] = None,
-+                *rest: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__2f90423a63bd0fc04016022e622b4bf01d35f365e38b15153d0a4d6fa014ee5b)
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
 +            check_type(argname="argument default_bar", value=default_bar, expected_type=type_hints["default_bar"])
 +            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
@@ -17970,21 +17424,1522 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
+@@ -8399,5 +9162,1502 @@
+ from . import nodirect
+ from . import onlystatic
+ from . import python_self
+ from . import submodule
+ from . import union
++
++def _typecheckingstub__8348af6419fc01178f78ba59cea59d0c7437626169866d772f4e957d09e6e13a(
++    seed: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__06c06b97e36be962012901c4c1f542b3f51b377154f91bf1154d1bd475221829(
++    str: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__0f076015f51de68c2d0e6902c0d199c9058ad0bff9c11f58b2aae99578ece6ae(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__81a2d86a9598fa10dde4af8bd70d369967edc6febb332dc788702f6aea07f33c(
++    inp: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__56056c33132184bd4ad46f69c534777112c49b9a987cc7b962d4026cf550998c(
++    value: StringEnum,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1ab9ae75c746f751d2bf2ac254bcd1bee8eae7281ec936e222c9f29765fdcfa4(
++    value: typing.List[typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f88e356a91a703923e622c02850435cc7f632a66f49ca79f00d42590d2928a5e(
++    value: typing.Mapping[builtins.str, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d81f1a89ccd850ccdb0b96a43000dfcde30f3542bf797051c754610d641f2316(
++    value: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__0c663902e9a8a1db9aff59eb8642a68c944dc2e3385744098d2b51ecf2e2e11f(
++    value: typing.List[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__106a83d3c77dbb6dbc6fcd706bca888d57ec37cd4beedf7dcc9d7d4428f44845(
++    value: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5e62ea2f9629943c1138cad77629f47906644279c178b9436e4303e5a5f74c8a(
++    value: datetime.datetime,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f0d83d5dde352e12690bd34359b2272194b20ad0d4585d4cd235a62a68413cc7(
++    value: AllTypesEnum,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8cddc5c03b0b87366a7bf274aedf92ced502b23fe811780c7f8c3da532cba3fc(
++    value: typing.Mapping[typing.Any, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ce34799b1443789feb28cffe434f5bcbb9cb940065992aa75dbb30eb89cd78e6(
++    value: typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c8fb4d044e2e7432d7e661aafdb286ebf21dfe5a82b9908dee57945f6892a63e(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4e3dc199e54a9fbd40ceb20cecf887aa2aeca670e9ba223707466d9670eec9b9(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4a9e87035008a2c1b649b911c8cfc02f2723230d8ced957948b2948c76caf61a(
++    value: typing.List[typing.Union[jsii.Number, _scope_jsii_calc_lib_c61f082f.NumericValue]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__62ebee42e1871545bc2e82cfb9c7fe43b5a607c8f662caff89dda0f0ed99a3df(
++    value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c9be2756a18e8a40eb03cf55231201574f76abf02996a73d0d75fefd1393473d(
++    value: typing.Union[builtins.str, jsii.Number, _scope_jsii_calc_lib_c61f082f.Number, Multiply],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e49729a44c21aef8c75584ff0991ddba3ee45184cacf816eb1a6a13b99e99ecc(
++    value: typing.List[typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f8de6b30de9bfa884f9de02e2abe57e9394fb7a387b5691f858b7b98817b1db7(
++    value: typing.Mapping[builtins.str, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__901c3574a81e006fdf36f73e34f66b34f65ada4bddcb11cd15a51d6e3d9b59e4(
++    value: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__705bed55c0dbc20a3a1bad9a21931270f0c285e5b3b276e13bca645ffa7ccb0f(
++    value: typing.Optional[StringEnum],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__99730dd857f01c8e93755d3e4f1e04f44efd2e63487e37db32f0fae8d36c618e(
++    _p1: builtins.str,
++    _p2: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7f25304a2274ca1691dbe05a223f32126250948b15187c5095780e5c9af08c2a(
++    with_param: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__12f6979e6d88948e4aebfe8c25ed814c21d19b4b549d6bc2db4620794e706238(
++    _x: builtins.str,
++    _y: jsii.Number,
++    _z: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ca978ab380897c8607252c370202d45bc72e8b5cdc52549bb53b870299333d52(
++    _x: builtins.str,
++    _y: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__35fb7428c2ad70583f7b280c07cec184905b51e8e896efe6cc88eaf83a6f65c3(
++    scope_: Bell,
++    *,
++    scope: builtins.str,
++    props: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__49537950cbbeb6e2c62cb1b8a079cc9bb5cc6d06d95cf2229128539d2be886a3(
++    mult: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__408890be1949f7684db536e79081b85d00d72250ca9eb19c74db6ad226564784(
++    lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++    rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__67894f861ef38d2769b440d2fe71f549cb9e333247b385c5d6ae862b2eb04fc5(
++    value: typing.Any,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__106b87a3d0b194bda7cee057654f752c82d9a92a3775bcc3b2dc5cf7814ba84d(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b0e9a9c8546dd024e1568b2e6d11bd847e53548d624f33afffdffacc77fe01ef(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c62707f1a80d6bc26c0b74205f8892c1777e6ed97359263df05628018d8ef6fc(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c74abb191c66f86aed2c139ec3e50b0442b6d3bdcd41beb06db17c9b3c5d93d0(
++    value: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1af5d9bb897bd9bfc2029e92d33fc306fc090e2d0a9bc0bd70fb01762e798fe6(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__349b2a1dce95cb7ff4c5a7772d81772697767c5f4e7e5fd709847ff5e526c3c1(
++    value: typing.Optional[typing.Union[Add, Multiply, Power]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__21033948ed66f89716ed818c4cf9e5a38a9252e042231e1e8e1672356d403bef(
++    *,
++    initial_value: typing.Optional[jsii.Number] = None,
++    maximum_value: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9e749834c2e46eee6370de7b60daabbff6e5c16febe9775b98a2b961b0d4e335(
++    union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__80b80f78c4ac7fda46ac2aec7ab826a87bef3eaaba64661c90f346972800baf5(
++    value: typing.List[typing.Mapping[builtins.str, typing.Union[StructA, StructB]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7eb49cfb1282d7f1bd28096ff0407c0806693194f02f5c053936f99756a2a8fd(
++    map: typing.Mapping[builtins.str, builtins.str],
++    array: typing.Sequence[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__964903eb68623806c91fc9026cacfdc726cfbb287698530724c5a9938a7bb2ca(
++    value: typing.List[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8dd7203701e4915203e4778820ee40fe6bdd6f0bb2855c200f375606277e06c8(
++    value: typing.Mapping[builtins.str, builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c0c76fec28076841e36c26581c26385de1e984d96e91ea434a61c4bf36c9b4d9(
++    value: typing.List[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5461a3c7bb81040765e4ca2e9effb12cc7f5fb018e5e1b8b21501a3f9cd6a8b3(
++    value: typing.Mapping[builtins.str, builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__11d94174b1d488125abef65967a384ceb599f4948eca6cb9be3d55e1979fb64f(
++    array: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    record: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    obj: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    *,
++    array_prop: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    obj_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    record_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c017a39e0da5d21f3a9acbfd00f6a5c84eb4cad306148504e7c835359d35537e(
++    int: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7a756cab89b47a2ae4c08f36162482b60fdf963b8ba638917a63c5e110b4d33e(
++    assert_: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__3afbef7e05ef43a18b9260b86660c09b15be66fabeae128c9a9f99b729da7143(
++    value: IMutableObjectLiteral,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__0b8f0f729686dad01c8555a3b1bc47509e495bd18f1560ef045b558884b2a1fb(
++    union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a8a15eb37393d5188c71779e29278367f7b3600c6dd48bdbcd502cdf510c3c15(
++    value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union[StructA, StructB]], typing.List[typing.Union[StructA, StructB]]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ec229cc92e04670f4dca9546759b3b39ee813eb1aa18057135bb155d08971e6a(
++    value: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.List[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, AbstractClass]]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__481b1113b85e6dc9d7ba31c3ef5654e3550abac1edef9204348ab0f9554f61c1(
++    *,
++    union_property: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.Sequence[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, AbstractClass]]]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5676fcb3395f1db1a013537fa52220553e5e418c2a9d97aa2f9541c00ffe259e(
++    consumer: PartiallyInitializedThisConsumer,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5c5defc6d683ee91707f8b7770d8d2fb11d381b9c928d7e5d6e2c5c495395f38(
++    delegate: IStructReturningDelegate,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1df814299f3f9720be108d84bdfd61bc591699a79a3c8ac6d450bfb0a9610278(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2f08bd2d56e856071db5f777b63fe2577f9e96dbfcd91e4044d0eda2d26f9017(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4a2b7f0a05298ddaec112cb088cc71cfa2856aaa1d8414a5157d581b6d5a7293(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f751da3f5766ea4973eb2d89086565259f0a3cd626425a7eec723afd7b64f392(
++    ringer: IConcreteBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__cca04fe4a4c41a0034087ab0c574d1d2f1d0427d87a806fc660446b6a7e5290a(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7bde53b867de290d21a419baa46b8e833a0d394835a1ce2be3b429179b2ddce5(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__988e53d92b16fb4b7224c654f985a074cbfa7dd5f567df005b41522641ad92ac(
++    ringer: IBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1d786308546ae61deacb465c6f501fe7e0be028973494548b57e0480759ed460(
++    ringer: IConcreteBellRinger,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__83037a3f429b90a38d2d9532a347144030578d83f68817b1a5677ebcd1b38e12(
++    obj: IAnotherPublicInterface,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__139bf4e63e56bef32e364c5972e055de5cba153d49cc821740fba1d51f73ef70(
++    obj: INonInternalInterface,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2be181b08e5a2c0e1e3f3a84732a423af31039117701d35431ee251d343ca9d5(
++    *,
++    array_prop: typing.Sequence[typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    obj_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++    record_prop: typing.Mapping[builtins.str, typing.Union[DummyObj, typing.Dict[str, typing.Any]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__dd941dcba8415b4b4dbb95bc3f55ac3404bdaf303822dfc7093fb615dc66b2cf(
++    data: typing.Mapping[builtins.str, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9008dfc97234c0f2895caaa88d20a94de081c3cd97c38f9a012f13cdae75fbd6(
++    map: typing.Mapping[builtins.str, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__019e6ec86ae7ee325dc404a7025eaf0edcb164e166535a831bccf6658adfbb10(
++    arg1: typing.Optional[jsii.Number] = None,
++    arg2: typing.Optional[builtins.str] = None,
++    arg3: typing.Optional[datetime.datetime] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f64945b01dd806fcd872f369983e1fa6b3db8811cb0682ac6adf88aebb0aabda(
++    readonly_string: builtins.str,
++    mutable_number: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__3aef3220b38be7daf4208453b1766d9eafb6a74bd51dfb351d21235a205afa34(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__cdee1d6893b4921a8d7cf0a9c957a543b69f7a98eb3cedd7ece84871fc81c767(
++    *,
++    readonly_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c544311353634d5a2f08144f0c184afbcb700d8304b9f49deae99f19e1e7b0af(
++    *,
++    anumber: jsii.Number,
++    astring: builtins.str,
++    first_optional: typing.Optional[typing.Sequence[builtins.str]] = None,
++    another_required: datetime.datetime,
++    bool: builtins.bool,
++    non_primitive: DoubleTrouble,
++    another_optional: typing.Optional[typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue]] = None,
++    optional_any: typing.Any = None,
++    optional_array: typing.Optional[typing.Sequence[builtins.str]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__865cdfdd094ca753189170221ee7d6a0e59c2c0bcfdeff3dc37bb87dd39515ca(
++    *,
++    hoisted_top: typing.Optional[builtins.str] = None,
++    left: typing.Optional[jsii.Number] = None,
++    right: typing.Optional[builtins.bool] = None,
++    bottom: typing.Optional[datetime.datetime] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__cfa52ba952c3d4a7e6df7fba3f619bf3ac14c52e829cce862a5fa495e45d0e70(
++    *,
++    base_level_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__354311bd3d60d2b3b4ea927d6a96bdf66aa6d1109c29bfcd96266051c7c30a5e(
++    *,
++    base_level_property: builtins.str,
++    first_mid_level_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8074c5f38699399b9e6f8708c125bef5d7c89118c36ffcce8582d66cac2197da(
++    *,
++    base_level_property: builtins.str,
++    second_mid_level_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9384691e88dd3ab7e55516762b2076445d94bd6d9348db1b93f79de9f4ae0ea1(
++    *,
++    base_level_property: builtins.str,
++    first_mid_level_property: builtins.str,
++    second_mid_level_property: builtins.str,
++    top_level_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5ae2124576c295a0c88fc75be0e57258f0f72e63c733e7493367b8558266510e(
++    new_value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8ffaadb351f5c2c48a7368068d5c88e0c7836deefe0e13aa9fe53ac104052fd5(
++    _required_any: typing.Any,
++    _optional_any: typing.Any = None,
++    _optional_string: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5af7b38b9b5c170ebd3e05c215e05f10e6843b03868850dad87a5a149b90e790(
++    optional: typing.Optional[builtins.str] = None,
++    *things: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ae5d543014149876cec8b005abbb94c112981cccaf318870c7fe4e8353c2c675(
++    *,
++    example: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c0d457497f870b36d210f01af9890c6624684d1e53da833858e801c18baf9fbb(
++    value_store: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4f40c12fae2ef2673f3f324c0c452f65c187c1b3e6552b86768465a2d20de051(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9106fb2a86e944ce0c61537852ab2d310a8a53448c6946af051de0325a67fa1a(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ad557fbd0532aa4220227645f5aae3e73ebae6b529cfe074430abf30d18cd5e9(
++    original_value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a4026611d197b83d9a37b973ba97c69254e674921a7d89d0eb57ac41a19b636e(
++    new_value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2a7f203302b2610301f1b36f34453db0f5572f2e02b0bc4c9933fd670e594222(
++    clock: IWallClock,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a90d161fb7d47a195a192cf987ac6968fc2c6fbe27005bdd7684478a3d956e66(
++    word: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b87cc89f87e9b1c180227625f3aba9395da5a8b258a88e605d466edb9004d709(
++    opts: typing.Union[EraseUndefinedHashValuesOptions, typing.Dict[str, typing.Any]],
++    key: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d34e4f5dab670ec3ea298ec2cda50be32700f7f52dcef6a618ca9cb3706062ee(
++    *,
++    option1: typing.Optional[builtins.str] = None,
++    option2: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6a92c7223d00e7a0a2f0611cbb689671885b835bb26eedc8eb4a4d12e4ed5021(
++    readonly_string: builtins.str,
++    mutable_number: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__52559292c6e04ad49e53e443b1a4c56149833b8f12876d779bb8860fcb231b41(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b0c8f4c6eca5af7072a4a7c737950b39e75c61a56c505deb94edc5cd0995ed7d(
++    *,
++    readonly_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__dad018fa707514e8023df185b5e6e0a4b611bec563fe57abd9b81939b8833ebb(
++    success: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__861a5ec03219f6c9fecd1b039faa2e53075227ff0d28f8eb66929909bc0c3096(
++    *,
++    boom: builtins.bool,
++    prop: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__82149b1f61aca58419f6ba4c74c8bb1c5c241433707e64ea4626937b294d8fe5(
++    readonly_string: builtins.str,
++    mutable_number: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8380ec30b1f8773df7b5b27be8811be79b04f1d17c8eca83f83927eb56cdfd34(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8e8843a5fc914ec2c1e3baccdad526ea4d48eee37296f6812f3c0673ef86794f(
++    *,
++    readonly_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__3dce87825e36304d54521ce5524aa7e230fa5d505b0abbc79101fd9014f2cbd9(
++    *,
++    name: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d17f0544be961cba6cabfbb40f28c196963de107fcaef9c56d8227bdcb359431(
++    friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__3eabfcad9a21b26024f4c1480ca127a3d6c6888067f0ae991d5922a49bfe81d4(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d127476ce3b6e59ff9f375f547c1b6e1826d7a3969612c0605ebd0017d2b985d(
++    bell: IBell,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2c34aaac5945bdc61c4f56492dee5608e1852940835d94d3e991fed377db66f2(
++    bell: Bell,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e4d76200a6c5bdbdd51f208229da8bfd8f6f4c967af28e1e733579780e9d4a0e(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6e68d313f3254be7145220b211c66f45749aa8efc15aaf93d96330eb3cb7c6c7(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8199a83e86f8a4cf29ddc53d2b2151c37c7fa10d29562b454127376d1867d6da(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a904d745cb9f037de717ed7a2b1d3a207493564662fdbe1d7c63e60a24f9bace(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5568c72c746dd5221cb6fb7b741ed7a3346c346d7a30863c5abe3d99ada53098(
++    arg1: builtins.str,
++    arg2: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__858de6e8785f18ad264a158ca83a0fc1e0a6299efa9f77a0b31eaaffaa5b086c(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c571c6749392bc04e123a99b926edaf10b88be6b6d6b6a3937cae9893af5119e(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e0395944061fad9d5156b633dc20682ff9759ae0acb88df574b159f4919ab3a5(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9d1e4198ba3f4e6b6a6f4ce0a4a185223ec216368c0c3304c69b029aba13ca49(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6774e195ab25dab5790e1d187eb30be56997804d5186753a9928f2575f81977b(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__831f664cd567fd4e707fd175e9c9e13519f3ca587b792d7d5bc79f427589a802(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__254a58386276f7b7d5a41dddd674375b8942c2cad4deb6c2d24b55d240d14350(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__10bb8b026d6c8368d479cf0da8b27c049c5f9088f173a63624e515dd36607439(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2df4d055b033cdfdf7ad915b451ddc787ad68fb64b7e02386a9d8e591c1657af(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b70592e4d080897239bf5f8b0de5b6b464cd9e888e39fca1082c04b5cbeca890(
++    *,
++    foo: _scope_jsii_calc_base_of_base_49fa37fe.Very,
++    bar: builtins.str,
++    goo: datetime.datetime,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1d6e348a61ed27bfc8b7928365798b43e0130ca2b720c1105baca04fa093d194(
++    count: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__30ce308abdc1d2462c00bf7a4acc194ec05d61ddee24b2e79c674aa7034e5ffa(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__eef7c487e6f0c4d81dd633cf70121104ff8f3458fa52a418df64bcab9fe4bd3e(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a7654af9a241e67ad498c3eb33b98e6cdb1558487bb9b02dcce41f75334b76ad(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__43f45c49ecee3d08351b82aa5cdc3548d9dafa534cd2d99da8b5c5c9188e9a54(
++    value: typing.Any = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ef705a05998260349d35c748c557e65cf539d53e136eb9191250080bdce852c3(
++    *,
++    value: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2a9e65060bf85c3d49b79ada1f9394ae146c380a4212c190065e031098d570b8(
++    *,
++    prop: typing.Union[LevelOne.PropBooleanValue, typing.Dict[str, typing.Any]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__479be5d5625f656c28cf12ffdc2cef9d6d74aae555551630f440fcb05351d261(
++    *,
++    prop: typing.Union[LevelOne.PropProperty, typing.Dict[str, typing.Any]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b3d89a25beb0ebd10c196d941aa924197ae9a2def08f1f414c190a2a6d943d9c(
++    *,
++    container_port: typing.Optional[jsii.Number] = None,
++    cpu: typing.Optional[builtins.str] = None,
++    memory_mib: typing.Optional[builtins.str] = None,
++    public_load_balancer: typing.Optional[builtins.bool] = None,
++    public_tasks: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7e73465ea858e34d4df8697d34f29a53ca3c3a41c47946382e5d49f498e3747d(
++    lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++    rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__04dae031a5097183ccda93eb91ec51a8a6fa1133134a6a398f1f05c581bc0091(
++    *,
++    number_prop: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__218107d38285901ff40e08163f0de0bac5d835bd64c21c0a735e8d72399ebe35(
++    _param1: builtins.str,
++    optional: typing.Any = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a109cd8429db09172895a3eb04ca7e9d5c92129c7ca7a50f85fa89b6f6ab366b(
++    value: typing.Any = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7102c29a709c4297fb88615c74a3e42a584364ac4ccba5c1db42a65e05184d1b(
++    value: typing.Optional[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ae8d47cabe4d36f88c891d250d7e792432b0d153223789ec3687e714ba92a5f3(
++    *,
++    array_with_three_elements_and_undefined_as_second_argument: typing.Sequence[typing.Any],
++    this_should_be_undefined: typing.Any = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__3c1812783ba0b3b2146a3dd9609a6e12af404502ff5fbb9b9a9be49bf576122b(
++    generator: IRandomNumberGenerator,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__151b90e9765ce9a05ae13e568f4ba7c9e36e34c1cd991c5c1ee0249869fd4cce(
++    gen: IRandomNumberGenerator,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__0f5a1cc548d3db6e156cec5671bc04b980132e529c77f3bb5aaa58427db35e7c(
++    value: IRandomNumberGenerator,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f5cb9f9511b0248cd4c0c4bec4eed9e75e7690012237fdb1b39b3f7b3bb0392e(
++    values: typing.Sequence[_scope_jsii_calc_lib_c61f082f.NumericValue],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ca5199647728e53a1ec89d4fd7dad9aeb7239f8c1213c51b4e2eda734daa4cf4(
++    values: typing.Mapping[builtins.str, _scope_jsii_calc_lib_c61f082f.NumericValue],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__da93d15e57e6e2a1857cd7df156fb2a55ec91715c97323f20268def40f72137c(
++    delegate: IInterfaceWithOptionalMethodArguments,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5f6c5e5b55379123a8bd2bc457d9a5e9a0d34dd512b2bd2f59c6a5bec2a95f14(
++    arg1: jsii.Number,
++    arg2: builtins.str,
++    arg3: typing.Optional[datetime.datetime] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__26ecd0d4ea200acf388a8b91f17bfd3c09b6c7f8e0a84228b89c27ace672d0b1(
++    *,
++    field: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__72ca8c3c148afe2b76dc14b63b8e2baf0bbf28802add3f88490cb5d3792825fb(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ca8d417ddf787890441d6903718eebaf7fde3508b3466202724fdac3a17ba79b(
++    obj: IReturnsNumber,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ae63c91319764cabd02536ac5b03026eb3f4071497b2a04adf93ca02985507ae(
++    scope: _scope_jsii_calc_lib_c61f082f.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f6db465208dd616dc4f171643676a159b21fe5963ec9a3d1fd752e5cb291868d(
++    *,
++    foo: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__85c3ad65f24d8d5af99d7777a0379b793f45ac0e0e39714f279b8f2d58dbcfdb(
++    obj: ConstructorPassesThisOut,
++    dt: datetime.datetime,
++    ev: AllTypesEnum,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__edbbf85a7c4217635da7418d28aa61c4e11f7a0c1e9c960528ed4e7bee1ad541(
++    friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__df4f41b4c003b9ba61f07f4d41a4059f167ea41c03ea29933966d2caeb831d8c(
++    base: _scope_jsii_calc_lib_c61f082f.NumericValue,
++    pow: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__235768085718ab33214221cff3145bb2a82c28916350f273995760a428a1aba3(
++    value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__100c679fa10c1938fc087475a1e5fcdf7c2cbff383b1c02b1d09471cb4f23123(
++    value: typing.Optional[_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__cf66d7b4f4a567aefacbafc24f61d33a942afde3d167676ed65ea82da95cd36e(
++    *,
++    string_prop: builtins.str,
++    nested_struct: typing.Optional[typing.Union[NestedStruct, typing.Dict[str, typing.Any]]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6db501e892de783af62ff728e59cc3155afc51ddc2dff77cce61ffe698e2e1f3(
++    arg1: typing.Optional[jsii.Number] = None,
++    arg2: typing.Optional[builtins.str] = None,
++    arg3: typing.Optional[datetime.datetime] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5978f09aaa3317742377437d5735571f672119325c2b5d69f26153bae6764c85(
++    arg: typing.Any = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c894904fd4904d7e110da91df846a8ec0970051a274bba5ad95c2b7dc1125cc2(
++    arg1: jsii.Number,
++    arg2: builtins.str,
++    arg3: typing.Optional[datetime.datetime] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e7383b9a36a10b88815e6c310c7b13c611260f5ccb143b75dac114873643350d(
++    *,
++    deeper_required_prop: builtins.str,
++    deeper_optional_prop: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2ccde09a2986c421795069d44c46d9e2d7470609094b8b7177c6b154360f7435(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__76cbdc0bba36d674ab013a40d091c1f3ccb139f10e78844ebc868bfa5d707ef8(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1b795ca2a3052da38144d10d87f230e74bcfa497af1262580f53908be48f6710(
++    *,
++    property: builtins.str,
++    yet_anoter_one: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8c577a76d55e32f4b62a2a005d0c321bf9d0784b2f6cea5f10e297f3f79fc4bb(
++    readonly_string: builtins.str,
++    mutable_number: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__737be2f0376e64bd8c0980aee9fc6afd796bb4d0cb3415eab28d054f15881752(
++    value: typing.Optional[jsii.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4bbf1eebbce12768b1d2ef90968ffdbe749e42ce8bcdaf4c8750314d2160c5ea(
++    *,
++    readonly_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__cf00e16ec45ebcadc1f7003eb344ecf452096a12a1a76ff0e15fce1066d716d2(
++    value: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__69df39c5fc3367bba974a46518d9122ce067721f56037ef6e1faedf479222822(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c4597464b7867e98bf0052f7808e080b75874d088aeac980865a4fc19e47a6d1(
++    name: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__748a4d0813e4a3ab750bd52215b9ff4dee315d39b160d47884780ea7c4b10daf(
++    value: Statics,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5d0ed37ae4b7f5bd294a768da342f4735c6636e0197883a5727e46ed81deec69(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__aa3b9a5342b6fe1366fac3279219c5bae15389881ddd050c544c1d0001853482(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c9e4f6413d6ce49f4a289256d84d0fa97f7abac1877fc8d49f80f4a7d83a4972(
++    *,
++    required_string: builtins.str,
++    optional_number: typing.Optional[jsii.Number] = None,
++    optional_string: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4d335a3a7bbc35ed76509a5e85466d6d29221efebdd6dd4de639ef040628f332(
++    *,
++    required_string: builtins.str,
++    optional_boolean: typing.Optional[builtins.bool] = None,
++    optional_struct_a: typing.Optional[typing.Union[StructA, typing.Dict[str, typing.Any]]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7eb7b6caeb33bbd3740ca0fc027022df9d4fade4a7d1943a334f2869ab44bd98(
++    *,
++    scope: builtins.str,
++    props: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e3587fc6359e7cd1adf0bb70ed66e1cd69faa462a530e07c8d25a96b942cb943(
++    _positional: jsii.Number,
++    *inputs: TopLevelStruct,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b60fd8dad9496da93546e0555f2f8a7a34711e7160c06dc64a47f095f1539d02(
++    _positional: jsii.Number,
++    *,
++    required: builtins.str,
++    second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
++    optional: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1c22dd35a08877498e4c2c0ed61e220c19d83da3b6a1e278dfcb7af4d76d2df8(
++    struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__bfb5d0235b42940b9a17c7bb3182f454c7652fdb031f8993719a701d42833623(
++    struct: typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e3e3d0b072ef214d95806fb0366dd1f4a92b97932f845c9364616c9348bce502(
++    which: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__06173422e8b2a410ef992bee26115592516245e72f1a99397919d18bfebc1259(
++    *,
++    union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[str, typing.Any]], typing.Union[StructB, typing.Dict[str, typing.Any]]]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9fac60639e71eb35a422d891e6b571b3ba2118da50de35e8ba784bbb73928be9(
++    *,
++    foo: StringEnum,
++    bar: typing.Optional[AllTypesEnum] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__21b11cdfe2d95237cdddef417a67936ff8529ea3cef4bd7e80fe498f1e27527d(
++    *,
++    default: builtins.str,
++    assert_: typing.Optional[builtins.str] = None,
++    result: typing.Optional[builtins.str] = None,
++    that: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e2e14d04b1a68f16d9aef0965aa4ffbc51af3cbd2d201ac6e236d861b10c2fbf(
++    value: typing.List[_scope_jsii_calc_lib_c61f082f.NumericValue],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__11e78aa6557af36be636eea7a1a9b1d6ebf38d63d876b270de65a5f23152b605(
++    *,
++    bar: jsii.Number,
++    id: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__46b91a4f1b85f01437aa8a6dda82c7c9e02f0b2ae5324f8c1591fa7ff74feaa0(
++    id_: jsii.Number,
++    *,
++    bar: jsii.Number,
++    id: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a961c6dee96c75a70470863d82c09136094c1d72d47aafe7f105c7733536dd4d(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f3d4d3109122672e8fa17c64fb60787d84a098ee0ee0857d4a10ffe5345a1908(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ba36c4cb32b9551fe1c3e91bd834b2e97f7ee93d0b5919acfb1c4fd3d6161295(
++    n: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7118412729d7ec6272cded791897b09f12ee70e1ca550853121f98ceb30ee0e7(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c361a6694d6564ff5c16af012cfaf94cac0a971928a1d0fb014c27f971287836(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d5d44f6e3395b0db421bab95a6dd7d1560538c63f136025c6b216ffb01eae179(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__64c8c65ae76fcafb4b6d28e75f8fd31efad60ab9e71d11cbd5877c28c45d8f70(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__52ea95020be0094da769c873214a182768aa2de47b1c4c3dff43f1226edfe281(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__21d6ffe465a7e42c257c8318bf2bee38ecbc6b1959e6e945e769e365afb3e55d(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__74359fdf4e6a6505a1c0bc4c2c687826dde0a7696de75fc39f9ed57d89137f96(
++    *,
++    required: builtins.str,
++    second_level: typing.Union[jsii.Number, typing.Union[SecondLevelStruct, typing.Dict[str, typing.Any]]],
++    optional: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e31f878fe14747887a58683a15ca9c8ab54ec35cd6e3a665ad70dd53deadb573(
++    operand: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__223de5294ccc50da976adb8794cb8556981e31d63a2c8b249f7dfbd9e2d99eac(
++    *,
++    bar: typing.Union[builtins.str, jsii.Number, AllTypes],
++    foo: typing.Optional[typing.Union[builtins.str, jsii.Number]] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__aaaf822e80c6473bff9b1da58151a278cd846ae0614db9af97bc57ea6f899ce2(
++    delegate: typing.Mapping[builtins.str, typing.Any],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__73d1545891c65d400938add489402441cb083c61d214ad7a922b6417d3984732(
++    obj: IInterfaceWithProperties,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__60f3870a6dceb3773397b75ec3f3b664f38c2cc3d2f37dc055262663d12f41a8(
++    ext: IInterfaceWithPropertiesExtension,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__42edcb376aed0b6e6fec7d7df016bda9e3a31df0e47ecabb5465d1c84d16a414(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6d238d6a2f6e464c570c3176db3d78d62e0be9908b705705c8f6d7b6b2385c54(
++    method: VariadicMethod,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__43f32dfb73f1a7fe9c86c00bbc381391db4812c13b5b72363ddcfcd57638c368(
++    *values: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__a33769c23320f9f6bce3e3a70c594135cf44ca5c9c6d1de1cae8cc62a99d49e9(
++    *prefix: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1c18f2c7d91dcdc13843ff1637ed95a1f1c1ed99384d6276ee493b0ca579b4a4(
++    first: jsii.Number,
++    *others: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f18ff2aa5c744d99cc2b37e705d6ed44823660f714c20539c148c9e34e123752(
++    *union: typing.Union[StructA, StructB],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__01944feab2feb5a9fdf3d356f62de139685f520d3bb3a38ddc5c42d0b03963fe(
++    value: typing.List[typing.Union[StructA, StructB]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5efa2ef42e261d5c38c59d5e216e587cb3005bbbb5b4a62e926087ee58478a36(
++    index: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ca8f2360b0292d0b5329ac52818673aece7fb01cf2f09567e60ff65b7728c9cc(
++    index: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5bc99fd66b59152ee7799cf716c91bec428d7091eb33ece69057f9ca9b9fdb19(
++    count: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__58451fb4813d1aa8877a55de41f1ef8bd30300048337edb2bcf16985abbb6f45(
++    count: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7ac4c09636b11fefb0a54fbd52b88fc2b4c5c356eb07189a0d2545601f3bef9c(
++    count: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__01fcbc911a24b1fa352275e1273526114db562d2c278b742181eba6e8cb11ad4(
++    private_field: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__af1f574dee5c4eb581961518ccf32b4060094ed2f9b7e60bece1ed48e3fc45a1(
++    name: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__c0e59e6ea7e78215051bf4fe6b69de179aefb4116a344decdfaab4b6b15189b8(
++    lhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++    rhs: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__fa23831ecd0b539d7689616a0557240dc1a45f924fafe58c0d5f0ac464eecf94(
++    value: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__84a0b7e93c52a4977e9726c1186b64f57ff35c59c5bc0e7250da1d3236e70208(
++    *,
++    foo: builtins.str,
++    bar: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__720d53a768711730e792d129fcff6272627608d1d3942f42e3010e61a3463b31(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5236e267a6763b672404dac13a3d5e50c03eb03d35fe2c18cbe7f649933301f1(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__1bd3b16d1aaf127e7610a230095bced32c4c3ef1cadc73f6b24c76b3ebffdd8e(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__4e685d8185af60a2f5c9bcffe812224568fe893228304e510b4d989f92c19b90(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__6499a25aa5ac6723e26c4c716dd2d62a1f9ecd75ae2a476d3213fa5fe8792a1d(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5da75e226d085b0daac7742a86525ea697c77a044896ce80d48677f5fadb2d57(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__538f9410afd2d028ca599a233896016121b326bd90d69693e949aff75d72caf3(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__ba8bf3471001981f03d1ad5b84a1b0a4a4d7d556c72734d25d96637a60ad2477(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__71399b17d07223b2b83f0d7b33d5172c49eb3d0cf3fe38d6059d4c9b7f471113(
++    read_only_string: builtins.str,
++    read_write_string: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e308499c7b9268c91ee3dc9e4a9c975efdfaa0cd72bd877383c6c64e8f2768d0(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__148cd823b5de47723c8a76d0553f3ff6c880ba8ecec14b9a86bd89025a18f4d3(
++    property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__e7aa949631662ae6f6ab2804e4a231fa264a1c879d86efa8267e53158c50e647(
++    operand: _scope_jsii_calc_lib_c61f082f.NumericValue,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2f90423a63bd0fc04016022e622b4bf01d35f365e38b15153d0a4d6fa014ee5b(
++    id: jsii.Number,
++    default_bar: typing.Optional[jsii.Number] = None,
++    props: typing.Optional[typing.Union[SupportsNiceJavaBuilderProps, typing.Dict[str, typing.Any]]] = None,
++    *rest: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/anonymous/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/anonymous/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/anonymous/__init__.py	--runtime-type-checking
-@@ -54,26 +54,41 @@
+@@ -54,31 +54,58 @@
      @builtins.classmethod
      def consume(cls, option: typing.Union[IOptionA, IOptionB]) -> builtins.str:
          '''
          :param option: -
          '''
 +        if __debug__:
-+            def stub(option: typing.Union[IOptionA, IOptionB]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__132536bffc9129421b4ae0a6539d0bbfdc1c52c3de007c4546d2f2626ba8c31e)
 +            check_type(argname="argument option", value=option, expected_type=type_hints["option"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "consume", [option]))
  
@@ -17995,9 +18950,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            def stub(which: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d461fff988e22833dcf37c5193332d48b9e455d605f2a1e708ab0d111a1659c7)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Any, jsii.sinvoke(cls, "privideAsAny", [which]))
  
@@ -18008,71 +18961,111 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param which: -
          '''
 +        if __debug__:
-+            def stub(which: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f841b966136dfd090628b12290eedd178724cc8f332e05aba2b3a035f07dae50)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[IOptionA, IOptionB], jsii.sinvoke(cls, "provide", [which]))
  
  
  __all__ = [
      "IOptionA",
+     "IOptionB",
+     "UseOptions",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__132536bffc9129421b4ae0a6539d0bbfdc1c52c3de007c4546d2f2626ba8c31e(
++    option: typing.Union[IOptionA, IOptionB],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__d461fff988e22833dcf37c5193332d48b9e455d605f2a1e708ab0d111a1659c7(
++    which: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f841b966136dfd090628b12290eedd178724cc8f332e05aba2b3a035f07dae50(
++    which: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/__init__.py	--runtime-type-checking
-@@ -42,10 +42,15 @@
+@@ -42,10 +42,13 @@
      def _unwrap(self, gen: _IRandomNumberGenerator_9643a8b9) -> jsii.Number:
          '''Implement this functin to return \`\`gen.next()\`\`. It is extremely important that the \`\`donotimport\`\` submodule is NEVER explicitly loaded in the testing application (otherwise this test is void).
  
          :param gen: a VERY pseudo random number generator.
          '''
 +        if __debug__:
-+            def stub(gen: _IRandomNumberGenerator_9643a8b9) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(jsii.Number, jsii.invoke(self, "unwrap", [gen]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Cdk16625).__jsii_proxy_class__ = lambda : _Cdk16625Proxy
+ 
+@@ -57,5 +60,11 @@
+ 
+ publication.publish()
+ 
+ # Loading modules to ensure their types are registered with the jsii runtime library
+ from . import donotimport
++
++def _typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b(
++    gen: _IRandomNumberGenerator_9643a8b9,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/donotimport/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/donotimport/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/donotimport/__init__.py	--runtime-type-checking
-@@ -31,10 +31,15 @@
+@@ -31,10 +31,13 @@
  
      def __init__(self, value: jsii.Number) -> None:
          '''
          :param value: -
          '''
 +        if __debug__:
-+            def stub(value: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e2659669d69691129e05836f0722a48449fe2efe197706d9d59c10c141470a4b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
      @jsii.member(jsii_name="next")
      def next(self) -> jsii.Number:
          '''Not quite random, but it'll do.
+@@ -47,5 +50,11 @@
+ __all__ = [
+     "UnimportedSubmoduleType",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__e2659669d69691129e05836f0722a48449fe2efe197706d9d59c10c141470a4b(
++    value: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/composition/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/composition/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/composition/__init__.py	--runtime-type-checking
-@@ -52,30 +52,45 @@
+@@ -52,30 +52,39 @@
          '''A set of postfixes to include in a decorated .toString().'''
          return typing.cast(typing.List[builtins.str], jsii.get(self, "decorationPostfixes"))
  
      @decoration_postfixes.setter
      def decoration_postfixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f546e09b5b6c86dfee3f946eff8913ea8feb763a4156fb8aad45ecc179c63e62)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPostfixes", value)
  
@@ -18085,9 +19078,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @decoration_prefixes.setter
      def decoration_prefixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.List[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__abce94053402e9d1fcf1605226fa2c285e1340ec8219cfd1061f917e876a9051)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPrefixes", value)
  
@@ -18100,193 +19091,271 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @string_style.setter
      def string_style(self, value: "CompositeOperation.CompositionStringStyle") -> None:
 +        if __debug__:
-+            def stub(value: CompositeOperation.CompositionStringStyle) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9dbbc353e0ea03d68edfa3977eadeb5446b56a89ffb921cb8406ba9fca0805b0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringStyle", value)
  
      @jsii.enum(
          jsii_type="jsii-calc.composition.CompositeOperation.CompositionStringStyle"
      )
+@@ -108,5 +117,23 @@
+ __all__ = [
+     "CompositeOperation",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__f546e09b5b6c86dfee3f946eff8913ea8feb763a4156fb8aad45ecc179c63e62(
++    value: typing.List[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__abce94053402e9d1fcf1605226fa2c285e1340ec8219cfd1061f917e876a9051(
++    value: typing.List[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__9dbbc353e0ea03d68edfa3977eadeb5446b56a89ffb921cb8406ba9fca0805b0(
++    value: CompositeOperation.CompositionStringStyle,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/derived_class_has_no_properties/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/derived_class_has_no_properties/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/derived_class_has_no_properties/__init__.py	--runtime-type-checking
-@@ -25,10 +25,15 @@
+@@ -25,10 +25,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
-+            def stub(value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__4b95d284137921c7cbf29a9e3a15da0a5cf9dda87efad87aa9ed601662f00b2c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
  
  class Derived(
      Base,
+@@ -43,5 +46,11 @@
+     "Base",
+     "Derived",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__4b95d284137921c7cbf29a9e3a15da0a5cf9dda87efad87aa9ed601662f00b2c(
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/homonymous_forward_references/bar/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/homonymous_forward_references/bar/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/homonymous_forward_references/bar/__init__.py	--runtime-type-checking
-@@ -46,10 +46,18 @@
+@@ -46,10 +46,13 @@
          '''
          :param homonymous: 
          '''
          if isinstance(homonymous, dict):
              homonymous = Homonymous(**homonymous)
 +        if __debug__:
-+            def stub(
-+                *,
-+                homonymous: typing.Union[Homonymous, typing.Dict[str, typing.Any]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a201923592702b83e439b8af921b7eae6f1b86b0eeeffb6c2b506d66a57d4c3a)
 +            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[str, typing.Any] = {
              "homonymous": homonymous,
          }
  
      @builtins.property
-@@ -78,10 +86,15 @@
+@@ -78,10 +81,13 @@
  class Homonymous:
      def __init__(self, *, numeric_property: jsii.Number) -> None:
          '''
          :param numeric_property: 
          '''
 +        if __debug__:
-+            def stub(*, numeric_property: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b7814834f12f5cbacf39dd7bdb11da208ae4c429011eff511d21e10d621cf9d5)
 +            check_type(argname="argument numeric_property", value=numeric_property, expected_type=type_hints["numeric_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "numeric_property": numeric_property,
          }
  
      @builtins.property
+@@ -107,5 +113,19 @@
+     "ConsumerProps",
+     "Homonymous",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__a201923592702b83e439b8af921b7eae6f1b86b0eeeffb6c2b506d66a57d4c3a(
++    *,
++    homonymous: typing.Union[Homonymous, typing.Dict[str, typing.Any]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b7814834f12f5cbacf39dd7bdb11da208ae4c429011eff511d21e10d621cf9d5(
++    *,
++    numeric_property: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/homonymous_forward_references/foo/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/homonymous_forward_references/foo/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/homonymous_forward_references/foo/__init__.py	--runtime-type-checking
-@@ -46,10 +46,18 @@
+@@ -46,10 +46,13 @@
          '''
          :param homonymous: 
          '''
          if isinstance(homonymous, dict):
              homonymous = Homonymous(**homonymous)
 +        if __debug__:
-+            def stub(
-+                *,
-+                homonymous: typing.Union[Homonymous, typing.Dict[str, typing.Any]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__56bad81fb024ccb6a97af9b4edcb748a4d5e34e81491c4222bb761bc0e5890b6)
 +            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[str, typing.Any] = {
              "homonymous": homonymous,
          }
  
      @builtins.property
-@@ -78,10 +86,15 @@
+@@ -78,10 +81,13 @@
  class Homonymous:
      def __init__(self, *, string_property: builtins.str) -> None:
          '''
          :param string_property: 
          '''
 +        if __debug__:
-+            def stub(*, string_property: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__57e873ae26cc34d45d619900518aa9fbc9f512fa9ca964387f9bcd933e461123)
 +            check_type(argname="argument string_property", value=string_property, expected_type=type_hints["string_property"])
          self._values: typing.Dict[str, typing.Any] = {
              "string_property": string_property,
          }
  
      @builtins.property
+@@ -107,5 +113,19 @@
+     "ConsumerProps",
+     "Homonymous",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__56bad81fb024ccb6a97af9b4edcb748a4d5e34e81491c4222bb761bc0e5890b6(
++    *,
++    homonymous: typing.Union[Homonymous, typing.Dict[str, typing.Any]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__57e873ae26cc34d45d619900518aa9fbc9f512fa9ca964387f9bcd933e461123(
++    *,
++    string_property: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/interface_in_namespace_includes_classes/__init__.py	--runtime-type-checking
-@@ -25,10 +25,15 @@
+@@ -25,10 +25,13 @@
      def bar(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "bar"))
  
      @bar.setter
      def bar(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[builtins.str]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3319085b675e83451882dd81f7704e88da2e392266f9d5188ecb22725f3f71bb)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "bar", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.InterfaceInNamespaceIncludesClasses.Hello",
-@@ -38,10 +43,15 @@
+@@ -38,10 +41,13 @@
  class Hello:
      def __init__(self, *, foo: jsii.Number) -> None:
          '''
          :param foo: 
          '''
 +        if __debug__:
-+            def stub(*, foo: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5c05b45db7e873d4164cc7295b5d2800ba4bed1813d4a2d57aad8cedb292186d)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
+@@ -66,5 +72,18 @@
+     "Foo",
+     "Hello",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__3319085b675e83451882dd81f7704e88da2e392266f9d5188ecb22725f3f71bb(
++    value: typing.Optional[builtins.str],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__5c05b45db7e873d4164cc7295b5d2800ba4bed1813d4a2d57aad8cedb292186d(
++    *,
++    foo: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/interface_in_namespace_only_interface/__init__.py	--runtime-type-checking
-@@ -21,10 +21,15 @@
+@@ -21,10 +21,13 @@
  class Hello:
      def __init__(self, *, foo: jsii.Number) -> None:
          '''
          :param foo: 
          '''
 +        if __debug__:
-+            def stub(*, foo: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cc86cfd2ea53d0ae81d6d80ed07db33f3ca7b140e37166ba1d572a8ed2a78d2c)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
+@@ -48,5 +51,12 @@
+ __all__ = [
+     "Hello",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__cc86cfd2ea53d0ae81d6d80ed07db33f3ca7b140e37166ba1d572a8ed2a78d2c(
++    *,
++    foo: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/jsii3656/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/jsii3656/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/jsii3656/__init__.py	--runtime-type-checking
-@@ -27,10 +27,20 @@
+@@ -27,10 +27,14 @@
      ) -> None:
          '''
          :param name: 
          :param count: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                name: builtins.str,
-+                count: typing.Optional[jsii.Number] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__9754f0ac616c8a4339db020e52a796e65577c9909ed5e25d0c696417da04377c)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -18294,37 +19363,53 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if count is not None:
              self._values["count"] = count
-@@ -69,10 +79,15 @@
+@@ -69,10 +73,13 @@
      @builtins.classmethod
      def call_abstract(cls, receiver: "OverrideMe") -> builtins.bool:
          '''
          :param receiver: -
          '''
 +        if __debug__:
-+            def stub(receiver: OverrideMe) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__37c9a298f20a606212f074bd150ba5bc37e38a4cc1f9b2672facafd80734afc1)
 +            check_type(argname="argument receiver", value=receiver, expected_type=type_hints["receiver"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "callAbstract", [receiver]))
  
      @jsii.member(jsii_name="implementMe")
      @abc.abstractmethod
      def implement_me(
+@@ -112,5 +119,19 @@
+     "ImplementMeOpts",
+     "OverrideMe",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__9754f0ac616c8a4339db020e52a796e65577c9909ed5e25d0c696417da04377c(
++    *,
++    name: builtins.str,
++    count: typing.Optional[jsii.Number] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__37c9a298f20a606212f074bd150ba5bc37e38a4cc1f9b2672facafd80734afc1(
++    receiver: OverrideMe,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2530/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2530/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2530/__init__.py	--runtime-type-checking
-@@ -21,25 +21,40 @@
+@@ -21,28 +21,55 @@
  
      def __init__(self, _: jsii.Number) -> None:
          '''
          :param _: -
          '''
 +        if __debug__:
-+            def stub(_: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d62f783e4108a6327009d506f8ae7f5aca2734de07314ffd120f24d3e918f697)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          jsii.create(self.__class__, self, [_])
  
@@ -18335,9 +19420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _: -
          '''
 +        if __debug__:
-+            def stub(_: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f35c91dda02ec538c4e5ee9182aaa01ba14f837c78951f48bb0abd1a866a4d5c)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.sinvoke(cls, "bar", [_]))
  
@@ -18347,153 +19430,205 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _: -
          '''
 +        if __debug__:
-+            def stub(_: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__dd74e61269fd21c6a0b0983199f27c5d4df8a4447ff77e770890f58f6c9b6969)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.invoke(self, "foo", [_]))
  
  
  __all__ = [
      "MyClass",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__d62f783e4108a6327009d506f8ae7f5aca2734de07314ffd120f24d3e918f697(
++    _: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f35c91dda02ec538c4e5ee9182aaa01ba14f837c78951f48bb0abd1a866a4d5c(
++    _: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__dd74e61269fd21c6a0b0983199f27c5d4df8a4447ff77e770890f58f6c9b6969(
++    _: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2647/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2647/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2647/__init__.py	--runtime-type-checking
-@@ -31,10 +31,15 @@
+@@ -31,10 +31,13 @@
          '''
          :param very: -
  
          :stability: deprecated
          '''
 +        if __debug__:
-+            def stub(very: scope.jsii_calc_base_of_base.Very) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__3b33906576528227344dbb0f079876c5dccd08a32f3dbaa0acdc3f444c5fe448)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
+@@ -48,5 +51,11 @@
+ __all__ = [
+     "ExtendAndImplement",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__3b33906576528227344dbb0f079876c5dccd08a32f3dbaa0acdc3f444c5fe448(
++    very: _scope_jsii_calc_base_of_base_49fa37fe.Very,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/methods/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/methods/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/methods/__init__.py	--runtime-type-checking
-@@ -29,17 +29,29 @@
-         _bar: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
+@@ -29,23 +29,41 @@
+         _bar: typing.Mapping[builtins.str, typing.Union[_scope_jsii_calc_base_734f0262.BaseProps, typing.Dict[str, typing.Any]]],
      ) -> None:
          '''
          :param _bar: -
          '''
 +        if __debug__:
-+            def stub(
-+                _bar: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__cfbe1bc46497cbad551fc80c4d304742daa30493dee8c65b7119cafdeb06e9af)
 +            check_type(argname="argument _bar", value=_bar, expected_type=type_hints["_bar"])
          return typing.cast(None, jsii.invoke(self, "bar", [_bar]))
  
      @jsii.member(jsii_name="foo")
-     def foo(self, _values: typing.Sequence[scope.jsii_calc_lib.Number]) -> None:
+     def foo(
+         self,
+         _values: typing.Sequence[_scope_jsii_calc_lib_c61f082f.Number],
+     ) -> None:
          '''
          :param _values: -
          '''
 +        if __debug__:
-+            def stub(_values: typing.Sequence[scope.jsii_calc_lib.Number]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__40045f17e26efacbabd3e103d903497e18761a611301d901fcdebc3cf8baaced)
 +            check_type(argname="argument _values", value=_values, expected_type=type_hints["_values"])
          return typing.cast(None, jsii.invoke(self, "foo", [_values]))
  
  
  __all__ = [
      "MyClass",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__cfbe1bc46497cbad551fc80c4d304742daa30493dee8c65b7119cafdeb06e9af(
++    _bar: typing.Mapping[builtins.str, typing.Union[_scope_jsii_calc_base_734f0262.BaseProps, typing.Dict[str, typing.Any]]],
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__40045f17e26efacbabd3e103d903497e18761a611301d901fcdebc3cf8baaced(
++    _values: typing.Sequence[_scope_jsii_calc_lib_c61f082f.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/structs/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/structs/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/structs/__init__.py	--runtime-type-checking
-@@ -30,10 +30,20 @@
+@@ -30,10 +30,14 @@
      ) -> None:
          '''
          :param base_map: 
          :param numbers: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                base_map: typing.Mapping[builtins.str, typing.Union[scope.jsii_calc_base.BaseProps, typing.Dict[str, typing.Any]]],
-+                numbers: typing.Sequence[scope.jsii_calc_lib.Number],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__71fe496245d27f33a2ded522fdf47757e7fb41b578fd3ec479cd5b45534588fc)
 +            check_type(argname="argument base_map", value=base_map, expected_type=type_hints["base_map"])
 +            check_type(argname="argument numbers", value=numbers, expected_type=type_hints["numbers"])
          self._values: typing.Dict[str, typing.Any] = {
              "base_map": base_map,
              "numbers": numbers,
          }
+ 
+@@ -66,5 +70,13 @@
+ __all__ = [
+     "MyStruct",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__71fe496245d27f33a2ded522fdf47757e7fb41b578fd3ec479cd5b45534588fc(
++    *,
++    base_map: typing.Mapping[builtins.str, typing.Union[_scope_jsii_calc_base_734f0262.BaseProps, typing.Dict[str, typing.Any]]],
++    numbers: typing.Sequence[_scope_jsii_calc_lib_c61f082f.Number],
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2692/submodule1/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2692/submodule1/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2692/submodule1/__init__.py	--runtime-type-checking
-@@ -21,10 +21,15 @@
+@@ -21,10 +21,13 @@
  class Bar:
      def __init__(self, *, bar1: builtins.str) -> None:
          '''
          :param bar1: 
          '''
 +        if __debug__:
-+            def stub(*, bar1: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__6602c05b71ef2e77c650dd283c33ba4543f756dbbca5d1c31752ee29f836b1f5)
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
          self._values: typing.Dict[str, typing.Any] = {
              "bar1": bar1,
          }
  
      @builtins.property
+@@ -48,5 +51,12 @@
+ __all__ = [
+     "Bar",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__6602c05b71ef2e77c650dd283c33ba4543f756dbbca5d1c31752ee29f836b1f5(
++    *,
++    bar1: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2692/submodule2/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2692/submodule2/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2692/submodule2/__init__.py	--runtime-type-checking
-@@ -23,10 +23,15 @@
+@@ -23,10 +23,13 @@
  class Bar:
      def __init__(self, *, bar2: builtins.str) -> None:
          '''
          :param bar2: 
          '''
 +        if __debug__:
-+            def stub(*, bar2: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__d9a43a9ecad39319deef77fa38822e65c584450447849fb04c34b767a8c0881d)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
          self._values: typing.Dict[str, typing.Any] = {
              "bar2": bar2,
          }
  
      @builtins.property
-@@ -63,10 +68,22 @@
+@@ -63,10 +66,15 @@
          '''
          :param bar2: 
          :param bar1: 
          :param foo2: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                bar2: builtins.str,
-+                bar1: builtins.str,
-+                foo2: builtins.str,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__717272f96a16c5ea04b9406364f96f18d1c2b16b183b81ef7bae856ebd371a43)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
 +            check_type(argname="argument foo2", value=foo2, expected_type=type_hints["foo2"])
@@ -18502,21 +19637,41 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar1": bar1,
              "foo2": foo2,
          }
+@@ -105,5 +113,21 @@
+     "Bar",
+     "Foo",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__d9a43a9ecad39319deef77fa38822e65c584450447849fb04c34b767a8c0881d(
++    *,
++    bar2: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__717272f96a16c5ea04b9406364f96f18d1c2b16b183b81ef7bae856ebd371a43(
++    *,
++    bar2: builtins.str,
++    bar1: builtins.str,
++    foo2: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/python_self/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/python_self/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/python_self/__init__.py	--runtime-type-checking
-@@ -19,17 +19,27 @@
+@@ -19,17 +19,23 @@
  ):
      def __init__(self_, self: builtins.str) -> None:
          '''
          :param self: -
          '''
 +        if __debug__:
-+            def stub(self: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__5cc662603963e69f50f446fe7bf40b3f3ccf17842ed59562f45f4eb63848155b)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          jsii.create(self_.__class__, self_, [self])
  
@@ -18526,156 +19681,197 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param self: -
          '''
 +        if __debug__:
-+            def stub(self: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__7085240966e9682f4d0598c65f482b932ae1281420f2cead92f0036488d061d4)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
      @builtins.property
      @jsii.member(jsii_name="self")
      def self(self) -> builtins.str:
-@@ -70,10 +80,15 @@
+@@ -70,10 +76,13 @@
      @jsii.member(jsii_name="method")
      def method(self_, self: jsii.Number) -> builtins.str:
          '''
          :param self: -
          '''
 +        if __debug__:
-+            def stub(self: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__8e4a50df1f139ac6d917c0954b0b6346aeeb47f16abae33b345a5aa2aa02fc99)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithSelf).__jsii_proxy_class__ = lambda : _IInterfaceWithSelfProxy
  
-@@ -86,10 +101,15 @@
+@@ -86,10 +95,13 @@
  class StructWithSelf:
      def __init__(self_, *, self: builtins.str) -> None:
          '''
          :param self: 
          '''
 +        if __debug__:
-+            def stub(*, self: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__796022ef7b07de2b3997ff905b7451854b30a5e8e06145e4cc31e88f0ea8b0d0)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          self_._values: typing.Dict[str, typing.Any] = {
              "self": self,
          }
  
      @builtins.property
+@@ -116,5 +128,30 @@
+     "IInterfaceWithSelf",
+     "StructWithSelf",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__5cc662603963e69f50f446fe7bf40b3f3ccf17842ed59562f45f4eb63848155b(
++    self: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__7085240966e9682f4d0598c65f482b932ae1281420f2cead92f0036488d061d4(
++    self: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__8e4a50df1f139ac6d917c0954b0b6346aeeb47f16abae33b345a5aa2aa02fc99(
++    self: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__796022ef7b07de2b3997ff905b7451854b30a5e8e06145e4cc31e88f0ea8b0d0(
++    *,
++    self: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/__init__.py	--runtime-type-checking
-@@ -39,10 +39,15 @@
+@@ -39,10 +39,13 @@
  
          :param foo: 
  
          :see: https://github.com/aws/jsii/issues/2637
          '''
 +        if __debug__:
-+            def stub(*, foo: jsii.Number) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__a44c39bd2002b354344d30dcb1ae0e2dc7ef8f604c2d31c61616cbbfc6a6fc40)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -107,10 +112,15 @@
+@@ -107,10 +110,13 @@
      def all_types(self) -> typing.Optional[_AllTypes_b08307c5]:
          return typing.cast(typing.Optional[_AllTypes_b08307c5], jsii.get(self, "allTypes"))
  
      @all_types.setter
      def all_types(self, value: typing.Optional[_AllTypes_b08307c5]) -> None:
 +        if __debug__:
-+            def stub(value: typing.Optional[_AllTypes_b08307c5]) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "allTypes", value)
  
  
  __all__ = [
      "Default",
+@@ -130,5 +136,18 @@
+ from . import child
+ from . import isolated
+ from . import nested_submodule
+ from . import param
+ from . import returnsparam
++
++def _typecheckingstub__a44c39bd2002b354344d30dcb1ae0e2dc7ef8f604c2d31c61616cbbfc6a6fc40(
++    *,
++    foo: jsii.Number,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1(
++    value: typing.Optional[_AllTypes_b08307c5],
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/back_references/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/back_references/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/back_references/__init__.py	--runtime-type-checking
-@@ -23,10 +23,15 @@
+@@ -23,10 +23,13 @@
  class MyClassReference:
      def __init__(self, *, reference: _MyClass_a2fdc0b6) -> None:
          '''
          :param reference: 
          '''
 +        if __debug__:
-+            def stub(*, reference: _MyClass_a2fdc0b6) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__e7f53d1efa418d6ee29ababd1c2660c1d3d9a5d3de3ad874b2d0cd7c6481139b)
 +            check_type(argname="argument reference", value=reference, expected_type=type_hints["reference"])
          self._values: typing.Dict[str, typing.Any] = {
              "reference": reference,
          }
  
      @builtins.property
+@@ -50,5 +53,12 @@
+ __all__ = [
+     "MyClassReference",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__e7f53d1efa418d6ee29ababd1c2660c1d3d9a5d3de3ad874b2d0cd7c6481139b(
++    *,
++    reference: _MyClass_a2fdc0b6,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/child/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/child/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/child/__init__.py	--runtime-type-checking
-@@ -73,10 +73,15 @@
+@@ -73,10 +73,13 @@
  class SomeStruct:
      def __init__(self, *, prop: SomeEnum) -> None:
          '''
          :param prop: 
          '''
 +        if __debug__:
-+            def stub(*, prop: SomeEnum) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__ce6e4bc4b6c503e757ba9e0640368ea37840d2ca58311e6ec8b98cdcda077f48)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[str, typing.Any] = {
              "prop": prop,
          }
  
      @builtins.property
-@@ -105,10 +110,15 @@
+@@ -105,10 +108,13 @@
  class Structure:
      def __init__(self, *, bool: builtins.bool) -> None:
          '''
          :param bool: 
          '''
 +        if __debug__:
-+            def stub(*, bool: builtins.bool) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__f4dc81f7243c5c317d71ab682231a51bf3c3a189d9be68c17b8d41246c0abef5)
 +            check_type(argname="argument bool", value=bool, expected_type=type_hints["bool"])
          self._values: typing.Dict[str, typing.Any] = {
              "bool": bool,
          }
  
      @builtins.property
-@@ -143,10 +153,20 @@
+@@ -143,10 +149,14 @@
      ) -> None:
          '''
          :param prop: 
          :param extra: 
          '''
 +        if __debug__:
-+            def stub(
-+                *,
-+                prop: SomeEnum,
-+                extra: typing.Optional[builtins.str] = None,
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__b3b6b38208a14cadd94ba787e4091f753debb361ad5dd2ee9d037908f5677d8b)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
 +            check_type(argname="argument extra", value=extra, expected_type=type_hints["extra"])
          self._values: typing.Dict[str, typing.Any] = {
@@ -18683,48 +19879,95 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if extra is not None:
              self._values["extra"] = extra
+@@ -184,5 +194,27 @@
+     "SomeStruct",
+     "Structure",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__ce6e4bc4b6c503e757ba9e0640368ea37840d2ca58311e6ec8b98cdcda077f48(
++    *,
++    prop: SomeEnum,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__f4dc81f7243c5c317d71ab682231a51bf3c3a189d9be68c17b8d41246c0abef5(
++    *,
++    bool: builtins.bool,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__b3b6b38208a14cadd94ba787e4091f753debb361ad5dd2ee9d037908f5677d8b(
++    *,
++    prop: SomeEnum,
++    extra: typing.Optional[builtins.str] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/param/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/param/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/param/__init__.py	--runtime-type-checking
-@@ -21,10 +21,15 @@
+@@ -21,10 +21,13 @@
  class SpecialParameter:
      def __init__(self, *, value: builtins.str) -> None:
          '''
          :param value: 
          '''
 +        if __debug__:
-+            def stub(*, value: builtins.str) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__25c6f5775c01f503690c503a264eb256af186a94c0c65bd43d6a11942ff54b1c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[str, typing.Any] = {
              "value": value,
          }
  
      @builtins.property
+@@ -48,5 +51,12 @@
+ __all__ = [
+     "SpecialParameter",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__25c6f5775c01f503690c503a264eb256af186a94c0c65bd43d6a11942ff54b1c(
++    *,
++    value: builtins.str,
++) -> None:
++    """Type checking stubs"""
++    pass
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/union/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/union/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/union/__init__.py	--runtime-type-checking
-@@ -23,10 +23,17 @@
-         param: typing.Union["IResolvable", "Resolvable", scope.jsii_calc_lib.IFriendly],
+@@ -23,10 +23,13 @@
+         param: typing.Union["IResolvable", "Resolvable", _scope_jsii_calc_lib_c61f082f.IFriendly],
      ) -> None:
          '''
          :param param: -
          '''
 +        if __debug__:
-+            def stub(
-+                param: typing.Union[IResolvable, Resolvable, scope.jsii_calc_lib.IFriendly],
-+            ) -> None:
-+                ...
-+            type_hints = typing.get_type_hints(stub)
++            type_hints = typing.get_type_hints(_typecheckingstub__62dfa3c0a0a719fea295807df31fd40fd66b0e76cf44d9f742ffb421f8e4ca77)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))
  
  
  @jsii.interface(jsii_type="jsii-calc.union.IResolvable")
  class IResolvable(typing_extensions.Protocol):
+@@ -58,5 +61,11 @@
+     "IResolvable",
+     "Resolvable",
+ ]
+ 
+ publication.publish()
++
++def _typecheckingstub__62dfa3c0a0a719fea295807df31fd40fd66b0e76cf44d9f742ffb421f8e4ca77(
++    param: typing.Union[IResolvable, Resolvable, _scope_jsii_calc_lib_c61f082f.IFriendly],
++) -> None:
++    """Type checking stubs"""
++    pass
 `;

--- a/packages/jsii-pacmak/test/targets/python/type-name.test.ts
+++ b/packages/jsii-pacmak/test/targets/python/type-name.test.ts
@@ -173,14 +173,19 @@ describe(toTypeName, () => {
     {
       name: 'User Type (Foreign)',
       input: { fqn: '@remote/classes.FancyClass' },
-      pythonType: `${REMOTE_MODULE}.FancyClass`,
-      requiredImports: { [REMOTE_MODULE]: new Set(['']) },
+      pythonType: `_remote_module_name_fb17b8fa.FancyClass`,
+      requiredImports: {
+        [`${REMOTE_MODULE} as _remote_module_name_fb17b8fa`]: new Set(['']),
+      },
     },
     {
       name: 'User Type (Foreign, Submodule)',
       input: { fqn: '@remote/classes.nested.SubmoduledType' },
-      pythonType: `${REMOTE_MODULE}.submodule.SubmoduledType`,
-      requiredImports: { [`${REMOTE_MODULE}.submodule`]: new Set(['']) },
+      pythonType: `_remote_module_name_submodule_fb17b8fa.SubmoduledType`,
+      requiredImports: {
+        [`${REMOTE_MODULE}.submodule as _remote_module_name_submodule_fb17b8fa`]:
+          new Set(['']),
+      },
     },
     {
       name: 'User Type (Local)',

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1917,6 +1917,14 @@ exports[`jsii-tree --all 1`] = `
  │   │     │ └─┬ obj
  │   │     │   └── type: jsii-calc.IReturnsNumber
  │   │     └── returns: number
+ │   ├─┬ class ParamShadowsScope (stable)
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer (stable)
+ │   │   └─┬ useScope(scope) method (stable)
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ scope
+ │   │     │   └── type: @scope/jsii-calc-lib.Number
+ │   │     └── returns: @scope/jsii-calc-lib.Number
  │   ├─┬ class PartiallyInitializedThisConsumer (stable)
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer (stable)
@@ -3903,6 +3911,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class OptionalStructConsumer
  │   ├── class OverridableProtectedMember
  │   ├── class OverrideReturnsObject
+ │   ├── class ParamShadowsScope
  │   ├── class PartiallyInitializedThisConsumer
  │   ├── class Polymorphism
  │   ├─┬ class Power
@@ -5034,6 +5043,10 @@ exports[`jsii-tree --members 1`] = `
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
  │   │   └── test(obj) method
+ │   ├─┬ class ParamShadowsScope
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   └── useScope(scope) method
  │   ├─┬ class PartiallyInitializedThisConsumer
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -6060,6 +6073,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class OptionalStructConsumer
  │   ├── class OverridableProtectedMember
  │   ├── class OverrideReturnsObject
+ │   ├── class ParamShadowsScope
  │   ├── class PartiallyInitializedThisConsumer
  │   ├── class Polymorphism
  │   ├── class Power

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -2091,6 +2091,14 @@ exports[`showAll 1`] = `
  │   │     │ └─┬ obj
  │   │     │   └── type: jsii-calc.IReturnsNumber
  │   │     └── returns: number
+ │   ├─┬ class ParamShadowsScope
+ │   │ └─┬ members
+ │   │   ├── <initializer>() initializer
+ │   │   └─┬ useScope(scope) method
+ │   │     ├─┬ parameters
+ │   │     │ └─┬ scope
+ │   │     │   └── type: @scope/jsii-calc-lib.Number
+ │   │     └── returns: @scope/jsii-calc-lib.Number
  │   ├─┬ class PartiallyInitializedThisConsumer
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -4075,6 +4083,7 @@ exports[`types 1`] = `
  │   ├── class OptionalStructConsumer
  │   ├── class OverridableProtectedMember
  │   ├── class OverrideReturnsObject
+ │   ├── class ParamShadowsScope
  │   ├── class PartiallyInitializedThisConsumer
  │   ├── class Polymorphism
  │   ├── class Power

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -118,6 +118,7 @@ exports[`TypeSystem.classes lists all the classes in the typesystem 1`] = `
   "jsii-calc.OptionalStructConsumer",
   "jsii-calc.OverridableProtectedMember",
   "jsii-calc.OverrideReturnsObject",
+  "jsii-calc.ParamShadowsScope",
   "jsii-calc.PartiallyInitializedThisConsumer",
   "jsii-calc.Polymorphism",
   "jsii-calc.Power",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3324,6 +3324,11 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
+constructs@10:
+  version "10.1.166"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.1.166.tgz#94c4091959a184136a455c424fb01d72b191b4d8"
+  integrity sha512-GNAz2A8Hxhr91wFnUnlVHIJe8xBNBAMjUfkFBGSW+h34L9UDlNcyE4kf+bULm1TQO8JpMdN6h69PcNHT3He9ig==
+
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz#896885d63b914a70d4934b59d2fe7bde1832b28c"


### PR DESCRIPTION
In certain cases, a function parameter may shadow an imported module name, resultin in run-time errors either during type-checking or during the type-cast that is performed before returning a kernel call's result.

This change adds a test case that covers this particular scenario in Python, and changes how foreign modules are imported so that an alias is always generated for those, removing the risk for collisions. It also moves the type-checking stubs out to the root of the module to remove the risk of more "runtime context" polluting the type evaluation.

Fixes https://github.com/aws/aws-cdk/issues/22975



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
