### PR TITLE
Update importlib resources to handle Python 3.11 deprecations

### DIFF
--- a/packages/@jsii/python-runtime/pyproject.toml
+++ b/packages/@jsii/python-runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools~=62.2", "wheel~=0.37"]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '\.(git|mypy_cache|env)'
 

--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     install_requires=[
         "attrs>=21.2,<23.0",
         "cattrs>=1.8,<22.3",
+        "importlib_resources; python_version<='3.9'",
         "publication>=0.0.3",  # This is used by all generated code.
         "typeguard~=2.13.3",  # This is used by all generated code.
         "python-dateutil",
@@ -48,6 +49,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
         "Typing :: Typed",

--- a/packages/@jsii/python-runtime/src/jsii/__meta__.py
+++ b/packages/@jsii/python-runtime/src/jsii/__meta__.py
@@ -3,7 +3,9 @@ import json
 from ._compat import importlib_resources
 
 # Load our version number and other metadata.
-_meta = json.loads(importlib_resources.read_text("jsii", "_metadata.json"))
+_meta = json.loads(
+    importlib_resources.files("jsii").joinpath("_metadata.json").read_text()
+)
 
 __version__ = _meta["version"]
 __jsii_runtime_version__ = _meta["jsii-runtime"]["version"]

--- a/packages/@jsii/python-runtime/src/jsii/_compat.py
+++ b/packages/@jsii/python-runtime/src/jsii/_compat.py
@@ -2,7 +2,7 @@
 import sys
 
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
 else:
     import importlib_resources

--- a/packages/@jsii/python-runtime/src/jsii/_kernel/providers/process.py
+++ b/packages/@jsii/python-runtime/src/jsii/_kernel/providers/process.py
@@ -237,7 +237,11 @@ class _NodeProcess:
         for resname, filename in resources.items():
             pathlib.Path(os.path.dirname(filename)).mkdir(exist_ok=True)
             with open(filename, "wb") as fp:
-                fp.write(importlib_resources.read_binary(jsii._embedded.jsii, resname))
+                fp.write(
+                    importlib_resources.files(jsii._embedded.jsii)
+                    .joinpath(resname)
+                    .read_bytes()
+                )
 
         # Return our first path, which should be the path for jsii-runtime.js
         return resources[jsii._embedded.jsii.ENTRYPOINT]

--- a/packages/@jsii/python-runtime/src/jsii/_runtime.py
+++ b/packages/@jsii/python-runtime/src/jsii/_runtime.py
@@ -44,11 +44,13 @@ class JSIIAssembly:
         assembly = cls(*args, **kwargs)
 
         # Actually load the assembly into the kernel, we're using the
-        # importlib.resources API here isntead of manually constructing the path, in
+        # importlib.resources API here instead of manually constructing the path, in
         # the hopes that this will make JSII modules able to be used with zipimport
         # instead of only on the FS.
-        with importlib_resources.path(
-            f"{assembly.module}._jsii", assembly.filename
+        with importlib_resources.as_file(
+            importlib_resources.files(f"{assembly.module}._jsii").joinpath(
+                assembly.filename
+            )
         ) as assembly_path:
             _kernel.load(assembly.name, assembly.version, os.fspath(assembly_path))
 


### PR DESCRIPTION
Python 3.11 deprecated some usage `importlib.resources` and has a new back-compatibility shim through 3.9. This updates the code to the new `files()`-based API usage and uses the shims for versions less than 3.9.

https://docs.python.org/3/library/importlib.resources.html#deprecated-functions
https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
https://discuss.python.org/t/deprecating-importlib-resources-legacy-api/11386

closes #3958

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
