### PR TITLE
Fix(Dockerfile): Use Node 18 (supported) rather than 14 (deprecated)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
     env:
       # Node version whose images will be aliased without the -nodeXX segment
-      DEFAULT_NODE_MAJOR_VERSION: 14
+      DEFAULT_NODE_MAJOR_VERSION: 18
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -203,7 +203,7 @@ COPY --from=bindist /opt/golang/go ${GOROOT}
 # Install Node 14+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
 # (Put this as late as possible in the Dockerfile so we get to reuse the layer cache
 # for most of the multiple builds).
-ARG NODE_MAJOR_VERSION="14"
+ARG NODE_MAJOR_VERSION="18"
 COPY superchain/gpg/nodesource.asc /tmp/nodesource.asc
 COPY superchain/gpg/yarn.asc /tmp/yarn.asc
 RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                                                           \

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -200,9 +200,11 @@ COPY superchain/m2-settings.xml /root/.m2/settings.xml
 # Install Go
 COPY --from=bindist /opt/golang/go ${GOROOT}
 
-# Install Node 14+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
+# Install Node 18+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
 # (Put this as late as possible in the Dockerfile so we get to reuse the layer cache
 # for most of the multiple builds).
+# This was previously node 14. Node 14 is EOL and 16 will be EOL early to coinside
+# with the deprecation of OpenSSL 1.1.1.
 ARG NODE_MAJOR_VERSION="18"
 COPY superchain/gpg/nodesource.asc /tmp/nodesource.asc
 COPY superchain/gpg/yarn.asc /tmp/yarn.asc


### PR DESCRIPTION
This PR changes the default node major version to 18, the current LTS, that will go out of support in 2025. 
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
