### PR TITLE
fix: revert "chore(deps): Bump aws-actions/stale-issue-cleanup from 5 to 6"

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v6
+    - uses: aws-actions/stale-issue-cleanup@v5
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
Reverts aws/jsii#3844

v6 is broken and was not ready for prod. It must have been accidentally released.

https://github.com/aws-actions/stale-issue-cleanup/tree/v6