### PR TITLE
chore: fix pr labeler workflow does not trigger auto-approval

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
     - run: gh pr edit ${{ github.event.pull_request.number }} --add-label "auto-approve" -R ${{ github.repository }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,4 +16,7 @@ jobs:
     steps:
     - run: gh pr edit ${{ github.event.pull_request.number }} --add-label "auto-approve" -R ${{ github.repository }}
       env:
+        # This workflow is intended to trigger the `auto-approve` workflow by adding a label to the PR
+        # In order for this to happen, it must run as the automation user and not the github-actions bot
+        # It is an intentional limitation by GitHub that the github-actions bot (identified by using `secrets.GITHUB_TOKEN`) cannot trigger other workflows
         GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}


### PR DESCRIPTION
The pr labeler workflow must run as the automation user and not the github-actions bot in order to trigger other workflows. This is an intentional limitation by GitHub.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
