### PR TITLE
feat(jsii): allow specifying a deprecation message regardless of stability

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -2125,7 +2125,14 @@ class Package {
       scripts,
     };
 
-    switch (this.metadata.docs?.stability) {
+    // Packages w/ a deprecated message may have a non-deprecated stability (e.g: when EoL happens
+    // for a stable package). We pretend it's deprecated for the purpose of trove classifiers when
+    // this happens.
+    switch (
+      this.metadata.docs?.deprecated
+        ? spec.Stability.Deprecated
+        : this.metadata.docs?.stability
+    ) {
       case spec.Stability.Experimental:
         setupKwargs.classifiers.push('Development Status :: 4 - Beta');
         break;

--- a/packages/jsii/lib/project-info.ts
+++ b/packages/jsii/lib/project-info.ts
@@ -484,7 +484,7 @@ function _validateStability(
   if (!stability && deprecated) {
     stability = spec.Stability.Deprecated;
   } else if (deprecated && stability !== spec.Stability.Deprecated) {
-    throw new Error(
+    console.warn(
       `Package is deprecated (${deprecated}), but it's stability is ${stability} and not ${spec.Stability.Deprecated}`,
     );
   }


### PR DESCRIPTION
Previously, `jsii` required the package's stability to be `deprecated` if there cas a `deprecated` message configured. This is however problematic when a `stable` package reaches End-of-Support and the maintainer wants to signal this in npmjs.com.

Instead of failing, only log a warning to possibly raise awareness on an unintended configuration.

Additionally - emit the `Development Status :: 7 - Inactive` trove classifier on packages with a `deprecated` message, even if their stability is not `deprecated`.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
