### PR TITLE
chore(deps): update setuptools to v65.5.1

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
+++ b/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
@@ -3,7 +3,7 @@
 # be installed in the virtual environment used for building the distribution
 # package (wheel, sdist), but not declared as build-system dependencies.
 
-setuptools~=62.1.0 # build-system
+setuptools~=65.5.1 # build-system
 wheel~=0.38.4      # build-system
 
 twine~=4.0.2


### PR DESCRIPTION
Based off of a dependabot alert:

```


Python Packaging Authority (PyPA)'s setuptools is a library designed to facilitate packaging Python projects. Setuptools 
version 65.5.0 and earlier could allow remote attackers to cause a denial of service by fetching malicious HTML from a 
PyPI package or custom PackageIndex page due to a vulnerable Regular Expression in package_index. This has been 
patched in version 65.5.1.

```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
