### PR TITLE
feat(check-node): export NodeRelease class

### DIFF
--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -32,7 +32,7 @@ export class NodeRelease {
       supportedRange: '^12.7.0',
     }),
 
-    // Currently active releases
+    // Currently active releases (as of last edit to this file...)
     new NodeRelease(14, {
       endOfLife: new Date('2023-04-30'),
       supportedRange: '^14.6.0',
@@ -46,9 +46,9 @@ export class NodeRelease {
       supportedRange: '^17.3.0',
     }),
     new NodeRelease(18, { endOfLife: new Date('2025-04-30') }),
+    new NodeRelease(19, { endOfLife: new Date('2023-06-01') }),
 
     // Future (planned releases)
-    new NodeRelease(19, { endOfLife: new Date('2023-06-01') }),
     new NodeRelease(20, { endOfLife: new Date('2026-04-30'), untested: true }),
   ];
 

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -4,6 +4,8 @@ import { version } from 'process';
 
 import { NodeRelease } from './constants';
 
+export { NodeRelease } from './constants';
+
 /**
  * Checks the current process' node runtime version against the release support
  * matrix, and issues a warning to STDERR if the current version is not fully


### PR DESCRIPTION
This can be useful, for example in projen templates, to automatically test fo all "supported" Node releases without having ot modify every single repository. This can serve as a central point of truth for what releases of node are supported by the Constructs ecosystem via jsii.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
