### PR TITLE
chore: add upgrade prompt at load of jsii and jsii-rosetta 1.x

### DIFF
--- a/packages/jsii-rosetta/lib/index.ts
+++ b/packages/jsii-rosetta/lib/index.ts
@@ -11,3 +11,5 @@ export * from './rosetta-translator';
 export * from './snippet';
 export * from './markdown';
 export * from './strict';
+
+import './upgrade-prompt';

--- a/packages/jsii-rosetta/lib/upgrade-prompt.ts
+++ b/packages/jsii-rosetta/lib/upgrade-prompt.ts
@@ -4,8 +4,8 @@ if (process.env.JSII_SUPPRESS_UPGRADE_PROMPT == null) {
     [
       '#######################################################################################################',
       '### You are currently using jsii-rosetta@1.x. We recommend upgrading to jsii-rosetta@5.0.x or       ###',
-      '### later, which will allow you to use modern TypeScript syntax, and improves compatibility with    ###',
-      '### many common dependencies, such as recent versions of @types/node.                               ###',
+      '### later. This will allow you to use modern TypeScript syntax, and improves compatibility with     ###',
+      '### many common dependencies. For example, recent versions of @types/node.                          ###',
       '###                                                                                                 ###',
       '### 5.0.x and subsequent releases of jsii-rosetta use the same major.minor version as the           ###',
       '### TypeScript compiler they are built on. We recommend declaring a minor-pinned (also known as     ###',

--- a/packages/jsii-rosetta/lib/upgrade-prompt.ts
+++ b/packages/jsii-rosetta/lib/upgrade-prompt.ts
@@ -1,0 +1,21 @@
+// Note: intentionally using the same environment variable as the compiler here instead of customizing...
+if (process.env.JSII_SUPPRESS_UPGRADE_PROMPT == null) {
+  console.error(
+    [
+      '#######################################################################################################',
+      '### You are currently using jsii-rosetta@1.x. We recommend upgrading to jsii-rosetta@5.0.x or       ###',
+      '### later, which will allow you to use modern TypeScript syntax, and improves compatibility with    ###',
+      '### many common dependencies, such as recent versions of @types/node.                               ###',
+      '###                                                                                                 ###',
+      '### 5.0.x and subsequent releases of jsii-rosetta use the same major.minor version as the           ###',
+      '### TypeScript compiler they are built on. We recommend declaring a minor-pinned (also known as     ###',
+      '### "tilde") dependency on jsii-rosetta (e.g: `"jsii-rosetta": "5.0.x"` or                          ###',
+      '### `"jsii-rosetta": "~5.0.7"`).                                                                    ###',
+      '###                                                                                                 ###',
+      '### For more information, see: https://aws.github.io/jsii/compiler-and-rosetta-maintenance/         ###',
+      '###                                                                                                 ###',
+      '### This warning can be suppressed by setting the JSII_SUPPRESS_UPGRADE_PROMPT environment variable ###',
+      '#######################################################################################################',
+    ].join('\n'),
+  );
+}

--- a/packages/jsii/lib/index.ts
+++ b/packages/jsii/lib/index.ts
@@ -1,3 +1,5 @@
+import './upgrade-prompt';
+
 export * from './jsii-diagnostic';
 export * from './symbol-id';
 export * from './helpers';

--- a/packages/jsii/lib/upgrade-prompt.ts
+++ b/packages/jsii/lib/upgrade-prompt.ts
@@ -1,0 +1,19 @@
+if (process.env.JSII_SUPPRESS_UPGRADE_PROMPT == null) {
+  console.error(
+    [
+      '#######################################################################################################',
+      '### You are currently using jsii@1.x. We recommend upgrading to jsii@5.0.x or later, which will     ###',
+      '### allow you to use modern TypeScript syntax, and improves compatibility with many common          ###',
+      '### dependencies, such as recent versions of @types/node.                                           ###',
+      '###                                                                                                 ###',
+      '### 5.0.x and subsequent releases of jsii use the same major.minor version as the TypeScript        ###',
+      '### compiler they are built on. We recommend declaring a minor-pinned (also known as "tilde")       ###',
+      '### dependency on jsii (e.g: `"jsii": "5.0.x"` or `"jsii": "~5.0.7"`).                              ###',
+      '###                                                                                                 ###',
+      '### For more information, see: https://aws.github.io/jsii/compiler-and-rosetta-maintenance/         ###',
+      '###                                                                                                 ###',
+      '### This warning can be suppressed by setting the JSII_SUPPRESS_UPGRADE_PROMPT environment variable ###',
+      '#######################################################################################################',
+    ].join('\n'),
+  );
+}

--- a/packages/jsii/lib/upgrade-prompt.ts
+++ b/packages/jsii/lib/upgrade-prompt.ts
@@ -2,9 +2,9 @@ if (process.env.JSII_SUPPRESS_UPGRADE_PROMPT == null) {
   console.error(
     [
       '#######################################################################################################',
-      '### You are currently using jsii@1.x. We recommend upgrading to jsii@5.0.x or later, which will     ###',
+      '### You are currently using jsii@1.x. We recommend upgrading to jsii@5.0.x or later. This will      ###',
       '### allow you to use modern TypeScript syntax, and improves compatibility with many common          ###',
-      '### dependencies, such as recent versions of @types/node.                                           ###',
+      '### dependencies. For example, recent versions of @types/node.                                      ###',
       '###                                                                                                 ###',
       '### 5.0.x and subsequent releases of jsii use the same major.minor version as the TypeScript        ###',
       '### compiler they are built on. We recommend declaring a minor-pinned (also known as "tilde")       ###',


### PR DESCRIPTION
This is to strongly incitate customers upgrade their dependencies, while trying to avoid alarming (there is 18 months left before the End-of-Support is scheduled, which is PLENTY of time).



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
