### PR TITLE
feat(jsii-pacmak): parsing arguments in non-strict mode

### DIFF
--- a/packages/jsii-pacmak/bin/jsii-pacmak.ts
+++ b/packages/jsii-pacmak/bin/jsii-pacmak.ts
@@ -165,8 +165,7 @@ import { VERSION_DESC } from '../lib/version';
       desc: 'Whether jsii assemblies should be validated. This can be expensive and is skipped by default.',
       default: false,
     })
-    .version(VERSION_DESC)
-    .strict().argv;
+    .version(VERSION_DESC).argv;
 
   configureLogging({ level: argv.verbose !== undefined ? argv.verbose : 0 });
 

--- a/packages/jsii-pacmak/test/build-test.sh
+++ b/packages/jsii-pacmak/test/build-test.sh
@@ -86,3 +86,8 @@ ${pacmak} ${OPTS} -v --no-parallel $packagedirs
 clean_dists
 echo "Testing yarn custom pack command."
 ${pacmak} ${OPTS} -v --pack-command='yarn pack -f custom.tgz -s && echo custom.tgz' ${PWD}/../../@scope/jsii-calc-base-of-base
+
+# Test custom mvn settings command
+clean_dists
+echo "Testing custom mvn parameters."
+${pacmak} ${OPTS} -v --mvn-builder=singlethreaded --mvn-threads=4 $packagedirs


### PR DESCRIPTION
Some targets support extra target-specific arguments so users can customize the behavior of the build tools. For example, the Java target allows users to customize the `mvn` CLI behaviour with `--mvn-*` parameters. However the `jsi-pacmak` CLI is blocking this feature because it is using strict mode when parsing arguments. This change lifts that gate.

This address [#3465](https://github.com/aws/jsii/discussions/3465)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
