### PR TITLE
chore: configure default tag for jsii & jsii-rosetta

### DIFF
--- a/packages/jsii-rosetta/package.json
+++ b/packages/jsii-rosetta/package.json
@@ -52,5 +52,8 @@
   },
   "engines": {
     "node": ">= 14.6.0"
+  },
+  "publishConfig": {
+    "tag": "v1"
   }
 }

--- a/packages/jsii/package.json
+++ b/packages/jsii/package.json
@@ -56,5 +56,8 @@
     "@types/semver": "^7.3.13",
     "clone": "^2.1.2",
     "jsii-build-tools": "^0.0.0"
+  },
+  "publishConfig": {
+    "tag": "v1"
   }
 }


### PR DESCRIPTION
Preparing for the upcoming release of jsii@v4.9 and jsii-rosetta@v4.9, set up `publishConfig` for both `v1` packages so they no longer get released against the `latest` dist-tag, and instead get released against the `v1` dist-tag (`latest` will promptly point to `4.9.0`).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
