### PR TITLE
fix(superchain): pipx installs to a location not in $PATH

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -155,6 +155,7 @@ RUN apt-get update                                                              
   && apt-get -y install python3 python3-dev python3-pip python3-venv                                                    \
   && python3 -m pip install --no-input --upgrade pip setuptools                                                         \
   && python3 -m pip install pipx                                                                                        \
+  && python3 -m pipx ensurepath                                                                                         \
   && python3 -m pipx install --system-site-packages awscli                                                              \
   && python3 -m pipx install --system-site-packages black                                                               \
   && python3 -m pipx install --system-site-packages twine                                                               \


### PR DESCRIPTION

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
