### PR TITLE
feat(go): register exported properties as callbacks

### DIFF
--- a/packages/@jsii/go-runtime-test/project/callbacks_test.go
+++ b/packages/@jsii/go-runtime-test/project/callbacks_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/aws/jsii-runtime-go"
 	calc "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3"
 )
 
@@ -18,10 +19,27 @@ func TestPureInterfacesCanBeUsedTransparently(t *testing.T) {
 	}
 }
 
+func TestPropertyAccessThroughAny(t *testing.T) {
+	any := &ABC{
+		PropA: "Hello",
+		ProbB: "World",
+	}
+	calc.AnyPropertyAccess_MutateProperties(any, jsii.String("a"), jsii.String("b"), jsii.String("result"))
+	if *any.PropC != "Hello+World" {
+		t.Errorf("Expected Hello+World; actual %v", any.PropC)
+	}
+}
+
 type StructReturningDelegate struct {
 	expected *calc.StructB
 }
 
 func (o *StructReturningDelegate) ReturnStruct() *calc.StructB {
 	return o.expected
+}
+
+type ABC struct {
+	PropA string  `json:"a"`
+	ProbB string  `json:"b"`
+	PropC *string `json:"result,omitempty"`
 }

--- a/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/manage-object.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/manage-object.go
@@ -1,7 +1,9 @@
 package kernel
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/aws/jsii-runtime-go/internal/api"
 )
@@ -18,6 +20,14 @@ func (c *Client) ManageObject(v reflect.Value) (ref api.ObjectRef, err error) {
 	}
 	interfaces, overrides := c.Types().DiscoverImplementation(vt)
 
+	found := make(map[string]bool)
+	for _, override := range overrides {
+		if prop, ok := override.(*api.PropertyOverride); ok {
+			found[prop.JsiiProperty] = true
+		}
+	}
+	overrides = appendExportedProperties(vt, overrides, found)
+
 	var resp CreateResponse
 	resp, err = c.Create(CreateProps{
 		FQN:        objectFQN,
@@ -32,4 +42,50 @@ func (c *Client) ManageObject(v reflect.Value) (ref api.ObjectRef, err error) {
 	}
 
 	return
+}
+
+func appendExportedProperties(vt reflect.Type, overrides []api.Override, found map[string]bool) []api.Override {
+	if vt.Kind() == reflect.Ptr {
+		vt = vt.Elem()
+	}
+
+	if vt.Kind() == reflect.Struct {
+		for idx := 0; idx < vt.NumField(); idx++ {
+			field := vt.Field(idx)
+			// Unexported fields are not relevant here...
+			if !field.IsExported() {
+				continue
+			}
+
+			// Anonymous fields are embed, we traverse them for fields, too...
+			if field.Anonymous {
+				overrides = appendExportedProperties(field.Type, overrides, found)
+				continue
+			}
+
+			jsonName := field.Tag.Get("json")
+			if jsonName == "-" {
+				// Explicit omit via `json:"-"`
+				continue
+			} else if jsonName != "" {
+				// There could be attributes after the field name (e.g. `json:"foo,omitempty"`)
+				jsonName = strings.Split(jsonName, ",")[0]
+			}
+			// The default behavior is to use the field name as-is in JSON.
+			if jsonName == "" {
+				jsonName = field.Name
+			}
+
+			if !found[jsonName] {
+				overrides = append(overrides, &api.PropertyOverride{
+					JsiiProperty: jsonName,
+					// Using the "." prefix to signify this isn't actually a getter, just raw field access.
+					GoGetter: fmt.Sprintf(".%s", field.Name),
+				})
+				found[jsonName] = true
+			}
+		}
+	}
+
+	return overrides
 }

--- a/packages/jsii-calc/lib/compliance.ts
+++ b/packages/jsii-calc/lib/compliance.ts
@@ -3141,3 +3141,24 @@ export class PromiseNothing {
     return PromiseNothing.promiseIt();
   }
 }
+
+export class AnyPropertyAccess {
+  /**
+   * Sets obj[resultProp] to `${obj[propA]}+${obj[propB]}`.
+   *
+   * @param obj the receiver object.
+   * @param propA the first property to read.
+   * @param propB the second property to read.
+   * @param resultProp the property to write into.
+   */
+  public static mutateProperties(
+    obj: any,
+    propA: string,
+    propB: string,
+    resultProp: string,
+  ) {
+    obj[resultProp] = `${obj[propA]}+${obj[propB]}`;
+  }
+
+  private constructor() {}
+}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -1538,6 +1538,72 @@
       "name": "AnonymousImplementationProvider",
       "symbolId": "lib/compliance:AnonymousImplementationProvider"
     },
+    "jsii-calc.AnyPropertyAccess": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.AnyPropertyAccess",
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/compliance.ts",
+        "line": 3145
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Sets obj[resultProp] to `${obj[propA]}+${obj[propB]}`."
+          },
+          "locationInModule": {
+            "filename": "lib/compliance.ts",
+            "line": 3154
+          },
+          "name": "mutateProperties",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "the receiver object."
+              },
+              "name": "obj",
+              "type": {
+                "primitive": "any"
+              }
+            },
+            {
+              "docs": {
+                "summary": "the first property to read."
+              },
+              "name": "propA",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "summary": "the second property to read."
+              },
+              "name": "propB",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "summary": "the property to write into."
+              },
+              "name": "resultProp",
+              "type": {
+                "primitive": "string"
+              }
+            }
+          ],
+          "static": true
+        }
+      ],
+      "name": "AnyPropertyAccess",
+      "symbolId": "lib/compliance:AnyPropertyAccess"
+    },
     "jsii-calc.AsyncVirtualMethods": {
       "assembly": "jsii-calc",
       "docs": {
@@ -18843,5 +18909,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "EH7xszNdCh9PCFUZ8Foi7g2CPhdrKeZm8CQaUCNv4GQ="
+  "fingerprint": "kOCIHox3N0mzJsbC3zUF0dELGRsdq5jP57dDIOu3fDE="
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -2918,6 +2918,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┃  ┣━ 📄 IOptionB.cs
        ┃           ┃  ┗━ 📄 UseOptions.cs
        ┃           ┣━ 📄 AnonymousImplementationProvider.cs
+       ┃           ┣━ 📄 AnyPropertyAccess.cs
        ┃           ┣━ 📄 AsyncVirtualMethods.cs
        ┃           ┣━ 📄 AugmentableClass.cs
        ┃           ┣━ 📄 BaseClass.cs
@@ -4174,6 +4175,45 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         public virtual Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe ProvideAsInterface()
         {
             return InvokeInstanceMethod<Amazon.JSII.Tests.CalculatorNamespace.IAnonymouslyImplementMe>(new System.Type[]{}, new object[]{})!;
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/AnyPropertyAccess.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.AnyPropertyAccess), fullyQualifiedName: "jsii-calc.AnyPropertyAccess")]
+    public class AnyPropertyAccess : DeputyBase
+    {
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected AnyPropertyAccess(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected AnyPropertyAccess(DeputyProps props): base(props)
+        {
+        }
+
+        /// <summary>Sets obj[resultProp] to \`\${obj[propA]}+\${obj[propB]}\`.</summary>
+        /// <param name="obj">the receiver object.</param>
+        /// <param name="propA">the first property to read.</param>
+        /// <param name="propB">the second property to read.</param>
+        /// <param name="resultProp">the property to write into.</param>
+        [JsiiMethod(name: "mutateProperties", parametersJson: "[{\\"docs\\":{\\"summary\\":\\"the receiver object.\\"},\\"name\\":\\"obj\\",\\"type\\":{\\"primitive\\":\\"any\\"}},{\\"docs\\":{\\"summary\\":\\"the first property to read.\\"},\\"name\\":\\"propA\\",\\"type\\":{\\"primitive\\":\\"string\\"}},{\\"docs\\":{\\"summary\\":\\"the second property to read.\\"},\\"name\\":\\"propB\\",\\"type\\":{\\"primitive\\":\\"string\\"}},{\\"docs\\":{\\"summary\\":\\"the property to write into.\\"},\\"name\\":\\"resultProp\\",\\"type\\":{\\"primitive\\":\\"string\\"}}]")]
+        public static void MutateProperties(object obj, string propA, string propB, string resultProp)
+        {
+            InvokeStaticVoidMethod(typeof(Amazon.JSII.Tests.CalculatorNamespace.AnyPropertyAccess), new System.Type[]{typeof(object), typeof(string), typeof(string), typeof(string)}, new object[]{obj, propA, propB, resultProp});
         }
     }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -2527,6 +2527,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃  ┣━ 📄 main.go
        ┃  ┗━ 📄 UseOptions.go
        ┣━ 📄 AnonymousImplementationProvider.go
+       ┣━ 📄 AnyPropertyAccess.go
        ┣━ 📄 AsyncVirtualMethods.go
        ┣━ 📄 AugmentableClass.go
        ┣━ 📄 BaseClass.go
@@ -4022,6 +4023,36 @@ func (a *jsiiProxy_AnonymousImplementationProvider) ProvideAsInterface() IAnonym
 	)
 
 	return returns
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/AnyPropertyAccess.go 1`] = `
+package jsiicalc
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type AnyPropertyAccess interface {
+}
+
+// The jsii proxy struct for AnyPropertyAccess
+type jsiiProxy_AnyPropertyAccess struct {
+	_ byte // padding
+}
+
+// Sets obj[resultProp] to \`\${obj[propA]}+\${obj[propB]}\`.
+func AnyPropertyAccess_MutateProperties(obj interface{}, propA *string, propB *string, resultProp *string) {
+	_init_.Initialize()
+
+	_jsii_.StaticInvokeVoid(
+		"jsii-calc.AnyPropertyAccess",
+		"mutateProperties",
+		[]interface{}{obj, propA, propB, resultProp},
+	)
 }
 
 
@@ -19331,6 +19362,14 @@ func init() {
 		},
 	)
 	_jsii_.RegisterClass(
+		"jsii-calc.AnyPropertyAccess",
+		reflect.TypeOf((*AnyPropertyAccess)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_AnyPropertyAccess{}
+		},
+	)
+	_jsii_.RegisterClass(
 		"jsii-calc.AsyncVirtualMethods",
 		reflect.TypeOf((*AsyncVirtualMethods)(nil)).Elem(),
 		[]_jsii_.Member{
@@ -24685,6 +24724,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
        ┃  ┣━ 🆕 UseOptions__checks.go
        ┃  ┣━ 🆕 UseOptions__no_checks.go
        ┃  ┗━ 📄 UseOptions.go.diff
+       ┣━ 🆕 AnyPropertyAccess__checks.go
+       ┣━ 🆕 AnyPropertyAccess__no_checks.go
+       ┣━ 📄 AnyPropertyAccess.go.diff
        ┣━ 🆕 AsyncVirtualMethods__checks.go
        ┣━ 🆕 AsyncVirtualMethods__no_checks.go
        ┣━ 📄 AsyncVirtualMethods.go.diff
@@ -26104,6 +26146,75 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/A
 +// Building without runtime type checking enabled, so all the below just return nil
 +
 +func validateNewAmbiguousParametersParameters(scope Bell, props *StructParameterType) error {
++	return nil
++}
++
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AnyPropertyAccess.go.diff 1`] = `
+--- go/jsiicalc/AnyPropertyAccess.go	--no-runtime-type-checking
++++ go/jsiicalc/AnyPropertyAccess.go	--runtime-type-checking
+@@ -15,10 +15,13 @@
+ 
+ // Sets obj[resultProp] to \`\${obj[propA]}+\${obj[propB]}\`.
+ func AnyPropertyAccess_MutateProperties(obj interface{}, propA *string, propB *string, resultProp *string) {
+ 	_init_.Initialize()
+ 
++	if err := validateAnyPropertyAccess_MutatePropertiesParameters(obj, propA, propB, resultProp); err != nil {
++		panic(err)
++	}
+ 	_jsii_.StaticInvokeVoid(
+ 		"jsii-calc.AnyPropertyAccess",
+ 		"mutateProperties",
+ 		[]interface{}{obj, propA, propB, resultProp},
+ 	)
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AnyPropertyAccess__checks.go.diff 1`] = `
+--- go/jsiicalc/AnyPropertyAccess__checks.go	--no-runtime-type-checking
++++ go/jsiicalc/AnyPropertyAccess__checks.go	--runtime-type-checking
+@@ -0,0 +1,28 @@
++//go:build !no_runtime_type_checking
++
++package jsiicalc
++
++import (
++	"fmt"
++)
++
++func validateAnyPropertyAccess_MutatePropertiesParameters(obj interface{}, propA *string, propB *string, resultProp *string) error {
++	if obj == nil {
++		return fmt.Errorf("parameter obj is required, but nil was provided")
++	}
++
++	if propA == nil {
++		return fmt.Errorf("parameter propA is required, but nil was provided")
++	}
++
++	if propB == nil {
++		return fmt.Errorf("parameter propB is required, but nil was provided")
++	}
++
++	if resultProp == nil {
++		return fmt.Errorf("parameter resultProp is required, but nil was provided")
++	}
++
++	return nil
++}
++
+`;
+
+exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/AnyPropertyAccess__no_checks.go.diff 1`] = `
+--- go/jsiicalc/AnyPropertyAccess__no_checks.go	--no-runtime-type-checking
++++ go/jsiicalc/AnyPropertyAccess__no_checks.go	--runtime-type-checking
+@@ -0,0 +1,10 @@
++//go:build no_runtime_type_checking
++
++package jsiicalc
++
++// Building without runtime type checking enabled, so all the below just return nil
++
++func validateAnyPropertyAccess_MutatePropertiesParameters(obj interface{}, propA *string, propB *string, resultProp *string) error {
 +	return nil
 +}
 +

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -3699,6 +3699,7 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┃  ┣━ 📄 IOptionB.java
           ┃                 ┃  ┗━ 📄 UseOptions.java
           ┃                 ┣━ 📄 AnonymousImplementationProvider.java
+          ┃                 ┣━ 📄 AnyPropertyAccess.java
           ┃                 ┣━ 📄 AsyncVirtualMethods.java
           ┃                 ┣━ 📄 AugmentableClass.java
           ┃                 ┣━ 📄 BaseClass.java
@@ -5393,6 +5394,40 @@ public class AnonymousImplementationProvider extends software.amazon.jsii.JsiiOb
     @Override
     public @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe provideAsInterface() {
         return software.amazon.jsii.Kernel.call(this, "provideAsInterface", software.amazon.jsii.NativeType.forClass(software.amazon.jsii.tests.calculator.IAnonymouslyImplementMe.class));
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/AnyPropertyAccess.java 1`] = `
+package software.amazon.jsii.tests.calculator;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.AnyPropertyAccess")
+public class AnyPropertyAccess extends software.amazon.jsii.JsiiObject {
+
+    protected AnyPropertyAccess(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected AnyPropertyAccess(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     * Sets obj[resultProp] to \`\${obj[propA]}+\${obj[propB]}\`.
+     * <p>
+     * @param obj the receiver object. This parameter is required.
+     * @param propA the first property to read. This parameter is required.
+     * @param propB the second property to read. This parameter is required.
+     * @param resultProp the property to write into. This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public static void mutateProperties(final @org.jetbrains.annotations.NotNull java.lang.Object obj, final @org.jetbrains.annotations.NotNull java.lang.String propA, final @org.jetbrains.annotations.NotNull java.lang.String propB, final @org.jetbrains.annotations.NotNull java.lang.String resultProp) {
+        software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.AnyPropertyAccess.class, "mutateProperties", software.amazon.jsii.NativeType.VOID, new Object[] { obj, java.util.Objects.requireNonNull(propA, "propA is required"), java.util.Objects.requireNonNull(propB, "propB is required"), java.util.Objects.requireNonNull(resultProp, "resultProp is required") });
     }
 }
 
@@ -28931,6 +28966,7 @@ jsii-calc.AllTypesEnum=software.amazon.jsii.tests.calculator.AllTypesEnum
 jsii-calc.AllowedMethodNames=software.amazon.jsii.tests.calculator.AllowedMethodNames
 jsii-calc.AmbiguousParameters=software.amazon.jsii.tests.calculator.AmbiguousParameters
 jsii-calc.AnonymousImplementationProvider=software.amazon.jsii.tests.calculator.AnonymousImplementationProvider
+jsii-calc.AnyPropertyAccess=software.amazon.jsii.tests.calculator.AnyPropertyAccess
 jsii-calc.AsyncVirtualMethods=software.amazon.jsii.tests.calculator.AsyncVirtualMethods
 jsii-calc.AugmentableClass=software.amazon.jsii.tests.calculator.AugmentableClass
 jsii-calc.BaseClass=software.amazon.jsii.tests.calculator.BaseClass

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -3490,6 +3490,29 @@ class AmbiguousParameters(
         return typing.cast("Bell", jsii.get(self, "scope"))
 
 
+class AnyPropertyAccess(
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.AnyPropertyAccess",
+):
+    @jsii.member(jsii_name="mutateProperties")
+    @builtins.classmethod
+    def mutate_properties(
+        cls,
+        obj: typing.Any,
+        prop_a: builtins.str,
+        prop_b: builtins.str,
+        result_prop: builtins.str,
+    ) -> None:
+        '''Sets obj[resultProp] to \`\`\${obj[propA]}+\${obj[propB]}\`\`.
+
+        :param obj: the receiver object.
+        :param prop_a: the first property to read.
+        :param prop_b: the second property to read.
+        :param result_prop: the property to write into.
+        '''
+        return typing.cast(None, jsii.sinvoke(cls, "mutateProperties", [obj, prop_a, prop_b, result_prop]))
+
+
 class AsyncVirtualMethods(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.AsyncVirtualMethods",
@@ -11296,6 +11319,7 @@ __all__ = [
     "AllowedMethodNames",
     "AmbiguousParameters",
     "AnonymousImplementationProvider",
+    "AnyPropertyAccess",
     "AsyncVirtualMethods",
     "AugmentableClass",
     "BaseClass",
@@ -14855,7 +14879,24 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [scope_, props_])
  
      @builtins.property
-@@ -480,10 +568,13 @@
+@@ -465,10 +553,16 @@
+         :param obj: the receiver object.
+         :param prop_a: the first property to read.
+         :param prop_b: the second property to read.
+         :param result_prop: the property to write into.
+         '''
++        if __debug__:
++            type_hints = typing.get_type_hints(_typecheckingstub__2e74ece926d1cff82c3a42c02b35b0b5b4427369dfc17caf49b658e36503a986)
++            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(argname="argument prop_a", value=prop_a, expected_type=type_hints["prop_a"])
++            check_type(argname="argument prop_b", value=prop_b, expected_type=type_hints["prop_b"])
++            check_type(argname="argument result_prop", value=result_prop, expected_type=type_hints["result_prop"])
+         return typing.cast(None, jsii.sinvoke(cls, "mutateProperties", [obj, prop_a, prop_b, result_prop]))
+ 
+ 
+ class AsyncVirtualMethods(
+     metaclass=jsii.JSIIMeta,
+@@ -503,10 +597,13 @@
      @jsii.member(jsii_name="overrideMe")
      def override_me(self, mult: jsii.Number) -> jsii.Number:
          '''
@@ -14869,7 +14910,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="overrideMeToo")
      def override_me_too(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeToo", []))
-@@ -544,10 +635,14 @@
+@@ -567,10 +664,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -14884,7 +14925,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
-@@ -608,10 +703,13 @@
+@@ -631,10 +732,13 @@
  
          :param value: the value that should be returned.
  
@@ -14898,7 +14939,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, BurriedAnonymousObject).__jsii_proxy_class__ = lambda : _BurriedAnonymousObjectProxy
  
-@@ -661,18 +759,24 @@
+@@ -684,18 +788,24 @@
      def add(self, value: jsii.Number) -> None:
          '''Adds a number to the current value.
  
@@ -14923,7 +14964,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="neg")
      def neg(self) -> None:
          '''Negates the current value.'''
-@@ -682,10 +786,13 @@
+@@ -705,10 +815,13 @@
      def pow(self, value: jsii.Number) -> None:
          '''Raises the current value by a power.
  
@@ -14937,7 +14978,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readUnionValue")
      def read_union_value(self) -> jsii.Number:
          '''Returns teh value of the union property (if defined).'''
-@@ -717,20 +824,26 @@
+@@ -740,20 +853,26 @@
          '''The current value.'''
          return typing.cast(_scope_jsii_calc_lib_c61f082f.NumericValue, jsii.get(self, "curr"))
  
@@ -14964,7 +15005,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -742,10 +855,13 @@
+@@ -765,10 +884,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -14978,7 +15019,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.CalculatorProps",
-@@ -762,10 +878,14 @@
+@@ -785,10 +907,14 @@
          '''Properties for Calculator.
  
          :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
@@ -14993,7 +15034,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["initial_value"] = initial_value
          if maximum_value is not None:
              self._values["maximum_value"] = maximum_value
-@@ -811,10 +931,13 @@
+@@ -834,10 +960,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -15007,7 +15048,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -825,10 +948,13 @@
+@@ -848,10 +977,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -15021,7 +15062,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithCollections(
      metaclass=jsii.JSIIMeta,
-@@ -841,10 +967,14 @@
+@@ -864,10 +996,14 @@
      ) -> None:
          '''
          :param map: -
@@ -15036,7 +15077,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="createAList")
      @builtins.classmethod
      def create_a_list(cls) -> typing.List[builtins.str]:
-@@ -860,37 +990,49 @@
+@@ -883,37 +1019,49 @@
      def static_array(cls) -> typing.List[builtins.str]:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[builtins.str], jsii.sget(cls, "staticArray"))
  
@@ -15086,7 +15127,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithContainerTypes(
      metaclass=jsii.JSIIMeta,
-@@ -912,10 +1054,15 @@
+@@ -935,10 +1083,15 @@
          :param obj: -
          :param array_prop: 
          :param obj_prop: 
@@ -15102,7 +15143,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          jsii.create(self.__class__, self, [array, record, obj, props])
-@@ -965,17 +1112,23 @@
+@@ -988,17 +1141,23 @@
  ):
      def __init__(self, int: builtins.str) -> None:
          '''
@@ -15126,7 +15167,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="int")
      def int(self) -> builtins.str:
-@@ -994,10 +1147,13 @@
+@@ -1017,10 +1176,13 @@
      def mutable_object(self) -> "IMutableObjectLiteral":
          return typing.cast("IMutableObjectLiteral", jsii.get(self, "mutableObject"))
  
@@ -15140,7 +15181,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithNestedUnion(
      metaclass=jsii.JSIIMeta,
-@@ -1008,10 +1164,13 @@
+@@ -1031,10 +1193,13 @@
          union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]]]],
      ) -> None:
          '''
@@ -15154,7 +15195,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -1022,10 +1181,13 @@
+@@ -1045,10 +1210,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -15168,7 +15209,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ConfusingToJackson(
      metaclass=jsii.JSIIMeta,
-@@ -1056,10 +1218,13 @@
+@@ -1079,10 +1247,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -15182,7 +15223,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ConfusingToJacksonStruct",
-@@ -1073,10 +1238,13 @@
+@@ -1096,10 +1267,13 @@
          union_property: typing.Optional[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, typing.Sequence[typing.Union[_scope_jsii_calc_lib_c61f082f.IFriendly, "AbstractClass"]]]] = None,
      ) -> None:
          '''
@@ -15196,7 +15237,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["union_property"] = union_property
  
      @builtins.property
-@@ -1104,10 +1272,13 @@
+@@ -1127,10 +1301,13 @@
  ):
      def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
          '''
@@ -15210,7 +15251,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Constructors(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Constructors"):
      def __init__(self) -> None:
-@@ -1155,10 +1326,13 @@
+@@ -1178,10 +1355,13 @@
  ):
      def __init__(self, delegate: "IStructReturningDelegate") -> None:
          '''
@@ -15224,7 +15265,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="workItBaby")
      def work_it_baby(self) -> "StructB":
          return typing.cast("StructB", jsii.invoke(self, "workItBaby", []))
-@@ -1187,10 +1361,13 @@
+@@ -1210,10 +1390,13 @@
  
          Returns whether the bell was rung.
  
@@ -15238,7 +15279,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticImplementedByPrivateClass")
      @builtins.classmethod
      def static_implemented_by_private_class(
-@@ -1201,10 +1378,13 @@
+@@ -1224,10 +1407,13 @@
  
          Return whether the bell was rung.
  
@@ -15252,7 +15293,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticImplementedByPublicClass")
      @builtins.classmethod
      def static_implemented_by_public_class(cls, ringer: "IBellRinger") -> builtins.bool:
-@@ -1212,10 +1392,13 @@
+@@ -1235,10 +1421,13 @@
  
          Return whether the bell was rung.
  
@@ -15266,7 +15307,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticWhenTypedAsClass")
      @builtins.classmethod
      def static_when_typed_as_class(cls, ringer: "IConcreteBellRinger") -> builtins.bool:
-@@ -1223,50 +1406,65 @@
+@@ -1246,50 +1435,65 @@
  
          Return whether the bell was rung.
  
@@ -15332,7 +15373,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ConsumersOfThisCrazyTypeSystem(
      metaclass=jsii.JSIIMeta,
-@@ -1281,20 +1479,26 @@
+@@ -1304,20 +1508,26 @@
          obj: "IAnotherPublicInterface",
      ) -> builtins.str:
          '''
@@ -15359,7 +15400,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ContainerProps",
-@@ -1316,10 +1520,15 @@
+@@ -1339,10 +1549,15 @@
          '''
          :param array_prop: 
          :param obj_prop: 
@@ -15375,7 +15416,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "obj_prop": obj_prop,
              "record_prop": record_prop,
          }
-@@ -1385,17 +1594,23 @@
+@@ -1408,17 +1623,23 @@
          data: typing.Mapping[builtins.str, typing.Any],
      ) -> builtins.str:
          '''
@@ -15399,7 +15440,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Default(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Default"):
      '''A class named "Default".
-@@ -1424,10 +1639,15 @@
+@@ -1447,10 +1668,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -15415,7 +15456,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -1485,10 +1705,14 @@
+@@ -1508,10 +1734,14 @@
  
          :deprecated: this constructor is "just" okay
  
@@ -15430,7 +15471,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -1518,10 +1742,13 @@
+@@ -1541,10 +1771,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15444,7 +15485,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.DeprecatedEnum")
  class DeprecatedEnum(enum.Enum):
-@@ -1557,10 +1784,13 @@
+@@ -1580,10 +1813,13 @@
  
          :deprecated: it just wraps a string
  
@@ -15458,7 +15499,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -1625,10 +1855,21 @@
+@@ -1648,10 +1884,21 @@
          :param non_primitive: An example of a non primitive property.
          :param another_optional: This is optional.
          :param optional_any: 
@@ -15480,7 +15521,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "astring": astring,
              "another_required": another_required,
              "bool": bool,
-@@ -1749,10 +1990,16 @@
+@@ -1772,10 +2019,16 @@
          :param hoisted_top: 
          :param left: 
          :param right: 
@@ -15497,7 +15538,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -1810,10 +2057,13 @@
+@@ -1833,10 +2086,13 @@
  class DiamondInheritanceBaseLevelStruct:
      def __init__(self, *, base_level_property: builtins.str) -> None:
          '''
@@ -15511,7 +15552,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -1851,10 +2101,14 @@
+@@ -1874,10 +2130,14 @@
      ) -> None:
          '''
          :param base_level_property: 
@@ -15526,7 +15567,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
          }
  
-@@ -1899,10 +2153,14 @@
+@@ -1922,10 +2182,14 @@
      ) -> None:
          '''
          :param base_level_property: 
@@ -15541,7 +15582,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_mid_level_property": second_mid_level_property,
          }
  
-@@ -1958,10 +2216,16 @@
+@@ -1981,10 +2245,16 @@
          :param base_level_property: 
          :param first_mid_level_property: 
          :param second_mid_level_property: 
@@ -15558,7 +15599,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
              "second_mid_level_property": second_mid_level_property,
              "top_level_property": top_level_property,
-@@ -2041,10 +2305,13 @@
+@@ -2064,10 +2334,13 @@
      @jsii.member(jsii_name="changePrivatePropertyValue")
      def change_private_property_value(self, new_value: builtins.str) -> None:
          '''
@@ -15572,7 +15613,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="privateMethodValue")
      def private_method_value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "privateMethodValue", []))
-@@ -2073,10 +2340,15 @@
+@@ -2096,10 +2369,15 @@
          '''
          :param _required_any: -
          :param _optional_any: -
@@ -15588,7 +15629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2140,10 +2412,14 @@
+@@ -2163,10 +2441,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
@@ -15603,7 +15644,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DummyObj",
-@@ -2153,10 +2429,13 @@
+@@ -2176,10 +2458,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
@@ -15617,7 +15658,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2185,28 +2464,37 @@
+@@ -2208,28 +2493,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
@@ -15655,7 +15696,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2215,20 +2503,26 @@
+@@ -2238,20 +2532,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
@@ -15682,7 +15723,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2241,10 +2535,13 @@
+@@ -2264,10 +2564,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
@@ -15696,7 +15737,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2272,10 +2569,13 @@
+@@ -2295,10 +2598,13 @@
  
          :param word: the value to return.
  
@@ -15710,7 +15751,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2312,10 +2612,14 @@
+@@ -2335,10 +2641,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
@@ -15725,7 +15766,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2343,10 +2647,14 @@
+@@ -2366,10 +2676,14 @@
      ) -> None:
          '''
          :param option1: 
@@ -15740,7 +15781,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2390,10 +2698,14 @@
+@@ -2413,10 +2727,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -15755,7 +15796,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2417,10 +2729,13 @@
+@@ -2440,10 +2758,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15769,7 +15810,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2448,10 +2763,13 @@
+@@ -2471,10 +2792,13 @@
          '''
          :param readonly_property: 
  
@@ -15783,7 +15824,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2481,10 +2799,13 @@
+@@ -2504,10 +2828,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
@@ -15797,7 +15838,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2500,10 +2821,14 @@
+@@ -2523,10 +2850,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
@@ -15812,7 +15853,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2545,10 +2870,14 @@
+@@ -2568,10 +2899,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -15827,7 +15868,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2572,10 +2901,13 @@
+@@ -2595,10 +2930,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15841,7 +15882,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2603,10 +2935,13 @@
+@@ -2626,10 +2964,13 @@
          '''
          :param readonly_property: 
  
@@ -15855,7 +15896,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2749,10 +3084,13 @@
+@@ -2772,10 +3113,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
@@ -15869,7 +15910,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["name"] = name
  
      @builtins.property
-@@ -2789,10 +3127,13 @@
+@@ -2812,10 +3156,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -15883,7 +15924,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2872,10 +3213,13 @@
+@@ -2895,10 +3242,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -15897,7 +15938,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2918,10 +3262,13 @@
+@@ -2941,10 +3291,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
@@ -15911,7 +15952,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -2946,10 +3293,13 @@
+@@ -2969,10 +3322,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -15925,7 +15966,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3005,10 +3355,13 @@
+@@ -3028,10 +3384,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15939,7 +15980,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3063,10 +3416,13 @@
+@@ -3086,10 +3445,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15953,7 +15994,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3108,10 +3464,13 @@
+@@ -3131,10 +3493,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -15967,7 +16008,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3157,10 +3516,13 @@
+@@ -3180,10 +3545,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15981,7 +16022,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3342,10 +3704,14 @@
+@@ -3365,10 +3733,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -15996,7 +16037,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3380,10 +3746,13 @@
+@@ -3403,10 +3775,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16010,7 +16051,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3413,10 +3782,13 @@
+@@ -3436,10 +3811,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -16024,7 +16065,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -3936,10 +4308,13 @@
+@@ -3959,10 +4337,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -16038,7 +16079,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -3975,19 +4350,25 @@
+@@ -3998,19 +4379,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -16064,7 +16105,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4020,10 +4401,13 @@
+@@ -4043,10 +4430,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -16078,7 +16119,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4216,10 +4600,13 @@
+@@ -4239,10 +4629,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16092,7 +16133,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4286,10 +4673,13 @@
+@@ -4309,10 +4702,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -16106,7 +16147,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4335,10 +4725,13 @@
+@@ -4358,10 +4754,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16120,7 +16161,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4356,10 +4749,15 @@
+@@ -4379,10 +4778,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -16136,7 +16177,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4434,10 +4832,13 @@
+@@ -4457,10 +4861,13 @@
          count: jsii.Number,
      ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
@@ -16150,7 +16191,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4542,19 +4943,25 @@
+@@ -4565,19 +4972,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -16176,7 +16217,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4776,10 +5183,13 @@
+@@ -4799,10 +5212,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -16190,7 +16231,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4881,10 +5291,13 @@
+@@ -4904,10 +5320,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -16204,7 +16245,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4914,10 +5327,13 @@
+@@ -4937,10 +5356,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -16218,7 +16259,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -4951,10 +5367,13 @@
+@@ -4974,10 +5396,13 @@
              '''
              :param prop: 
              '''
@@ -16232,7 +16273,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -4989,10 +5408,13 @@
+@@ -5012,10 +5437,13 @@
          '''
          :param prop: 
          '''
@@ -16246,7 +16287,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5040,10 +5462,17 @@
+@@ -5063,10 +5491,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -16264,7 +16305,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5170,10 +5599,14 @@
+@@ -5193,10 +5628,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16279,7 +16320,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5221,10 +5654,13 @@
+@@ -5244,10 +5683,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -16293,7 +16334,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5295,17 +5731,24 @@
+@@ -5318,17 +5760,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -16318,7 +16359,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5333,10 +5776,13 @@
+@@ -5356,10 +5805,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -16332,7 +16373,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5355,10 +5801,14 @@
+@@ -5378,10 +5830,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -16347,7 +16388,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5393,17 +5843,23 @@
+@@ -5416,17 +5872,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
@@ -16371,7 +16412,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5413,10 +5869,13 @@
+@@ -5436,10 +5898,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
@@ -16385,7 +16426,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5434,10 +5893,13 @@
+@@ -5457,10 +5922,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -16399,7 +16440,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5445,10 +5907,13 @@
+@@ -5468,10 +5936,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -16413,7 +16454,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5489,10 +5954,13 @@
+@@ -5512,10 +5983,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
@@ -16427,7 +16468,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5515,10 +5983,15 @@
+@@ -5538,10 +6012,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16443,7 +16484,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5543,10 +6016,13 @@
+@@ -5566,10 +6045,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16457,7 +16498,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["field"] = field
  
      @builtins.property
-@@ -5622,10 +6098,13 @@
+@@ -5645,10 +6127,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -16471,7 +16512,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5637,10 +6116,13 @@
+@@ -5660,10 +6145,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
@@ -16485,7 +16526,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5662,10 +6144,14 @@
+@@ -5685,10 +6173,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -16500,7 +16541,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5695,10 +6181,15 @@
+@@ -5718,10 +6210,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -16516,7 +16557,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5751,10 +6242,13 @@
+@@ -5774,10 +6271,13 @@
          scope: _scope_jsii_calc_lib_c61f082f.Number,
      ) -> _scope_jsii_calc_lib_c61f082f.Number:
          '''
@@ -16530,7 +16571,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5765,10 +6259,13 @@
+@@ -5788,10 +6288,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -16544,7 +16585,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5823,10 +6320,15 @@
+@@ -5846,10 +6349,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -16560,7 +16601,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5841,10 +6343,13 @@
+@@ -5864,10 +6372,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16574,7 +16615,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5861,10 +6366,14 @@
+@@ -5884,10 +6395,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -16589,7 +16630,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -6087,10 +6596,13 @@
+@@ -6110,10 +6625,13 @@
          value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
      ) -> None:
          '''
@@ -16603,7 +16644,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6101,10 +6613,13 @@
+@@ -6124,10 +6642,13 @@
      @foo.setter
      def foo(
          self,
@@ -16617,7 +16658,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6146,10 +6661,14 @@
+@@ -6169,10 +6690,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -16632,7 +16673,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6216,17 +6735,25 @@
+@@ -6239,17 +6764,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16658,7 +16699,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6238,10 +6765,15 @@
+@@ -6261,10 +6794,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -16674,7 +16715,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6260,10 +6792,14 @@
+@@ -6283,10 +6821,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -16689,7 +16730,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6325,10 +6861,13 @@
+@@ -6348,10 +6890,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -16703,7 +16744,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6347,10 +6886,13 @@
+@@ -6370,10 +6915,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -16717,7 +16758,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6374,10 +6916,14 @@
+@@ -6397,10 +6945,14 @@
      ) -> None:
          '''
          :param property: 
@@ -16732,7 +16773,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6428,10 +6974,14 @@
+@@ -6451,10 +7003,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -16747,7 +16788,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6446,10 +6996,13 @@
+@@ -6469,10 +7025,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16761,7 +16802,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6465,10 +7018,13 @@
+@@ -6488,10 +7047,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -16775,7 +16816,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6505,10 +7061,13 @@
+@@ -6528,10 +7090,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -16789,7 +16830,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6538,19 +7097,25 @@
+@@ -6561,19 +7126,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -16815,7 +16856,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6587,19 +7152,25 @@
+@@ -6610,19 +7181,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -16841,7 +16882,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6622,10 +7193,13 @@
+@@ -6645,10 +7222,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -16855,7 +16896,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6648,10 +7222,15 @@
+@@ -6671,10 +7251,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -16871,7 +16912,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6709,10 +7288,15 @@
+@@ -6732,10 +7317,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -16887,7 +16928,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6764,10 +7348,14 @@
+@@ -6787,10 +7377,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -16902,7 +16943,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6810,10 +7398,14 @@
+@@ -6833,10 +7427,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -16917,7 +16958,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6828,10 +7420,13 @@
+@@ -6851,10 +7449,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -16931,7 +16972,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6848,10 +7443,13 @@
+@@ -6871,10 +7472,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -16945,7 +16986,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6859,18 +7457,24 @@
+@@ -6882,18 +7486,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -16970,7 +17011,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6884,10 +7488,13 @@
+@@ -6907,10 +7517,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -16984,7 +17025,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6924,10 +7531,14 @@
+@@ -6947,10 +7560,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -16999,7 +17040,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -6983,10 +7594,16 @@
+@@ -7006,10 +7623,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -17016,7 +17057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7056,10 +7673,13 @@
+@@ -7079,10 +7702,13 @@
      @parts.setter
      def parts(
          self,
@@ -17030,7 +17071,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7075,10 +7695,14 @@
+@@ -7098,10 +7724,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -17045,7 +17086,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -7127,10 +7751,13 @@
+@@ -7150,10 +7780,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -17059,7 +17100,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7168,17 +7795,23 @@
+@@ -7191,17 +7824,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -17083,7 +17124,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7198,17 +7831,23 @@
+@@ -7221,17 +7860,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -17107,7 +17148,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7219,46 +7858,61 @@
+@@ -7242,46 +7887,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -17169,7 +17210,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7341,10 +7995,15 @@
+@@ -7364,10 +8024,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17185,7 +17226,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7435,10 +8094,13 @@
+@@ -7458,10 +8123,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17199,7 +17240,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -7469,10 +8131,14 @@
+@@ -7492,10 +8160,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -17214,7 +17255,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7509,10 +8175,13 @@
+@@ -7532,10 +8204,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -17228,7 +17269,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
-@@ -7555,10 +8224,13 @@
+@@ -7578,10 +8253,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
@@ -17242,7 +17283,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7569,17 +8241,23 @@
+@@ -7592,17 +8270,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
@@ -17266,7 +17307,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7589,25 +8267,34 @@
+@@ -7612,25 +8296,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -17301,7 +17342,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7616,10 +8303,14 @@
+@@ -7639,10 +8332,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -17316,7 +17357,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7627,19 +8318,25 @@
+@@ -7650,19 +8347,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
@@ -17342,7 +17383,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7651,38 +8348,53 @@
+@@ -7674,38 +8377,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -17396,7 +17437,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7730,10 +8442,13 @@
+@@ -7753,10 +8471,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -17410,7 +17451,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7774,10 +8489,13 @@
+@@ -7797,10 +8518,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -17424,7 +17465,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7793,10 +8511,14 @@
+@@ -7816,10 +8540,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -17439,7 +17480,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7840,10 +8562,13 @@
+@@ -7863,10 +8591,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -17453,7 +17494,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7854,10 +8579,14 @@
+@@ -7877,10 +8608,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -17468,7 +17509,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7898,37 +8627,49 @@
+@@ -7921,37 +8656,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17518,7 +17559,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -7943,37 +8684,49 @@
+@@ -7966,37 +8713,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17568,7 +17609,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -7991,10 +8744,14 @@
+@@ -8014,10 +8773,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -17583,7 +17624,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8005,10 +8762,13 @@
+@@ -8028,10 +8791,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17597,7 +17638,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8123,10 +8883,13 @@
+@@ -8146,10 +8912,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -17611,7 +17652,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8147,10 +8910,13 @@
+@@ -8170,10 +8939,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17625,7 +17666,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8210,10 +8976,16 @@
+@@ -8233,10 +9005,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -17642,7 +17683,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8509,5 +9281,1522 @@
+@@ -8533,5 +9311,1531 @@
  from . import nodirect
  from . import onlystatic
  from . import python_self
@@ -17820,6 +17861,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 +    *,
 +    scope: builtins.str,
 +    props: typing.Optional[builtins.bool] = None,
++) -> None:
++    """Type checking stubs"""
++    pass
++
++def _typecheckingstub__2e74ece926d1cff82c3a42c02b35b0b5b4427369dfc17caf49b658e36503a986(
++    obj: typing.Any,
++    prop_a: builtins.str,
++    prop_b: builtins.str,
++    result_prop: builtins.str,
 +) -> None:
 +    """Type checking stubs"""
 +    pass

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -833,6 +833,20 @@ exports[`jsii-tree --all 1`] = `
  │   │   │ └── returns: jsii-calc.Implementation
  │   │   └─┬ provideAsInterface() method (stable)
  │   │     └── returns: jsii-calc.IAnonymouslyImplementMe
+ │   ├─┬ class AnyPropertyAccess (stable)
+ │   │ └─┬ members
+ │   │   └─┬ static mutateProperties(obj,propA,propB,resultProp) method (stable)
+ │   │     ├── static
+ │   │     ├─┬ parameters
+ │   │     │ ├─┬ obj
+ │   │     │ │ └── type: any
+ │   │     │ ├─┬ propA
+ │   │     │ │ └── type: string
+ │   │     │ ├─┬ propB
+ │   │     │ │ └── type: string
+ │   │     │ └─┬ resultProp
+ │   │     │   └── type: string
+ │   │     └── returns: void
  │   ├─┬ class AsyncVirtualMethods (stable)
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer (stable)
@@ -3856,6 +3870,7 @@ exports[`jsii-tree --inheritance 1`] = `
  │   ├── class AmbiguousParameters
  │   ├─┬ class AnonymousImplementationProvider
  │   │ └── interfaces: IAnonymousImplementationProvider
+ │   ├── class AnyPropertyAccess
  │   ├── class AsyncVirtualMethods
  │   ├── class AugmentableClass
  │   ├── class BaseClass
@@ -4612,6 +4627,9 @@ exports[`jsii-tree --members 1`] = `
  │   │   ├── <initializer>() initializer
  │   │   ├── provideAsClass() method
  │   │   └── provideAsInterface() method
+ │   ├─┬ class AnyPropertyAccess
+ │   │ └─┬ members
+ │   │   └── static mutateProperties(obj,propA,propB,resultProp) method
  │   ├─┬ class AsyncVirtualMethods
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -6069,6 +6087,7 @@ exports[`jsii-tree --types 1`] = `
  │   ├── class AllowedMethodNames
  │   ├── class AmbiguousParameters
  │   ├── class AnonymousImplementationProvider
+ │   ├── class AnyPropertyAccess
  │   ├── class AsyncVirtualMethods
  │   ├── class AugmentableClass
  │   ├── class BaseClass

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -1010,6 +1010,20 @@ exports[`showAll 1`] = `
  │   │   │ └── returns: jsii-calc.Implementation
  │   │   └─┬ provideAsInterface() method
  │   │     └── returns: jsii-calc.IAnonymouslyImplementMe
+ │   ├─┬ class AnyPropertyAccess
+ │   │ └─┬ members
+ │   │   └─┬ static mutateProperties(obj,propA,propB,resultProp) method
+ │   │     ├── static
+ │   │     ├─┬ parameters
+ │   │     │ ├─┬ obj
+ │   │     │ │ └── type: any
+ │   │     │ ├─┬ propA
+ │   │     │ │ └── type: string
+ │   │     │ ├─┬ propB
+ │   │     │ │ └── type: string
+ │   │     │ └─┬ resultProp
+ │   │     │   └── type: string
+ │   │     └── returns: void
  │   ├─┬ class AsyncVirtualMethods
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
@@ -4054,6 +4068,7 @@ exports[`types 1`] = `
  │   ├── class AllowedMethodNames
  │   ├── class AmbiguousParameters
  │   ├── class AnonymousImplementationProvider
+ │   ├── class AnyPropertyAccess
  │   ├── class AsyncVirtualMethods
  │   ├── class AugmentableClass
  │   ├── class BaseClass

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -32,6 +32,7 @@ exports[`TypeSystem.classes lists all the classes in the typesystem 1`] = `
   "jsii-calc.AllowedMethodNames",
   "jsii-calc.AmbiguousParameters",
   "jsii-calc.AnonymousImplementationProvider",
+  "jsii-calc.AnyPropertyAccess",
   "jsii-calc.AsyncVirtualMethods",
   "jsii-calc.AugmentableClass",
   "jsii-calc.BaseClass",


### PR DESCRIPTION
When passing arbitrary structs through an `interface{}` type, the JS value had no properties or methods, leading to it having an empty object JSON representation.

In order to improve the situation, discover exported properties of such structs, and register them as property callbacks, more closely matching the behavior of JS in the same configuration.

The callbacks use the same naming transformation as the standard JSON serialization mechanism in go: using the `json` tag if present with the same semantics as `encoding/json`, and fall back to the raw field name otherwise (with no case conversion applied).

Related: cdk8s-team/cdk8s#1326



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
