### PR TITLE
chore: silence node end of life warning in tests

### DIFF
--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -23,7 +23,7 @@ export function checkNode(envPrefix = 'JSII'): void {
   if (nodeRelease?.endOfLife) {
     const silenceVariable = `${envPrefix}_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`;
     const acknowledgeNodeEol =
-      'I acknowledge end of life status for this node version';
+      'I acknowledge end of life(EOL) status for this node version. The CDK reserves the right to pull support of EOL runtime releases a month after they went EOL status, and people are recommended to stop using those as soon as possible';
     const qualifier = nodeRelease.endOfLifeDate
       ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
       : '';

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -22,10 +22,12 @@ export function checkNode(envPrefix = 'JSII'): void {
 
   if (nodeRelease?.endOfLife) {
     const silenceVariable = `${envPrefix}_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`;
+    const acknowledgeNodeEol =
+      'I acknowledge end of life status for this node version';
     const qualifier = nodeRelease.endOfLifeDate
       ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
       : '';
-    if (!process.env[silenceVariable])
+    if (!(process.env[silenceVariable] === acknowledgeNodeEol))
       veryVisibleMessage(
         bgRed.white.bold,
         `Node ${nodeRelease.majorVersion} has reached end-of-life${qualifier} and is not supported.`,

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -21,14 +21,16 @@ export function checkNode(envPrefix = 'JSII'): void {
     'Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.';
 
   if (nodeRelease?.endOfLife) {
+    const silenceVariable = `${envPrefix}_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`;
     const qualifier = nodeRelease.endOfLifeDate
       ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
       : '';
-    veryVisibleMessage(
-      bgRed.white.bold,
-      `Node ${nodeRelease.majorVersion} has reached end-of-life${qualifier} and is not supported.`,
-      `Please upgrade to a supported node version as soon as possible.`,
-    );
+    if (!process.env[silenceVariable])
+      veryVisibleMessage(
+        bgRed.white.bold,
+        `Node ${nodeRelease.majorVersion} has reached end-of-life${qualifier} and is not supported.`,
+        `Please upgrade to a supported node version as soon as possible.`,
+      );
   } else if (knownBroken) {
     const silenceVariable = `${envPrefix}_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION`;
     if (!process.env[silenceVariable])

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -23,7 +23,7 @@ export function checkNode(envPrefix = 'JSII'): void {
   if (nodeRelease?.endOfLife) {
     const silenceVariable = `${envPrefix}_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`;
     const acknowledgeNodeEol =
-      'I acknowledge end of life(EOL) status for this node version. The CDK reserves the right to pull support of EOL runtime releases a month after they went EOL status, and people are recommended to stop using those as soon as possible';
+      'Node14 is now end of life (EOL) as of April 30, 2023. Support of EOL runtimes are only guaranteed for 30 days after EOL. By silencing this warning you acknowledge that you are using an EOL version of Node and will upgrade to a supported version as soon as possible.';
     const qualifier = nodeRelease.endOfLifeDate
       ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
       : '';

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -11,6 +11,9 @@ def silence_node_deprecation_warnings():
     test output assertions to be invalidated.
     """
 
+    nodeEolAcknowledgement = "I acknowledge end of life status for this node version"
+    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
+
     variables = [
         "JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION",
         "JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION",

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -11,9 +11,6 @@ def silence_node_deprecation_warnings():
     test output assertions to be invalidated.
     """
 
-    nodeEolAcknowledgement = "I acknowledge end of life status for this node version"
-    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
-
     variables = [
         "JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION",
         "JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION",
@@ -25,6 +22,9 @@ def silence_node_deprecation_warnings():
 
     for var in variables:
         environ[var] = "1"
+
+    nodeEolAcknowledgement = "I acknowledge end of life status for this node version"
+    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
 
     # Execute the test
     yield

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -15,6 +15,7 @@ def silence_node_deprecation_warnings():
         "JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION",
         "JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION",
         "JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION",
+        "JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION",
     ]
 
     store = {var: environ.get(var, "") for var in variables}

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -23,7 +23,7 @@ def silence_node_deprecation_warnings():
     for var in variables:
         environ[var] = "1"
 
-    nodeEolAcknowledgement = "I acknowledge end of life status for this node version"
+    nodeEolAcknowledgement = "I acknowledge end of life(EOL) status for this node version. The CDK reserves the right to pull support of EOL runtime releases a month after they went EOL status, and people are recommended to stop using those as soon as possible"
     environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
 
     # Execute the test

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -23,7 +23,7 @@ def silence_node_deprecation_warnings():
     for var in variables:
         environ[var] = "1"
 
-    nodeEolAcknowledgement = "I acknowledge end of life(EOL) status for this node version. The CDK reserves the right to pull support of EOL runtime releases a month after they went EOL status, and people are recommended to stop using those as soon as possible"
+    nodeEolAcknowledgement = "Node14 is now end of life (EOL) as of April 30, 2023. Support of EOL runtimes are only guaranteed for 30 days after EOL. By silencing this warning you acknowledge that you are using an EOL version of Node and will upgrade to a supported version as soon as possible."
     environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
 
     # Execute the test


### PR DESCRIPTION
Currently tests are failing with end of life warning messages. This PR is adding env variable for tests to silence these errors.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
