### PR TITLE
chore: suppress extraneous upgrade prompts

### DIFF
--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -1,3 +1,5 @@
+import './suppress-jsii-upgrade-prompts';
+
 import { TypeSystem } from 'jsii-reflect';
 import { Rosetta, UnknownSnippetMode } from 'jsii-rosetta';
 import { resolve } from 'path';

--- a/packages/jsii-pacmak/lib/suppress-jsii-upgrade-prompts.ts
+++ b/packages/jsii-pacmak/lib/suppress-jsii-upgrade-prompts.ts
@@ -1,0 +1,2 @@
+// Suppress the upgrade prompt from jsii and jsii-rosetta
+process.env.JSII_SUPPRESS_UPGRADE_PROMPT = '1';

--- a/packages/jsii-rosetta/lib/index.ts
+++ b/packages/jsii-rosetta/lib/index.ts
@@ -1,3 +1,5 @@
+import './upgrade-prompt';
+
 export * from './translate';
 export { renderTree } from './o-tree';
 export { TargetLanguage } from './languages/target-language';
@@ -11,5 +13,3 @@ export * from './rosetta-translator';
 export * from './snippet';
 export * from './markdown';
 export * from './strict';
-
-import './upgrade-prompt';

--- a/packages/jsii-rosetta/lib/upgrade-prompt.ts
+++ b/packages/jsii-rosetta/lib/upgrade-prompt.ts
@@ -18,4 +18,7 @@ if (process.env.JSII_SUPPRESS_UPGRADE_PROMPT == null) {
       '#######################################################################################################',
     ].join('\n'),
   );
+
+  // Suppress any further upgrade prompts (e.g: the one from jsii, which is a dependency of jsii-rosetta)...
+  process.env.JSII_SUPPRESS_UPGRADE_PROMPT = '1';
 }


### PR DESCRIPTION
`jsii-pacmak` has a dependency on `jsii-rosetta`, which has a dependency on `jsii`. An upgrade prompt will be printed for `jsii` and then `jsii-rosetta`, despite customers have no way to influence the version that is installed as a transitive dependency from `jsii-pacmak`.

This adds suppressions such that:
- `jsii-pacmak` suppresses the warning before loading `jsii-rosetta`
- `jsii-rosetta` suppresses further warnings after having emitted its own, and now emits the warning first thing when it loads (instead of last before)



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
