### PR TITLE
chore: use node 16 in upgrade workflows

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 14
+          node-version: 16
 
       - name: Install Tools
         run: |-


### PR DESCRIPTION
Our dependencies are starting to [reject](https://github.com/aws/jsii/actions/runs/5532321392/jobs/10105940432) node 14.

```console
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
error @typescript-eslint/eslint-plugin@[6](https://github.com/aws/jsii/actions/runs/5532321392/jobs/10105940432#step:8:7).0.0: The engine "node" is incompatible with this module. Expected version "^16.0.0 || >=18.0.0". Got "14.21.3"
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
