### PR TITLE
fix(rosetta): flakey trim-cache test

### DIFF
--- a/packages/jsii-rosetta/lib/json.ts
+++ b/packages/jsii-rosetta/lib/json.ts
@@ -1,4 +1,4 @@
-import { Readable, Writable, pipeline } from 'node:stream';
+import { Readable, pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import { parser } from 'stream-json';
 import * as Assembler from 'stream-json/Assembler';
@@ -36,12 +36,15 @@ export async function parse(reader: Readable): Promise<any> {
  * better performance.
  *
  * @param value the value to be serialized.
- * @param writer the write in which to write the JSON text.
+ * @param writers the sequence of write streams to use to output the JSON text.
  */
-export async function stringify(value: any, writer: Writable): Promise<void> {
+export async function stringify(
+  value: any,
+  ...writers: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream>
+): Promise<void> {
   const reader = new Readable({ objectMode: true });
   reader.push(value);
   reader.push(null);
 
-  return asyncPipeline(reader, disassembler(), stringer(), writer);
+  return asyncPipeline(reader, disassembler(), stringer(), ...writers);
 }

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -182,7 +182,7 @@ export class LanguageTablet {
    * Saves the tablet schema to a file. If the compress option is passed, then
    * the schema will be gzipped before writing to the file.
    */
-  public async save(filename: string, compress = false) {
+  public async save(filename: string, compress = false): Promise<void> {
     await fs.mkdir(path.dirname(filename), { recursive: true });
 
     const writeStream: Writable = createWriteStream(filename, { flags: 'w' });
@@ -197,7 +197,7 @@ export class LanguageTablet {
         gzip.once('close', ok);
       });
 
-    return Promise.all([stringify(this.toSchema(), gzip ?? writeStream), gzipFinished]).then(() => void undefined);
+    await Promise.all([stringify(this.toSchema(), gzip ?? writeStream), gzipFinished]);
   }
 
   private toSchema(): TabletSchema {

--- a/packages/jsii-rosetta/lib/tablets/tablets.ts
+++ b/packages/jsii-rosetta/lib/tablets/tablets.ts
@@ -187,17 +187,8 @@ export class LanguageTablet {
 
     const writeStream: Writable = createWriteStream(filename, { flags: 'w' });
     const gzip = compress ? zlib.createGzip() : undefined;
-    gzip?.pipe(writeStream, { end: true });
 
-    // If we GZip, this promise ensures the GZip stream is closed before we return.
-    const gzipFinished =
-      gzip &&
-      new Promise<void>((ok, ko) => {
-        gzip.once('error', ko);
-        gzip.once('close', ok);
-      });
-
-    await Promise.all([stringify(this.toSchema(), gzip ?? writeStream), gzipFinished]);
+    return stringify(this.toSchema(), ...(gzip ? [gzip] : []), writeStream);
   }
 
   private toSchema(): TabletSchema {


### PR DESCRIPTION
It appears the trim-cache test using tablet compression occasionally fails in CI/CD. I suspect this is due to the `save` function returning before the GZip stream has bene closed, resulting in the subsequent read attempting to consume an incomplete GZip object.

This adds the necessary provisions to ensure the GZip stream is closed (or failed) before `save` returns.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
