### PR TITLE
fix(dotnet): target netcoreapp3.1 with RollForward

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/ComplianceTests.cs
@@ -937,7 +937,7 @@ namespace Amazon.JSII.Runtime.IntegrationTests
         [Fact(DisplayName = Prefix + nameof(JsiiAgentIsCorrect))]
         public void JsiiAgentIsCorrect()
         {
-            Assert.Equal("DotNet/" + Environment.Version + "/.NETCoreApp,Version=v6.0/1.0.0.0", JsiiAgent.Value);
+            Assert.Equal("DotNet/" + Environment.Version + "/.NETCoreApp,Version=v3.1/1.0.0.0", JsiiAgent.Value);
         }
 
         [Fact(DisplayName = Prefix + nameof(ReceiveInstanceOfPrivateClass))]

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
@@ -2,7 +2,8 @@
   <Import Project="../NuGet.Metadata.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
     <PackageId>Amazon.JSII.Runtime</PackageId>
     <Title>.NET Runtime for JSII</Title>
     <PackageIcon>icon.png</PackageIcon>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Services/TypeCache.cs
@@ -202,7 +202,7 @@ namespace Amazon.JSII.Runtime.Services
                     }
                 }
 
-                return e.Types;
+                return e.Types ?? Array.Empty<Type?>();
             }
         }
     }

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -18,7 +18,7 @@ import { toReleaseVersion } from './version-utils';
 
 import { TargetName } from '.';
 
-export const TARGET_FRAMEWORK = 'net6.0';
+export const TARGET_FRAMEWORK = 'netcoreapp3.1';
 
 /**
  * Build .NET packages all together, by generating an aggregate solution file

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -112,6 +112,8 @@ export class FileGenerator {
     propertyGroup.ele('Nullable', 'enable');
     propertyGroup.ele('SymbolPackageFormat', 'snupkg');
     propertyGroup.ele('TargetFramework', TARGET_FRAMEWORK);
+    // Transparently rolll forward across major SDK releases if needed
+    propertyGroup.ele('RollForward', 'Major');
 
     const itemGroup1 = rootNode.ele('ItemGroup');
     const embeddedResource = itemGroup1.ele('EmbeddedResource');

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -88,7 +88,8 @@ exports[`diamond-struct-parameter.ts: <outDir>/dotnet/Example.Test.Demo/Example.
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="testpkg-0.0.1.tgz" />
@@ -1622,7 +1623,8 @@ exports[`nested-types.ts: <outDir>/dotnet/Example.Test.Demo/Example.Test.Demo.cs
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="testpkg-0.0.1.tgz" />

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -77,7 +77,8 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/Com
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="foo-1.2.3.tgz" />
@@ -586,7 +587,8 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="foo-1.2.3.tgz" />
@@ -1095,7 +1097,8 @@ exports[`foo@2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/Com.Acme.Foo.csproj 1`] =
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="foo-2.0.0-rc.42.tgz" />
@@ -1581,7 +1584,8 @@ exports[`foo@4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/Com.Acme.Foo.csproj 1`
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="foo-4.5.6-pre.1337.tgz" />

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -50,7 +50,8 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/dotnet/Amazon.JSII
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <None Include="resources\\default-256-dark.png" Pack="true" PackagePath="\\resources" />
@@ -569,7 +570,8 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/dotnet/Ama
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="scope-jsii-calc-base-of-base-2.1.1.tgz" />
@@ -1068,7 +1070,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/dotnet/Amazon.JSII.
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="scope-jsii-calc-lib-0.0.0.tgz" />
@@ -3331,7 +3334,8 @@ exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.Calcu
     <IncludeSource>true</IncludeSource>
     <Nullable>enable</Nullable>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <None Include="resources\\AWSLogo128x128.png" Pack="true" PackagePath="\\resources" />


### PR DESCRIPTION
Issues where encountered with SDK compatibility when the target
was set to `net6.0` even when the .NET SDK 6.0 or newer was in
use. I suspect this is because of conflicting framework dependency
requirements across various packages.

Re-target `netcoreapp3.1` while setting a roll-forward policy allowing
use of newer major-releases of the SDK when no exact match is found (this
is tested to work correctly for all supported .NET SDK releases by our
automated test suite).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
