### PR TITLE
chore: fix version updates

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -68,15 +68,18 @@ jobs:
 
       - name: Run "ncu -u"
         # We special-case typescript because it's not semantically versionned, and major.minor is the API contract
+        # We special-case @types/fs-extra because 9.0.13 is the last version that supports typescript@3.9
+        # We special-case @types/yargs because 17.0.13 is the last version that doesn't break
+        # We special-case eslint-plugin-import because 26 is the last version that works for us.
         run: |-
           # Upgrade devDependencies at repository root
           ncu --upgrade --target=minor --filter=@types/inquirer,@types/node,@jest/types,jest-config,jest-circus
           ncu --upgrade --target=patch --filter=typescript
-          ncu --upgrade --target=latest --reject=@types/inquirer,@types/node,typescript,@jest/types,jest-config,jest-circus
+          ncu --upgrade --target=latest --reject=@types/inquirer,@types/node,typescript,@jest/types,jest-config,jest-circus,eslint-plugin-import
 
           # Upgrade all production dependencies (and other always major-pinned dependencies)
           lerna exec --parallel ncu -- --upgrade --target=minor                                     \
-            --filter='${{ steps.production-dependencies.outputs.list }}'                            \
+            --filter='@types/fs-extra,${{ steps.production-dependencies.outputs.list }}'                            \
             --reject='typescript,${{ steps.monorepo-packages.outputs.list }}'
 
           # Upgrade all minor-pinned dependencies
@@ -85,7 +88,7 @@ jobs:
 
           # Upgrade all other dependencies (devDependencies) to the latest
           lerna exec --parallel ncu -- --upgrade --target=latest                                    \
-            --reject='@types/inquirer,@types/node,typescript,${{ steps.production-dependencies.outputs.list }},${{ steps.monorepo-packages.outputs.list }}'
+            --reject='@types/inquirer,@types/node,typescript,@types/fs-extra,@types/yargs,${{ steps.production-dependencies.outputs.list }},${{ steps.monorepo-packages.outputs.list }}'
 
       # This will ensure the current lockfile is up-to-date with the dependency specifications (necessary for "yarn update" to run)
       - name: Run "yarn install"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.3.1",
     "jest-circus": "^28.1.3",
@@ -53,5 +53,8 @@
       "**/@fixtures/jsii-calc-bundled/**",
       "**/typescript"
     ]
+  },
+  "resolutions": {
+    "@types/yargs": "17.0.19"
   }
 }

--- a/packages/jsii-config/package.json
+++ b/packages/jsii-config/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/inquirer": "^8.2.3",
-    "@types/yargs": "^17.0.19",
+    "@types/yargs": "17.0.19",
     "jest-expect-message": "^1.1.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,7 +2234,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
 
-"@types/yargs@^17.0.19", "@types/yargs@^17.0.8":
+"@types/yargs@17.0.19", "@types/yargs@^17.0.8":
   version "17.0.19"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.19.tgz#8dbecdc9ab48bee0cb74f6e3327de3fa0d0c98ae"
   integrity sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==
@@ -3944,7 +3944,7 @@ eslint-module-utils@^2.7.3:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.26.0:
+eslint-plugin-import@2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==


### PR DESCRIPTION
There are a couple of issues with some version updates

- Only do minor version updates for `@types/fs-extra` This is the last major version that is compatible with typescript@3.9

- `@types/yargs` is on longer compatible with typescript@3.9 so we need to pin it
  - Other deps have a transient dependency on `@types/yargs` so add a resolution to keep the version
- `eslint-plugin-import@27` breaks something. For some reason when this is upgraded the build for `@scope/jsii-calc-base-of-base` fails with this error and I have no idea why
```
packages/jsii-rosetta/lib/languages/record-references.js:11
class RecordReferencesVisitor extends default_1.DefaultVisitor {
                                                ^

TypeError: Class extends value undefined is not a constructor or null
    at Object.<anonymous> (packages/jsii-rosetta/lib/languages/record-references.js:11:49)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (packages/jsii-rosetta/lib/tablets/key.js:5:29)
```

Also updated the `yarn-upgrade` workflow to have these exceptions

This is to fix issues in https://github.com/aws/jsii/pull/3945.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
