### PR TITLE
chore: fix confusing comment about FD number 4 that does not exist

### DIFF
--- a/packages/@jsii/runtime/bin/jsii-runtime.ts
+++ b/packages/@jsii/runtime/bin/jsii-runtime.ts
@@ -9,8 +9,7 @@ import { Duplex } from 'stream';
 // Spawn another node process, with the following file descriptor setup:
 // - No STDIN will be provided
 // - STDOUT and STDERR will be intercepted, contents wrapped & forward to STDERR
-// - FD#3 is the communication pipe to read jsii API messages
-// - FD#4 is the communication pipe to write jsii API responses
+// - FD#3 is the communication pipe to read & write jsii API messages
 const child = spawn(
   process.execPath,
   [...process.execArgv, resolve(__dirname, '..', 'lib', 'program.js')],


### PR DESCRIPTION
This was leftover from a time when we tried using non-duplex streams, but since we are using a single duplex stream there's only 4 FDs (0 through 3), and not 5.

Thanks to @TimothyJones for finding it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
