### PR TITLE
feat(jsii-diff): allow external stability to be treated as error

### DIFF
--- a/packages/jsii-diff/README.md
+++ b/packages/jsii-diff/README.md
@@ -2,61 +2,82 @@
 
 __jsii-diff__ compares two jsii assemblies for compatibility.
 
-In the future, it will be able to do generic comparisons, but for
+In the future, it will be able to do generic comparisons.
+But for
 now it will compare assemblies for API compatibility, and exit
-with a non-zero exit code if any **stable** APIs have had incompatible
-changes.
+with a non-zero exit code if any __stable__ or __deprecated__ APIs have had incompatible changes.
 
-API items that have no stability are treated as **stable**. To treat
-unmarked API items as experimental, pass the `--default-experimental` flag.
+API items that have no stability are treated as __stable__.
+To treat unmarked API items as experimental, pass the `--default-experimental` flag.
 
 ## Usage
 
 To compare two JSII packages:
 
-    jsii-diff <old> [new]
+```console
+jsii-diff <old> [new]
+```
 
 Packages can be identified by either:
 
-* **A path**, in which case it should be the path to a JSII package directory,
+* __A path__, in which case it should be the path to a JSII package directory,
   or to a `.jsii` file.
-* **An NPM package specifier** of the form `npm:[<package>[@version]]`, in
+* __An NPM package specifier__ of the form `npm:[<package>[@version]]`, in
   which case the indicated version is downloaded and used. If `@version` is
   left out, the latest version will be used. If `package` is left out,
   the assembly name of `.jsii` in the current directory will be used.
 
 To compare current package against latest published NPM release:
 
-    jsii-diff npm:
+```console
+jsii-diff npm:<package>
+```
+
+### Stability Error Classes
+
+By default only incompatible changes to `stable` or `deprecated` APIs are treated as errors and fail the command.
+Changes to `experimental` or `external` APIs will emit a Warning.
+
+You might change this behavior by passing the `--error-on` flag:
+
+```console
+jsii-diff npm:<package> --error-on=stable --error-on=external 
+```
+
+Or fail for all incompatible changes:
+
+```console
+jsii-diff npm:<package> --error-on=all
+```
 
 ## Details
 
-__jsii-diff__ will assert that code written against version **A** of a library
-will still typecheck when compiled against version **B** of that library. It
+__jsii-diff__ will assert that code written against version __A__ of a library
+will still typecheck when compiled against version __B__ of that library. It
 does this by verifying the following properties:
 
-- Any type (class/interface/enum) in **A** must also exist in **B**.
-- Enums have only added members.
-- Classes and interfaces have only added members, or modified existing
+* Any type (class/interface/enum) in __A__ must also exist in __B__.
+* Enums have only added members.
+* Classes and interfaces have only added members, or modified existing
   members in an allowed way.
-- Property types are the same or have been strengthened (see below).
-- Methods have only added optional arguments, existing argument types have
+* Property types are the same or have been strengthened (see below).
+* Methods have only added optional arguments, existing argument types have
   only been weakened, and the return type has only been strengthened (see below).
 
 ### Strengthening and weakening
 
-- *Strengthening* a type refers to *excluding* more possible values. Changing
+* *Strengthening* a type refers to *excluding* more possible values. Changing
   a field from `optional` to `required`, or changing a type from `any` to
   `string` are examples of strengthening.
 
-- As the opposite of strengthening, *weakening* refers to *allowing* more
+* As the opposite of strengthening, *weakening* refers to *allowing* more
   possible values. Changing a field from `required` to `optional`, or
   changing a type to a superclass or interface are examples of weakening.
 
 An API can change in the following way without breaking its consumer:
 
-- It can *weaken* its input (require *less* from the caller); and
-- It can *strengthen* its output (guarantee *more* to the caller).
+* It can *weaken* its input (require *less* from the caller); and
+* It can *strengthen* its output (guarantee *more* to the caller).
 
 ### Struct types
 
@@ -64,12 +85,12 @@ Structs (interfaces consisting completely of `readonly` properties) are
 treated as bags of data. Their API compatibility will be evaluated depending
 on whether they appear in input or output position of operations.
 
-- Structs are *weakened* if all types of all of its properties are weakened.
+* Structs are *weakened* if all types of all of its properties are weakened.
   Normally removing properties would also be considered weakening, but
   because that may cause references to the fields in existing code bases to
   become undefined (which is not allowed in most programming languages) we
   disallow removing properties.
-- Structs are *strengthened* if all types of all of its properties are
+* Structs are *strengthened* if all types of all of its properties are
   strengthened, or if fields are added.
 
 __jsii-diff__ will check the evolution of structs against their position

--- a/packages/jsii-diff/README.md
+++ b/packages/jsii-diff/README.md
@@ -35,20 +35,22 @@ jsii-diff npm:<package>
 
 ### Stability Error Classes
 
-By default only incompatible changes to `stable` or `deprecated` APIs are treated as errors and fail the command.
-Changes to `experimental` or `external` APIs will emit a Warning.
+By default only incompatible changes to `stable` or `deprecated` APIs are treated as errors and will fail the command.
+Changes to `experimental` or `external` APIs emit a warning.
 
-You might change this behavior by passing the `--error-on` flag:
-
-```console
-jsii-diff npm:<package> --error-on=stable --error-on=external 
-```
-
-Or fail for all incompatible changes:
+Change this behavior with the `--error-on` flag:
 
 ```console
 jsii-diff npm:<package> --error-on=all
 ```
+
+The following `--error-on` groups are available:
+
+| `--error-on`       | Stabilities that cause an ERROR                    |
+| ------------------ | -------------------------------------------------- |
+| `prod` (default)   | `stable`, `deprecated`                             |
+| `non-experimental` | `stable`, `deprecated`, `external`                 |
+| `all`              | `stable`, `deprecated`, `experimental`, `external` |
 
 ## Details
 

--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -45,11 +45,11 @@ async function main(): Promise<number> {
       type: 'boolean',
       default: false,
       desc: 'Error on experimental API changes',
-      deprecate: 'Use `--errors` instead',
+      deprecate: 'Use `--error-on` instead',
     })
     .option('error-on', {
-      type: 'array',
-      default: ['prod'],
+      type: 'string',
+      default: 'prod',
       choices: ERROR_CLASSES,
       desc: 'Which type of API changes should be treated as an error',
     })
@@ -129,10 +129,7 @@ async function main(): Promise<number> {
   if (mismatches.count > 0) {
     const diags = classifyDiagnostics(
       mismatches,
-      treatAsError(
-        argv['error-on'] as ErrorClass[],
-        argv['experimental-errors'],
-      ),
+      treatAsError(argv['error-on'] as ErrorClass, argv['experimental-errors']),
       await loadFilter(argv['ignore-file']),
     );
 

--- a/packages/jsii-diff/bin/jsii-diff.ts
+++ b/packages/jsii-diff/bin/jsii-diff.ts
@@ -9,8 +9,11 @@ import * as yargs from 'yargs';
 import { compareAssemblies } from '../lib';
 import {
   classifyDiagnostics,
+  treatAsError,
   formatDiagnostic,
   hasErrors,
+  ErrorClass,
+  ERROR_CLASSES,
 } from '../lib/diagnostics';
 import {
   DownloadFailure,
@@ -42,6 +45,13 @@ async function main(): Promise<number> {
       type: 'boolean',
       default: false,
       desc: 'Error on experimental API changes',
+      deprecate: 'Use `--errors` instead',
+    })
+    .option('error-on', {
+      type: 'array',
+      default: ['prod'],
+      choices: ERROR_CLASSES,
+      desc: 'Which type of API changes should be treated as an error',
     })
     .option('ignore-file', {
       alias: 'i',
@@ -119,7 +129,10 @@ async function main(): Promise<number> {
   if (mismatches.count > 0) {
     const diags = classifyDiagnostics(
       mismatches,
-      argv['experimental-errors'],
+      treatAsError(
+        argv['error-on'] as ErrorClass[],
+        argv['experimental-errors'],
+      ),
       await loadFilter(argv['ignore-file']),
     );
 
@@ -127,7 +140,7 @@ async function main(): Promise<number> {
       `Original assembly: ${original.name}@${original.version}\n`,
     );
     process.stderr.write(
-      `Updated assembly:  ${updated.name}@${updated.version}\n`,
+      `Updated assembly: ${updated.name}@${updated.version}\n`,
     );
     process.stderr.write('API elements with incompatible changes:\n');
     for (const diag of diags) {

--- a/packages/jsii-diff/lib/diagnostics.ts
+++ b/packages/jsii-diff/lib/diagnostics.ts
@@ -44,47 +44,33 @@ export function onlyWarnings(diags: Diagnostic[]) {
   return diags.filter((diag) => diag.level === DiagLevel.Warning);
 }
 
-export const ERROR_CLASSES = [
-  'prod',
-  'non-experimental',
-  'all',
-  'stable',
-  'experimental',
-  'external',
-  'deprecated',
-] as const;
+export const ERROR_CLASSES = ['prod', 'non-experimental', 'all'] as const;
 
 export type ErrorClass = (typeof ERROR_CLASSES)[number];
 
 export const ERROR_CLASSES_TO_STABILITIES: Record<ErrorClass, Stability[]> = {
-  stable: [Stability.Stable],
-  experimental: [Stability.Experimental],
-  external: [Stability.External],
-  deprecated: [Stability.Deprecated],
   prod: [Stability.Stable, Stability.Deprecated],
+  'non-experimental': [
+    Stability.Stable,
+    Stability.Deprecated,
+    Stability.External,
+  ],
   all: [
     Stability.Stable,
     Stability.Experimental,
     Stability.External,
     Stability.Deprecated,
   ],
-  'non-experimental': [
-    Stability.Stable,
-    Stability.Deprecated,
-    Stability.External,
-  ],
 };
 
 export function treatAsError(
-  errorClasses: ErrorClass[],
+  errorClass: ErrorClass,
   deprecatedExperimentalErrors = false,
 ): Set<Stability> {
   const shouldError = new Set<Stability>();
 
-  for (const error of errorClasses) {
-    for (const stability of ERROR_CLASSES_TO_STABILITIES[error]) {
-      shouldError.add(stability);
-    }
+  for (const stability of ERROR_CLASSES_TO_STABILITIES[errorClass]) {
+    shouldError.add(stability);
   }
 
   if (deprecatedExperimentalErrors) {

--- a/packages/jsii-diff/test/diagnostics.test.ts
+++ b/packages/jsii-diff/test/diagnostics.test.ts
@@ -1,23 +1,56 @@
-import { classifyDiagnostics, hasErrors } from '../lib/diagnostics';
+import { Stability } from '@jsii/spec';
+
+import {
+  classifyDiagnostics,
+  treatAsError,
+  hasErrors,
+  onlyErrors,
+  onlyWarnings,
+  ErrorClass,
+} from '../lib/diagnostics';
 import { compare } from './util';
 
 // ----------------------------------------------------------------------
-test('experimental elements lead to warnings', () => {
+test('experimental stability violations lead to warnings', () => {
   const mms = compare(
     `
     /** @experimental */
     export class Foo1 { }
   `,
     `
-    export class Foo2 { }
+    export class FooNew { }
   `,
   );
 
-  const experimentalErrors = false;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+  const diags = classifyDiagnostics(mms, treatAsError(['stable']));
 
   expect(diags.length).toBe(1);
   expect(hasErrors(diags)).toBeFalsy();
+});
+
+// ----------------------------------------------------------------------
+test('only experimental stability violations are turned into errors', () => {
+  const mms = compare(
+    `
+    /** @experimental */
+    export class Foo1 { }
+
+    /** @stability external */
+    export class Foo2 { }    
+  `,
+    `
+    export class FooNew { }
+  `,
+  );
+
+  const diags = classifyDiagnostics(
+    mms,
+    treatAsError(['stable', 'experimental']),
+  );
+
+  expect(onlyErrors(diags).length).toBe(1);
+  expect(onlyWarnings(diags).length).toBe(1);
+  expect(hasErrors(diags)).toBeTruthy();
 });
 
 // ----------------------------------------------------------------------
@@ -26,59 +59,121 @@ test('external stability violations are reported as warnings', () => {
     `
     /** @stability external */
     export class Foo1 { }
+    
   `,
     `
-    export class Foo2 { }
+    export class FooNew { }
   `,
   );
 
-  const experimentalErrors = false;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+  const diags = classifyDiagnostics(mms, treatAsError(['stable']));
 
   expect(diags.length).toBe(1);
   expect(hasErrors(diags)).toBeFalsy();
 });
 
 // ----------------------------------------------------------------------
-test('warnings can be turned into errors', () => {
-  const mms = compare(
-    `
-    /** @experimental */
-    export class Foo1 { }
-  `,
-    `
-    export class Foo2 { }
-  `,
-  );
-
-  const experimentalErrors = true;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
-
-  expect(diags.length).toBe(1);
-  expect(hasErrors(diags)).toBeTruthy();
-});
-
-// ----------------------------------------------------------------------
-test('external stability violations are never turned into errors', () => {
+test('only external stability violations are turned into errors', () => {
   const mms = compare(
     `
     /** @stability external */
     export class Foo1 { }
+
+    /** @stability experimental */
+    export class Foo2 { }    
   `,
     `
-    export class Foo2 { }
+    export class FooNew { }
   `,
   );
 
-  const experimentalErrors = true;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+  const diags = classifyDiagnostics(mms, treatAsError(['stable', 'external']));
+
+  expect(onlyErrors(diags).length).toBe(1);
+  expect(onlyWarnings(diags).length).toBe(1);
+  expect(hasErrors(diags)).toBeTruthy();
+});
+
+// ----------------------------------------------------------------------
+test('deprecated stability violations are reported as warnings', () => {
+  const mms = compare(
+    `
+    /** @deprecated for some reason */
+    export class Foo1 { }
+    
+  `,
+    `
+    export class FooNew { }
+  `,
+  );
+
+  const diags = classifyDiagnostics(mms, treatAsError(['stable']));
 
   expect(diags.length).toBe(1);
   expect(hasErrors(diags)).toBeFalsy();
 });
 
 // ----------------------------------------------------------------------
-test('errors can be skipped', () => {
+test('only deprecated stability violations are turned into errors', () => {
+  const mms = compare(
+    `
+    /** @deprecated for some reason */
+    export class Foo1 { }
+
+    /** @stability experimental */
+    export class Foo2 { }    
+  `,
+    `
+    export class FooNew { }
+  `,
+  );
+
+  const diags = classifyDiagnostics(
+    mms,
+    treatAsError(['stable', 'deprecated']),
+  );
+
+  expect(onlyErrors(diags).length).toBe(1);
+  expect(onlyWarnings(diags).length).toBe(1);
+  expect(hasErrors(diags)).toBeTruthy();
+});
+
+// ----------------------------------------------------------------------
+describe('treatAsError', () => {
+  test.each<[ErrorClass[], Stability[]]>([
+    [['prod'], [Stability.Deprecated, Stability.Stable]],
+    [
+      ['all'],
+      [
+        Stability.Deprecated,
+        Stability.Experimental,
+        Stability.External,
+        Stability.Stable,
+      ],
+    ],
+    [
+      ['non-experimental'],
+      [Stability.Deprecated, Stability.External, Stability.Stable],
+    ],
+    [['stable'], [Stability.Stable]],
+    [['experimental'], [Stability.Experimental]],
+    [['external'], [Stability.External]],
+    [['deprecated'], [Stability.Deprecated]],
+    [
+      ['stable', 'deprecated'],
+      [Stability.Stable, Stability.Deprecated],
+    ],
+  ])('%s', (errorClasses, expectedStabilities) => {
+    const shouldError = treatAsError(errorClasses);
+    expect(shouldError.size).toBe(expectedStabilities.length);
+    expect([...expectedStabilities].every((s) => shouldError.has(s))).toBe(
+      true,
+    );
+  });
+});
+
+// ----------------------------------------------------------------------
+test('errors can be skipped by key', () => {
   const mms = compare(
     `
     export class Foo1 { }
@@ -88,10 +183,9 @@ test('errors can be skipped', () => {
   `,
   );
 
-  const experimentalErrors = true;
   const diags = classifyDiagnostics(
     mms,
-    experimentalErrors,
+    treatAsError(['stable', 'experimental']),
     new Set([mms.mismatches[0].violationKey]),
   );
 
@@ -112,8 +206,7 @@ test('changing stable to experimental is breaking', () => {
   `,
   );
 
-  const experimentalErrors = false;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+  const diags = classifyDiagnostics(mms, treatAsError(['stable']));
 
   expect(diags.length).toBeGreaterThan(0);
   expect(
@@ -127,7 +220,6 @@ test('changing stable to experimental is breaking', () => {
 });
 
 // ----------------------------------------------------------------------
-
 test('can make fields optional in output struct if it is marked @external', () => {
   const mms = compare(
     `
@@ -152,8 +244,7 @@ test('can make fields optional in output struct if it is marked @external', () =
     `,
   );
 
-  const experimentalErrors = true;
-  const diags = classifyDiagnostics(mms, experimentalErrors, new Set());
+  const diags = classifyDiagnostics(mms, treatAsError(['stable']));
 
   expect(diags.length).toBe(1);
   expect(hasErrors(diags)).toBeFalsy();


### PR DESCRIPTION
In certain situations one might want to treat changes to `external` APIs as errors.
This could be to check the external APIs for any breaking changes and have an opportunity to selectively reject, heal or soften an upstream change.

This change introduces a new cli option `--error-on` which can be one of three classes:

| `--error-on`       | Stabilities that cause an ERROR                    |
| ------------------ | -------------------------------------------------- |
| `prod` (default)   | `stable`, `deprecated`                             |
| `non-experimental` | `stable`, `deprecated`, `external`                 |
| `all`              | `stable`, `deprecated`, `experimental`, `external` |

**Fixes `deprecated` APIs not being treated as `stable`.**
In jsii, deprecations are treated as a stability.
However for the purpose of jsii-diff they should be treated as stable.
Otherwise one could do `stable -> deprecated, make breaking change, deprecated -> stable`, which should not be allowed. 
We also can't prohibit the transition from deprecated back to stable, as it's perfectly okay to un-deprecate an API.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
