### PR TITLE
fix(jsii-pacmak): emit correct `@return` tag for JavaDocs

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2226,7 +2226,7 @@ class JavaGenerator extends Generator {
     this.code.line();
     this.code.line('/**');
     this.code.line(
-      ` * @returns a newly built instance of {@link ${builtType}}.`,
+      ` * @return a newly built instance of {@link ${builtType}}.`,
     );
     this.code.line(' */');
     this.emitStabilityAnnotations(cls.initializer);

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -5338,7 +5338,7 @@ public class AmbiguousParameters extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.AmbiguousParameters}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.AmbiguousParameters}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -6052,7 +6052,7 @@ public class Calculator extends software.amazon.jsii.tests.calculator.compositio
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.Calculator}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.Calculator}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -6838,7 +6838,7 @@ public class ClassWithContainerTypes extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.ClassWithContainerTypes}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.ClassWithContainerTypes}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -16821,7 +16821,7 @@ public class LevelOne extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.LevelOne}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.LevelOne}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -18421,7 +18421,7 @@ public class OptionalStructConsumer extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.OptionalStructConsumer}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.OptionalStructConsumer}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -18637,7 +18637,7 @@ public class ParamShadowsBuiltins extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.ParamShadowsBuiltins}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.ParamShadowsBuiltins}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -22215,7 +22215,7 @@ public class SupportsNiceJavaBuilder extends software.amazon.jsii.tests.calculat
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilder}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -22497,7 +22497,7 @@ public class SupportsNiceJavaBuilderWithRequiredProps extends software.amazon.js
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.SupportsNiceJavaBuilderWithRequiredProps}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -24159,7 +24159,7 @@ public class AcceptsPath extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.cdk22369.AcceptsPath}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.cdk22369.AcceptsPath}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -27405,7 +27405,7 @@ public class ClassWithSelfKwarg extends software.amazon.jsii.JsiiObject {
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.python_self.ClassWithSelfKwarg}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.python_self.ClassWithSelfKwarg}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override
@@ -27827,7 +27827,7 @@ public class MyClass extends software.amazon.jsii.JsiiObject implements software
         }
 
         /**
-         * @returns a newly built instance of {@link software.amazon.jsii.tests.calculator.submodule.MyClass}.
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.submodule.MyClass}.
          */
         @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
         @Override


### PR DESCRIPTION
We are currently emitting `@returns`, but:

```
error: unknown tag: returns
* @returns a newly built instance of {@link software.amazon.awscdk.services.codedeploy.EcsDeploymentConfig}.
```

It should be `@return`.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
