### PR TITLE
feat: jsii-reflect now renders union candidates sorted

### DIFF
--- a/packages/jsii-reflect/lib/type-ref.ts
+++ b/packages/jsii-reflect/lib/type-ref.ts
@@ -27,7 +27,9 @@ export class TypeReference {
       return `Map<string => ${this.mapOfType.toString()}>`;
     }
     if (this.unionOfTypes) {
-      return this.unionOfTypes.map((x) => x.toString()).join(' | ');
+      const union = this.unionOfTypes.map((x) => x.toString());
+      union.sort();
+      return union.join(' | ');
     }
 
     throw new Error('Invalid type reference');

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -647,7 +647,7 @@ exports[`jsii-tree --all 1`] = `
  │ │     │     ├── static
  │ │     │     ├─┬ parameters
  │ │     │     │ └─┬ param
- │ │     │     │   └── type: jsii-calc.union.IResolvable | jsii-calc.union.Resolvable | @scope/jsii-calc-lib.IFriendly
+ │ │     │     │   └── type: @scope/jsii-calc-lib.IFriendly | jsii-calc.union.IResolvable | jsii-calc.union.Resolvable
  │ │     │     └── returns: void
  │ │     ├─┬ class Resolvable (stable)
  │ │     │ ├── interfaces: IResolvable
@@ -767,11 +767,11 @@ exports[`jsii-tree --all 1`] = `
  │   │   ├─┬ stringProperty property (stable)
  │   │   │ └── type: string
  │   │   ├─┬ unionArrayProperty property (stable)
- │   │   │ └── type: Array<number | @scope/jsii-calc-lib.NumericValue>
+ │   │   │ └── type: Array<@scope/jsii-calc-lib.NumericValue | number>
  │   │   ├─┬ unionMapProperty property (stable)
- │   │   │ └── type: Map<string => string | number | @scope/jsii-calc-lib.Number>
+ │   │   │ └── type: Map<string => @scope/jsii-calc-lib.Number | number | string>
  │   │   ├─┬ unionProperty property (stable)
- │   │   │ └── type: string | number | @scope/jsii-calc-lib.Number | jsii-calc.Multiply
+ │   │   │ └── type: @scope/jsii-calc-lib.Number | jsii-calc.Multiply | number | string
  │   │   ├─┬ unknownArrayProperty property (stable)
  │   │   │ └── type: Array<any>
  │   │   ├─┬ unknownMapProperty property (stable)
@@ -1054,9 +1054,9 @@ exports[`jsii-tree --all 1`] = `
  │   │   ├─┬ <initializer>(unionProperty) initializer (stable)
  │   │   │ └─┬ parameters
  │   │   │   └─┬ unionProperty
- │   │   │     └── type: Array<Map<string => jsii-calc.StructA | jsii-calc.StructB> | Array<jsii-calc.StructA | jsii-calc.StructB>>
+ │   │   │     └── type: Array<Array<jsii-calc.StructA | jsii-calc.StructB> | Map<string => jsii-calc.StructA | jsii-calc.StructB>>
  │   │   └─┬ unionProperty property (stable)
- │   │     └── type: Array<Map<string => jsii-calc.StructA | jsii-calc.StructB> | Array<jsii-calc.StructA | jsii-calc.StructB>>
+ │   │     └── type: Array<Array<jsii-calc.StructA | jsii-calc.StructB> | Map<string => jsii-calc.StructA | jsii-calc.StructB>>
  │   ├─┬ class ClassWithPrivateConstructorAndAutomaticProperties (stable)
  │   │ ├── interfaces: IInterfaceWithProperties
  │   │ └─┬ members
@@ -3372,7 +3372,7 @@ exports[`jsii-tree --all 1`] = `
  │   │   ├─┬ secondLevel property (stable)
  │   │   │ ├── abstract
  │   │   │ ├── immutable
- │   │   │ └── type: number | jsii-calc.SecondLevelStruct
+ │   │   │ └── type: jsii-calc.SecondLevelStruct | number
  │   │   └─┬ optional property (stable)
  │   │     ├── abstract
  │   │     ├── immutable
@@ -3382,11 +3382,11 @@ exports[`jsii-tree --all 1`] = `
  │   │   ├─┬ bar property (stable)
  │   │   │ ├── abstract
  │   │   │ ├── immutable
- │   │   │ └── type: string | number | jsii-calc.AllTypes
+ │   │   │ └── type: jsii-calc.AllTypes | number | string
  │   │   └─┬ foo property (stable)
  │   │     ├── abstract
  │   │     ├── immutable
- │   │     └── type: Optional<string | number>
+ │   │     └── type: Optional<number | string>
  │   ├─┬ enum AllTypesEnum (stable)
  │   │ ├── MY_ENUM_VALUE (stable)
  │   │ ├── YOUR_ENUM_VALUE (stable)

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -824,7 +824,7 @@ exports[`showAll 1`] = `
  │ │     │     ├── static
  │ │     │     ├─┬ parameters
  │ │     │     │ └─┬ param
- │ │     │     │   └── type: jsii-calc.union.IResolvable | jsii-calc.union.Resolvable | @scope/jsii-calc-lib.IFriendly
+ │ │     │     │   └── type: @scope/jsii-calc-lib.IFriendly | jsii-calc.union.IResolvable | jsii-calc.union.Resolvable
  │ │     │     └── returns: void
  │ │     ├─┬ class Resolvable
  │ │     │ ├── interfaces: IResolvable
@@ -944,11 +944,11 @@ exports[`showAll 1`] = `
  │   │   ├─┬ stringProperty property
  │   │   │ └── type: string
  │   │   ├─┬ unionArrayProperty property
- │   │   │ └── type: Array<number | @scope/jsii-calc-lib.NumericValue>
+ │   │   │ └── type: Array<@scope/jsii-calc-lib.NumericValue | number>
  │   │   ├─┬ unionMapProperty property
- │   │   │ └── type: Map<string => string | number | @scope/jsii-calc-lib.Number>
+ │   │   │ └── type: Map<string => @scope/jsii-calc-lib.Number | number | string>
  │   │   ├─┬ unionProperty property
- │   │   │ └── type: string | number | @scope/jsii-calc-lib.Number | jsii-calc.Multiply
+ │   │   │ └── type: @scope/jsii-calc-lib.Number | jsii-calc.Multiply | number | string
  │   │   ├─┬ unknownArrayProperty property
  │   │   │ └── type: Array<any>
  │   │   ├─┬ unknownMapProperty property
@@ -1231,9 +1231,9 @@ exports[`showAll 1`] = `
  │   │   ├─┬ <initializer>(unionProperty) initializer
  │   │   │ └─┬ parameters
  │   │   │   └─┬ unionProperty
- │   │   │     └── type: Array<Map<string => jsii-calc.StructA | jsii-calc.StructB> | Array<jsii-calc.StructA | jsii-calc.StructB>>
+ │   │   │     └── type: Array<Array<jsii-calc.StructA | jsii-calc.StructB> | Map<string => jsii-calc.StructA | jsii-calc.StructB>>
  │   │   └─┬ unionProperty property
- │   │     └── type: Array<Map<string => jsii-calc.StructA | jsii-calc.StructB> | Array<jsii-calc.StructA | jsii-calc.StructB>>
+ │   │     └── type: Array<Array<jsii-calc.StructA | jsii-calc.StructB> | Map<string => jsii-calc.StructA | jsii-calc.StructB>>
  │   ├─┬ class ClassWithPrivateConstructorAndAutomaticProperties
  │   │ ├── interfaces: IInterfaceWithProperties
  │   │ └─┬ members
@@ -3549,7 +3549,7 @@ exports[`showAll 1`] = `
  │   │   ├─┬ secondLevel property
  │   │   │ ├── abstract
  │   │   │ ├── immutable
- │   │   │ └── type: number | jsii-calc.SecondLevelStruct
+ │   │   │ └── type: jsii-calc.SecondLevelStruct | number
  │   │   └─┬ optional property
  │   │     ├── abstract
  │   │     ├── immutable
@@ -3559,11 +3559,11 @@ exports[`showAll 1`] = `
  │   │   ├─┬ bar property
  │   │   │ ├── abstract
  │   │   │ ├── immutable
- │   │   │ └── type: string | number | jsii-calc.AllTypes
+ │   │   │ └── type: jsii-calc.AllTypes | number | string
  │   │   └─┬ foo property
  │   │     ├── abstract
  │   │     ├── immutable
- │   │     └── type: Optional<string | number>
+ │   │     └── type: Optional<number | string>
  │   ├─┬ enum AllTypesEnum
  │   │ ├── MY_ENUM_VALUE
  │   │ ├── YOUR_ENUM_VALUE


### PR DESCRIPTION
Sorting union members guarantees a uniform order is always presented, making it easier to visually compare assemblies (or pre-process them with `jsii-reflect` before using a textual `diff` tool). This also effects how `jsii-diff` compares assemblies, removing many false positives in breaking change detection.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
