### PR TITLE
chore: fix 1.83.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.83.0](https://github.com/aws/jsii/compare/v1.82.0...v1.83.0) (2023-06-07)
 
-
-### Features
-
-* **go:** register exported properties as callbacks ([#4104](https://github.com/aws/jsii/issues/4104)) ([fa921ec](https://github.com/aws/jsii/commit/fa921ecfb1dab52144e89cbbeeba0b334779cde9)), closes [cdk8s-team/cdk8s#1326](https://github.com/cdk8s-team/cdk8s/issues/1326)
-* **superchain:** switch to JDK 20 ([#4082](https://github.com/aws/jsii/issues/4082)) ([f0a1dfc](https://github.com/aws/jsii/commit/f0a1dfce8edb06a1b71758b49886580e6ee271ff))
-
-
-### Bug Fixes
-
-* **jsii-pacmak:** disable `doclint` ([#4103](https://github.com/aws/jsii/issues/4103)) ([30afa09](https://github.com/aws/jsii/commit/30afa095e296d71d3700a2a56a36483a92c5457d))
-* **jsii-pacmak:** emit correct `[@return](https://github.com/return)` tag for JavaDocs ([#4095](https://github.com/aws/jsii/issues/4095)) ([fc7ab7c](https://github.com/aws/jsii/commit/fc7ab7c57f4a94949794cc963bbf644ad491d246))
-* **jsii-pacmak:** escape documentation in all positions ([#4096](https://github.com/aws/jsii/issues/4096)) ([6a2248d](https://github.com/aws/jsii/commit/6a2248dde982d2758976cc1b5d4c3e7676b0f204))
-* **pacmak:** _ is not treated as a keyword in Java  ([#4094](https://github.com/aws/jsii/issues/4094)) ([eaaf3ee](https://github.com/aws/jsii/commit/eaaf3ee20ad64ba5d5ed4441aa12f27f024e7c85))
-
 ## [1.82.0](https://github.com/aws/jsii/compare/v1.81.0...v1.82.0) (2023-05-22)
 
 


### PR DESCRIPTION
These were generated incorrectly during the release because the previous release PR was accidentally squashed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
