### PR TITLE
chore(superchain): maven version, docs: CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,8 @@ our own CI/CD: the ["superchain" image][superchain] from.
 The image can be built for local usage, too:
 
 ```console
-$ cd jsii # go to the root of the jsii repo
 $ IMAGE=superchain
-$ docker buildx build -t $IMAGE --target $IMAGE -f superchain/Dockerfile .
+$ docker build -t ${IMAGE} -f superchain/Dockerfile .
 ```
 
 In order to get an interactive shell within a Docker container using the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ our own CI/CD: the ["superchain" image][superchain] from.
 The image can be built for local usage, too:
 
 ```console
+$ cd jsii # go to the root of the jsii repo
 $ IMAGE=superchain
-$ docker build -t ${IMAGE} ./superchain
+$ docker buildx build -t $IMAGE -f superchain/Dockerfile .
 ```
 
 In order to get an interactive shell within a Docker container using the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The image can be built for local usage, too:
 ```console
 $ cd jsii # go to the root of the jsii repo
 $ IMAGE=superchain
-$ docker buildx build -t $IMAGE -f superchain/Dockerfile .
+$ docker buildx build -t $IMAGE --target $IMAGE -f superchain/Dockerfile .
 ```
 
 In order to get an interactive shell within a Docker container using the

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -39,7 +39,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
 SHELL ["/bin/zsh", "-c"]
 
 # Prepare maven binary distribution
-ARG M2_VERSION="3.9.2"
+ARG M2_VERSION="3.9.3"
 ENV M2_DISTRO="https://www.apache.org/dist/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                             \


### PR DESCRIPTION
This PR resolves Issue #4080 and bumps version of the maven from `3.9.2` to `3.9.3`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
