### PR TITLE
fix(rosetta): go may incorrectly emit _ instead of .

### DIFF
--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -494,7 +494,7 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
     // for the last "." - delimited segment if there's dots in there...
     const expressionLooksLikeTypeReference =
       expressionType.symbol == null &&
-      /(?:\.|^)[A-Z][^.(]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;
+      /(?:\.|^)[A-Z][^.)]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;
 
     // Whether the node is an enum member reference.
     const isEnumMember =

--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -493,7 +493,7 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
     // a regex that checks for the last "."-delimited segment if there's dots in there...
     const expressionLooksLikeTypeReference =
       expressionType.symbol == null &&
-      /(?:\.|^)[A-Z][^.]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;
+      /(?:\.|^)[A-Z][^.(]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;
 
     // Whether the node is an enum member reference.
     const isEnumMember =

--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -487,10 +487,11 @@ export class GoVisitor extends DefaultVisitor<GoLanguageContext> {
     const isClassStaticMethodAccess =
       isStaticMember && !isClassStaticPropertyAccess && ts.isMethodDeclaration(valueSymbol.valueDeclaration);
 
-    // When the expression has an unknown type (unresolved symbol), and has an upper-case first
-    // letter, we assume it's a type name... In such cases, what comes after can be considered a
-    // static member access. Note that the expression might be further qualified, so we check using
-    // a regex that checks for the last "."-delimited segment if there's dots in there...
+    // When the expression has an unknown type (unresolved symbol), has an upper-case first letter,
+    // and doesn't end in a call expression (as hinted by the presence of parentheses), we assume
+    // it's a type name... In such cases, what comes after can be considered a static member access.
+    // Note that the expression might be further qualified, so we check using a regex that checks
+    // for the last "." - delimited segment if there's dots in there...
     const expressionLooksLikeTypeReference =
       expressionType.symbol == null &&
       /(?:\.|^)[A-Z][^.(]*$/.exec(node.expression.getText(node.expression.getSourceFile())) != null;


### PR DESCRIPTION
The go transliteration uses a heuristic to determine if a property access expression is possibly a type name reference, however it failed to check whether the lead contains a call expression, which would make it impossible that the overall expression is a type reference.

This fixes the regular expression to address this.

Backports a fix from [4.9](https://github.com/aws/jsii-rosetta/pull/7).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
