### PR TITLE
fix(pacmak): go docs overview displays repeating description

### DIFF
--- a/packages/codemaker/src/codemaker.ts
+++ b/packages/codemaker/src/codemaker.ts
@@ -196,6 +196,14 @@ export class CodeMaker {
     return caseutils.toSnakeCase(s, sep);
   }
 
+  /**
+   * Gets currently opened file path
+   * @returns Currently opened file path.
+   */
+  public getCurrentFilePath(): string | undefined {
+    return this.currentFile?.filePath;
+  }
+
   private makeIndent(): string {
     const length = this.currentIndentLength;
     if (length <= 0) {

--- a/packages/codemaker/src/codemaker.ts
+++ b/packages/codemaker/src/codemaker.ts
@@ -197,7 +197,7 @@ export class CodeMaker {
   }
 
   /**
-   * Gets currently opened file path
+   * Gets currently opened file path.
    * @returns Currently opened file path.
    */
   public getCurrentFilePath(): string | undefined {

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -37,6 +37,7 @@ import { VersionFile } from './version-file';
 
 export const GOMOD_FILENAME = 'go.mod';
 export const GO_VERSION = '1.18';
+const MAIN_FILE = 'main.go';
 
 /*
  * Package represents a single `.go` source file within a package. This can be the root package file or a submodule
@@ -203,9 +204,9 @@ export abstract class Package {
     if (this.types.length > 0) {
       const { code } = context;
 
-      const initFile = join(this.directory, `main.go`);
+      const initFile = join(this.directory, MAIN_FILE);
       code.openFile(initFile);
-      code.line(`package ${this.packageName}`);
+      this.emitHeader(code);
       code.line();
       importGoModules(code, [GO_REFLECT, JSII_RT_MODULE]);
       code.line();
@@ -470,7 +471,12 @@ export class RootPackage extends Package {
   }
 
   protected emitHeader(code: CodeMaker) {
-    if (this.assembly.description !== '') {
+    const currentFilePath = code.getCurrentFilePath();
+    if (
+      this.assembly.description !== '' &&
+      currentFilePath !== undefined &&
+      currentFilePath.includes(MAIN_FILE)
+    ) {
       code.line(`// ${this.assembly.description}`);
     }
     code.line(`package ${this.packageName}`);

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -207,7 +207,6 @@ export abstract class Package {
       const initFile = join(this.directory, MAIN_FILE);
       code.openFile(initFile);
       this.emitHeader(code);
-      code.line();
       importGoModules(code, [GO_REFLECT, JSII_RT_MODULE]);
       code.line();
       code.openBlock('func init()');

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -528,7 +528,6 @@ exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/main.go 1`] = `
 // testpkg
 package testpkg
 
-
 import (
 	"reflect"
 
@@ -2112,7 +2111,6 @@ func Initialize() {
 exports[`nested-types.ts: <outDir>/go/testpkg/main.go 1`] = `
 // testpkg
 package testpkg
-
 
 import (
 	"reflect"

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -382,7 +382,6 @@ namespace Example.Test.Demo.Internal.DependencyResolution
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/Baz.go 1`] = `
-// testpkg
 package testpkg
 
 
@@ -396,7 +395,6 @@ type Baz struct {
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/Consumer.go 1`] = `
-// testpkg
 package testpkg
 
 import (
@@ -431,7 +429,6 @@ func Consumer_ConsumeBaz(baz *Baz) {
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/Consumer__checks.go 1`] = `
 //go:build !no_runtime_type_checking
 
-// testpkg
 package testpkg
 
 import (
@@ -457,7 +454,6 @@ func validateConsumer_ConsumeBazParameters(baz *Baz) error {
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/Consumer__no_checks.go 1`] = `
 //go:build no_runtime_type_checking
 
-// testpkg
 package testpkg
 
 // Building without runtime type checking enabled, so all the below just return nil
@@ -470,7 +466,6 @@ func validateConsumer_ConsumeBazParameters(baz *Baz) error {
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/Foo.go 1`] = `
-// testpkg
 package testpkg
 
 
@@ -482,7 +477,6 @@ type Foo struct {
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/FooBar.go 1`] = `
-// testpkg
 package testpkg
 
 
@@ -531,7 +525,9 @@ func Initialize() {
 `;
 
 exports[`diamond-struct-parameter.ts: <outDir>/go/testpkg/main.go 1`] = `
+// testpkg
 package testpkg
+
 
 import (
 	"reflect"
@@ -1856,7 +1852,6 @@ namespace Example.Test.Demo
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace1.go 1`] = `
-// testpkg
 package testpkg
 
 import (
@@ -1909,7 +1904,6 @@ func (n *jsiiProxy_Namespace1) Foo() {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace1_Foo.go 1`] = `
-// testpkg
 package testpkg
 
 
@@ -1921,7 +1915,6 @@ type Namespace1_Foo struct {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace1_IBar.go 1`] = `
-// testpkg
 package testpkg
 
 import (
@@ -1960,7 +1953,6 @@ func (j *jsiiProxy_Namespace1_IBar) Bar() *string {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace2.go 1`] = `
-// testpkg
 package testpkg
 
 import (
@@ -2013,7 +2005,6 @@ func (n *jsiiProxy_Namespace2) Foo() {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace2_Foo.go 1`] = `
-// testpkg
 package testpkg
 
 
@@ -2028,7 +2019,6 @@ const (
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/Namespace2_Foo_Final.go 1`] = `
-// testpkg
 package testpkg
 
 import (
@@ -2120,7 +2110,9 @@ func Initialize() {
 `;
 
 exports[`nested-types.ts: <outDir>/go/testpkg/main.go 1`] = `
+// testpkg
 package testpkg
+
 
 import (
 	"reflect"

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -438,7 +438,6 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/main.go 1`]
 // An example direct dependency for jsii-calc.
 package jcb
 
-
 import (
 	"reflect"
 
@@ -899,7 +898,6 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejs
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/main.go 1`] = `
 // An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
-
 
 import (
 	"reflect"
@@ -1951,7 +1949,6 @@ func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) *map[string]interf
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/main.go 1`] = `
 package customsubmodulename
 
-
 import (
 	"reflect"
 
@@ -2077,7 +2074,6 @@ func InterfaceFactory_Create() IInterface {
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/deprecationremoval/main.go 1`] = `
 package deprecationremoval
 
-
 import (
 	"reflect"
 
@@ -2167,7 +2163,6 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/main.go 1`] = `
 // A simple calcuator library built on JSII.
 package scopejsiicalclib
-
 
 import (
 	"reflect"
@@ -18016,7 +18011,6 @@ func UseOptions_Provide(which *string) interface{} {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/anonymous/main.go 1`] = `
 package anonymous
 
-
 import (
 	"reflect"
 
@@ -18195,7 +18189,6 @@ type Type__jsiicalcIRandomNumberGenerator = jsiicalc.IRandomNumberGenerator
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/main.go 1`] = `
 package donotimport
 
-
 import (
 	"reflect"
 
@@ -18221,7 +18214,6 @@ func init() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/main.go 1`] = `
 package cdk16625
-
 
 import (
 	"reflect"
@@ -18302,7 +18294,6 @@ type AcceptsPathProps struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk22369/main.go 1`] = `
 package cdk22369
-
 
 import (
 	"reflect"
@@ -18510,7 +18501,6 @@ type Type__scopejsiicalclibOperation = scopejsiicalclib.Operation
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/main.go 1`] = `
 package composition
 
-
 import (
 	"reflect"
 
@@ -18680,7 +18670,6 @@ func (j *jsiiProxy_Derived)SetProp(val *string) {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/main.go 1`] = `
 package derivedclasshasnoproperties
 
-
 import (
 	"reflect"
 
@@ -18795,7 +18784,6 @@ type Homonymous struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/homonymousforwardreferences/bar/main.go 1`] = `
 package bar
 
-
 import (
 	"reflect"
 
@@ -18881,7 +18869,6 @@ type Homonymous struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/homonymousforwardreferences/foo/main.go 1`] = `
 package foo
-
 
 import (
 	"reflect"
@@ -18988,7 +18975,6 @@ type Hello struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/main.go 1`] = `
 package interfaceinnamespaceincludesclasses
 
-
 import (
 	"reflect"
 
@@ -19027,7 +19013,6 @@ type Hello struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceonlyinterface/main.go 1`] = `
 package interfaceinnamespaceonlyinterface
-
 
 import (
 	"reflect"
@@ -19165,7 +19150,6 @@ func (o *jsiiProxy_OverrideMe) ImplementMe(opts *ImplementMeOpts) *bool {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/main.go 1`] = `
 package jsii3656
 
-
 import (
 	"reflect"
 
@@ -19194,7 +19178,6 @@ func init() {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/main.go 1`] = `
 // A simple calcuator built on JSII.
 package jsiicalc
-
 
 import (
 	"reflect"
@@ -21632,7 +21615,6 @@ func (m *jsiiProxy_MyClass) Foo(_arg *string) {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/main.go 1`] = `
 package module2530
 
-
 import (
 	"reflect"
 
@@ -21695,7 +21677,6 @@ func OnlyStatics_Foo() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/main.go 1`] = `
 package module2617
-
 
 import (
 	"reflect"
@@ -21824,7 +21805,6 @@ type Type__scopejsiicalclibIFriendly = scopejsiicalclib.IFriendly
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/main.go 1`] = `
 package module2647
 
-
 import (
 	"reflect"
 
@@ -21917,7 +21897,6 @@ func (m *jsiiProxy_MyClass) Foo(_values *[]scopejsiicalclib.Number) {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/main.go 1`] = `
 package methods
-
 
 import (
 	"reflect"
@@ -22012,7 +21991,6 @@ func NewMyClass_Override(m MyClass) {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/main.go 1`] = `
 package props
-
 
 import (
 	"reflect"
@@ -22113,7 +22091,6 @@ func (m *jsiiProxy_MyClass) Foo() *[]scopejsiicalclib.Number {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/main.go 1`] = `
 package retval
 
-
 import (
 	"reflect"
 
@@ -22155,7 +22132,6 @@ type MyStruct struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/structs/main.go 1`] = `
 package structs
 
-
 import (
 	"reflect"
 
@@ -22184,7 +22160,6 @@ type Bar struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/main.go 1`] = `
 package submodule1
-
 
 import (
 	"reflect"
@@ -22227,7 +22202,6 @@ type Foo struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/main.go 1`] = `
 package submodule2
-
 
 import (
 	"reflect"
@@ -22449,7 +22423,6 @@ func (j *jsiiProxy_IFoo) Baz() *float64 {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/main.go 1`] = `
 package module2700
-
 
 import (
 	"reflect"
@@ -23138,7 +23111,6 @@ type Type__jcbIBaseInterface = jcb.IBaseInterface
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/main.go 1`] = `
 package module2702
 
-
 import (
 	"reflect"
 
@@ -23372,7 +23344,6 @@ func (t *jsiiProxy_TypeFromSub1) Sub1() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub1/main.go 1`] = `
 package sub1
 
-
 import (
 	"reflect"
 
@@ -23454,7 +23425,6 @@ func (t *jsiiProxy_TypeFromSub2) Sub2() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/main.go 1`] = `
 package sub2
 
-
 import (
 	"reflect"
 
@@ -23513,7 +23483,6 @@ func OnlyStaticMethods_StaticMethod() *string {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/main.go 1`] = `
 package onlystatic
-
 
 import (
 	"reflect"
@@ -23703,7 +23672,6 @@ type StructWithSelf struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/main.go 1`] = `
 package pythonself
-
 
 import (
 	"reflect"
@@ -23918,7 +23886,6 @@ type MyClassReference struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/main.go 1`] = `
 package backreferences
 
-
 import (
 	"reflect"
 
@@ -24128,7 +24095,6 @@ type Structure struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/main.go 1`] = `
 package child
 
-
 import (
 	"reflect"
 
@@ -24249,7 +24215,6 @@ This is the readme of the \`jsii-calc.submodule.isolated\` module.
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/main.go 1`] = `
 package isolated
 
-
 import (
 	"reflect"
 
@@ -24271,7 +24236,6 @@ func init() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/main.go 1`] = `
 package submodule
-
 
 import (
 	"reflect"
@@ -24383,7 +24347,6 @@ func (j *jsiiProxy_INamespaced) DefinedAt() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/main.go 1`] = `
 package deeplynested
 
-
 import (
 	"reflect"
 
@@ -24416,7 +24379,6 @@ type Type__deeplynestedINamespaced = deeplynested.INamespaced
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/main.go 1`] = `
 package nestedsubmodule
-
 
 import (
 	"reflect"
@@ -24455,7 +24417,6 @@ type SpecialParameter struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/param/main.go 1`] = `
 package param
-
 
 import (
 	"reflect"
@@ -24533,7 +24494,6 @@ func (r *jsiiProxy_ReturnsSpecialParameter) ReturnsSpecialParam() *param.Special
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/returnsparam/main.go 1`] = `
 package returnsparam
-
 
 import (
 	"reflect"
@@ -24652,7 +24612,6 @@ func (r *jsiiProxy_Resolvable) Resolve() interface{} {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/union/main.go 1`] = `
 package union
-
 
 import (
 	"reflect"

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -21,7 +21,6 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/Base.go 1`] = `
-// An example direct dependency for jsii-calc.
 package jcb
 
 import (
@@ -67,7 +66,6 @@ func (b *jsiiProxy_Base) TypeName() interface{} {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/BaseProps.go 1`] = `
-// An example direct dependency for jsii-calc.
 package jcb
 
 import (
@@ -83,7 +81,6 @@ type BaseProps struct {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/IBaseInterface.go 1`] = `
-// An example direct dependency for jsii-calc.
 package jcb
 
 import (
@@ -326,7 +323,6 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/StaticConsumer.go 1`] = `
-// An example direct dependency for jsii-calc.
 package jcb
 
 import (
@@ -439,7 +435,9 @@ func Initialize() {
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/jsii/scope-jsii-calc-base-0.0.0.tgz 1`] = `go/jcb/jsii/scope-jsii-calc-base-0.0.0.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-base": <outDir>/go/jcb/main.go 1`] = `
+// An example direct dependency for jsii-calc.
 package jcb
+
 
 import (
 	"reflect"
@@ -516,7 +514,6 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/IVeryBaseInterface.go 1`] = `
-// An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
 
 import (
@@ -755,7 +752,6 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/StaticConsumer.go 1`] = `
-// An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
 
 import (
@@ -790,7 +786,6 @@ func StaticConsumer_Consume(_args ...interface{}) {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/Very.go 1`] = `
-// An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
 
 import (
@@ -853,7 +848,6 @@ func (v *jsiiProxy_Very) Hey() *float64 {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/VeryBaseProps.go 1`] = `
-// An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
 
 
@@ -903,7 +897,9 @@ func Initialize() {
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/jsii/scope-jsii-calc-base-of-base-2.1.1.tgz 1`] = `go/scopejsiicalcbaseofbase/jsii/scope-jsii-calc-base-of-base-2.1.1.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/go/scopejsiicalcbaseofbase/main.go 1`] = `
+// An example transitive dependency for jsii-calc.
 package scopejsiicalcbaseofbase
+
 
 import (
 	"reflect"
@@ -1000,7 +996,6 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/BaseFor2647.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1067,7 +1062,6 @@ func (b *jsiiProxy_BaseFor2647) Foo(obj jcb.IBaseInterface) {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/DiamondLeft.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 
@@ -1083,7 +1077,6 @@ type DiamondLeft struct {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/DiamondRight.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 
@@ -1099,7 +1092,6 @@ type DiamondRight struct {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/EnumFromScopedModule.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 
@@ -1120,7 +1112,6 @@ const (
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/IDoublable.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1153,7 +1144,6 @@ func (j *jsiiProxy_IDoublable) DoubleValue() *float64 {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/IFriendly.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1193,7 +1183,6 @@ func (i *jsiiProxy_IFriendly) Hello() *string {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/IThreeLevelsInterface.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1436,7 +1425,6 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/MyFirstStruct.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 
@@ -1463,7 +1451,6 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/Number.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1575,7 +1562,6 @@ func (n *jsiiProxy_Number) TypeName() interface{} {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/NumericValue.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1658,7 +1644,6 @@ func (n *jsiiProxy_NumericValue) TypeName() interface{} {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/Operation.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 import (
@@ -1738,7 +1723,6 @@ func (o *jsiiProxy_Operation) TypeName() interface{} {
 `;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/StructWithOnlyOptionals.go 1`] = `
-// A simple calcuator library built on JSII.
 package scopejsiicalclib
 
 
@@ -1967,6 +1951,7 @@ func (r *jsiiProxy_Reflector) AsMap(reflectable IReflectable) *map[string]interf
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/customsubmodulename/main.go 1`] = `
 package customsubmodulename
 
+
 import (
 	"reflect"
 
@@ -2092,6 +2077,7 @@ func InterfaceFactory_Create() IInterface {
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/deprecationremoval/main.go 1`] = `
 package deprecationremoval
 
+
 import (
 	"reflect"
 
@@ -2179,7 +2165,9 @@ func Initialize() {
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/jsii/scope-jsii-calc-lib-0.0.0.tgz 1`] = `go/scopejsiicalclib/jsii/scope-jsii-calc-lib-0.0.0.tgz is a tarball`;
 
 exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/go/scopejsiicalclib/main.go 1`] = `
+// A simple calcuator library built on JSII.
 package scopejsiicalclib
+
 
 import (
 	"reflect"
@@ -2328,7 +2316,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/ 1
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/BaseFor2647.go.diff 1`] = `
 --- go/scopejsiicalclib/BaseFor2647.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/BaseFor2647.go	--runtime-type-checking
-@@ -29,10 +29,13 @@
+@@ -28,10 +28,13 @@
  
  // Deprecated.
  func NewBaseFor2647(very scopejsiicalcbaseofbase.Very) BaseFor2647 {
@@ -2342,7 +2330,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
  	_jsii_.Create(
  		"@scope/jsii-calc-lib.BaseFor2647",
  		[]interface{}{very},
-@@ -52,10 +55,13 @@
+@@ -51,10 +54,13 @@
  		b,
  	)
  }
@@ -2361,10 +2349,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/BaseFor2647__checks.go.diff 1`] = `
 --- go/scopejsiicalclib/BaseFor2647__checks.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/BaseFor2647__checks.go	--runtime-type-checking
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator library built on JSII.
 +package scopejsiicalclib
 +
 +import (
@@ -2395,10 +2382,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/BaseFor2647__no_checks.go.diff 1`] = `
 --- go/scopejsiicalclib/BaseFor2647__no_checks.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/BaseFor2647__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator library built on JSII.
 +package scopejsiicalclib
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -2416,7 +2402,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/Number.go.diff 1`] = `
 --- go/scopejsiicalclib/Number.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/Number.go	--runtime-type-checking
-@@ -55,10 +55,13 @@
+@@ -54,10 +54,13 @@
  // Creates a Number object.
  // Deprecated.
  func NewNumber(value *float64) Number {
@@ -2435,10 +2421,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/Number__checks.go.diff 1`] = `
 --- go/scopejsiicalclib/Number__checks.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/Number__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator library built on JSII.
 +package scopejsiicalclib
 +
 +import (
@@ -2458,10 +2443,9 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/go/scopejsiicalclib/Number__no_checks.go.diff 1`] = `
 --- go/scopejsiicalclib/Number__no_checks.go	--no-runtime-type-checking
 +++ go/scopejsiicalclib/Number__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator library built on JSII.
 +package scopejsiicalclib
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -2932,7 +2916,6 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AbstractClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3016,7 +2999,6 @@ func (a *jsiiProxy_AbstractClass) NonAbstractMethod() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AbstractClassBase.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3058,7 +3040,6 @@ func NewAbstractClassBase_Override(a AbstractClassBase) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AbstractClassReturner.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3142,7 +3123,6 @@ func (a *jsiiProxy_AbstractClassReturner) GiveMeInterface() IInterfaceImplemente
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AbstractSuite.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3223,7 +3203,6 @@ func (a *jsiiProxy_AbstractSuite) WorkItAll(seed *string) *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Add.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3355,7 +3334,6 @@ func (a *jsiiProxy_Add) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AllTypes.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3816,7 +3794,6 @@ func (a *jsiiProxy_AllTypes) EnumMethod(value StringEnum) StringEnum {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AllTypesEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -3832,7 +3809,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AllowedMethodNames.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3919,7 +3895,6 @@ func (a *jsiiProxy_AllowedMethodNames) SetFoo(_x *string, _y *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AmbiguousParameters.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -3986,7 +3961,6 @@ func NewAmbiguousParameters_Override(a AmbiguousParameters, scope Bell, props *S
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AnonymousImplementationProvider.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4059,7 +4033,6 @@ func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsInterface() IAnonym
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AsyncVirtualMethods.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4193,7 +4166,6 @@ func (a *jsiiProxy_AsyncVirtualMethods) OverrideMeToo() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AugmentableClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4255,7 +4227,6 @@ func (a *jsiiProxy_AugmentableClass) MethodTwo() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/BaseClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4311,7 +4282,6 @@ func (b *jsiiProxy_BaseClass) Method() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/BaseJsii976.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4355,7 +4325,6 @@ func NewBaseJsii976_Override(b BaseJsii976) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Bell.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4430,7 +4399,6 @@ func (b *jsiiProxy_Bell) Ring() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/BinaryOperation.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4552,7 +4520,6 @@ func (b *jsiiProxy_BinaryOperation) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/BurriedAnonymousObject.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4614,7 +4581,6 @@ func (b *jsiiProxy_BurriedAnonymousObject) GiveItBack(value interface{}) interfa
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Calculator.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -4944,7 +4910,6 @@ func (c *jsiiProxy_Calculator) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/CalculatorProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -4962,7 +4927,6 @@ type CalculatorProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ChildStruct982.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -4975,7 +4939,6 @@ type ChildStruct982 struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassThatImplementsTheInternalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5101,7 +5064,6 @@ func (j *jsiiProxy_ClassThatImplementsTheInternalInterface)SetD(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassThatImplementsThePrivateInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5227,7 +5189,6 @@ func (j *jsiiProxy_ClassThatImplementsThePrivateInterface)SetE(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithCollectionOfUnions.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5292,7 +5253,6 @@ func (j *jsiiProxy_ClassWithCollectionOfUnions)SetUnionProperty(val *[]*map[stri
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithCollections.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5447,7 +5407,6 @@ func ClassWithCollections_SetStaticMap(val *map[string]*string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithContainerTypes.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5536,7 +5495,6 @@ func NewClassWithContainerTypes_Override(c ClassWithContainerTypes, array *[]*Du
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithDocs.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5590,7 +5548,6 @@ func NewClassWithDocs_Override(c ClassWithDocs) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithJavaReservedWords.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5660,7 +5617,6 @@ func (c *jsiiProxy_ClassWithJavaReservedWords) Import(assert *string) *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithMutableObjectLiteralProperty.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5725,7 +5681,6 @@ func (j *jsiiProxy_ClassWithMutableObjectLiteralProperty)SetMutableObject(val IM
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithNestedUnion.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5790,7 +5745,6 @@ func (j *jsiiProxy_ClassWithNestedUnion)SetUnionProperty(val *[]interface{}) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5859,7 +5813,6 @@ func ClassWithPrivateConstructorAndAutomaticProperties_Create(readOnlyString *st
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConfusingToJackson.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5933,7 +5886,6 @@ func ConfusingToJackson_MakeStructInstance() *ConfusingToJacksonStruct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConfusingToJacksonStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -5945,7 +5897,6 @@ type ConfusingToJacksonStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConstructorPassesThisOut.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -5989,7 +5940,6 @@ func NewConstructorPassesThisOut_Override(c ConstructorPassesThisOut, consumer P
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Constructors.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6138,7 +6088,6 @@ func Constructors_MakeInterfaces() *[]IPublicInterface {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConsumePureInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6196,7 +6145,6 @@ func (c *jsiiProxy_ConsumePureInterface) WorkItBaby() *StructB {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConsumerCanRingBell.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6384,7 +6332,6 @@ func (c *jsiiProxy_ConsumerCanRingBell) WhenTypedAsClass(ringer IConcreteBellRin
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ConsumersOfThisCrazyTypeSystem.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6456,7 +6403,6 @@ func (c *jsiiProxy_ConsumersOfThisCrazyTypeSystem) ConsumeNonInternalInterface(o
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ContainerProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6470,7 +6416,6 @@ type ContainerProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DataRenderer.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6559,7 +6504,6 @@ func (d *jsiiProxy_DataRenderer) RenderMap(map_ *map[string]interface{}) *string
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Default.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6615,7 +6559,6 @@ func (d *jsiiProxy_Default) PleaseCompile() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DefaultedConstructorArgument.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6695,7 +6638,6 @@ func NewDefaultedConstructorArgument_Override(d DefaultedConstructorArgument, ar
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Demonstrate982.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6775,7 +6717,6 @@ func Demonstrate982_TakeThisToo() *ParentStruct982 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DeprecatedClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6867,7 +6808,6 @@ func (d *jsiiProxy_DeprecatedClass) Method() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DeprecatedEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6885,7 +6825,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DeprecatedStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6899,7 +6838,6 @@ type DeprecatedStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DerivedStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6932,7 +6870,6 @@ type DerivedStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DiamondBottom.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -6953,7 +6890,6 @@ type DiamondBottom struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DiamondInheritanceBaseLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6965,7 +6901,6 @@ type DiamondInheritanceBaseLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DiamondInheritanceFirstMidLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6978,7 +6913,6 @@ type DiamondInheritanceFirstMidLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DiamondInheritanceSecondMidLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -6991,7 +6925,6 @@ type DiamondInheritanceSecondMidLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DiamondInheritanceTopLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -7006,7 +6939,6 @@ type DiamondInheritanceTopLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DisappointingCollectionSource.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7051,7 +6983,6 @@ func DisappointingCollectionSource_MaybeMap() *map[string]*float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DoNotOverridePrivates.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7132,7 +7063,6 @@ func (d *jsiiProxy_DoNotOverridePrivates) PrivatePropertyValue() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DoNotRecognizeAnyAsOptional.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7186,7 +7116,6 @@ func (d *jsiiProxy_DoNotRecognizeAnyAsOptional) Method(_requiredAny interface{},
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DocumentedClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7276,7 +7205,6 @@ func (d *jsiiProxy_DocumentedClass) Hola() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DontComplainAboutVariadicAfterOptional.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7339,7 +7267,6 @@ func (d *jsiiProxy_DontComplainAboutVariadicAfterOptional) OptionalAndVariadic(o
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DoubleTrouble.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7414,7 +7341,6 @@ func (d *jsiiProxy_DoubleTrouble) Next() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DummyObj.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -7426,7 +7352,6 @@ type DummyObj struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DynamicPropertyBearer.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7512,7 +7437,6 @@ func (j *jsiiProxy_DynamicPropertyBearer)SetValueStore(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/DynamicPropertyBearerChild.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7626,7 +7550,6 @@ func (d *jsiiProxy_DynamicPropertyBearerChild) OverrideValue(newValue *string) *
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Entropy.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7692,7 +7615,6 @@ func (e *jsiiProxy_Entropy) Repeat(word *string) *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/EnumDispenser.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7742,7 +7664,6 @@ func EnumDispenser_RandomStringLikeEnum() StringEnum {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/EraseUndefinedHashValues.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7837,7 +7758,6 @@ func EraseUndefinedHashValues_Prop2IsUndefined() *map[string]interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/EraseUndefinedHashValuesOptions.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -7850,7 +7770,6 @@ type EraseUndefinedHashValuesOptions struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExperimentalClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -7942,7 +7861,6 @@ func (e *jsiiProxy_ExperimentalClass) Method() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExperimentalEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -7960,7 +7878,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExperimentalStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -7974,7 +7891,6 @@ type ExperimentalStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExportedBaseClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8030,7 +7946,6 @@ func NewExportedBaseClass_Override(e ExportedBaseClass, success *bool) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExtendsInternalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -8043,7 +7958,6 @@ type ExtendsInternalInterface struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExternalClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8128,7 +8042,6 @@ func (e *jsiiProxy_ExternalClass) Method() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExternalEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -8143,7 +8056,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ExternalStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -8155,7 +8067,6 @@ type ExternalStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/FullCombo.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8203,7 +8114,6 @@ func (f *jsiiProxy_FullCombo) Method() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/GiveMeStructs.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8306,7 +8216,6 @@ func (g *jsiiProxy_GiveMeStructs) ReadFirstNumber(first *scopejsiicalclib.MyFirs
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Greetee.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -8320,7 +8229,6 @@ type Greetee struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/GreetingAugmenter.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8380,7 +8288,6 @@ func (g *jsiiProxy_GreetingAugmenter) BetterGreeting(friendly scopejsiicalclib.I
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IAnonymousImplementationProvider.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8428,7 +8335,6 @@ func (i *jsiiProxy_IAnonymousImplementationProvider) ProvideAsInterface() IAnony
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IAnonymouslyImplementMe.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8472,7 +8378,6 @@ func (j *jsiiProxy_IAnonymouslyImplementMe) Value() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IAnotherPublicInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8511,7 +8416,6 @@ func (j *jsiiProxy_IAnotherPublicInterface)SetA(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IBell.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8539,7 +8443,6 @@ func (i *jsiiProxy_IBell) Ring() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IBellRinger.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8568,7 +8471,6 @@ func (i *jsiiProxy_IBellRinger) YourTurn(bell IBell) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IConcreteBellRinger.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8597,7 +8499,6 @@ func (i *jsiiProxy_IConcreteBellRinger) YourTurn(bell Bell) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IDeprecatedInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8649,7 +8550,6 @@ func (j *jsiiProxy_IDeprecatedInterface)SetMutableProperty(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IExperimentalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8701,7 +8601,6 @@ func (j *jsiiProxy_IExperimentalInterface)SetMutableProperty(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IExtendsPrivateInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8751,7 +8650,6 @@ func (j *jsiiProxy_IExtendsPrivateInterface)SetPrivate(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IExternalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8799,7 +8697,6 @@ func (j *jsiiProxy_IExternalInterface)SetMutableProperty(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IFriendlier.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8855,7 +8752,6 @@ func (i *jsiiProxy_IFriendlier) Goodbye() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IFriendlyRandomGenerator.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8906,7 +8802,6 @@ func (i *jsiiProxy_IFriendlyRandomGenerator) Next() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IIndirectlyImplemented.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8950,7 +8845,6 @@ func (j *jsiiProxy_IIndirectlyImplemented) Property() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceImplementedByAbstractClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -8981,7 +8875,6 @@ func (j *jsiiProxy_IInterfaceImplementedByAbstractClass) PropFromInterface() *st
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceThatShouldNotBeADataType.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9013,7 +8906,6 @@ func (j *jsiiProxy_IInterfaceThatShouldNotBeADataType) OtherValue() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceWithInternal.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9041,7 +8933,6 @@ func (i *jsiiProxy_IInterfaceWithInternal) Visible() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceWithMethods.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9080,7 +8971,6 @@ func (j *jsiiProxy_IInterfaceWithMethods) Value() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceWithOptionalMethodArguments.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9109,7 +8999,6 @@ func (i *jsiiProxy_IInterfaceWithOptionalMethodArguments) Hello(arg1 *string, ar
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceWithProperties.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9159,7 +9048,6 @@ func (j *jsiiProxy_IInterfaceWithProperties)SetReadWriteString(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IInterfaceWithPropertiesExtension.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9199,7 +9087,6 @@ func (j *jsiiProxy_IInterfaceWithPropertiesExtension)SetFoo(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJSII417Derived.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9248,7 +9135,6 @@ func (j *jsiiProxy_IJSII417Derived) Property() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJSII417PublicBaseOfBase.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9287,7 +9173,6 @@ func (j *jsiiProxy_IJSII417PublicBaseOfBase) HasRoot() *bool {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJavaReservedWordsInAnInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9776,7 +9661,6 @@ func (j *jsiiProxy_IJavaReservedWordsInAnInterface) While() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJsii487External.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -9792,7 +9676,6 @@ type jsiiProxy_IJsii487External struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJsii487External2.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -9808,7 +9691,6 @@ type jsiiProxy_IJsii487External2 struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IJsii496.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -9824,7 +9706,6 @@ type jsiiProxy_IJsii496 struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IMutableObjectLiteral.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9863,7 +9744,6 @@ func (j *jsiiProxy_IMutableObjectLiteral)SetValue(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/INonInternalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9923,7 +9803,6 @@ func (j *jsiiProxy_INonInternalInterface)SetC(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IObjectWithProperty.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -9977,7 +9856,6 @@ func (j *jsiiProxy_IObjectWithProperty)SetProperty(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IOptionalMethod.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10011,7 +9889,6 @@ func (i *jsiiProxy_IOptionalMethod) Optional() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IPrivatelyImplemented.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10041,7 +9918,6 @@ func (j *jsiiProxy_IPrivatelyImplemented) Success() *bool {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IPublicInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10074,7 +9950,6 @@ func (i *jsiiProxy_IPublicInterface) Bye() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IPublicInterface2.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10107,7 +9982,6 @@ func (i *jsiiProxy_IPublicInterface2) Ciao() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IRandomNumberGenerator.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10144,7 +10018,6 @@ func (i *jsiiProxy_IRandomNumberGenerator) Next() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IReturnJsii976.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10175,7 +10048,6 @@ func (j *jsiiProxy_IReturnJsii976) Foo() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IReturnsNumber.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10221,7 +10093,6 @@ func (j *jsiiProxy_IReturnsNumber) NumberProp() scopejsiicalclib.Number {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IStableInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10269,7 +10140,6 @@ func (j *jsiiProxy_IStableInterface)SetMutableProperty(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IStructReturningDelegate.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10303,7 +10173,6 @@ func (i *jsiiProxy_IStructReturningDelegate) ReturnStruct() *StructB {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/IWallClock.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10338,7 +10207,6 @@ func (i *jsiiProxy_IWallClock) Iso8601Now() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ImplementInternalInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10403,7 +10271,6 @@ func (j *jsiiProxy_ImplementInternalInterface)SetProp(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Implementation.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10459,7 +10326,6 @@ func NewImplementation_Override(i Implementation) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ImplementsInterfaceWithInternal.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10513,7 +10379,6 @@ func (i *jsiiProxy_ImplementsInterfaceWithInternal) Visible() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ImplementsInterfaceWithInternalSubclass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10567,7 +10432,6 @@ func (i *jsiiProxy_ImplementsInterfaceWithInternalSubclass) Visible() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ImplementsPrivateInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10632,7 +10496,6 @@ func (j *jsiiProxy_ImplementsPrivateInterface)SetPrivate(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ImplictBaseOfBase.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10651,7 +10514,6 @@ type ImplictBaseOfBase struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/InbetweenClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10721,7 +10583,6 @@ func (i *jsiiProxy_InbetweenClass) Hello() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/InterfaceCollections.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10804,7 +10665,6 @@ func InterfaceCollections_MapOfStructs() *map[string]*StructA {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/InterfacesMaker.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10842,7 +10702,6 @@ func InterfacesMaker_MakeInterfaces(count *float64) *[]scopejsiicalclib.IDoublab
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Isomorphism.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10890,7 +10749,6 @@ func (i *jsiiProxy_Isomorphism) Myself() Isomorphism {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Issue2638.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10943,7 +10801,6 @@ func NewIssue2638_Override(i Issue2638) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Issue2638B.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -10987,7 +10844,6 @@ func NewIssue2638B_Override(i Issue2638B) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JSII417Derived.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11097,7 +10953,6 @@ func (j *jsiiProxy_JSII417Derived) Foo() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JSII417PublicBaseOfBase.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11177,7 +11032,6 @@ func (j *jsiiProxy_JSII417PublicBaseOfBase) Foo() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JSObjectLiteralForInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11251,7 +11105,6 @@ func (j *jsiiProxy_JSObjectLiteralForInterface) GiveMeFriendlyGenerator() IFrien
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JSObjectLiteralToNative.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11309,7 +11162,6 @@ func (j *jsiiProxy_JSObjectLiteralToNative) ReturnLiteral() JSObjectLiteralToNat
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JSObjectLiteralToNativeClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11394,7 +11246,6 @@ func (j *jsiiProxy_JSObjectLiteralToNativeClass)SetPropB(val *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JavaReservedWords.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11927,7 +11778,6 @@ func (j *jsiiProxy_JavaReservedWords) Volatile() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Jsii487Derived.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -11974,7 +11824,6 @@ func NewJsii487Derived_Override(j Jsii487Derived) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Jsii496Derived.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12019,7 +11868,6 @@ func NewJsii496Derived_Override(j Jsii496Derived) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JsiiAgent.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12075,7 +11923,6 @@ func JsiiAgent_Value() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/JsonFormatter.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12513,7 +12360,6 @@ exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LICENSE 1`] = `
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LevelOne.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12570,7 +12416,6 @@ func NewLevelOne_Override(l LevelOne, props *LevelOneProps) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LevelOne_PropBooleanValue.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -12582,7 +12427,6 @@ type LevelOne_PropBooleanValue struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LevelOne_PropProperty.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -12594,7 +12438,6 @@ type LevelOne_PropProperty struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LevelOneProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -12606,7 +12449,6 @@ type LevelOneProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/LoadBalancedFargateServiceProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -12654,7 +12496,6 @@ type LoadBalancedFargateServiceProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/MethodNamedProperty.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12724,7 +12565,6 @@ func (m *jsiiProxy_MethodNamedProperty) Property() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Multiply.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -12911,7 +12751,6 @@ Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Negate.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13060,7 +12899,6 @@ func (n *jsiiProxy_Negate) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NestedClassInstance.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13097,7 +12935,6 @@ func NestedClassInstance_MakeInstance() customsubmodulename.NestingClass_NestedC
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NestedStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -13110,7 +12947,6 @@ type NestedStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NodeStandardLibrary.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13219,7 +13055,6 @@ func (n *jsiiProxy_NodeStandardLibrary) FsReadFileSync() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NullShouldBeTreatedAsUndefined.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13312,7 +13147,6 @@ func (n *jsiiProxy_NullShouldBeTreatedAsUndefined) VerifyPropertyIsUndefined() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NullShouldBeTreatedAsUndefinedData.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -13325,7 +13159,6 @@ type NullShouldBeTreatedAsUndefinedData struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/NumberGenerator.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13419,7 +13252,6 @@ func (n *jsiiProxy_NumberGenerator) NextTimes100() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ObjectRefsInCollections.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13496,7 +13328,6 @@ func (o *jsiiProxy_ObjectRefsInCollections) SumFromMap(values *map[string]scopej
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ObjectWithPropertyProvider.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13531,7 +13362,6 @@ func ObjectWithPropertyProvider_Provide() IObjectWithProperty {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Old.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13594,7 +13424,6 @@ func (o *jsiiProxy_Old) DoAThing() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OptionalArgumentInvoker.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13656,7 +13485,6 @@ func (o *jsiiProxy_OptionalArgumentInvoker) InvokeWithoutOptional() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OptionalConstructorArgument.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13736,7 +13564,6 @@ func NewOptionalConstructorArgument_Override(o OptionalConstructorArgument, arg1
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OptionalStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -13748,7 +13575,6 @@ type OptionalStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OptionalStructConsumer.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13815,7 +13641,6 @@ func NewOptionalStructConsumer_Override(o OptionalStructConsumer, optionalStruct
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OverridableProtectedMember.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13930,7 +13755,6 @@ func (o *jsiiProxy_OverridableProtectedMember) ValueFromProtected() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/OverrideReturnsObject.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -13988,7 +13812,6 @@ func (o *jsiiProxy_OverrideReturnsObject) Test(obj IReturnsNumber) *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ParamShadowsBuiltins.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14033,7 +13856,6 @@ func NewParamShadowsBuiltins_Override(p ParamShadowsBuiltins, builtins *string, 
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ParamShadowsBuiltinsProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -14047,7 +13869,6 @@ type ParamShadowsBuiltinsProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ParamShadowsScope.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14110,7 +13931,6 @@ func (p *jsiiProxy_ParamShadowsScope) UseScope(scope scopejsiicalclib.Number) sc
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ParentStruct982.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -14123,7 +13943,6 @@ type ParentStruct982 struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/PartiallyInitializedThisConsumer.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14169,7 +13988,6 @@ func (p *jsiiProxy_PartiallyInitializedThisConsumer) ConsumePartiallyInitialized
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Polymorphism.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14229,7 +14047,6 @@ func (p *jsiiProxy_Polymorphism) SayHello(friendly scopejsiicalclib.IFriendly) *
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Power.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14425,7 +14242,6 @@ func (p *jsiiProxy_Power) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/PromiseNothing.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14488,7 +14304,6 @@ func (p *jsiiProxy_PromiseNothing) InstancePromiseIt() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/PropertyNamedProperty.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14556,7 +14371,6 @@ func NewPropertyNamedProperty_Override(p PropertyNamedProperty) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/PublicClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14609,7 +14423,6 @@ func (p *jsiiProxy_PublicClass) Hello() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/PythonReservedWords.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -14969,7 +14782,6 @@ foo := "bar"
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ReferenceEnumFromScopedPackage.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15060,7 +14872,6 @@ func (r *jsiiProxy_ReferenceEnumFromScopedPackage) SaveFoo(value scopejsiicalcli
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/ReturnsPrivateImplementationOfInterface.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15121,7 +14932,6 @@ func NewReturnsPrivateImplementationOfInterface_Override(r ReturnsPrivateImpleme
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/RootStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15139,7 +14949,6 @@ type RootStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/RootStructValidator.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15169,7 +14978,6 @@ func RootStructValidator_Validate(struct_ *RootStruct) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/RuntimeTypeChecking.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15243,7 +15051,6 @@ func (r *jsiiProxy_RuntimeTypeChecking) MethodWithOptionalArguments(arg1 *float6
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SecondLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15258,7 +15065,6 @@ type SecondLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SingleInstanceTwoTypes.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15335,7 +15141,6 @@ func (s *jsiiProxy_SingleInstanceTwoTypes) Interface2() IPublicInterface {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SingletonInt.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15371,7 +15176,6 @@ func (s *jsiiProxy_SingletonInt) IsSingletonInt(value *float64) *bool {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SingletonIntEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15387,7 +15191,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SingletonString.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15423,7 +15226,6 @@ func (s *jsiiProxy_SingletonString) IsSingletonString(value *string) *bool {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SingletonStringEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15439,7 +15241,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SmellyStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15452,7 +15253,6 @@ type SmellyStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SomeTypeJsii976.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15526,7 +15326,6 @@ func SomeTypeJsii976_ReturnReturn() IReturnJsii976 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StableClass.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15611,7 +15410,6 @@ func (s *jsiiProxy_StableClass) Method() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StableEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15626,7 +15424,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StableStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15638,7 +15435,6 @@ type StableStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StaticContext.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15696,7 +15492,6 @@ func StaticContext_SetStaticVariable(val *bool) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StaticHelloChild.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15738,7 +15533,6 @@ func StaticHelloChild_Property() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StaticHelloParent.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15808,7 +15602,6 @@ func StaticHelloParent_Property() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Statics.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -15978,7 +15771,6 @@ func (s *jsiiProxy_Statics) JustMethod() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StringEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -15994,7 +15786,6 @@ const (
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StripInternal.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16059,7 +15850,6 @@ func (j *jsiiProxy_StripInternal)SetYouSeeMe(val *string) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructA.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16074,7 +15864,6 @@ type StructA struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructB.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16089,7 +15878,6 @@ type StructB struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructParameterType.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16105,7 +15893,6 @@ type StructParameterType struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructPassing.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16185,7 +15972,6 @@ func StructPassing_RoundTrip(_positional *float64, input *TopLevelStruct) *TopLe
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructUnionConsumer.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16250,7 +16036,6 @@ func StructUnionConsumer_ProvideStruct(which *string) interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructWithCollectionOfUnionts.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16262,7 +16047,6 @@ type StructWithCollectionOfUnionts struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructWithEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16277,7 +16061,6 @@ type StructWithEnum struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/StructWithJavaReservedWords.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16292,7 +16075,6 @@ type StructWithJavaReservedWords struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Sum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16483,7 +16265,6 @@ func (s *jsiiProxy_Sum) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SupportsNiceJavaBuilder.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16584,7 +16365,6 @@ func NewSupportsNiceJavaBuilder_Override(s SupportsNiceJavaBuilder, id *float64,
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SupportsNiceJavaBuilderProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -16601,7 +16381,6 @@ type SupportsNiceJavaBuilderProps struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16681,7 +16460,6 @@ func NewSupportsNiceJavaBuilderWithRequiredProps_Override(s SupportsNiceJavaBuil
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/SyncVirtualMethods.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -16962,7 +16740,6 @@ func (s *jsiiProxy_SyncVirtualMethods) WriteA(value *float64) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/TestStructWithEnum.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17061,7 +16838,6 @@ func (t *jsiiProxy_TestStructWithEnum) IsStringEnumB(input *StructWithEnum) *boo
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/Thrower.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17114,7 +16890,6 @@ func (t *jsiiProxy_Thrower) ThrowError() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/TopLevelStruct.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -17131,7 +16906,6 @@ type TopLevelStruct struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/TwoMethodsWithSimilarCapitalization.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17246,7 +17020,6 @@ func (t *jsiiProxy_TwoMethodsWithSimilarCapitalization) ToISOString() *string {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UmaskCheck.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17285,7 +17058,6 @@ func UmaskCheck_Mode() *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UnaryOperation.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17376,7 +17148,6 @@ func (u *jsiiProxy_UnaryOperation) TypeName() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UnionProperties.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 
@@ -17389,7 +17160,6 @@ type UnionProperties struct {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UpcasingReflectable.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17461,7 +17231,6 @@ func UpcasingReflectable_Reflector() customsubmodulename.Reflector {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UseBundledDependency.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17519,7 +17288,6 @@ func (u *jsiiProxy_UseBundledDependency) Value() interface{} {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UseCalcBase.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17580,7 +17348,6 @@ func (u *jsiiProxy_UseCalcBase) Hello() jcb.Base {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/UsesInterfaceWithProperties.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17678,7 +17445,6 @@ func (u *jsiiProxy_UsesInterfaceWithProperties) WriteAndRead(value *string) *str
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/VariadicInvoker.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17741,7 +17507,6 @@ func (v *jsiiProxy_VariadicInvoker) AsArray(values ...*float64) *[]*float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/VariadicMethod.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17814,7 +17579,6 @@ func (v *jsiiProxy_VariadicMethod) AsArray(first *float64, others ...*float64) *
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/VariadicTypeUnion.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -17889,7 +17653,6 @@ func (j *jsiiProxy_VariadicTypeUnion)SetUnion(val *[]interface{}) {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/VirtualMethodPlayground.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -18003,7 +17766,6 @@ func (v *jsiiProxy_VirtualMethodPlayground) SumSync(count *float64) *float64 {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/VoidCallback.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -18068,7 +17830,6 @@ func (v *jsiiProxy_VoidCallback) OverrideMe() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/WithPrivatePropertyInConstructor.go 1`] = `
-// A simple calcuator built on JSII.
 package jsiicalc
 
 import (
@@ -18255,6 +18016,7 @@ func UseOptions_Provide(which *string) interface{} {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/anonymous/main.go 1`] = `
 package anonymous
 
+
 import (
 	"reflect"
 
@@ -18433,6 +18195,7 @@ type Type__jsiicalcIRandomNumberGenerator = jsiicalc.IRandomNumberGenerator
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/donotimport/main.go 1`] = `
 package donotimport
 
+
 import (
 	"reflect"
 
@@ -18458,6 +18221,7 @@ func init() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk16625/main.go 1`] = `
 package cdk16625
+
 
 import (
 	"reflect"
@@ -18538,6 +18302,7 @@ type AcceptsPathProps struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/cdk22369/main.go 1`] = `
 package cdk22369
+
 
 import (
 	"reflect"
@@ -18745,6 +18510,7 @@ type Type__scopejsiicalclibOperation = scopejsiicalclib.Operation
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/composition/main.go 1`] = `
 package composition
 
+
 import (
 	"reflect"
 
@@ -18914,6 +18680,7 @@ func (j *jsiiProxy_Derived)SetProp(val *string) {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/derivedclasshasnoproperties/main.go 1`] = `
 package derivedclasshasnoproperties
 
+
 import (
 	"reflect"
 
@@ -19028,6 +18795,7 @@ type Homonymous struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/homonymousforwardreferences/bar/main.go 1`] = `
 package bar
 
+
 import (
 	"reflect"
 
@@ -19113,6 +18881,7 @@ type Homonymous struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/homonymousforwardreferences/foo/main.go 1`] = `
 package foo
+
 
 import (
 	"reflect"
@@ -19219,6 +18988,7 @@ type Hello struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceincludesclasses/main.go 1`] = `
 package interfaceinnamespaceincludesclasses
 
+
 import (
 	"reflect"
 
@@ -19257,6 +19027,7 @@ type Hello struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/interfaceinnamespaceonlyinterface/main.go 1`] = `
 package interfaceinnamespaceonlyinterface
+
 
 import (
 	"reflect"
@@ -19394,6 +19165,7 @@ func (o *jsiiProxy_OverrideMe) ImplementMe(opts *ImplementMeOpts) *bool {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/jsii3656/main.go 1`] = `
 package jsii3656
 
+
 import (
 	"reflect"
 
@@ -19420,7 +19192,9 @@ func init() {
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/main.go 1`] = `
+// A simple calcuator built on JSII.
 package jsiicalc
+
 
 import (
 	"reflect"
@@ -21858,6 +21632,7 @@ func (m *jsiiProxy_MyClass) Foo(_arg *string) {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2530/main.go 1`] = `
 package module2530
 
+
 import (
 	"reflect"
 
@@ -21920,6 +21695,7 @@ func OnlyStatics_Foo() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2617/main.go 1`] = `
 package module2617
+
 
 import (
 	"reflect"
@@ -22048,6 +21824,7 @@ type Type__scopejsiicalclibIFriendly = scopejsiicalclib.IFriendly
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2647/main.go 1`] = `
 package module2647
 
+
 import (
 	"reflect"
 
@@ -22140,6 +21917,7 @@ func (m *jsiiProxy_MyClass) Foo(_values *[]scopejsiicalclib.Number) {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/methods/main.go 1`] = `
 package methods
+
 
 import (
 	"reflect"
@@ -22234,6 +22012,7 @@ func NewMyClass_Override(m MyClass) {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/props/main.go 1`] = `
 package props
+
 
 import (
 	"reflect"
@@ -22334,6 +22113,7 @@ func (m *jsiiProxy_MyClass) Foo() *[]scopejsiicalclib.Number {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/retval/main.go 1`] = `
 package retval
 
+
 import (
 	"reflect"
 
@@ -22375,6 +22155,7 @@ type MyStruct struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2689/structs/main.go 1`] = `
 package structs
 
+
 import (
 	"reflect"
 
@@ -22403,6 +22184,7 @@ type Bar struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule1/main.go 1`] = `
 package submodule1
+
 
 import (
 	"reflect"
@@ -22445,6 +22227,7 @@ type Foo struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2692/submodule2/main.go 1`] = `
 package submodule2
+
 
 import (
 	"reflect"
@@ -22666,6 +22449,7 @@ func (j *jsiiProxy_IFoo) Baz() *float64 {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2700/main.go 1`] = `
 package module2700
+
 
 import (
 	"reflect"
@@ -23354,6 +23138,7 @@ type Type__jcbIBaseInterface = jcb.IBaseInterface
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/module2702/main.go 1`] = `
 package module2702
 
+
 import (
 	"reflect"
 
@@ -23587,6 +23372,7 @@ func (t *jsiiProxy_TypeFromSub1) Sub1() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub1/main.go 1`] = `
 package sub1
 
+
 import (
 	"reflect"
 
@@ -23668,6 +23454,7 @@ func (t *jsiiProxy_TypeFromSub2) Sub2() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/nodirect/sub2/main.go 1`] = `
 package sub2
 
+
 import (
 	"reflect"
 
@@ -23726,6 +23513,7 @@ func OnlyStaticMethods_StaticMethod() *string {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/onlystatic/main.go 1`] = `
 package onlystatic
+
 
 import (
 	"reflect"
@@ -23915,6 +23703,7 @@ type StructWithSelf struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pythonself/main.go 1`] = `
 package pythonself
+
 
 import (
 	"reflect"
@@ -24129,6 +23918,7 @@ type MyClassReference struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/backreferences/main.go 1`] = `
 package backreferences
 
+
 import (
 	"reflect"
 
@@ -24338,6 +24128,7 @@ type Structure struct {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/child/main.go 1`] = `
 package child
 
+
 import (
 	"reflect"
 
@@ -24458,6 +24249,7 @@ This is the readme of the \`jsii-calc.submodule.isolated\` module.
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/isolated/main.go 1`] = `
 package isolated
 
+
 import (
 	"reflect"
 
@@ -24479,6 +24271,7 @@ func init() {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/main.go 1`] = `
 package submodule
+
 
 import (
 	"reflect"
@@ -24590,6 +24383,7 @@ func (j *jsiiProxy_INamespaced) DefinedAt() *string {
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/deeplynested/main.go 1`] = `
 package deeplynested
 
+
 import (
 	"reflect"
 
@@ -24622,6 +24416,7 @@ type Type__deeplynestedINamespaced = deeplynested.INamespaced
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/nestedsubmodule/main.go 1`] = `
 package nestedsubmodule
+
 
 import (
 	"reflect"
@@ -24660,6 +24455,7 @@ type SpecialParameter struct {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/param/main.go 1`] = `
 package param
+
 
 import (
 	"reflect"
@@ -24737,6 +24533,7 @@ func (r *jsiiProxy_ReturnsSpecialParameter) ReturnsSpecialParam() *param.Special
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/submodule/returnsparam/main.go 1`] = `
 package returnsparam
+
 
 import (
 	"reflect"
@@ -24855,6 +24652,7 @@ func (r *jsiiProxy_Resolvable) Resolve() interface{} {
 
 exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/union/main.go 1`] = `
 package union
+
 
 import (
 	"reflect"
@@ -25266,7 +25064,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractClass.go.diff 1`] = `
 --- go/jsiicalc/AbstractClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractClass.go	--runtime-type-checking
-@@ -51,10 +51,13 @@
+@@ -50,10 +50,13 @@
  		a,
  	)
  }
@@ -25285,10 +25083,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractClass__checks.go.diff 1`] = `
 --- go/jsiicalc/AbstractClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -25308,10 +25105,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AbstractClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -25325,7 +25121,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractSuite.go.diff 1`] = `
 --- go/jsiicalc/AbstractSuite.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractSuite.go	--runtime-type-checking
-@@ -40,18 +40,24 @@
+@@ -39,18 +39,24 @@
  		a,
  	)
  }
@@ -25350,7 +25146,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
  	_jsii_.Invoke(
  		a,
  		"someMethod",
-@@ -61,10 +67,13 @@
+@@ -60,10 +66,13 @@
  
  	return returns
  }
@@ -25369,10 +25165,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractSuite__checks.go.diff 1`] = `
 --- go/jsiicalc/AbstractSuite__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractSuite__checks.go	--runtime-type-checking
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -25408,10 +25203,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AbstractSuite__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AbstractSuite__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AbstractSuite__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -25433,7 +25227,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Add.go.diff 1`] = `
 --- go/jsiicalc/Add.go	--no-runtime-type-checking
 +++ go/jsiicalc/Add.go	--runtime-type-checking
-@@ -63,10 +63,13 @@
+@@ -62,10 +62,13 @@
  
  // Creates a BinaryOperation.
  func NewAdd(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Add {
@@ -25452,10 +25246,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Add__checks.go.diff 1`] = `
 --- go/jsiicalc/Add__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Add__checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -25481,10 +25274,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Add__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Add__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Add__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -25498,7 +25290,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllTypes.go.diff 1`] = `
 --- go/jsiicalc/AllTypes.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllTypes.go	--runtime-type-checking
-@@ -276,82 +276,112 @@
+@@ -275,82 +275,112 @@
  		a,
  	)
  }
@@ -25611,7 +25403,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
  		"numberProperty",
  		val,
  	)
-@@ -364,66 +394,90 @@
+@@ -363,66 +393,90 @@
  		val,
  	)
  }
@@ -25702,7 +25494,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
  		"anyIn",
  		[]interface{}{inp},
  	)
-@@ -441,10 +495,13 @@
+@@ -440,10 +494,13 @@
  
  	return returns
  }
@@ -25721,10 +25513,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllTypes__checks.go.diff 1`] = `
 --- go/jsiicalc/AllTypes__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllTypes__checks.go	--runtime-type-checking
-@@ -0,0 +1,336 @@
+@@ -0,0 +1,335 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26063,10 +25854,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllTypes__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AllTypes__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllTypes__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,82 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26152,7 +25942,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllowedMethodNames.go.diff 1`] = `
 --- go/jsiicalc/AllowedMethodNames.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllowedMethodNames.go	--runtime-type-checking
-@@ -43,18 +43,24 @@
+@@ -42,18 +42,24 @@
  		a,
  	)
  }
@@ -26177,7 +25967,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
  	_jsii_.Invoke(
  		a,
  		"getFoo",
-@@ -64,18 +70,24 @@
+@@ -63,18 +69,24 @@
  
  	return returns
  }
@@ -26207,10 +25997,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllowedMethodNames__checks.go.diff 1`] = `
 --- go/jsiicalc/AllowedMethodNames__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllowedMethodNames__checks.go	--runtime-type-checking
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,56 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26270,10 +26059,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AllowedMethodNames__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AllowedMethodNames__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AllowedMethodNames__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26299,7 +26087,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AmbiguousParameters.go.diff 1`] = `
 --- go/jsiicalc/AmbiguousParameters.go	--no-runtime-type-checking
 +++ go/jsiicalc/AmbiguousParameters.go	--runtime-type-checking
-@@ -38,10 +38,13 @@
+@@ -37,10 +37,13 @@
  
  
  func NewAmbiguousParameters(scope Bell, props *StructParameterType) AmbiguousParameters {
@@ -26318,10 +26106,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AmbiguousParameters__checks.go.diff 1`] = `
 --- go/jsiicalc/AmbiguousParameters__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AmbiguousParameters__checks.go	--runtime-type-checking
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26350,10 +26137,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AmbiguousParameters__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AmbiguousParameters__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AmbiguousParameters__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26367,7 +26153,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AsyncVirtualMethods.go.diff 1`] = `
 --- go/jsiicalc/AsyncVirtualMethods.go	--no-runtime-type-checking
 +++ go/jsiicalc/AsyncVirtualMethods.go	--runtime-type-checking
-@@ -101,10 +101,13 @@
+@@ -100,10 +100,13 @@
  
  	return returns
  }
@@ -26386,10 +26172,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AsyncVirtualMethods__checks.go.diff 1`] = `
 --- go/jsiicalc/AsyncVirtualMethods__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AsyncVirtualMethods__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26409,10 +26194,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AsyncVirtualMethods__no_checks.go.diff 1`] = `
 --- go/jsiicalc/AsyncVirtualMethods__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/AsyncVirtualMethods__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26426,7 +26210,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Bell.go.diff 1`] = `
 --- go/jsiicalc/Bell.go	--no-runtime-type-checking
 +++ go/jsiicalc/Bell.go	--runtime-type-checking
-@@ -52,10 +52,13 @@
+@@ -51,10 +51,13 @@
  		b,
  	)
  }
@@ -26445,10 +26229,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Bell__checks.go.diff 1`] = `
 --- go/jsiicalc/Bell__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Bell__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26468,10 +26251,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Bell__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Bell__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Bell__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26485,10 +26267,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/BinaryOperation__checks.go.diff 1`] = `
 --- go/jsiicalc/BinaryOperation__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/BinaryOperation__checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26514,10 +26295,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/BinaryOperation__no_checks.go.diff 1`] = `
 --- go/jsiicalc/BinaryOperation__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/BinaryOperation__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26531,7 +26311,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/BurriedAnonymousObject.go.diff 1`] = `
 --- go/jsiicalc/BurriedAnonymousObject.go	--no-runtime-type-checking
 +++ go/jsiicalc/BurriedAnonymousObject.go	--runtime-type-checking
-@@ -42,10 +42,13 @@
+@@ -41,10 +41,13 @@
  
  	return returns
  }
@@ -26550,10 +26330,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/BurriedAnonymousObject__checks.go.diff 1`] = `
 --- go/jsiicalc/BurriedAnonymousObject__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/BurriedAnonymousObject__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26573,10 +26352,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/BurriedAnonymousObject__no_checks.go.diff 1`] = `
 --- go/jsiicalc/BurriedAnonymousObject__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/BurriedAnonymousObject__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26590,7 +26368,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/B
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Calculator.go.diff 1`] = `
 --- go/jsiicalc/Calculator.go	--no-runtime-type-checking
 +++ go/jsiicalc/Calculator.go	--runtime-type-checking
-@@ -181,10 +181,13 @@
+@@ -180,10 +180,13 @@
  
  // Creates a Calculator object.
  func NewCalculator(props *CalculatorProps) Calculator {
@@ -26604,7 +26382,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Create(
  		"jsii-calc.Calculator",
  		[]interface{}{props},
-@@ -204,26 +207,35 @@
+@@ -203,26 +206,35 @@
  		c,
  	)
  }
@@ -26640,7 +26418,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  		"decorationPrefixes",
  		val,
  	)
-@@ -236,34 +248,46 @@
+@@ -235,34 +247,46 @@
  		val,
  	)
  }
@@ -26687,7 +26465,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  		"mul",
  		[]interface{}{value},
  	)
-@@ -276,10 +300,13 @@
+@@ -275,10 +299,13 @@
  		nil, // no parameters
  	)
  }
@@ -26706,10 +26484,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Calculator__checks.go.diff 1`] = `
 --- go/jsiicalc/Calculator__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Calculator__checks.go	--runtime-type-checking
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,94 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26807,10 +26584,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Calculator__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Calculator__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Calculator__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,42 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26856,7 +26632,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsTheInternalInterface.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsTheInternalInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsTheInternalInterface.go	--runtime-type-checking
-@@ -87,34 +87,46 @@
+@@ -86,34 +86,46 @@
  		c,
  	)
  }
@@ -26908,10 +26684,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsTheInternalInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsTheInternalInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsTheInternalInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,40 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -26955,10 +26730,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsTheInternalInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsTheInternalInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsTheInternalInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -26984,7 +26758,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsThePrivateInterface.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsThePrivateInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsThePrivateInterface.go	--runtime-type-checking
-@@ -87,34 +87,46 @@
+@@ -86,34 +86,46 @@
  		c,
  	)
  }
@@ -27036,10 +26810,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsThePrivateInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsThePrivateInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsThePrivateInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,40 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27083,10 +26856,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassThatImplementsThePrivateInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassThatImplementsThePrivateInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassThatImplementsThePrivateInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27112,7 +26884,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollectionOfUnions.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollectionOfUnions.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollectionOfUnions.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewClassWithCollectionOfUnions(unionProperty *[]*map[string]interface{}) ClassWithCollectionOfUnions {
@@ -27126,7 +26898,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Create(
  		"jsii-calc.ClassWithCollectionOfUnions",
  		[]interface{}{unionProperty},
-@@ -50,10 +53,13 @@
+@@ -49,10 +52,13 @@
  		c,
  	)
  }
@@ -27145,10 +26917,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollectionOfUnions__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollectionOfUnions__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollectionOfUnions__checks.go	--runtime-type-checking
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,90 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27242,10 +27013,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollectionOfUnions__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollectionOfUnions__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollectionOfUnions__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27263,7 +27033,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollections.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollections.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollections.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  
  
  func NewClassWithCollections(map_ *map[string]*string, array *[]*string) ClassWithCollections {
@@ -27277,7 +27047,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Create(
  		"jsii-calc.ClassWithCollections",
  		[]interface{}{map_, array},
-@@ -62,18 +65,24 @@
+@@ -61,18 +64,24 @@
  		c,
  	)
  }
@@ -27302,7 +27072,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  		"map",
  		val,
  	)
-@@ -120,10 +129,13 @@
+@@ -119,10 +128,13 @@
  	return returns
  }
  
@@ -27316,7 +27086,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  		"staticArray",
  		val,
  	)
-@@ -140,10 +152,13 @@
+@@ -139,10 +151,13 @@
  	return returns
  }
  
@@ -27335,10 +27105,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollections__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollections__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollections__checks.go	--runtime-type-checking
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,52 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27394,10 +27163,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithCollections__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithCollections__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithCollections__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,26 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27427,7 +27195,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithContainerTypes.go.diff 1`] = `
 --- go/jsiicalc/ClassWithContainerTypes.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithContainerTypes.go	--runtime-type-checking
-@@ -60,10 +60,13 @@
+@@ -59,10 +59,13 @@
  
  
  func NewClassWithContainerTypes(array *[]*DummyObj, record *map[string]*DummyObj, obj *map[string]*DummyObj, props *ContainerProps) ClassWithContainerTypes {
@@ -27446,10 +27214,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithContainerTypes__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithContainerTypes__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithContainerTypes__checks.go	--runtime-type-checking
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,45 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27498,10 +27265,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithContainerTypes__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithContainerTypes__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithContainerTypes__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27515,7 +27281,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithJavaReservedWords.go.diff 1`] = `
 --- go/jsiicalc/ClassWithJavaReservedWords.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithJavaReservedWords.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewClassWithJavaReservedWords(int *string) ClassWithJavaReservedWords {
@@ -27529,7 +27295,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Create(
  		"jsii-calc.ClassWithJavaReservedWords",
  		[]interface{}{int},
-@@ -50,10 +53,13 @@
+@@ -49,10 +52,13 @@
  		c,
  	)
  }
@@ -27548,10 +27314,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithJavaReservedWords__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithJavaReservedWords__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithJavaReservedWords__checks.go	--runtime-type-checking
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27579,10 +27344,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithJavaReservedWords__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithJavaReservedWords__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithJavaReservedWords__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27600,7 +27364,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithMutableObjectLiteralProperty.go.diff 1`] = `
 --- go/jsiicalc/ClassWithMutableObjectLiteralProperty.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithMutableObjectLiteralProperty.go	--runtime-type-checking
-@@ -50,10 +50,13 @@
+@@ -49,10 +49,13 @@
  		c,
  	)
  }
@@ -27619,10 +27383,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithMutableObjectLiteralProperty__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithMutableObjectLiteralProperty__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithMutableObjectLiteralProperty__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27642,10 +27405,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithMutableObjectLiteralProperty__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithMutableObjectLiteralProperty__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithMutableObjectLiteralProperty__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -27659,7 +27421,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithNestedUnion.go.diff 1`] = `
 --- go/jsiicalc/ClassWithNestedUnion.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithNestedUnion.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewClassWithNestedUnion(unionProperty *[]interface{}) ClassWithNestedUnion {
@@ -27673,7 +27435,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Create(
  		"jsii-calc.ClassWithNestedUnion",
  		[]interface{}{unionProperty},
-@@ -50,10 +53,13 @@
+@@ -49,10 +52,13 @@
  		c,
  	)
  }
@@ -27692,10 +27454,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithNestedUnion__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithNestedUnion__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithNestedUnion__checks.go	--runtime-type-checking
-@@ -0,0 +1,299 @@
+@@ -0,0 +1,298 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -27997,10 +27758,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithNestedUnion__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithNestedUnion__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithNestedUnion__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28018,7 +27778,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties.go.diff 1`] = `
 --- go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties.go	--runtime-type-checking
-@@ -39,20 +39,26 @@
+@@ -38,20 +38,26 @@
  	return returns
  }
  
@@ -28050,10 +27810,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__checks.go	--runtime-type-checking
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,28 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28085,10 +27844,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ClassWithPrivateConstructorAndAutomaticProperties__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28106,7 +27864,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConfusingToJackson.go.diff 1`] = `
 --- go/jsiicalc/ConfusingToJackson.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConfusingToJackson.go	--runtime-type-checking
-@@ -29,10 +29,13 @@
+@@ -28,10 +28,13 @@
  	return returns
  }
  
@@ -28125,10 +27883,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConfusingToJackson__checks.go.diff 1`] = `
 --- go/jsiicalc/ConfusingToJackson__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConfusingToJackson__checks.go	--runtime-type-checking
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,54 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28186,10 +27943,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConfusingToJackson__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ConfusingToJackson__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConfusingToJackson__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28203,7 +27959,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConstructorPassesThisOut.go.diff 1`] = `
 --- go/jsiicalc/ConstructorPassesThisOut.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConstructorPassesThisOut.go	--runtime-type-checking
-@@ -15,10 +15,13 @@
+@@ -14,10 +14,13 @@
  }
  
  func NewConstructorPassesThisOut(consumer PartiallyInitializedThisConsumer) ConstructorPassesThisOut {
@@ -28222,10 +27978,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConstructorPassesThisOut__checks.go.diff 1`] = `
 --- go/jsiicalc/ConstructorPassesThisOut__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConstructorPassesThisOut__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28245,10 +28000,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConstructorPassesThisOut__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ConstructorPassesThisOut__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConstructorPassesThisOut__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28262,7 +28016,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumePureInterface.go.diff 1`] = `
 --- go/jsiicalc/ConsumePureInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumePureInterface.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
+@@ -15,10 +15,13 @@
  }
  
  func NewConsumePureInterface(delegate IStructReturningDelegate) ConsumePureInterface {
@@ -28281,10 +28035,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumePureInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumePureInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumePureInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28304,10 +28057,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumePureInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumePureInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumePureInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28321,7 +28073,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumerCanRingBell.go.diff 1`] = `
 --- go/jsiicalc/ConsumerCanRingBell.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumerCanRingBell.go	--runtime-type-checking
-@@ -62,10 +62,13 @@
+@@ -61,10 +61,13 @@
  //
  // Returns whether the bell was rung.
  func ConsumerCanRingBell_StaticImplementedByObjectLiteral(ringer IBellRinger) *bool {
@@ -28335,7 +28087,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.StaticInvoke(
  		"jsii-calc.ConsumerCanRingBell",
  		"staticImplementedByObjectLiteral",
-@@ -80,10 +83,13 @@
+@@ -79,10 +82,13 @@
  //
  // Return whether the bell was rung.
  func ConsumerCanRingBell_StaticImplementedByPrivateClass(ringer IBellRinger) *bool {
@@ -28349,7 +28101,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.StaticInvoke(
  		"jsii-calc.ConsumerCanRingBell",
  		"staticImplementedByPrivateClass",
-@@ -98,10 +104,13 @@
+@@ -97,10 +103,13 @@
  //
  // Return whether the bell was rung.
  func ConsumerCanRingBell_StaticImplementedByPublicClass(ringer IBellRinger) *bool {
@@ -28363,7 +28115,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.StaticInvoke(
  		"jsii-calc.ConsumerCanRingBell",
  		"staticImplementedByPublicClass",
-@@ -116,10 +125,13 @@
+@@ -115,10 +124,13 @@
  //
  // Return whether the bell was rung.
  func ConsumerCanRingBell_StaticWhenTypedAsClass(ringer IConcreteBellRinger) *bool {
@@ -28377,7 +28129,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.StaticInvoke(
  		"jsii-calc.ConsumerCanRingBell",
  		"staticWhenTypedAsClass",
-@@ -129,10 +141,13 @@
+@@ -128,10 +140,13 @@
  
  	return returns
  }
@@ -28391,7 +28143,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Invoke(
  		c,
  		"implementedByObjectLiteral",
-@@ -142,10 +157,13 @@
+@@ -141,10 +156,13 @@
  
  	return returns
  }
@@ -28405,7 +28157,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Invoke(
  		c,
  		"implementedByPrivateClass",
-@@ -155,10 +173,13 @@
+@@ -154,10 +172,13 @@
  
  	return returns
  }
@@ -28419,7 +28171,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Invoke(
  		c,
  		"implementedByPublicClass",
-@@ -168,10 +189,13 @@
+@@ -167,10 +188,13 @@
  
  	return returns
  }
@@ -28438,10 +28190,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumerCanRingBell__checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumerCanRingBell__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumerCanRingBell__checks.go	--runtime-type-checking
-@@ -0,0 +1,73 @@
+@@ -0,0 +1,72 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28517,10 +28268,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumerCanRingBell__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumerCanRingBell__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumerCanRingBell__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,38 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28562,7 +28312,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumersOfThisCrazyTypeSystem.go.diff 1`] = `
 --- go/jsiicalc/ConsumersOfThisCrazyTypeSystem.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumersOfThisCrazyTypeSystem.go	--runtime-type-checking
-@@ -39,10 +39,13 @@
+@@ -38,10 +38,13 @@
  		c,
  	)
  }
@@ -28576,7 +28326,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
  	_jsii_.Invoke(
  		c,
  		"consumeAnotherPublicInterface",
-@@ -52,10 +55,13 @@
+@@ -51,10 +54,13 @@
  
  	return returns
  }
@@ -28595,10 +28345,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumersOfThisCrazyTypeSystem__checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumersOfThisCrazyTypeSystem__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumersOfThisCrazyTypeSystem__checks.go	--runtime-type-checking
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28626,10 +28375,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ConsumersOfThisCrazyTypeSystem__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ConsumersOfThisCrazyTypeSystem__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ConsumersOfThisCrazyTypeSystem__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28647,7 +28395,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/C
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DataRenderer.go.diff 1`] = `
 --- go/jsiicalc/DataRenderer.go	--no-runtime-type-checking
 +++ go/jsiicalc/DataRenderer.go	--runtime-type-checking
-@@ -43,10 +43,13 @@
+@@ -42,10 +42,13 @@
  		d,
  	)
  }
@@ -28661,7 +28409,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
  	_jsii_.Invoke(
  		d,
  		"render",
-@@ -56,10 +59,13 @@
+@@ -55,10 +58,13 @@
  
  	return returns
  }
@@ -28675,7 +28423,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
  	_jsii_.Invoke(
  		d,
  		"renderArbitrary",
-@@ -69,10 +75,13 @@
+@@ -68,10 +74,13 @@
  
  	return returns
  }
@@ -28694,10 +28442,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DataRenderer__checks.go.diff 1`] = `
 --- go/jsiicalc/DataRenderer__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DataRenderer__checks.go	--runtime-type-checking
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,36 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28737,10 +28484,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DataRenderer__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DataRenderer__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DataRenderer__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28762,7 +28508,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DeprecatedClass.go.diff 1`] = `
 --- go/jsiicalc/DeprecatedClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/DeprecatedClass.go	--runtime-type-checking
-@@ -46,10 +46,13 @@
+@@ -45,10 +45,13 @@
  
  // Deprecated: this constructor is "just" okay.
  func NewDeprecatedClass(readonlyString *string, mutableNumber *float64) DeprecatedClass {
@@ -28781,10 +28527,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DeprecatedClass__checks.go.diff 1`] = `
 --- go/jsiicalc/DeprecatedClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DeprecatedClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28804,10 +28549,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DeprecatedClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DeprecatedClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DeprecatedClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28821,7 +28565,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotOverridePrivates.go.diff 1`] = `
 --- go/jsiicalc/DoNotOverridePrivates.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotOverridePrivates.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  		d,
  	)
  }
@@ -28840,10 +28584,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotOverridePrivates__checks.go.diff 1`] = `
 --- go/jsiicalc/DoNotOverridePrivates__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotOverridePrivates__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28863,10 +28606,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotOverridePrivates__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DoNotOverridePrivates__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotOverridePrivates__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28880,7 +28622,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotRecognizeAnyAsOptional.go.diff 1`] = `
 --- go/jsiicalc/DoNotRecognizeAnyAsOptional.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotRecognizeAnyAsOptional.go	--runtime-type-checking
-@@ -39,10 +39,13 @@
+@@ -38,10 +38,13 @@
  		d,
  	)
  }
@@ -28899,10 +28641,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotRecognizeAnyAsOptional__checks.go.diff 1`] = `
 --- go/jsiicalc/DoNotRecognizeAnyAsOptional__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotRecognizeAnyAsOptional__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28922,10 +28663,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DoNotRecognizeAnyAsOptional__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DoNotRecognizeAnyAsOptional__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DoNotRecognizeAnyAsOptional__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28939,7 +28679,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass.go	--runtime-type-checking
-@@ -62,10 +62,13 @@
+@@ -61,10 +61,13 @@
  		d,
  	)
  }
@@ -28958,10 +28698,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass__checks.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -28981,10 +28720,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -28998,7 +28736,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearer.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearer.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearer.go	--runtime-type-checking
-@@ -41,10 +41,13 @@
+@@ -40,10 +40,13 @@
  
  
  func NewDynamicPropertyBearer(valueStore *string) DynamicPropertyBearer {
@@ -29012,7 +28750,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
  	_jsii_.Create(
  		"jsii-calc.DynamicPropertyBearer",
  		[]interface{}{valueStore},
-@@ -63,18 +66,24 @@
+@@ -62,18 +65,24 @@
  		d,
  	)
  }
@@ -29042,10 +28780,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearer__checks.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearer__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearer__checks.go	--runtime-type-checking
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29081,10 +28818,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearer__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearer__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearer__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29106,7 +28842,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearerChild.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearerChild.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearerChild.go	--runtime-type-checking
-@@ -56,10 +56,13 @@
+@@ -55,10 +55,13 @@
  
  
  func NewDynamicPropertyBearerChild(originalValue *string) DynamicPropertyBearerChild {
@@ -29120,7 +28856,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
  	_jsii_.Create(
  		"jsii-calc.DynamicPropertyBearerChild",
  		[]interface{}{originalValue},
-@@ -78,26 +81,35 @@
+@@ -77,26 +80,35 @@
  		d,
  	)
  }
@@ -29161,10 +28897,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearerChild__checks.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearerChild__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearerChild__checks.go	--runtime-type-checking
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,40 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29208,10 +28943,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DynamicPropertyBearerChild__no_checks.go.diff 1`] = `
 --- go/jsiicalc/DynamicPropertyBearerChild__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/DynamicPropertyBearerChild__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29237,7 +28971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Entropy.go.diff 1`] = `
 --- go/jsiicalc/Entropy.go	--no-runtime-type-checking
 +++ go/jsiicalc/Entropy.go	--runtime-type-checking
-@@ -46,10 +46,13 @@
+@@ -45,10 +45,13 @@
  
  	return returns
  }
@@ -29256,10 +28990,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Entropy__checks.go.diff 1`] = `
 --- go/jsiicalc/Entropy__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Entropy__checks.go	--runtime-type-checking
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29287,10 +29020,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Entropy__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Entropy__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Entropy__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29308,7 +29040,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/EraseUndefinedHashValues.go.diff 1`] = `
 --- go/jsiicalc/EraseUndefinedHashValues.go	--no-runtime-type-checking
 +++ go/jsiicalc/EraseUndefinedHashValues.go	--runtime-type-checking
-@@ -43,10 +43,13 @@
+@@ -42,10 +42,13 @@
  // Used to check that undefined/null hash values
  // are being erased when sending values from native code to JS.
  func EraseUndefinedHashValues_DoesKeyExist(opts *EraseUndefinedHashValuesOptions, key *string) *bool {
@@ -29327,10 +29059,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/EraseUndefinedHashValues__checks.go.diff 1`] = `
 --- go/jsiicalc/EraseUndefinedHashValues__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/EraseUndefinedHashValues__checks.go	--runtime-type-checking
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29359,10 +29090,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/EraseUndefinedHashValues__no_checks.go.diff 1`] = `
 --- go/jsiicalc/EraseUndefinedHashValues__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/EraseUndefinedHashValues__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29376,7 +29106,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExperimentalClass.go.diff 1`] = `
 --- go/jsiicalc/ExperimentalClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExperimentalClass.go	--runtime-type-checking
-@@ -46,10 +46,13 @@
+@@ -45,10 +45,13 @@
  
  // Experimental.
  func NewExperimentalClass(readonlyString *string, mutableNumber *float64) ExperimentalClass {
@@ -29395,10 +29125,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExperimentalClass__checks.go.diff 1`] = `
 --- go/jsiicalc/ExperimentalClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExperimentalClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29418,10 +29147,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExperimentalClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ExperimentalClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExperimentalClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29435,7 +29163,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExportedBaseClass.go.diff 1`] = `
 --- go/jsiicalc/ExportedBaseClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExportedBaseClass.go	--runtime-type-checking
-@@ -27,10 +27,13 @@
+@@ -26,10 +26,13 @@
  
  
  func NewExportedBaseClass(success *bool) ExportedBaseClass {
@@ -29454,10 +29182,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExportedBaseClass__checks.go.diff 1`] = `
 --- go/jsiicalc/ExportedBaseClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExportedBaseClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29477,10 +29204,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExportedBaseClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ExportedBaseClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExportedBaseClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29494,7 +29220,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExternalClass.go.diff 1`] = `
 --- go/jsiicalc/ExternalClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExternalClass.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  
  
  func NewExternalClass(readonlyString *string, mutableNumber *float64) ExternalClass {
@@ -29513,10 +29239,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExternalClass__checks.go.diff 1`] = `
 --- go/jsiicalc/ExternalClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExternalClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29536,10 +29261,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ExternalClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ExternalClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ExternalClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29553,7 +29277,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/E
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GiveMeStructs.go.diff 1`] = `
 --- go/jsiicalc/GiveMeStructs.go	--no-runtime-type-checking
 +++ go/jsiicalc/GiveMeStructs.go	--runtime-type-checking
-@@ -57,10 +57,13 @@
+@@ -56,10 +56,13 @@
  		g,
  	)
  }
@@ -29567,7 +29291,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
  	_jsii_.Invoke(
  		g,
  		"derivedToFirst",
-@@ -70,10 +73,13 @@
+@@ -69,10 +72,13 @@
  
  	return returns
  }
@@ -29581,7 +29305,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
  	_jsii_.Invoke(
  		g,
  		"readDerivedNonPrimitive",
-@@ -83,10 +89,13 @@
+@@ -82,10 +88,13 @@
  
  	return returns
  }
@@ -29600,10 +29324,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GiveMeStructs__checks.go.diff 1`] = `
 --- go/jsiicalc/GiveMeStructs__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/GiveMeStructs__checks.go	--runtime-type-checking
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,45 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29652,10 +29375,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GiveMeStructs__no_checks.go.diff 1`] = `
 --- go/jsiicalc/GiveMeStructs__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/GiveMeStructs__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29677,7 +29399,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GreetingAugmenter.go.diff 1`] = `
 --- go/jsiicalc/GreetingAugmenter.go	--no-runtime-type-checking
 +++ go/jsiicalc/GreetingAugmenter.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  		g,
  	)
  }
@@ -29696,10 +29418,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GreetingAugmenter__checks.go.diff 1`] = `
 --- go/jsiicalc/GreetingAugmenter__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/GreetingAugmenter__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29721,10 +29442,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/GreetingAugmenter__no_checks.go.diff 1`] = `
 --- go/jsiicalc/GreetingAugmenter__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/GreetingAugmenter__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29738,7 +29458,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/G
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IAnotherPublicInterface.go.diff 1`] = `
 --- go/jsiicalc/IAnotherPublicInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/IAnotherPublicInterface.go	--runtime-type-checking
-@@ -24,10 +24,13 @@
+@@ -23,10 +23,13 @@
  	)
  	return returns
  }
@@ -29757,10 +29477,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IAnotherPublicInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/IAnotherPublicInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IAnotherPublicInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29780,10 +29499,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IAnotherPublicInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IAnotherPublicInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IAnotherPublicInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29797,7 +29515,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IBellRinger.go.diff 1`] = `
 --- go/jsiicalc/IBellRinger.go	--no-runtime-type-checking
 +++ go/jsiicalc/IBellRinger.go	--runtime-type-checking
-@@ -14,10 +14,13 @@
+@@ -13,10 +13,13 @@
  type jsiiProxy_IBellRinger struct {
  	_ byte // padding
  }
@@ -29816,10 +29534,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IBellRinger__checks.go.diff 1`] = `
 --- go/jsiicalc/IBellRinger__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IBellRinger__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29839,10 +29556,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IBellRinger__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IBellRinger__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IBellRinger__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29856,7 +29572,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IConcreteBellRinger.go.diff 1`] = `
 --- go/jsiicalc/IConcreteBellRinger.go	--no-runtime-type-checking
 +++ go/jsiicalc/IConcreteBellRinger.go	--runtime-type-checking
-@@ -14,10 +14,13 @@
+@@ -13,10 +13,13 @@
  type jsiiProxy_IConcreteBellRinger struct {
  	_ byte // padding
  }
@@ -29875,10 +29591,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IConcreteBellRinger__checks.go.diff 1`] = `
 --- go/jsiicalc/IConcreteBellRinger__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IConcreteBellRinger__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29898,10 +29613,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IConcreteBellRinger__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IConcreteBellRinger__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IConcreteBellRinger__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29915,7 +29629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IExtendsPrivateInterface.go.diff 1`] = `
 --- go/jsiicalc/IExtendsPrivateInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/IExtendsPrivateInterface.go	--runtime-type-checking
-@@ -35,10 +35,13 @@
+@@ -34,10 +34,13 @@
  	)
  	return returns
  }
@@ -29934,10 +29648,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IExtendsPrivateInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/IExtendsPrivateInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IExtendsPrivateInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -29957,10 +29670,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IExtendsPrivateInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IExtendsPrivateInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IExtendsPrivateInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -29974,7 +29686,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithOptionalMethodArguments.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithOptionalMethodArguments.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithOptionalMethodArguments.go	--runtime-type-checking
-@@ -14,10 +14,13 @@
+@@ -13,10 +13,13 @@
  type jsiiProxy_IInterfaceWithOptionalMethodArguments struct {
  	_ byte // padding
  }
@@ -29993,10 +29705,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithOptionalMethodArguments__checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithOptionalMethodArguments__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithOptionalMethodArguments__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30016,10 +29727,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithOptionalMethodArguments__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithOptionalMethodArguments__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithOptionalMethodArguments__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30033,7 +29743,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithProperties.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithProperties.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithProperties.go	--runtime-type-checking
-@@ -35,10 +35,13 @@
+@@ -34,10 +34,13 @@
  	)
  	return returns
  }
@@ -30052,10 +29762,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithProperties__checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithProperties__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithProperties__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30075,10 +29784,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithProperties__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithProperties__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithProperties__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30092,7 +29800,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithPropertiesExtension.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithPropertiesExtension.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithPropertiesExtension.go	--runtime-type-checking
-@@ -25,10 +25,13 @@
+@@ -24,10 +24,13 @@
  	)
  	return returns
  }
@@ -30111,10 +29819,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithPropertiesExtension__checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithPropertiesExtension__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithPropertiesExtension__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30134,10 +29841,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IInterfaceWithPropertiesExtension__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IInterfaceWithPropertiesExtension__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IInterfaceWithPropertiesExtension__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30151,7 +29857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IMutableObjectLiteral.go.diff 1`] = `
 --- go/jsiicalc/IMutableObjectLiteral.go	--no-runtime-type-checking
 +++ go/jsiicalc/IMutableObjectLiteral.go	--runtime-type-checking
-@@ -24,10 +24,13 @@
+@@ -23,10 +23,13 @@
  	)
  	return returns
  }
@@ -30170,10 +29876,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IMutableObjectLiteral__checks.go.diff 1`] = `
 --- go/jsiicalc/IMutableObjectLiteral__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IMutableObjectLiteral__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30193,10 +29898,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IMutableObjectLiteral__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IMutableObjectLiteral__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IMutableObjectLiteral__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30210,7 +29914,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/INonInternalInterface.go.diff 1`] = `
 --- go/jsiicalc/INonInternalInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/INonInternalInterface.go	--runtime-type-checking
-@@ -27,10 +27,13 @@
+@@ -26,10 +26,13 @@
  	)
  	return returns
  }
@@ -30224,7 +29928,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
  		"b",
  		val,
  	)
-@@ -45,10 +48,13 @@
+@@ -44,10 +47,13 @@
  	)
  	return returns
  }
@@ -30243,10 +29947,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/INonInternalInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/INonInternalInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/INonInternalInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30274,10 +29977,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/INonInternalInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/INonInternalInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/INonInternalInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30295,7 +29997,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IObjectWithProperty.go.diff 1`] = `
 --- go/jsiicalc/IObjectWithProperty.go	--no-runtime-type-checking
 +++ go/jsiicalc/IObjectWithProperty.go	--runtime-type-checking
-@@ -39,10 +39,13 @@
+@@ -38,10 +38,13 @@
  	)
  	return returns
  }
@@ -30314,10 +30016,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IObjectWithProperty__checks.go.diff 1`] = `
 --- go/jsiicalc/IObjectWithProperty__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IObjectWithProperty__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30337,10 +30038,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/IObjectWithProperty__no_checks.go.diff 1`] = `
 --- go/jsiicalc/IObjectWithProperty__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/IObjectWithProperty__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30354,7 +30054,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementInternalInterface.go.diff 1`] = `
 --- go/jsiicalc/ImplementInternalInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementInternalInterface.go	--runtime-type-checking
-@@ -50,10 +50,13 @@
+@@ -49,10 +49,13 @@
  		i,
  	)
  }
@@ -30373,10 +30073,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementInternalInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/ImplementInternalInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementInternalInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30396,10 +30095,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementInternalInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ImplementInternalInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementInternalInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30413,7 +30111,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementsPrivateInterface.go.diff 1`] = `
 --- go/jsiicalc/ImplementsPrivateInterface.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementsPrivateInterface.go	--runtime-type-checking
-@@ -50,10 +50,13 @@
+@@ -49,10 +49,13 @@
  		i,
  	)
  }
@@ -30432,10 +30130,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementsPrivateInterface__checks.go.diff 1`] = `
 --- go/jsiicalc/ImplementsPrivateInterface__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementsPrivateInterface__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30455,10 +30152,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ImplementsPrivateInterface__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ImplementsPrivateInterface__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ImplementsPrivateInterface__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30472,7 +30168,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/InterfacesMaker.go.diff 1`] = `
 --- go/jsiicalc/InterfacesMaker.go	--no-runtime-type-checking
 +++ go/jsiicalc/InterfacesMaker.go	--runtime-type-checking
-@@ -18,10 +18,13 @@
+@@ -17,10 +17,13 @@
  }
  
  func InterfacesMaker_MakeInterfaces(count *float64) *[]scopejsiicalclib.IDoublable {
@@ -30491,10 +30187,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/InterfacesMaker__checks.go.diff 1`] = `
 --- go/jsiicalc/InterfacesMaker__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/InterfacesMaker__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30514,10 +30209,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/InterfacesMaker__no_checks.go.diff 1`] = `
 --- go/jsiicalc/InterfacesMaker__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/InterfacesMaker__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30531,7 +30225,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/I
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSII417Derived.go.diff 1`] = `
 --- go/jsiicalc/JSII417Derived.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSII417Derived.go	--runtime-type-checking
-@@ -42,10 +42,13 @@
+@@ -41,10 +41,13 @@
  
  
  func NewJSII417Derived(property *string) JSII417Derived {
@@ -30550,10 +30244,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSII417Derived__checks.go.diff 1`] = `
 --- go/jsiicalc/JSII417Derived__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSII417Derived__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30573,10 +30266,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSII417Derived__no_checks.go.diff 1`] = `
 --- go/jsiicalc/JSII417Derived__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSII417Derived__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30590,7 +30282,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSObjectLiteralToNativeClass.go.diff 1`] = `
 --- go/jsiicalc/JSObjectLiteralToNativeClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSObjectLiteralToNativeClass.go	--runtime-type-checking
-@@ -62,18 +62,24 @@
+@@ -61,18 +61,24 @@
  		j,
  	)
  }
@@ -30620,10 +30312,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSObjectLiteralToNativeClass__checks.go.diff 1`] = `
 --- go/jsiicalc/JSObjectLiteralToNativeClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSObjectLiteralToNativeClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,24 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30651,10 +30342,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JSObjectLiteralToNativeClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/JSObjectLiteralToNativeClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JSObjectLiteralToNativeClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30672,7 +30362,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JavaReservedWords.go.diff 1`] = `
 --- go/jsiicalc/JavaReservedWords.go	--no-runtime-type-checking
 +++ go/jsiicalc/JavaReservedWords.go	--runtime-type-checking
-@@ -102,10 +102,13 @@
+@@ -101,10 +101,13 @@
  		j,
  	)
  }
@@ -30691,10 +30381,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JavaReservedWords__checks.go.diff 1`] = `
 --- go/jsiicalc/JavaReservedWords__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JavaReservedWords__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30714,10 +30403,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/JavaReservedWords__no_checks.go.diff 1`] = `
 --- go/jsiicalc/JavaReservedWords__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/JavaReservedWords__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30731,7 +30419,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/J
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/LevelOne.go.diff 1`] = `
 --- go/jsiicalc/LevelOne.go	--no-runtime-type-checking
 +++ go/jsiicalc/LevelOne.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewLevelOne(props *LevelOneProps) LevelOne {
@@ -30750,10 +30438,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/L
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/LevelOne__checks.go.diff 1`] = `
 --- go/jsiicalc/LevelOne__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/LevelOne__checks.go	--runtime-type-checking
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,21 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30778,10 +30465,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/L
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/LevelOne__no_checks.go.diff 1`] = `
 --- go/jsiicalc/LevelOne__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/LevelOne__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30795,7 +30481,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/L
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Multiply.go.diff 1`] = `
 --- go/jsiicalc/Multiply.go	--no-runtime-type-checking
 +++ go/jsiicalc/Multiply.go	--runtime-type-checking
-@@ -73,10 +73,13 @@
+@@ -72,10 +72,13 @@
  
  // Creates a BinaryOperation.
  func NewMultiply(lhs scopejsiicalclib.NumericValue, rhs scopejsiicalclib.NumericValue) Multiply {
@@ -30814,10 +30500,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/M
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Multiply__checks.go.diff 1`] = `
 --- go/jsiicalc/Multiply__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Multiply__checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30843,10 +30528,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/M
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Multiply__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Multiply__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Multiply__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30860,7 +30544,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/M
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Negate.go.diff 1`] = `
 --- go/jsiicalc/Negate.go	--no-runtime-type-checking
 +++ go/jsiicalc/Negate.go	--runtime-type-checking
-@@ -55,10 +55,13 @@
+@@ -54,10 +54,13 @@
  
  
  func NewNegate(operand scopejsiicalclib.NumericValue) Negate {
@@ -30879,10 +30563,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Negate__checks.go.diff 1`] = `
 --- go/jsiicalc/Negate__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Negate__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30904,10 +30587,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Negate__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Negate__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Negate__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -30921,7 +30603,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NullShouldBeTreatedAsUndefined.go.diff 1`] = `
 --- go/jsiicalc/NullShouldBeTreatedAsUndefined.go	--no-runtime-type-checking
 +++ go/jsiicalc/NullShouldBeTreatedAsUndefined.go	--runtime-type-checking
-@@ -32,10 +32,13 @@
+@@ -31,10 +31,13 @@
  
  
  func NewNullShouldBeTreatedAsUndefined(_param1 *string, optional interface{}) NullShouldBeTreatedAsUndefined {
@@ -30935,7 +30617,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
  	_jsii_.Create(
  		"jsii-calc.NullShouldBeTreatedAsUndefined",
  		[]interface{}{_param1, optional},
-@@ -70,10 +73,13 @@
+@@ -69,10 +72,13 @@
  		[]interface{}{value},
  	)
  }
@@ -30954,10 +30636,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NullShouldBeTreatedAsUndefined__checks.go.diff 1`] = `
 --- go/jsiicalc/NullShouldBeTreatedAsUndefined__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/NullShouldBeTreatedAsUndefined__checks.go	--runtime-type-checking
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,29 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -30990,10 +30671,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NullShouldBeTreatedAsUndefined__no_checks.go.diff 1`] = `
 --- go/jsiicalc/NullShouldBeTreatedAsUndefined__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/NullShouldBeTreatedAsUndefined__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31011,7 +30691,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NumberGenerator.go.diff 1`] = `
 --- go/jsiicalc/NumberGenerator.go	--no-runtime-type-checking
 +++ go/jsiicalc/NumberGenerator.go	--runtime-type-checking
-@@ -31,10 +31,13 @@
+@@ -30,10 +30,13 @@
  
  
  func NewNumberGenerator(generator IRandomNumberGenerator) NumberGenerator {
@@ -31025,7 +30705,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
  	_jsii_.Create(
  		"jsii-calc.NumberGenerator",
  		[]interface{}{generator},
-@@ -53,18 +56,24 @@
+@@ -52,18 +55,24 @@
  		n,
  	)
  }
@@ -31055,10 +30735,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NumberGenerator__checks.go.diff 1`] = `
 --- go/jsiicalc/NumberGenerator__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/NumberGenerator__checks.go	--runtime-type-checking
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31094,10 +30773,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/NumberGenerator__no_checks.go.diff 1`] = `
 --- go/jsiicalc/NumberGenerator__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/NumberGenerator__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31119,7 +30797,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/N
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ObjectRefsInCollections.go.diff 1`] = `
 --- go/jsiicalc/ObjectRefsInCollections.go	--no-runtime-type-checking
 +++ go/jsiicalc/ObjectRefsInCollections.go	--runtime-type-checking
-@@ -44,10 +44,13 @@
+@@ -43,10 +43,13 @@
  		o,
  	)
  }
@@ -31133,7 +30811,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
  	_jsii_.Invoke(
  		o,
  		"sumFromArray",
-@@ -57,10 +60,13 @@
+@@ -56,10 +59,13 @@
  
  	return returns
  }
@@ -31152,10 +30830,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ObjectRefsInCollections__checks.go.diff 1`] = `
 --- go/jsiicalc/ObjectRefsInCollections__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ObjectRefsInCollections__checks.go	--runtime-type-checking
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,26 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31185,10 +30862,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ObjectRefsInCollections__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ObjectRefsInCollections__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ObjectRefsInCollections__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31206,7 +30882,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalArgumentInvoker.go.diff 1`] = `
 --- go/jsiicalc/OptionalArgumentInvoker.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalArgumentInvoker.go	--runtime-type-checking
-@@ -17,10 +17,13 @@
+@@ -16,10 +16,13 @@
  }
  
  func NewOptionalArgumentInvoker(delegate IInterfaceWithOptionalMethodArguments) OptionalArgumentInvoker {
@@ -31225,10 +30901,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalArgumentInvoker__checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalArgumentInvoker__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalArgumentInvoker__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31248,10 +30923,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalArgumentInvoker__no_checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalArgumentInvoker__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalArgumentInvoker__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31265,7 +30939,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalConstructorArgument.go.diff 1`] = `
 --- go/jsiicalc/OptionalConstructorArgument.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalConstructorArgument.go	--runtime-type-checking
-@@ -51,10 +51,13 @@
+@@ -50,10 +50,13 @@
  
  
  func NewOptionalConstructorArgument(arg1 *float64, arg2 *string, arg3 *time.Time) OptionalConstructorArgument {
@@ -31284,10 +30958,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalConstructorArgument__checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalConstructorArgument__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalConstructorArgument__checks.go	--runtime-type-checking
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,20 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31311,10 +30984,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalConstructorArgument__no_checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalConstructorArgument__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalConstructorArgument__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31328,7 +31000,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalStructConsumer.go.diff 1`] = `
 --- go/jsiicalc/OptionalStructConsumer.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalStructConsumer.go	--runtime-type-checking
-@@ -38,10 +38,13 @@
+@@ -37,10 +37,13 @@
  
  
  func NewOptionalStructConsumer(optionalStruct *OptionalStruct) OptionalStructConsumer {
@@ -31347,10 +31019,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalStructConsumer__checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalStructConsumer__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalStructConsumer__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31370,10 +31041,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OptionalStructConsumer__no_checks.go.diff 1`] = `
 --- go/jsiicalc/OptionalStructConsumer__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OptionalStructConsumer__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31387,7 +31057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverridableProtectedMember.go.diff 1`] = `
 --- go/jsiicalc/OverridableProtectedMember.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverridableProtectedMember.go	--runtime-type-checking
-@@ -66,10 +66,13 @@
+@@ -65,10 +65,13 @@
  		o,
  	)
  }
@@ -31406,10 +31076,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverridableProtectedMember__checks.go.diff 1`] = `
 --- go/jsiicalc/OverridableProtectedMember__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverridableProtectedMember__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31429,10 +31098,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverridableProtectedMember__no_checks.go.diff 1`] = `
 --- go/jsiicalc/OverridableProtectedMember__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverridableProtectedMember__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31446,7 +31114,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverrideReturnsObject.go.diff 1`] = `
 --- go/jsiicalc/OverrideReturnsObject.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverrideReturnsObject.go	--runtime-type-checking
-@@ -38,10 +38,13 @@
+@@ -37,10 +37,13 @@
  		o,
  	)
  }
@@ -31465,10 +31133,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverrideReturnsObject__checks.go.diff 1`] = `
 --- go/jsiicalc/OverrideReturnsObject__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverrideReturnsObject__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31488,10 +31155,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/OverrideReturnsObject__no_checks.go.diff 1`] = `
 --- go/jsiicalc/OverrideReturnsObject__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/OverrideReturnsObject__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31505,7 +31171,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/O
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsBuiltins.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsBuiltins.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsBuiltins.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
+@@ -15,10 +15,13 @@
  }
  
  func NewParamShadowsBuiltins(builtins *string, str *string, props *ParamShadowsBuiltinsProps) ParamShadowsBuiltins {
@@ -31524,10 +31190,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsBuiltins__checks.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsBuiltins__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsBuiltins__checks.go	--runtime-type-checking
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,29 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31560,10 +31225,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsBuiltins__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsBuiltins__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsBuiltins__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31577,7 +31241,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsScope.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsScope.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsScope.go	--runtime-type-checking
-@@ -43,10 +43,13 @@
+@@ -42,10 +42,13 @@
  		p,
  	)
  }
@@ -31596,10 +31260,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsScope__checks.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsScope__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsScope__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31621,10 +31284,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ParamShadowsScope__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ParamShadowsScope__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ParamShadowsScope__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31638,7 +31300,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/PartiallyInitializedThisConsumer.go.diff 1`] = `
 --- go/jsiicalc/PartiallyInitializedThisConsumer.go	--no-runtime-type-checking
 +++ go/jsiicalc/PartiallyInitializedThisConsumer.go	--runtime-type-checking
-@@ -26,10 +26,13 @@
+@@ -25,10 +25,13 @@
  		p,
  	)
  }
@@ -31657,10 +31319,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/PartiallyInitializedThisConsumer__checks.go.diff 1`] = `
 --- go/jsiicalc/PartiallyInitializedThisConsumer__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/PartiallyInitializedThisConsumer__checks.go	--runtime-type-checking
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31689,10 +31350,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/PartiallyInitializedThisConsumer__no_checks.go.diff 1`] = `
 --- go/jsiicalc/PartiallyInitializedThisConsumer__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/PartiallyInitializedThisConsumer__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31706,7 +31366,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Polymorphism.go.diff 1`] = `
 --- go/jsiicalc/Polymorphism.go	--no-runtime-type-checking
 +++ go/jsiicalc/Polymorphism.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  		p,
  	)
  }
@@ -31725,10 +31385,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Polymorphism__checks.go.diff 1`] = `
 --- go/jsiicalc/Polymorphism__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Polymorphism__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31750,10 +31409,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Polymorphism__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Polymorphism__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Polymorphism__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31767,7 +31425,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Power.go.diff 1`] = `
 --- go/jsiicalc/Power.go	--no-runtime-type-checking
 +++ go/jsiicalc/Power.go	--runtime-type-checking
-@@ -116,10 +116,13 @@
+@@ -115,10 +115,13 @@
  
  // Creates a Power operation.
  func NewPower(base scopejsiicalclib.NumericValue, pow scopejsiicalclib.NumericValue) Power {
@@ -31781,7 +31439,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
  	_jsii_.Create(
  		"jsii-calc.Power",
  		[]interface{}{base, pow},
-@@ -139,26 +142,35 @@
+@@ -138,26 +141,35 @@
  		p,
  	)
  }
@@ -31822,10 +31480,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Power__checks.go.diff 1`] = `
 --- go/jsiicalc/Power__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Power__checks.go	--runtime-type-checking
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,47 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31876,10 +31533,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Power__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Power__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Power__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31905,7 +31561,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/P
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ReferenceEnumFromScopedPackage.go.diff 1`] = `
 --- go/jsiicalc/ReferenceEnumFromScopedPackage.go	--no-runtime-type-checking
 +++ go/jsiicalc/ReferenceEnumFromScopedPackage.go	--runtime-type-checking
-@@ -76,10 +76,13 @@
+@@ -75,10 +75,13 @@
  
  	return returns
  }
@@ -31924,10 +31580,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ReferenceEnumFromScopedPackage__checks.go.diff 1`] = `
 --- go/jsiicalc/ReferenceEnumFromScopedPackage__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ReferenceEnumFromScopedPackage__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -31949,10 +31604,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/ReferenceEnumFromScopedPackage__no_checks.go.diff 1`] = `
 --- go/jsiicalc/ReferenceEnumFromScopedPackage__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/ReferenceEnumFromScopedPackage__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -31966,7 +31620,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RootStructValidator.go.diff 1`] = `
 --- go/jsiicalc/RootStructValidator.go	--no-runtime-type-checking
 +++ go/jsiicalc/RootStructValidator.go	--runtime-type-checking
-@@ -15,10 +15,13 @@
+@@ -14,10 +14,13 @@
  }
  
  func RootStructValidator_Validate(struct_ *RootStruct) {
@@ -31985,10 +31639,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RootStructValidator__checks.go.diff 1`] = `
 --- go/jsiicalc/RootStructValidator__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/RootStructValidator__checks.go	--runtime-type-checking
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,21 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32013,10 +31666,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RootStructValidator__no_checks.go.diff 1`] = `
 --- go/jsiicalc/RootStructValidator__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/RootStructValidator__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32030,7 +31682,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RuntimeTypeChecking.go.diff 1`] = `
 --- go/jsiicalc/RuntimeTypeChecking.go	--no-runtime-type-checking
 +++ go/jsiicalc/RuntimeTypeChecking.go	--runtime-type-checking
-@@ -59,10 +59,13 @@
+@@ -58,10 +58,13 @@
  		[]interface{}{arg},
  	)
  }
@@ -32049,10 +31701,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RuntimeTypeChecking__checks.go.diff 1`] = `
 --- go/jsiicalc/RuntimeTypeChecking__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/RuntimeTypeChecking__checks.go	--runtime-type-checking
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,20 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32076,10 +31727,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/RuntimeTypeChecking__no_checks.go.diff 1`] = `
 --- go/jsiicalc/RuntimeTypeChecking__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/RuntimeTypeChecking__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32093,7 +31743,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/R
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonInt.go.diff 1`] = `
 --- go/jsiicalc/SingletonInt.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonInt.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
+@@ -15,10 +15,13 @@
  type jsiiProxy_SingletonInt struct {
  	_ byte // padding
  }
@@ -32112,10 +31762,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonInt__checks.go.diff 1`] = `
 --- go/jsiicalc/SingletonInt__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonInt__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32135,10 +31784,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonInt__no_checks.go.diff 1`] = `
 --- go/jsiicalc/SingletonInt__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonInt__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32152,7 +31800,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonString.go.diff 1`] = `
 --- go/jsiicalc/SingletonString.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonString.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
+@@ -15,10 +15,13 @@
  type jsiiProxy_SingletonString struct {
  	_ byte // padding
  }
@@ -32171,10 +31819,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonString__checks.go.diff 1`] = `
 --- go/jsiicalc/SingletonString__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonString__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32194,10 +31841,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SingletonString__no_checks.go.diff 1`] = `
 --- go/jsiicalc/SingletonString__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SingletonString__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32211,7 +31857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StableClass.go.diff 1`] = `
 --- go/jsiicalc/StableClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/StableClass.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  
  
  func NewStableClass(readonlyString *string, mutableNumber *float64) StableClass {
@@ -32230,10 +31876,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StableClass__checks.go.diff 1`] = `
 --- go/jsiicalc/StableClass__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StableClass__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32253,10 +31898,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StableClass__no_checks.go.diff 1`] = `
 --- go/jsiicalc/StableClass__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StableClass__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32270,7 +31914,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StaticContext.go.diff 1`] = `
 --- go/jsiicalc/StaticContext.go	--no-runtime-type-checking
 +++ go/jsiicalc/StaticContext.go	--runtime-type-checking
-@@ -43,10 +43,13 @@
+@@ -42,10 +42,13 @@
  	return returns
  }
  
@@ -32289,10 +31933,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StaticContext__checks.go.diff 1`] = `
 --- go/jsiicalc/StaticContext__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StaticContext__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32312,10 +31955,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StaticContext__no_checks.go.diff 1`] = `
 --- go/jsiicalc/StaticContext__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StaticContext__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32329,7 +31971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Statics.go.diff 1`] = `
 --- go/jsiicalc/Statics.go	--no-runtime-type-checking
 +++ go/jsiicalc/Statics.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewStatics(value *string) Statics {
@@ -32343,7 +31985,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  	_jsii_.Create(
  		"jsii-calc.Statics",
  		[]interface{}{value},
-@@ -53,10 +56,13 @@
+@@ -52,10 +55,13 @@
  
  // Jsdocs for static method.
  func Statics_StaticMethod(name *string) *string {
@@ -32357,7 +31999,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  	_jsii_.StaticInvoke(
  		"jsii-calc.Statics",
  		"staticMethod",
-@@ -111,10 +117,13 @@
+@@ -110,10 +116,13 @@
  	return returns
  }
  
@@ -32371,7 +32013,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  		"instance",
  		val,
  	)
-@@ -131,10 +140,13 @@
+@@ -130,10 +139,13 @@
  	return returns
  }
  
@@ -32390,10 +32032,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Statics__checks.go.diff 1`] = `
 --- go/jsiicalc/Statics__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Statics__checks.go	--runtime-type-checking
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,40 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32437,10 +32078,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Statics__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Statics__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Statics__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32466,7 +32106,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StripInternal.go.diff 1`] = `
 --- go/jsiicalc/StripInternal.go	--no-runtime-type-checking
 +++ go/jsiicalc/StripInternal.go	--runtime-type-checking
-@@ -50,10 +50,13 @@
+@@ -49,10 +49,13 @@
  		s,
  	)
  }
@@ -32485,10 +32125,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StripInternal__checks.go.diff 1`] = `
 --- go/jsiicalc/StripInternal__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StripInternal__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32508,10 +32147,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StripInternal__no_checks.go.diff 1`] = `
 --- go/jsiicalc/StripInternal__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StripInternal__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32525,7 +32163,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructPassing.go.diff 1`] = `
 --- go/jsiicalc/StructPassing.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructPassing.go	--runtime-type-checking
-@@ -40,10 +40,13 @@
+@@ -39,10 +39,13 @@
  }
  
  func StructPassing_HowManyVarArgsDidIPass(_positional *float64, inputs ...*TopLevelStruct) *float64 {
@@ -32539,7 +32177,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  		args = append(args, a)
  	}
  
-@@ -60,10 +63,13 @@
+@@ -59,10 +62,13 @@
  }
  
  func StructPassing_RoundTrip(_positional *float64, input *TopLevelStruct) *TopLevelStruct {
@@ -32558,10 +32196,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructPassing__checks.go.diff 1`] = `
 --- go/jsiicalc/StructPassing__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructPassing__checks.go	--runtime-type-checking
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,39 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32604,10 +32241,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructPassing__no_checks.go.diff 1`] = `
 --- go/jsiicalc/StructPassing__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructPassing__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32625,7 +32261,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructUnionConsumer.go.diff 1`] = `
 --- go/jsiicalc/StructUnionConsumer.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructUnionConsumer.go	--runtime-type-checking
-@@ -15,10 +15,13 @@
+@@ -14,10 +14,13 @@
  }
  
  func StructUnionConsumer_IsStructA(struct_ interface{}) *bool {
@@ -32639,7 +32275,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  	_jsii_.StaticInvoke(
  		"jsii-calc.StructUnionConsumer",
  		"isStructA",
-@@ -30,10 +33,13 @@
+@@ -29,10 +32,13 @@
  }
  
  func StructUnionConsumer_IsStructB(struct_ interface{}) *bool {
@@ -32653,7 +32289,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  	_jsii_.StaticInvoke(
  		"jsii-calc.StructUnionConsumer",
  		"isStructB",
-@@ -45,10 +51,13 @@
+@@ -44,10 +50,13 @@
  }
  
  func StructUnionConsumer_ProvideStruct(which *string) interface{} {
@@ -32672,10 +32308,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructUnionConsumer__checks.go.diff 1`] = `
 --- go/jsiicalc/StructUnionConsumer__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructUnionConsumer__checks.go	--runtime-type-checking
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,90 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32769,10 +32404,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/StructUnionConsumer__no_checks.go.diff 1`] = `
 --- go/jsiicalc/StructUnionConsumer__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/StructUnionConsumer__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32794,7 +32428,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Sum.go.diff 1`] = `
 --- go/jsiicalc/Sum.go	--no-runtime-type-checking
 +++ go/jsiicalc/Sum.go	--runtime-type-checking
-@@ -126,34 +126,46 @@
+@@ -125,34 +125,46 @@
  		s,
  	)
  }
@@ -32846,10 +32480,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Sum__checks.go.diff 1`] = `
 --- go/jsiicalc/Sum__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Sum__checks.go	--runtime-type-checking
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,43 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32896,10 +32529,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/Sum__no_checks.go.diff 1`] = `
 --- go/jsiicalc/Sum__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/Sum__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32925,7 +32557,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilder.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilder.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilder.go	--runtime-type-checking
-@@ -62,10 +62,13 @@
+@@ -61,10 +61,13 @@
  
  
  func NewSupportsNiceJavaBuilder(id *float64, defaultBar *float64, props *SupportsNiceJavaBuilderProps, rest ...*string) SupportsNiceJavaBuilder {
@@ -32943,10 +32575,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilder__checks.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilder__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilder__checks.go	--runtime-type-checking
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,22 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -32972,10 +32603,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilder__no_checks.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilder__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilder__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -32989,7 +32619,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps.go	--runtime-type-checking
-@@ -51,10 +51,13 @@
+@@ -50,10 +50,13 @@
  
  
  func NewSupportsNiceJavaBuilderWithRequiredProps(id *float64, props *SupportsNiceJavaBuilderProps) SupportsNiceJavaBuilderWithRequiredProps {
@@ -33008,10 +32638,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__checks.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__checks.go	--runtime-type-checking
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33040,10 +32669,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__no_checks.go.diff 1`] = `
 --- go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SupportsNiceJavaBuilderWithRequiredProps__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33057,7 +32685,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SyncVirtualMethods.go.diff 1`] = `
 --- go/jsiicalc/SyncVirtualMethods.go	--no-runtime-type-checking
 +++ go/jsiicalc/SyncVirtualMethods.go	--runtime-type-checking
-@@ -119,42 +119,57 @@
+@@ -118,42 +118,57 @@
  		s,
  	)
  }
@@ -33115,7 +32743,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  		"valueOfOtherProperty",
  		val,
  	)
-@@ -185,18 +200,24 @@
+@@ -184,18 +199,24 @@
  
  	return returns
  }
@@ -33140,7 +32768,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  		"modifyValueOfTheProperty",
  		[]interface{}{value},
  	)
-@@ -253,10 +274,13 @@
+@@ -252,10 +273,13 @@
  
  	return returns
  }
@@ -33154,7 +32782,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
  	_jsii_.Invoke(
  		s,
  		"virtualMethod",
-@@ -266,10 +290,13 @@
+@@ -265,10 +289,13 @@
  
  	return returns
  }
@@ -33173,10 +32801,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SyncVirtualMethods__checks.go.diff 1`] = `
 --- go/jsiicalc/SyncVirtualMethods__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SyncVirtualMethods__checks.go	--runtime-type-checking
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,80 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33260,10 +32887,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/SyncVirtualMethods__no_checks.go.diff 1`] = `
 --- go/jsiicalc/SyncVirtualMethods__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/SyncVirtualMethods__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,42 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33309,7 +32935,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/S
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/TestStructWithEnum.go.diff 1`] = `
 --- go/jsiicalc/TestStructWithEnum.go	--no-runtime-type-checking
 +++ go/jsiicalc/TestStructWithEnum.go	--runtime-type-checking
-@@ -66,10 +66,13 @@
+@@ -65,10 +65,13 @@
  		t,
  	)
  }
@@ -33323,7 +32949,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/T
  	_jsii_.Invoke(
  		t,
  		"isStringEnumA",
-@@ -79,10 +82,13 @@
+@@ -78,10 +81,13 @@
  
  	return returns
  }
@@ -33342,10 +32968,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/T
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/TestStructWithEnum__checks.go.diff 1`] = `
 --- go/jsiicalc/TestStructWithEnum__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/TestStructWithEnum__checks.go	--runtime-type-checking
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33381,10 +33006,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/T
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/TestStructWithEnum__no_checks.go.diff 1`] = `
 --- go/jsiicalc/TestStructWithEnum__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/TestStructWithEnum__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33402,10 +33026,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/T
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UnaryOperation__checks.go.diff 1`] = `
 --- go/jsiicalc/UnaryOperation__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UnaryOperation__checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33427,10 +33050,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UnaryOperation__no_checks.go.diff 1`] = `
 --- go/jsiicalc/UnaryOperation__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UnaryOperation__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33444,7 +33066,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UpcasingReflectable.go.diff 1`] = `
 --- go/jsiicalc/UpcasingReflectable.go	--no-runtime-type-checking
 +++ go/jsiicalc/UpcasingReflectable.go	--runtime-type-checking
-@@ -32,10 +32,13 @@
+@@ -31,10 +31,13 @@
  
  
  func NewUpcasingReflectable(delegate *map[string]interface{}) UpcasingReflectable {
@@ -33463,10 +33085,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UpcasingReflectable__checks.go.diff 1`] = `
 --- go/jsiicalc/UpcasingReflectable__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UpcasingReflectable__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33486,10 +33107,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UpcasingReflectable__no_checks.go.diff 1`] = `
 --- go/jsiicalc/UpcasingReflectable__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UpcasingReflectable__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33503,7 +33123,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UsesInterfaceWithProperties.go.diff 1`] = `
 --- go/jsiicalc/UsesInterfaceWithProperties.go	--no-runtime-type-checking
 +++ go/jsiicalc/UsesInterfaceWithProperties.go	--runtime-type-checking
-@@ -30,10 +30,13 @@
+@@ -29,10 +29,13 @@
  
  
  func NewUsesInterfaceWithProperties(obj IInterfaceWithProperties) UsesInterfaceWithProperties {
@@ -33517,7 +33137,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
  	_jsii_.Create(
  		"jsii-calc.UsesInterfaceWithProperties",
  		[]interface{}{obj},
-@@ -65,10 +68,13 @@
+@@ -64,10 +67,13 @@
  
  	return returns
  }
@@ -33531,7 +33151,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
  	_jsii_.Invoke(
  		u,
  		"readStringAndNumber",
-@@ -78,10 +84,13 @@
+@@ -77,10 +83,13 @@
  
  	return returns
  }
@@ -33550,10 +33170,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UsesInterfaceWithProperties__checks.go.diff 1`] = `
 --- go/jsiicalc/UsesInterfaceWithProperties__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UsesInterfaceWithProperties__checks.go	--runtime-type-checking
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,32 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33589,10 +33208,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/UsesInterfaceWithProperties__no_checks.go.diff 1`] = `
 --- go/jsiicalc/UsesInterfaceWithProperties__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/UsesInterfaceWithProperties__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33614,7 +33232,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/U
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicInvoker.go.diff 1`] = `
 --- go/jsiicalc/VariadicInvoker.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicInvoker.go	--runtime-type-checking
-@@ -16,10 +16,13 @@
+@@ -15,10 +15,13 @@
  }
  
  func NewVariadicInvoker(method VariadicMethod) VariadicInvoker {
@@ -33633,10 +33251,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicInvoker__checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicInvoker__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicInvoker__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33656,10 +33273,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicInvoker__no_checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicInvoker__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicInvoker__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33673,7 +33289,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicMethod.go.diff 1`] = `
 --- go/jsiicalc/VariadicMethod.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicMethod.go	--runtime-type-checking
-@@ -48,10 +48,13 @@
+@@ -47,10 +47,13 @@
  		v,
  	)
  }
@@ -33691,10 +33307,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicMethod__checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicMethod__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicMethod__checks.go	--runtime-type-checking
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,16 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33714,10 +33329,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicMethod__no_checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicMethod__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicMethod__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,11 @@
+@@ -0,0 +1,10 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33731,7 +33345,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicTypeUnion.go.diff 1`] = `
 --- go/jsiicalc/VariadicTypeUnion.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicTypeUnion.go	--runtime-type-checking
-@@ -28,10 +28,13 @@
+@@ -27,10 +27,13 @@
  
  
  func NewVariadicTypeUnion(union ...interface{}) VariadicTypeUnion {
@@ -33745,7 +33359,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
  		args = append(args, a)
  	}
  
-@@ -60,10 +63,13 @@
+@@ -59,10 +62,13 @@
  		v,
  	)
  }
@@ -33764,10 +33378,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicTypeUnion__checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicTypeUnion__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicTypeUnion__checks.go	--runtime-type-checking
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,83 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -33854,10 +33467,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VariadicTypeUnion__no_checks.go.diff 1`] = `
 --- go/jsiicalc/VariadicTypeUnion__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VariadicTypeUnion__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil
@@ -33875,7 +33487,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VirtualMethodPlayground.go.diff 1`] = `
 --- go/jsiicalc/VirtualMethodPlayground.go	--no-runtime-type-checking
 +++ go/jsiicalc/VirtualMethodPlayground.go	--runtime-type-checking
-@@ -42,10 +42,13 @@
+@@ -41,10 +41,13 @@
  		v,
  	)
  }
@@ -33889,7 +33501,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
  	_jsii_.Invoke(
  		v,
  		"overrideMeAsync",
-@@ -55,10 +58,13 @@
+@@ -54,10 +57,13 @@
  
  	return returns
  }
@@ -33903,7 +33515,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
  	_jsii_.Invoke(
  		v,
  		"overrideMeSync",
-@@ -68,10 +74,13 @@
+@@ -67,10 +73,13 @@
  
  	return returns
  }
@@ -33917,7 +33529,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
  	_jsii_.Invoke(
  		v,
  		"parallelSumAsync",
-@@ -81,10 +90,13 @@
+@@ -80,10 +89,13 @@
  
  	return returns
  }
@@ -33931,7 +33543,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
  	_jsii_.Invoke(
  		v,
  		"serialSumAsync",
-@@ -94,10 +106,13 @@
+@@ -93,10 +105,13 @@
  
  	return returns
  }
@@ -33950,10 +33562,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VirtualMethodPlayground__checks.go.diff 1`] = `
 --- go/jsiicalc/VirtualMethodPlayground__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VirtualMethodPlayground__checks.go	--runtime-type-checking
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,48 @@
 +//go:build !no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +import (
@@ -34005,10 +33616,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/V
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/VirtualMethodPlayground__no_checks.go.diff 1`] = `
 --- go/jsiicalc/VirtualMethodPlayground__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/VirtualMethodPlayground__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,26 @@
 +//go:build no_runtime_type_checking
 +
-+// A simple calcuator built on JSII.
 +package jsiicalc
 +
 +// Building without runtime type checking enabled, so all the below just return nil


### PR DESCRIPTION
Our `go docs` have been broken since jsii `v1.65.0`. This was due to moving to emitting one file per type and headers being added to all those files: [Impacting PR](https://github.com/aws/jsii/pull/3698/files#diff-0a99c713a1282d6efe349c932d74dbfbdf1d926834c46ebfb5d65daeb27073f3R263)

The first occurrence was in [docs for cdk v2.39.0](https://pkg.go.dev/github.com/aws/aws-cdk-go/awscdk/v2@v2.39.0) and is still present in the [latest version](https://pkg.go.dev/github.com/aws/aws-cdk-go/awscdk/v2).

The header being added is `Version 2 of the AWS Cloud Development Kit library` to multiple files. It's determining this value from the [package.json](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/package.json#L4) file of `aws-cdk-lib`. I see adding this is most relevant for [maven](https://github.com/aws/jsii/blob/main/packages/jsii-reflect/lib/assembly.ts#L46-L52), hence removing it from `go` since I do not believe it's bringing much value to our documentation. Let me know if you feel otherwise :) 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
