### PR TITLE
chore: remove node: pseudo-protocol

### DIFF
--- a/packages/jsii-rosetta/lib/json.ts
+++ b/packages/jsii-rosetta/lib/json.ts
@@ -1,5 +1,5 @@
-import { Readable, pipeline } from 'node:stream';
-import { promisify } from 'node:util';
+import { Readable, pipeline } from 'stream';
+import { promisify } from 'util';
 import { parser } from 'stream-json';
 import * as Assembler from 'stream-json/Assembler';
 import { disassembler } from 'stream-json/Disassembler';

--- a/packages/jsii-rosetta/lib/json.ts
+++ b/packages/jsii-rosetta/lib/json.ts
@@ -1,9 +1,9 @@
 import { Readable, pipeline } from 'stream';
-import { promisify } from 'util';
 import { parser } from 'stream-json';
 import * as Assembler from 'stream-json/Assembler';
 import { disassembler } from 'stream-json/Disassembler';
 import { stringer } from 'stream-json/Stringer';
+import { promisify } from 'util';
 
 // NB: In node 15+, there is a node:stream.promises object that has this built-in.
 const asyncPipeline = promisify(pipeline);


### PR DESCRIPTION
https://github.com/aws/jsii/commit/d2ecb6d2a6a460e309e4985dc001a6b749b3aac7 inadvertently introduced `node:` pseudo-protocol imports, which require use of more modern nodes than what is advertised. Massage them back into the old-school un-qualified name.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
