### PR TITLE
fix(pacmak): use builtins.str instead of str for type annotations

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -311,7 +311,7 @@ class UserType implements TypeName {
     const wrapType =
       typeAnnotation && parameterType && isStruct
         ? (pyType: string) =>
-            `typing.Union[${pyType}, typing.Dict[str, typing.Any]]`
+            `typing.Union[${pyType}, typing.Dict[builtins.str, typing.Any]]`
         : (pyType: string) => pyType;
 
     // Emit aliased imports for dependencies (this avoids name collisions)

--- a/packages/jsii-pacmak/test/targets/python/type-name.test.ts
+++ b/packages/jsii-pacmak/test/targets/python/type-name.test.ts
@@ -246,8 +246,8 @@ describe(toTypeName, () => {
     {
       name: 'Struct parameter type annotation',
       input: { fqn: `${assembly.name}.Struct` },
-      forwardPythonType: `typing.Union["Struct", typing.Dict[str, typing.Any]]`,
-      pythonType: `typing.Union[Struct, typing.Dict[str, typing.Any]]`,
+      forwardPythonType: `typing.Union["Struct", typing.Dict[builtins.str, typing.Any]]`,
+      pythonType: `typing.Union[Struct, typing.Dict[builtins.str, typing.Any]]`,
       context: {
         typeAnnotation: true,
         parameterType: true,


### PR DESCRIPTION
This should solve a bug I encountered where runtime values are being mistaken for type annotations.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
