### PR TITLE
feat(python): deprecation message when using Python <= 3.7

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/__init__.py
+++ b/packages/@jsii/python-runtime/src/jsii/__init__.py
@@ -37,12 +37,12 @@ sinvoke = kernel.sinvoke
 stats = kernel.stats
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from platform import python_version
     import warnings
 
     warnings.warn(
-        f"WARNING: You are using python release {python_version()}, which has reached end-of-life! Support for EOL Python releases may be dropped in the future. Please consider upgrading to Python >= 3.7 as soon as possible.",
+        f"WARNING: You are using python release {python_version()}, which has reached end-of-life! Support for EOL Python releases may be dropped in the future. Please consider upgrading to Python >= 3.8 as soon as possible.",
     )
 
 

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -57,7 +57,6 @@ class TestInvokeBinScript:
         assert result.returncode == 0
         assert result.stdout == b"Hello World!\n  arguments: arg1, arg2\n"
 
-
     @pytest.mark.skipif(
         platform.system() == "Windows",
         reason="jsii-pacmak does not generate windows scripts",

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 from datetime import datetime
 import pytest
+import sys
 
 
 @pytest.fixture()
@@ -44,7 +45,6 @@ class TestInvokeBinScript:
 
         assert result.returncode == 0
         assert result.stdout == b"Hello World!\n"
-        assert result.stderr == b""
 
     @pytest.mark.skipif(
         platform.system() == "Windows",
@@ -56,7 +56,7 @@ class TestInvokeBinScript:
 
         assert result.returncode == 0
         assert result.stdout == b"Hello World!\n  arguments: arg1, arg2\n"
-        assert result.stderr == b""
+
 
     @pytest.mark.skipif(
         platform.system() == "Windows",
@@ -70,7 +70,7 @@ class TestInvokeBinScript:
 
         assert result.returncode == 3
         assert result.stdout == b"Hello World!\n  arguments: arg1, fail\n"
-        assert result.stderr == b"error message to stderr\n"
+        assert result.stderr.endswith(b"error message to stderr\n")
 
     @pytest.mark.skipif(
         platform.system() == "Windows",

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -3,7 +3,6 @@ import platform
 import subprocess
 from datetime import datetime
 import pytest
-import sys
 
 
 @pytest.fixture()

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -69,7 +69,7 @@ class TestInvokeBinScript:
 
         assert result.returncode == 3
         assert result.stdout == b"Hello World!\n  arguments: arg1, fail\n"
-        assert result.stderr.endswith(b"error message to stderr\n")
+        assert result.stderr.startswith(b"error message to stderr\n")
 
     @pytest.mark.skipif(
         platform.system() == "Windows",


### PR DESCRIPTION
As Python 3.7 has reached end-of-life on 2023-06-27, we will now be warning customers using it, and prompting them to upgrade to Python 3.8 or newer at their earliest convenience.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
