### PR TITLE
fix: export transliterateAssembly and fix bug with transliterate cli (backport)

### DIFF
--- a/packages/jsii-rosetta/bin/jsii-rosetta.ts
+++ b/packages/jsii-rosetta/bin/jsii-rosetta.ts
@@ -288,7 +288,6 @@ function main() {
             describe: 'Assembly to transliterate',
           })
           .option('language', {
-            alias: 'l',
             type: 'string',
             array: true,
             default: [],
@@ -319,15 +318,17 @@ function main() {
         );
         const languages =
           args.language.length > 0
-            ? args.language.map((lang) => {
-                const target = Object.entries(TargetLanguage).find(([k]) => k === lang)?.[1];
-                if (target == null) {
-                  throw new Error(
-                    `Unknown target language: ${lang}. Expected one of ${Object.keys(TargetLanguage).join(', ')}`,
-                  );
-                }
-                return target;
-              })
+            ? args.language
+                .map((lang) => lang.toUpperCase())
+                .map((lang) => {
+                  const target = Object.entries(TargetLanguage).find(([k]) => k === lang)?.[1];
+                  if (target == null) {
+                    throw new Error(
+                      `Unknown target language: ${lang}. Expected one of ${Object.keys(TargetLanguage).join(', ')}`,
+                    );
+                  }
+                  return target;
+                })
             : Object.values(TargetLanguage);
         return transliterateAssembly(assemblies, languages, args);
       }),

--- a/packages/jsii-rosetta/lib/index.ts
+++ b/packages/jsii-rosetta/lib/index.ts
@@ -12,4 +12,5 @@ export * from './rosetta-reader';
 export * from './rosetta-translator';
 export * from './snippet';
 export * from './markdown';
+export * from './commands/transliterate';
 export * from './strict';


### PR DESCRIPTION
Backport of https://github.com/aws/jsii-rosetta/pull/121

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
