### PR TITLE
chore(deps): bump setuptools to avoid CVE

### DIFF
--- a/packages/@jsii/python-runtime/requirements.txt
+++ b/packages/@jsii/python-runtime/requirements.txt
@@ -3,7 +3,7 @@ mypy==0.812
 pip~=22.3
 pytest~=7.2
 pytest-mypy~=0.10
-setuptools~=62.2
+setuptools==65.5.1
 wheel~=0.38
 
 -e .

--- a/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
+++ b/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
@@ -3,7 +3,7 @@
 # be installed in the virtual environment used for building the distribution
 # package (wheel, sdist), but not declared as build-system dependencies.
 
-setuptools~=62.1.0 # build-system
+setuptools==65.5.1 # build-system
 wheel~=0.38.4      # build-system
 
 twine~=4.0.2


### PR DESCRIPTION
ReDoS vulnerability in old versions of setuptools.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
