### PR TITLE
chore(superchain): use `pipx` instead of `pip` to install CLIs

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -149,11 +149,16 @@ RUN set -eo pipefail                                                            
   && chmod -R a+rw ${CARGO_HOME}
 ENV PATH=$PATH:${CARGO_HOME}/bin
 
-# Install Python 3
+# Install Python 3. Use 'pipx' for CLI scripts, so each gets its own venv
+ENV PATH=$PATH:/root/.local/bin
 RUN apt-get update                                                                                                      \
   && apt-get -y install python3 python3-dev python3-pip python3-venv                                                    \
-  && python3 -m pip install --no-input --upgrade pip                                                                    \
-  && python3 -m pip install --no-input --upgrade awscli black setuptools twine wheel                                    \
+  && python3 -m pip install --no-input --upgrade pip setuptools                                                         \
+  && python3 -m pip install pipx                                                                                        \
+  && python3 -m pipx install --system-site-packages awscli                                                              \
+  && python3 -m pipx install --system-site-packages black                                                               \
+  && python3 -m pipx install --system-site-packages twine                                                               \
+  && python3 -m pipx inject --system-site-packages twine wheel                                                          \
   && rm -rf $(pip cache dir)                                                                                            \
   && rm -rf /var/lib/apt/lists/*
 
@@ -216,7 +221,7 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
   && rm -rf /var/lib/apt/lists/*
 
 # Install SAM CLI
-RUN pip install aws-sam-cli                                                                                             \
+RUN python3 -m pipx install --system-site-packages aws-sam-cli                                                          \
   && sam --version
 
 # Install Amazon SSM agent (allows debugging of builds via `codebuild-breakpoint`, https://go.aws/3TVW7vL)


### PR DESCRIPTION
We recently ran into a situation where we ended up with with a Python distribution where the following failed:

```shell
$ python3
>>> import OpenSSL
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/local/lib/python3.7/dist-packages/OpenSSL/crypto.py", line 3268, in <module>
    _lib.OpenSSL_add_all_algorithms()
AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'
```

Because we had `cryptography==39.0.0` but `PyOpenSSL==22.0.0`, which should have been `22.1.0`.

The reason `PyOpenSSL` was held back looks to be because SAM CLI had a hardcoded dependency on the old version.

To prevent this from happening in the future, use `pipx` to install CLIs, so that each CLI gets its own virtual env and their dependency sets don't interfere with each other.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
