### PR TITLE
fix(pacmak): runtime dependency should match pacmak release

### DIFF
--- a/packages/jsii-pacmak/generate.sh
+++ b/packages/jsii-pacmak/generate.sh
@@ -14,10 +14,10 @@ VERSION=$(node -p "require('./package.json').version.replace(/\\+[0-9a-f]+\$/, '
 cat > lib/version.ts <<HERE
 // Generated at $(date -u +"%Y-%m-%dT%H:%M:%SZ") by generate.sh
 
-/** The short version number for this JSII compiler (e.g: \`X.Y.Z\`) */
+/** The short version number for this jsii-pacmak release (e.g: \`X.Y.Z\`) */
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const VERSION: string = '${VERSION}';
 
-/** The qualified version number for this JSII compiler (e.g: \`X.Y.Z (build #######)\`) */
+/** The qualified version number for this jsii-pacmak release (e.g: \`X.Y.Z (build #######)\`) */
 export const VERSION_DESC = '${VERSION} (build ${commit:0:7}${suffix:-})';
 HERE

--- a/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/filegenerator.ts
@@ -5,6 +5,7 @@ import * as xmlbuilder from 'xmlbuilder';
 
 import { TargetName } from '..';
 import * as logging from '../../logging';
+import { VERSION } from '../../version';
 import { TARGET_FRAMEWORK } from '../dotnet';
 import { toNuGetVersionRange, toReleaseVersion } from '../version-utils';
 import { DotNetNameUtils } from './nameutils';
@@ -119,13 +120,10 @@ export class FileGenerator {
     const embeddedResource = itemGroup1.ele('EmbeddedResource');
     embeddedResource.att('Include', this.tarballFileName);
 
-    // Strip " (build abcdef)" from the jsii version
-    const jsiiVersion = assembly.jsiiVersion.replace(/ .*$/, '');
-
     const itemGroup2 = rootNode.ele('ItemGroup');
     const packageReference = itemGroup2.ele('PackageReference');
     packageReference.att('Include', 'Amazon.JSII.Runtime');
-    packageReference.att('Version', toNuGetVersionRange(`^${jsiiVersion}`));
+    packageReference.att('Version', toNuGetVersionRange(`^${VERSION}`));
 
     dependencies.forEach((value: DotNetDependency) => {
       if (value.partOfCompilation) {

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -18,6 +18,7 @@ import { warn } from '../logging';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
 import { shell } from '../util';
+import { VERSION } from '../version';
 import { renderSummary, PropertyDefinition } from './_utils';
 import {
   NamingContext,
@@ -2080,12 +2081,6 @@ class Package {
     );
     code.closeFile('README.md');
 
-    // Strip " (build abcdef)" from the jsii version
-    const jsiiVersionSimple = toReleaseVersion(
-      this.metadata.jsiiVersion.replace(/ .*$/, ''),
-      TargetName.PYTHON,
-    );
-
     const setupKwargs = {
       name: this.name,
       version: this.version,
@@ -2109,7 +2104,7 @@ class Package {
       package_data: packageData,
       python_requires: '~=3.7',
       install_requires: [
-        `jsii${toPythonVersionRange(`^${jsiiVersionSimple}`)}`,
+        `jsii${toPythonVersionRange(`^${VERSION}`)}`,
         'publication>=0.0.3',
         'typeguard~=2.13.3',
       ]

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -84,7 +84,7 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/Com
     <EmbeddedResource Include="foo-1.2.3.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="[1337.42.1337,1338.0.0)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
     <PackageReference Include="Com.Acme.Bar" Version="[2.0.0-rc.42,3.0.0)" />
   </ItemGroup>
   <PropertyGroup>
@@ -453,7 +453,7 @@ kwargs = json.loads(
     "python_requires": "~=3.7",
     "install_requires": [
         "bar>=2.0.0.rc42, <3.0.0",
-        "jsii>=1337.42.1337, <1338.0.0",
+        "jsii<0.0.1",
         "publication>=0.0.3",
         "typeguard~=2.13.3"
     ],
@@ -595,7 +595,7 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/
     <EmbeddedResource Include="foo-1.2.3.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="[1337.42.1337,1338.0.0)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
     <PackageReference Include="Com.Acme.Bar" Version="[4.5.6-pre.1337,5.0.0)" />
   </ItemGroup>
   <PropertyGroup>
@@ -964,7 +964,7 @@ kwargs = json.loads(
     "python_requires": "~=3.7",
     "install_requires": [
         "bar>=4.5.6.dev1337, <5.0.0",
-        "jsii>=1337.42.1337, <1338.0.0",
+        "jsii<0.0.1",
         "publication>=0.0.3",
         "typeguard~=2.13.3"
     ],
@@ -1106,7 +1106,7 @@ exports[`foo@2.0.0-rc.42: <outDir>/dotnet/Com.Acme.Foo/Com.Acme.Foo.csproj 1`] =
     <EmbeddedResource Include="foo-2.0.0-rc.42.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="[1337.42.1337,1338.0.0)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -1454,7 +1454,7 @@ kwargs = json.loads(
     },
     "python_requires": "~=3.7",
     "install_requires": [
-        "jsii>=1337.42.1337, <1338.0.0",
+        "jsii<0.0.1",
         "publication>=0.0.3",
         "typeguard~=2.13.3"
     ],
@@ -1594,7 +1594,7 @@ exports[`foo@4.5.6-pre.1337: <outDir>/dotnet/Com.Acme.Foo/Com.Acme.Foo.csproj 1`
     <EmbeddedResource Include="foo-4.5.6-pre.1337.tgz" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.JSII.Runtime" Version="[1337.42.1337,1338.0.0)" />
+    <PackageReference Include="Amazon.JSII.Runtime" Version="[0.0.0,)" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Silence [Obsolete] warnings -->
@@ -1942,7 +1942,7 @@ kwargs = json.loads(
     },
     "python_requires": "~=3.7",
     "install_requires": [
-        "jsii>=1337.42.1337, <1338.0.0",
+        "jsii<0.0.1",
         "publication>=0.0.3",
         "typeguard~=2.13.3"
     ],


### PR DESCRIPTION
The code generated by `jsii-pacmak` has a dependency on jsii runtime versions that are expected to match that of `jsii-pacmak` itself. This fixes the .NET and Python generators using the assembly's `jsiiVersion` property, which is a metadata field supposed to only indicate what version of the compiler was used to build the assembly.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
