### PR TITLE
fix(jsii-pacmak): comment lines should not contain comment ending

### DIFF
--- a/packages/jsii-calc/bin/run.ts
+++ b/packages/jsii-calc/bin/run.ts
@@ -13,7 +13,7 @@ const runCommand = async () => {
 
     if (args.includes('delay')) {
       for (let i = 1; i <= 5; i++) {
-        console.log('sleeping 1s', i);
+        console.log(`sleeping 1s ${i}`);
         // eslint-disable-next-line no-await-in-loop
         await delay(1000);
       }

--- a/packages/jsii-calc/lib/documented.ts
+++ b/packages/jsii-calc/lib/documented.ts
@@ -40,11 +40,8 @@ export class DocumentedClass {
   }
 
   /**
-  * The relative resource name identifying the VPC network that is using this configuration.
+  * Some comments have an escaped star backslash in them, ending the comment if left unescaped.
 For example: 'projects/*\/global/networks/network-1'.
-Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-  * 
-  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
   */
   public moin(): void {
     process.stdout.write('servus');

--- a/packages/jsii-calc/lib/documented.ts
+++ b/packages/jsii-calc/lib/documented.ts
@@ -40,11 +40,12 @@ export class DocumentedClass {
   }
 
   /**
-   * Say Moin, which is German for "Good morning"
-   * *\/ (this comment is escaped because it contains a star slash)
-   *
-   * @experimental
-   */
+  * The relative resource name identifying the VPC network that is using this configuration.
+For example: 'projects/*\/global/networks/network-1'.
+Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
+  */
   public moin(): void {
     process.stdout.write('servus');
   }

--- a/packages/jsii-calc/lib/documented.ts
+++ b/packages/jsii-calc/lib/documented.ts
@@ -38,6 +38,16 @@ export class DocumentedClass {
   public hola(): void {
     process.stdout.write('bonjour');
   }
+
+  /**
+   * Say Moin, which is German for "Good morning"
+   * *\/ (this comment is escaped because it contains a star slash)
+   *
+   * @experimental
+   */
+  public moin(): void {
+    process.stdout.write('servus');
+  }
 }
 
 /**

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -5077,13 +5077,13 @@
         },
         {
           "docs": {
-            "remarks": "For example: 'projects/*\\/global/networks/network-1'.\nCurrently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.\n\nDocs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}",
+            "remarks": "For example: 'projects/*\\/global/networks/network-1'.",
             "stability": "stable",
-            "summary": "The relative resource name identifying the VPC network that is using this configuration."
+            "summary": "Some comments have an escaped star backslash in them, ending the comment if left unescaped."
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 49
+            "line": 46
           },
           "name": "moin"
         }
@@ -5155,7 +5155,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 85
+        "line": 82
       },
       "name": "DontUseMe",
       "properties": [
@@ -5169,7 +5169,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 91
+            "line": 88
           },
           "name": "dontSetMe",
           "optional": true,
@@ -6229,7 +6229,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 57
+        "line": 54
       },
       "name": "Greetee",
       "properties": [
@@ -6243,7 +6243,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 63
+            "line": 60
           },
           "name": "name",
           "optional": true,
@@ -11152,7 +11152,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 72
+        "line": 69
       },
       "methods": [
         {
@@ -11162,7 +11162,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 76
+            "line": 73
           },
           "name": "doAThing"
         }
@@ -16074,7 +16074,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 99
+        "line": 96
       },
       "name": "WeirdDocs",
       "properties": [
@@ -16086,7 +16086,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 105
+            "line": 102
           },
           "name": "dontReadMe",
           "optional": true,
@@ -18996,5 +18996,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "x/t8QvSwKsWT5uRlWN9P+Au/6XXaEJfXFLQ4Zi+sroQ="
+  "fingerprint": "qoT4xo5rhn5qx9EIbP7DMeSFV9/lr8qwScm8SvGRZE4="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -5074,6 +5074,17 @@
             "line": 38
           },
           "name": "hola"
+        },
+        {
+          "docs": {
+            "stability": "experimental",
+            "summary": "Say Moin, which is German for \"Good morning\" *\\/ (this comment is escaped because it contains a star slash)."
+          },
+          "locationInModule": {
+            "filename": "lib/documented.ts",
+            "line": 48
+          },
+          "name": "moin"
         }
       ],
       "name": "DocumentedClass",
@@ -5143,7 +5154,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 74
+        "line": 84
       },
       "name": "DontUseMe",
       "properties": [
@@ -5157,7 +5168,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 80
+            "line": 90
           },
           "name": "dontSetMe",
           "optional": true,
@@ -6217,7 +6228,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 46
+        "line": 56
       },
       "name": "Greetee",
       "properties": [
@@ -6231,7 +6242,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 52
+            "line": 62
           },
           "name": "name",
           "optional": true,
@@ -11140,7 +11151,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 61
+        "line": 71
       },
       "methods": [
         {
@@ -11150,7 +11161,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 65
+            "line": 75
           },
           "name": "doAThing"
         }
@@ -16062,7 +16073,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 88
+        "line": 98
       },
       "name": "WeirdDocs",
       "properties": [
@@ -16074,7 +16085,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 94
+            "line": 104
           },
           "name": "dontReadMe",
           "optional": true,
@@ -18984,5 +18995,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "P8PbBkSVSEXGN8+6wTvu1VFR499+MbQMrLXt+jdZgBo="
+  "fingerprint": "1znLDac1syH7Up70HRPGedZwlc6AY4p6CgCfyvVUXLQ="
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -5077,12 +5077,13 @@
         },
         {
           "docs": {
-            "stability": "experimental",
-            "summary": "Say Moin, which is German for \"Good morning\" *\\/ (this comment is escaped because it contains a star slash)."
+            "remarks": "For example: 'projects/*\\/global/networks/network-1'.\nCurrently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.\n\nDocs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}",
+            "stability": "stable",
+            "summary": "The relative resource name identifying the VPC network that is using this configuration."
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 48
+            "line": 49
           },
           "name": "moin"
         }
@@ -5154,7 +5155,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 84
+        "line": 85
       },
       "name": "DontUseMe",
       "properties": [
@@ -5168,7 +5169,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 90
+            "line": 91
           },
           "name": "dontSetMe",
           "optional": true,
@@ -6228,7 +6229,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 56
+        "line": 57
       },
       "name": "Greetee",
       "properties": [
@@ -6242,7 +6243,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 62
+            "line": 63
           },
           "name": "name",
           "optional": true,
@@ -11151,7 +11152,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 71
+        "line": 72
       },
       "methods": [
         {
@@ -11161,7 +11162,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 75
+            "line": 76
           },
           "name": "doAThing"
         }
@@ -16073,7 +16074,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/documented.ts",
-        "line": 98
+        "line": 99
       },
       "name": "WeirdDocs",
       "properties": [
@@ -16085,7 +16086,7 @@
           },
           "locationInModule": {
             "filename": "lib/documented.ts",
-            "line": 104
+            "line": 105
           },
           "name": "dontReadMe",
           "optional": true,
@@ -18995,5 +18996,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "1znLDac1syH7Up70HRPGedZwlc6AY4p6CgCfyvVUXLQ="
+  "fingerprint": "x/t8QvSwKsWT5uRlWN9P+Au/6XXaEJfXFLQ4Zi+sroQ="
 }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2808,7 +2808,7 @@ class JavaGenerator extends Generator {
 
     this.code.line('/**');
     for (const line of lines) {
-      this.code.line(` * ${line}`);
+      this.code.line(` * ${escapeEndingComment(line)}`);
     }
     this.code.line(' */');
   }
@@ -3676,4 +3676,9 @@ function myMarkDownToJavaDoc(source: string) {
 
 function stripNewLines(x: string) {
   return x.replace(/\n/g, '');
+}
+
+// Replace */ with *\/ to avoid closing the comment block
+function escapeEndingComment(x: string) {
+  return x.replace(/\*\//g, '*\\/');
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -7309,6 +7309,16 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
         {
             InvokeInstanceVoidMethod(new System.Type[]{}, new object[]{});
         }
+
+        /// <summary>(experimental) Say Moin, which is German for "Good morning" *\\/ (this comment is escaped because it contains a star slash).</summary>
+        /// <remarks>
+        /// <strong>Stability</strong>: Experimental
+        /// </remarks>
+        [JsiiMethod(name: "moin")]
+        public virtual void Moin()
+        {
+            InvokeInstanceVoidMethod(new System.Type[]{}, new object[]{});
+        }
     }
 }
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -7310,12 +7310,9 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             InvokeInstanceVoidMethod(new System.Type[]{}, new object[]{});
         }
 
-        /// <summary>The relative resource name identifying the VPC network that is using this configuration.</summary>
+        /// <summary>Some comments have an escaped star backslash in them, ending the comment if left unescaped.</summary>
         /// <remarks>
         /// For example: 'projects/*/global/networks/network-1'.
-        /// Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-        ///
-        /// Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
         /// </remarks>
         [JsiiMethod(name: "moin")]
         public virtual void Moin()

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -7310,9 +7310,12 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             InvokeInstanceVoidMethod(new System.Type[]{}, new object[]{});
         }
 
-        /// <summary>(experimental) Say Moin, which is German for "Good morning" *\\/ (this comment is escaped because it contains a star slash).</summary>
+        /// <summary>The relative resource name identifying the VPC network that is using this configuration.</summary>
         /// <remarks>
-        /// <strong>Stability</strong>: Experimental
+        /// For example: 'projects/*/global/networks/network-1'.
+        /// Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+        ///
+        /// Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
         /// </remarks>
         [JsiiMethod(name: "moin")]
         public virtual void Moin()

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -7384,8 +7384,12 @@ type DocumentedClass interface {
 	// Say ¡Hola!
 	// Experimental.
 	Hola()
-	// Say Moin, which is German for "Good morning" *\\/ (this comment is escaped because it contains a star slash).
-	// Experimental.
+	// The relative resource name identifying the VPC network that is using this configuration.
+	//
+	// For example: 'projects/*\\/global/networks/network-1'.
+	// Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+	//
+	// Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
 	Moin()
 }
 
@@ -29083,7 +29087,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass.go	--runtime-type-checking
-@@ -64,10 +64,13 @@
+@@ -68,10 +68,13 @@
  		d,
  	)
  }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -7384,12 +7384,9 @@ type DocumentedClass interface {
 	// Say ¡Hola!
 	// Experimental.
 	Hola()
-	// The relative resource name identifying the VPC network that is using this configuration.
+	// Some comments have an escaped star backslash in them, ending the comment if left unescaped.
 	//
 	// For example: 'projects/*\\/global/networks/network-1'.
-	// Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-	//
-	// Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
 	Moin()
 }
 
@@ -29087,7 +29084,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass.go	--runtime-type-checking
-@@ -68,10 +68,13 @@
+@@ -65,10 +65,13 @@
  		d,
  	)
  }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -7384,6 +7384,9 @@ type DocumentedClass interface {
 	// Say ¡Hola!
 	// Experimental.
 	Hola()
+	// Say Moin, which is German for "Good morning" *\\/ (this comment is escaped because it contains a star slash).
+	// Experimental.
+	Moin()
 }
 
 // The jsii proxy struct for DocumentedClass
@@ -7432,6 +7435,14 @@ func (d *jsiiProxy_DocumentedClass) Hola() {
 	_jsii_.InvokeVoid(
 		d,
 		"hola",
+		nil, // no parameters
+	)
+}
+
+func (d *jsiiProxy_DocumentedClass) Moin() {
+	_jsii_.InvokeVoid(
+		d,
+		"moin",
 		nil, // no parameters
 	)
 }
@@ -20110,6 +20121,7 @@ func init() {
 		[]_jsii_.Member{
 			_jsii_.MemberMethod{JsiiMethod: "greet", GoMethod: "Greet"},
 			_jsii_.MemberMethod{JsiiMethod: "hola", GoMethod: "Hola"},
+			_jsii_.MemberMethod{JsiiMethod: "moin", GoMethod: "Moin"},
 		},
 		func() interface{} {
 			return &jsiiProxy_DocumentedClass{}
@@ -29071,7 +29083,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/D
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/DocumentedClass.go.diff 1`] = `
 --- go/jsiicalc/DocumentedClass.go	--no-runtime-type-checking
 +++ go/jsiicalc/DocumentedClass.go	--runtime-type-checking
-@@ -61,10 +61,13 @@
+@@ -64,10 +64,13 @@
  		d,
  	)
  }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -9787,6 +9787,14 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
     public void hola() {
         software.amazon.jsii.Kernel.call(this, "hola", software.amazon.jsii.NativeType.VOID);
     }
+
+    /**
+     * (experimental) Say Moin, which is German for "Good morning" *&#47; (this comment is escaped because it contains a star slash).
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    public void moin() {
+        software.amazon.jsii.Kernel.call(this, "moin", software.amazon.jsii.NativeType.VOID);
+    }
 }
 
 `;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -9789,11 +9789,9 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
     }
 
     /**
-     * The relative resource name identifying the VPC network that is using this configuration.
+     * Some comments have an escaped star backslash in them, ending the comment if left unescaped.
      * <p>
-     * For example: 'projects/*\\/global/networks/network-1'.
-     * Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-     * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
+     * For example: 'projects/*&#47;global/networks/network-1'.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public void moin() {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -9791,7 +9791,7 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
     /**
      * The relative resource name identifying the VPC network that is using this configuration.
      * <p>
-     * For example: 'projects/*/global/networks/network-1'.
+     * For example: 'projects/*\\/global/networks/network-1'.
      * Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
      * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
      */

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -9789,9 +9789,13 @@ public class DocumentedClass extends software.amazon.jsii.JsiiObject {
     }
 
     /**
-     * (experimental) Say Moin, which is German for "Good morning" *&#47; (this comment is escaped because it contains a star slash).
+     * The relative resource name identifying the VPC network that is using this configuration.
+     * <p>
+     * For example: 'projects/*/global/networks/network-1'.
+     * Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+     * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
      */
-    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Experimental)
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public void moin() {
         software.amazon.jsii.Kernel.call(this, "moin", software.amazon.jsii.NativeType.VOID);
     }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -5262,9 +5262,12 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
     @jsii.member(jsii_name="moin")
     def moin(self) -> None:
-        '''(experimental) Say Moin, which is German for "Good morning" */ (this comment is escaped because it contains a star slash).
+        '''The relative resource name identifying the VPC network that is using this configuration.
 
-        :stability: experimental
+        For example: 'projects/*/global/networks/network-1'.
+        Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+
+        Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
         '''
         return typing.cast(None, jsii.invoke(self, "moin", []))
 
@@ -15776,7 +15779,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2171,10 +2449,14 @@
+@@ -2174,10 +2452,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
@@ -15791,7 +15794,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DontUseMe",
-@@ -2187,10 +2469,13 @@
+@@ -2190,10 +2472,13 @@
  
     Don't use this interface An interface that shouldn't be used, with the annotation in a weird place.
  
@@ -15805,7 +15808,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["dont_set_me"] = dont_set_me
  
      @builtins.property
-@@ -2224,10 +2509,13 @@
+@@ -2227,10 +2512,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
@@ -15819,7 +15822,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2256,28 +2544,37 @@
+@@ -2259,28 +2547,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
@@ -15857,7 +15860,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2286,20 +2583,26 @@
+@@ -2289,20 +2586,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
@@ -15884,7 +15887,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2312,10 +2615,13 @@
+@@ -2315,10 +2618,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
@@ -15898,7 +15901,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2343,10 +2649,13 @@
+@@ -2346,10 +2652,13 @@
  
          :param word: the value to return.
  
@@ -15912,7 +15915,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2383,10 +2692,14 @@
+@@ -2386,10 +2695,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
@@ -15927,7 +15930,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2414,10 +2727,14 @@
+@@ -2417,10 +2730,14 @@
      ) -> None:
          '''
          :param option1: 
@@ -15942,7 +15945,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2461,10 +2778,14 @@
+@@ -2464,10 +2781,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -15957,7 +15960,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2488,10 +2809,13 @@
+@@ -2491,10 +2812,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15971,7 +15974,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2519,10 +2843,13 @@
+@@ -2522,10 +2846,13 @@
          '''
          :param readonly_property: 
  
@@ -15985,7 +15988,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2552,10 +2879,13 @@
+@@ -2555,10 +2882,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
@@ -15999,7 +16002,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2571,10 +2901,14 @@
+@@ -2574,10 +2904,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
@@ -16014,7 +16017,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2616,10 +2950,14 @@
+@@ -2619,10 +2953,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -16029,7 +16032,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2643,10 +2981,13 @@
+@@ -2646,10 +2984,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16043,7 +16046,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2674,10 +3015,13 @@
+@@ -2677,10 +3018,13 @@
          '''
          :param readonly_property: 
  
@@ -16057,7 +16060,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2820,10 +3164,13 @@
+@@ -2823,10 +3167,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
@@ -16071,7 +16074,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["name"] = name
  
      @builtins.property
-@@ -2860,10 +3207,13 @@
+@@ -2863,10 +3210,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16085,7 +16088,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2943,10 +3293,13 @@
+@@ -2946,10 +3296,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16099,7 +16102,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2989,10 +3342,13 @@
+@@ -2992,10 +3345,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
@@ -16113,7 +16116,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -3017,10 +3373,13 @@
+@@ -3020,10 +3376,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -16127,7 +16130,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3076,10 +3435,13 @@
+@@ -3079,10 +3438,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16141,7 +16144,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3134,10 +3496,13 @@
+@@ -3137,10 +3499,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16155,7 +16158,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3179,10 +3544,13 @@
+@@ -3182,10 +3547,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16169,7 +16172,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3228,10 +3596,13 @@
+@@ -3231,10 +3599,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16183,7 +16186,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3413,10 +3784,14 @@
+@@ -3416,10 +3787,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -16198,7 +16201,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3451,10 +3826,13 @@
+@@ -3454,10 +3829,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16212,7 +16215,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3484,10 +3862,13 @@
+@@ -3487,10 +3865,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -16226,7 +16229,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -4007,10 +4388,13 @@
+@@ -4010,10 +4391,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -16240,7 +16243,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -4046,19 +4430,25 @@
+@@ -4049,19 +4433,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -16266,7 +16269,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4091,10 +4481,13 @@
+@@ -4094,10 +4484,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -16280,7 +16283,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4287,10 +4680,13 @@
+@@ -4290,10 +4683,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16294,7 +16297,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4357,10 +4753,13 @@
+@@ -4360,10 +4756,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -16308,7 +16311,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4406,10 +4805,13 @@
+@@ -4409,10 +4808,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16322,7 +16325,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4427,10 +4829,15 @@
+@@ -4430,10 +4832,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -16338,7 +16341,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4505,10 +4912,13 @@
+@@ -4508,10 +4915,13 @@
          count: jsii.Number,
      ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
@@ -16352,7 +16355,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4613,19 +5023,25 @@
+@@ -4616,19 +5026,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -16378,7 +16381,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4847,10 +5263,13 @@
+@@ -4850,10 +5266,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -16392,7 +16395,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4952,10 +5371,13 @@
+@@ -4955,10 +5374,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -16406,7 +16409,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4985,10 +5407,13 @@
+@@ -4988,10 +5410,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -16420,7 +16423,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5022,10 +5447,13 @@
+@@ -5025,10 +5450,13 @@
              '''
              :param prop: 
              '''
@@ -16434,7 +16437,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5060,10 +5488,13 @@
+@@ -5063,10 +5491,13 @@
          '''
          :param prop: 
          '''
@@ -16448,7 +16451,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5111,10 +5542,17 @@
+@@ -5114,10 +5545,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -16466,7 +16469,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5241,10 +5679,14 @@
+@@ -5244,10 +5682,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16481,7 +16484,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5292,10 +5734,13 @@
+@@ -5295,10 +5737,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -16495,7 +16498,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5366,17 +5811,24 @@
+@@ -5369,17 +5814,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -16520,7 +16523,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5404,10 +5856,13 @@
+@@ -5407,10 +5859,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -16534,7 +16537,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5426,10 +5881,14 @@
+@@ -5429,10 +5884,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -16549,7 +16552,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5464,17 +5923,23 @@
+@@ -5467,17 +5926,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
@@ -16573,7 +16576,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5484,10 +5949,13 @@
+@@ -5487,10 +5952,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
@@ -16587,7 +16590,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5505,10 +5973,13 @@
+@@ -5508,10 +5976,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -16601,7 +16604,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5516,10 +5987,13 @@
+@@ -5519,10 +5990,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -16615,7 +16618,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5560,10 +6034,13 @@
+@@ -5563,10 +6037,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
@@ -16629,7 +16632,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5586,10 +6063,15 @@
+@@ -5589,10 +6066,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16645,7 +16648,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5614,10 +6096,13 @@
+@@ -5617,10 +6099,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16659,7 +16662,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["field"] = field
  
      @builtins.property
-@@ -5693,10 +6178,13 @@
+@@ -5696,10 +6181,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -16673,7 +16676,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5708,10 +6196,13 @@
+@@ -5711,10 +6199,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
@@ -16687,7 +16690,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5733,10 +6224,14 @@
+@@ -5736,10 +6227,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -16702,7 +16705,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5766,10 +6261,15 @@
+@@ -5769,10 +6264,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -16718,7 +16721,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5822,10 +6322,13 @@
+@@ -5825,10 +6325,13 @@
          scope: _scope_jsii_calc_lib_c61f082f.Number,
      ) -> _scope_jsii_calc_lib_c61f082f.Number:
          '''
@@ -16732,7 +16735,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5836,10 +6339,13 @@
+@@ -5839,10 +6342,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -16746,7 +16749,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5894,10 +6400,15 @@
+@@ -5897,10 +6403,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -16762,7 +16765,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5912,10 +6423,13 @@
+@@ -5915,10 +6426,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16776,7 +16779,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5932,10 +6446,14 @@
+@@ -5935,10 +6449,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -16791,7 +16794,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -6158,10 +6676,13 @@
+@@ -6161,10 +6679,13 @@
          value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
      ) -> None:
          '''
@@ -16805,7 +16808,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6172,10 +6693,13 @@
+@@ -6175,10 +6696,13 @@
      @foo.setter
      def foo(
          self,
@@ -16819,7 +16822,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6217,10 +6741,14 @@
+@@ -6220,10 +6744,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -16834,7 +16837,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6287,17 +6815,25 @@
+@@ -6290,17 +6818,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16860,7 +16863,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6309,10 +6845,15 @@
+@@ -6312,10 +6848,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -16876,7 +16879,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6331,10 +6872,14 @@
+@@ -6334,10 +6875,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -16891,7 +16894,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6396,10 +6941,13 @@
+@@ -6399,10 +6944,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -16905,7 +16908,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6418,10 +6966,13 @@
+@@ -6421,10 +6969,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -16919,7 +16922,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6445,10 +6996,14 @@
+@@ -6448,10 +6999,14 @@
      ) -> None:
          '''
          :param property: 
@@ -16934,7 +16937,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6499,10 +7054,14 @@
+@@ -6502,10 +7057,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -16949,7 +16952,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6517,10 +7076,13 @@
+@@ -6520,10 +7079,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16963,7 +16966,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6536,10 +7098,13 @@
+@@ -6539,10 +7101,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -16977,7 +16980,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6576,10 +7141,13 @@
+@@ -6579,10 +7144,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -16991,7 +16994,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6609,19 +7177,25 @@
+@@ -6612,19 +7180,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -17017,7 +17020,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6658,19 +7232,25 @@
+@@ -6661,19 +7235,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -17043,7 +17046,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6693,10 +7273,13 @@
+@@ -6696,10 +7276,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -17057,7 +17060,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6719,10 +7302,15 @@
+@@ -6722,10 +7305,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -17073,7 +17076,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6780,10 +7368,15 @@
+@@ -6783,10 +7371,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -17089,7 +17092,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6835,10 +7428,14 @@
+@@ -6838,10 +7431,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -17104,7 +17107,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6881,10 +7478,14 @@
+@@ -6884,10 +7481,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -17119,7 +17122,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6899,10 +7500,13 @@
+@@ -6902,10 +7503,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17133,7 +17136,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6919,10 +7523,13 @@
+@@ -6922,10 +7526,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17147,7 +17150,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6930,18 +7537,24 @@
+@@ -6933,18 +7540,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17172,7 +17175,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6955,10 +7568,13 @@
+@@ -6958,10 +7571,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -17186,7 +17189,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6995,10 +7611,14 @@
+@@ -6998,10 +7614,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -17201,7 +17204,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -7054,10 +7674,16 @@
+@@ -7057,10 +7677,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -17218,7 +17221,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7127,10 +7753,13 @@
+@@ -7130,10 +7756,13 @@
      @parts.setter
      def parts(
          self,
@@ -17232,7 +17235,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7146,10 +7775,14 @@
+@@ -7149,10 +7778,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -17247,7 +17250,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -7198,10 +7831,13 @@
+@@ -7201,10 +7834,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -17261,7 +17264,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7239,17 +7875,23 @@
+@@ -7242,17 +7878,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -17285,7 +17288,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7269,17 +7911,23 @@
+@@ -7272,17 +7914,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -17309,7 +17312,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7290,46 +7938,61 @@
+@@ -7293,46 +7941,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -17371,7 +17374,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7412,10 +8075,15 @@
+@@ -7415,10 +8078,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17387,7 +17390,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7506,10 +8174,13 @@
+@@ -7509,10 +8177,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17401,7 +17404,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -7540,10 +8211,14 @@
+@@ -7543,10 +8214,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -17416,7 +17419,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7580,10 +8255,13 @@
+@@ -7583,10 +8258,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -17430,7 +17433,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
-@@ -7626,10 +8304,13 @@
+@@ -7629,10 +8307,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
@@ -17444,7 +17447,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7640,17 +8321,23 @@
+@@ -7643,17 +8324,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
@@ -17468,7 +17471,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7660,25 +8347,34 @@
+@@ -7663,25 +8350,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -17503,7 +17506,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7687,10 +8383,14 @@
+@@ -7690,10 +8386,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -17518,7 +17521,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7698,19 +8398,25 @@
+@@ -7701,19 +8401,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
@@ -17544,7 +17547,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7722,38 +8428,53 @@
+@@ -7725,38 +8431,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -17598,7 +17601,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7815,10 +8536,13 @@
+@@ -7818,10 +8539,13 @@
          '''
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "dontReadMe"))
  
@@ -17612,7 +17615,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class WithPrivatePropertyInConstructor(
      metaclass=jsii.JSIIMeta,
-@@ -7828,10 +8552,13 @@
+@@ -7831,10 +8555,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -17626,7 +17629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7872,10 +8599,13 @@
+@@ -7875,10 +8602,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -17640,7 +17643,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7891,10 +8621,14 @@
+@@ -7894,10 +8624,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -17655,7 +17658,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7938,10 +8672,13 @@
+@@ -7941,10 +8675,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -17669,7 +17672,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7952,10 +8689,14 @@
+@@ -7955,10 +8692,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -17684,7 +17687,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7996,37 +8737,49 @@
+@@ -7999,37 +8740,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17734,7 +17737,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -8041,37 +8794,49 @@
+@@ -8044,37 +8797,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17784,7 +17787,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -8089,10 +8854,14 @@
+@@ -8092,10 +8857,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -17799,7 +17802,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8103,10 +8872,13 @@
+@@ -8106,10 +8875,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17813,7 +17816,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8221,10 +8993,13 @@
+@@ -8224,10 +8996,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -17827,7 +17830,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8245,10 +9020,13 @@
+@@ -8248,10 +9023,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17841,7 +17844,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8308,10 +9086,16 @@
+@@ -8311,10 +9089,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -17858,7 +17861,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8610,5 +9394,1544 @@
+@@ -8613,5 +9397,1544 @@
  from . import nodirect
  from . import onlystatic
  from . import python_self

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -5262,12 +5262,9 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
 
     @jsii.member(jsii_name="moin")
     def moin(self) -> None:
-        '''The relative resource name identifying the VPC network that is using this configuration.
+        '''Some comments have an escaped star backslash in them, ending the comment if left unescaped.
 
         For example: 'projects/*/global/networks/network-1'.
-        Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-
-        Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/4.75.0/docs/resources/network_services_gateway#network NetworkServicesGateway#network}
         '''
         return typing.cast(None, jsii.invoke(self, "moin", []))
 
@@ -15779,7 +15776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2174,10 +2452,14 @@
+@@ -2171,10 +2449,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
@@ -15794,7 +15791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DontUseMe",
-@@ -2190,10 +2472,13 @@
+@@ -2187,10 +2469,13 @@
  
     Don't use this interface An interface that shouldn't be used, with the annotation in a weird place.
  
@@ -15808,7 +15805,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["dont_set_me"] = dont_set_me
  
      @builtins.property
-@@ -2227,10 +2512,13 @@
+@@ -2224,10 +2509,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
@@ -15822,7 +15819,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2259,28 +2547,37 @@
+@@ -2256,28 +2544,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
@@ -15860,7 +15857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2289,20 +2586,26 @@
+@@ -2286,20 +2583,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
@@ -15887,7 +15884,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2315,10 +2618,13 @@
+@@ -2312,10 +2615,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
@@ -15901,7 +15898,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2346,10 +2652,13 @@
+@@ -2343,10 +2649,13 @@
  
          :param word: the value to return.
  
@@ -15915,7 +15912,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2386,10 +2695,14 @@
+@@ -2383,10 +2692,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
@@ -15930,7 +15927,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2417,10 +2730,14 @@
+@@ -2414,10 +2727,14 @@
      ) -> None:
          '''
          :param option1: 
@@ -15945,7 +15942,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2464,10 +2781,14 @@
+@@ -2461,10 +2778,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -15960,7 +15957,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2491,10 +2812,13 @@
+@@ -2488,10 +2809,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15974,7 +15971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2522,10 +2846,13 @@
+@@ -2519,10 +2843,13 @@
          '''
          :param readonly_property: 
  
@@ -15988,7 +15985,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2555,10 +2882,13 @@
+@@ -2552,10 +2879,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
@@ -16002,7 +15999,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2574,10 +2904,14 @@
+@@ -2571,10 +2901,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
@@ -16017,7 +16014,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2619,10 +2953,14 @@
+@@ -2616,10 +2950,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -16032,7 +16029,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2646,10 +2984,13 @@
+@@ -2643,10 +2981,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16046,7 +16043,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2677,10 +3018,13 @@
+@@ -2674,10 +3015,13 @@
          '''
          :param readonly_property: 
  
@@ -16060,7 +16057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2823,10 +3167,13 @@
+@@ -2820,10 +3164,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
@@ -16074,7 +16071,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["name"] = name
  
      @builtins.property
-@@ -2863,10 +3210,13 @@
+@@ -2860,10 +3207,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16088,7 +16085,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2946,10 +3296,13 @@
+@@ -2943,10 +3293,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16102,7 +16099,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2992,10 +3345,13 @@
+@@ -2989,10 +3342,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
@@ -16116,7 +16113,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -3020,10 +3376,13 @@
+@@ -3017,10 +3373,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -16130,7 +16127,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3079,10 +3438,13 @@
+@@ -3076,10 +3435,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16144,7 +16141,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3137,10 +3499,13 @@
+@@ -3134,10 +3496,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16158,7 +16155,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3182,10 +3547,13 @@
+@@ -3179,10 +3544,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16172,7 +16169,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3231,10 +3599,13 @@
+@@ -3228,10 +3596,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16186,7 +16183,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3416,10 +3787,14 @@
+@@ -3413,10 +3784,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -16201,7 +16198,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3454,10 +3829,13 @@
+@@ -3451,10 +3826,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16215,7 +16212,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3487,10 +3865,13 @@
+@@ -3484,10 +3862,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -16229,7 +16226,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -4010,10 +4391,13 @@
+@@ -4007,10 +4388,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -16243,7 +16240,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -4049,19 +4433,25 @@
+@@ -4046,19 +4430,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -16269,7 +16266,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4094,10 +4484,13 @@
+@@ -4091,10 +4481,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -16283,7 +16280,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4290,10 +4683,13 @@
+@@ -4287,10 +4680,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16297,7 +16294,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4360,10 +4756,13 @@
+@@ -4357,10 +4753,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -16311,7 +16308,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4409,10 +4808,13 @@
+@@ -4406,10 +4805,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16325,7 +16322,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4430,10 +4832,15 @@
+@@ -4427,10 +4829,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -16341,7 +16338,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4508,10 +4915,13 @@
+@@ -4505,10 +4912,13 @@
          count: jsii.Number,
      ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
@@ -16355,7 +16352,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4616,19 +5026,25 @@
+@@ -4613,19 +5023,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -16381,7 +16378,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4850,10 +5266,13 @@
+@@ -4847,10 +5263,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -16395,7 +16392,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4955,10 +5374,13 @@
+@@ -4952,10 +5371,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -16409,7 +16406,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4988,10 +5410,13 @@
+@@ -4985,10 +5407,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -16423,7 +16420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5025,10 +5450,13 @@
+@@ -5022,10 +5447,13 @@
              '''
              :param prop: 
              '''
@@ -16437,7 +16434,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5063,10 +5491,13 @@
+@@ -5060,10 +5488,13 @@
          '''
          :param prop: 
          '''
@@ -16451,7 +16448,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5114,10 +5545,17 @@
+@@ -5111,10 +5542,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -16469,7 +16466,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5244,10 +5682,14 @@
+@@ -5241,10 +5679,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16484,7 +16481,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5295,10 +5737,13 @@
+@@ -5292,10 +5734,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -16498,7 +16495,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5369,17 +5814,24 @@
+@@ -5366,17 +5811,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -16523,7 +16520,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5407,10 +5859,13 @@
+@@ -5404,10 +5856,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -16537,7 +16534,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5429,10 +5884,14 @@
+@@ -5426,10 +5881,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -16552,7 +16549,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5467,17 +5926,23 @@
+@@ -5464,17 +5923,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
@@ -16576,7 +16573,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5487,10 +5952,13 @@
+@@ -5484,10 +5949,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
@@ -16590,7 +16587,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5508,10 +5976,13 @@
+@@ -5505,10 +5973,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -16604,7 +16601,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5519,10 +5990,13 @@
+@@ -5516,10 +5987,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -16618,7 +16615,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5563,10 +6037,13 @@
+@@ -5560,10 +6034,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
@@ -16632,7 +16629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5589,10 +6066,15 @@
+@@ -5586,10 +6063,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16648,7 +16645,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5617,10 +6099,13 @@
+@@ -5614,10 +6096,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16662,7 +16659,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["field"] = field
  
      @builtins.property
-@@ -5696,10 +6181,13 @@
+@@ -5693,10 +6178,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -16676,7 +16673,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5711,10 +6199,13 @@
+@@ -5708,10 +6196,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
@@ -16690,7 +16687,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5736,10 +6227,14 @@
+@@ -5733,10 +6224,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -16705,7 +16702,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5769,10 +6264,15 @@
+@@ -5766,10 +6261,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -16721,7 +16718,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5825,10 +6325,13 @@
+@@ -5822,10 +6322,13 @@
          scope: _scope_jsii_calc_lib_c61f082f.Number,
      ) -> _scope_jsii_calc_lib_c61f082f.Number:
          '''
@@ -16735,7 +16732,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5839,10 +6342,13 @@
+@@ -5836,10 +6339,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -16749,7 +16746,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5897,10 +6403,15 @@
+@@ -5894,10 +6400,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -16765,7 +16762,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5915,10 +6426,13 @@
+@@ -5912,10 +6423,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16779,7 +16776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5935,10 +6449,14 @@
+@@ -5932,10 +6446,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -16794,7 +16791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -6161,10 +6679,13 @@
+@@ -6158,10 +6676,13 @@
          value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
      ) -> None:
          '''
@@ -16808,7 +16805,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6175,10 +6696,13 @@
+@@ -6172,10 +6693,13 @@
      @foo.setter
      def foo(
          self,
@@ -16822,7 +16819,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6220,10 +6744,14 @@
+@@ -6217,10 +6741,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -16837,7 +16834,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6290,17 +6818,25 @@
+@@ -6287,17 +6815,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16863,7 +16860,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6312,10 +6848,15 @@
+@@ -6309,10 +6845,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -16879,7 +16876,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6334,10 +6875,14 @@
+@@ -6331,10 +6872,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -16894,7 +16891,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6399,10 +6944,13 @@
+@@ -6396,10 +6941,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -16908,7 +16905,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6421,10 +6969,13 @@
+@@ -6418,10 +6966,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -16922,7 +16919,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6448,10 +6999,14 @@
+@@ -6445,10 +6996,14 @@
      ) -> None:
          '''
          :param property: 
@@ -16937,7 +16934,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6502,10 +7057,14 @@
+@@ -6499,10 +7054,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -16952,7 +16949,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6520,10 +7079,13 @@
+@@ -6517,10 +7076,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16966,7 +16963,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6539,10 +7101,13 @@
+@@ -6536,10 +7098,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -16980,7 +16977,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6579,10 +7144,13 @@
+@@ -6576,10 +7141,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -16994,7 +16991,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6612,19 +7180,25 @@
+@@ -6609,19 +7177,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -17020,7 +17017,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6661,19 +7235,25 @@
+@@ -6658,19 +7232,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -17046,7 +17043,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6696,10 +7276,13 @@
+@@ -6693,10 +7273,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -17060,7 +17057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6722,10 +7305,15 @@
+@@ -6719,10 +7302,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -17076,7 +17073,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6783,10 +7371,15 @@
+@@ -6780,10 +7368,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -17092,7 +17089,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6838,10 +7431,14 @@
+@@ -6835,10 +7428,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -17107,7 +17104,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6884,10 +7481,14 @@
+@@ -6881,10 +7478,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -17122,7 +17119,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6902,10 +7503,13 @@
+@@ -6899,10 +7500,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17136,7 +17133,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6922,10 +7526,13 @@
+@@ -6919,10 +7523,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17150,7 +17147,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6933,18 +7540,24 @@
+@@ -6930,18 +7537,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17175,7 +17172,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6958,10 +7571,13 @@
+@@ -6955,10 +7568,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -17189,7 +17186,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6998,10 +7614,14 @@
+@@ -6995,10 +7611,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -17204,7 +17201,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -7057,10 +7677,16 @@
+@@ -7054,10 +7674,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -17221,7 +17218,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7130,10 +7756,13 @@
+@@ -7127,10 +7753,13 @@
      @parts.setter
      def parts(
          self,
@@ -17235,7 +17232,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7149,10 +7778,14 @@
+@@ -7146,10 +7775,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -17250,7 +17247,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -7201,10 +7834,13 @@
+@@ -7198,10 +7831,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -17264,7 +17261,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7242,17 +7878,23 @@
+@@ -7239,17 +7875,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -17288,7 +17285,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7272,17 +7914,23 @@
+@@ -7269,17 +7911,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -17312,7 +17309,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7293,46 +7941,61 @@
+@@ -7290,46 +7938,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -17374,7 +17371,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7415,10 +8078,15 @@
+@@ -7412,10 +8075,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17390,7 +17387,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7509,10 +8177,13 @@
+@@ -7506,10 +8174,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17404,7 +17401,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -7543,10 +8214,14 @@
+@@ -7540,10 +8211,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -17419,7 +17416,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7583,10 +8258,13 @@
+@@ -7580,10 +8255,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -17433,7 +17430,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
-@@ -7629,10 +8307,13 @@
+@@ -7626,10 +8304,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
@@ -17447,7 +17444,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7643,17 +8324,23 @@
+@@ -7640,17 +8321,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
@@ -17471,7 +17468,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7663,25 +8350,34 @@
+@@ -7660,25 +8347,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -17506,7 +17503,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7690,10 +8386,14 @@
+@@ -7687,10 +8383,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -17521,7 +17518,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7701,19 +8401,25 @@
+@@ -7698,19 +8398,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
@@ -17547,7 +17544,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7725,38 +8431,53 @@
+@@ -7722,38 +8428,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -17601,7 +17598,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7818,10 +8539,13 @@
+@@ -7815,10 +8536,13 @@
          '''
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "dontReadMe"))
  
@@ -17615,7 +17612,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class WithPrivatePropertyInConstructor(
      metaclass=jsii.JSIIMeta,
-@@ -7831,10 +8555,13 @@
+@@ -7828,10 +8552,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -17629,7 +17626,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7875,10 +8602,13 @@
+@@ -7872,10 +8599,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -17643,7 +17640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7894,10 +8624,14 @@
+@@ -7891,10 +8621,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -17658,7 +17655,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7941,10 +8675,13 @@
+@@ -7938,10 +8672,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -17672,7 +17669,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7955,10 +8692,14 @@
+@@ -7952,10 +8689,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -17687,7 +17684,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7999,37 +8740,49 @@
+@@ -7996,37 +8737,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17737,7 +17734,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -8044,37 +8797,49 @@
+@@ -8041,37 +8794,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17787,7 +17784,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -8092,10 +8857,14 @@
+@@ -8089,10 +8854,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -17802,7 +17799,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8106,10 +8875,13 @@
+@@ -8103,10 +8872,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17816,7 +17813,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8224,10 +8996,13 @@
+@@ -8221,10 +8993,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -17830,7 +17827,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8248,10 +9023,13 @@
+@@ -8245,10 +9020,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17844,7 +17841,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8311,10 +9089,16 @@
+@@ -8308,10 +9086,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -17861,7 +17858,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8613,5 +9397,1544 @@
+@@ -8610,5 +9394,1544 @@
  from . import nodirect
  from . import onlystatic
  from . import python_self

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -5260,6 +5260,14 @@ class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedCl
         '''
         return typing.cast(None, jsii.invoke(self, "hola", []))
 
+    @jsii.member(jsii_name="moin")
+    def moin(self) -> None:
+        '''(experimental) Say Moin, which is German for "Good morning" */ (this comment is escaped because it contains a star slash).
+
+        :stability: experimental
+        '''
+        return typing.cast(None, jsii.invoke(self, "moin", []))
+
 
 class DontComplainAboutVariadicAfterOptional(
     metaclass=jsii.JSIIMeta,
@@ -15768,7 +15776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2163,10 +2441,14 @@
+@@ -2171,10 +2449,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
@@ -15783,7 +15791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DontUseMe",
-@@ -2179,10 +2461,13 @@
+@@ -2187,10 +2469,13 @@
  
     Don't use this interface An interface that shouldn't be used, with the annotation in a weird place.
  
@@ -15797,7 +15805,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["dont_set_me"] = dont_set_me
  
      @builtins.property
-@@ -2216,10 +2501,13 @@
+@@ -2224,10 +2509,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
@@ -15811,7 +15819,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2248,28 +2536,37 @@
+@@ -2256,28 +2544,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
@@ -15849,7 +15857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2278,20 +2575,26 @@
+@@ -2286,20 +2583,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
@@ -15876,7 +15884,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2304,10 +2607,13 @@
+@@ -2312,10 +2615,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
@@ -15890,7 +15898,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2335,10 +2641,13 @@
+@@ -2343,10 +2649,13 @@
  
          :param word: the value to return.
  
@@ -15904,7 +15912,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2375,10 +2684,14 @@
+@@ -2383,10 +2692,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
@@ -15919,7 +15927,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2406,10 +2719,14 @@
+@@ -2414,10 +2727,14 @@
      ) -> None:
          '''
          :param option1: 
@@ -15934,7 +15942,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2453,10 +2770,14 @@
+@@ -2461,10 +2778,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -15949,7 +15957,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2480,10 +2801,13 @@
+@@ -2488,10 +2809,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -15963,7 +15971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2511,10 +2835,13 @@
+@@ -2519,10 +2843,13 @@
          '''
          :param readonly_property: 
  
@@ -15977,7 +15985,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2544,10 +2871,13 @@
+@@ -2552,10 +2879,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
@@ -15991,7 +15999,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2563,10 +2893,14 @@
+@@ -2571,10 +2901,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
@@ -16006,7 +16014,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2608,10 +2942,14 @@
+@@ -2616,10 +2950,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -16021,7 +16029,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2635,10 +2973,13 @@
+@@ -2643,10 +2981,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16035,7 +16043,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2666,10 +3007,13 @@
+@@ -2674,10 +3015,13 @@
          '''
          :param readonly_property: 
  
@@ -16049,7 +16057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2812,10 +3156,13 @@
+@@ -2820,10 +3164,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
@@ -16063,7 +16071,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["name"] = name
  
      @builtins.property
-@@ -2852,10 +3199,13 @@
+@@ -2860,10 +3207,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16077,7 +16085,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
  class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2935,10 +3285,13 @@
+@@ -2943,10 +3293,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16091,7 +16099,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2981,10 +3334,13 @@
+@@ -2989,10 +3342,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
@@ -16105,7 +16113,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -3009,10 +3365,13 @@
+@@ -3017,10 +3373,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -16119,7 +16127,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3068,10 +3427,13 @@
+@@ -3076,10 +3435,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16133,7 +16141,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3126,10 +3488,13 @@
+@@ -3134,10 +3496,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16147,7 +16155,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3171,10 +3536,13 @@
+@@ -3179,10 +3544,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16161,7 +16169,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3220,10 +3588,13 @@
+@@ -3228,10 +3596,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16175,7 +16183,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3405,10 +3776,14 @@
+@@ -3413,10 +3784,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -16190,7 +16198,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3443,10 +3818,13 @@
+@@ -3451,10 +3826,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16204,7 +16212,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3476,10 +3854,13 @@
+@@ -3484,10 +3862,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -16218,7 +16226,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -3999,10 +4380,13 @@
+@@ -4007,10 +4388,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -16232,7 +16240,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -4038,19 +4422,25 @@
+@@ -4046,19 +4430,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -16258,7 +16266,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4083,10 +4473,13 @@
+@@ -4091,10 +4481,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -16272,7 +16280,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4279,10 +4672,13 @@
+@@ -4287,10 +4680,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16286,7 +16294,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4349,10 +4745,13 @@
+@@ -4357,10 +4753,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -16300,7 +16308,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4398,10 +4797,13 @@
+@@ -4406,10 +4805,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16314,7 +16322,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4419,10 +4821,15 @@
+@@ -4427,10 +4829,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -16330,7 +16338,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4497,10 +4904,13 @@
+@@ -4505,10 +4912,13 @@
          count: jsii.Number,
      ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
@@ -16344,7 +16352,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4605,19 +5015,25 @@
+@@ -4613,19 +5023,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -16370,7 +16378,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4839,10 +5255,13 @@
+@@ -4847,10 +5263,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -16384,7 +16392,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4944,10 +5363,13 @@
+@@ -4952,10 +5371,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -16398,7 +16406,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4977,10 +5399,13 @@
+@@ -4985,10 +5407,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -16412,7 +16420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5014,10 +5439,13 @@
+@@ -5022,10 +5447,13 @@
              '''
              :param prop: 
              '''
@@ -16426,7 +16434,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5052,10 +5480,13 @@
+@@ -5060,10 +5488,13 @@
          '''
          :param prop: 
          '''
@@ -16440,7 +16448,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5103,10 +5534,17 @@
+@@ -5111,10 +5542,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -16458,7 +16466,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5233,10 +5671,14 @@
+@@ -5241,10 +5679,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16473,7 +16481,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5284,10 +5726,13 @@
+@@ -5292,10 +5734,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -16487,7 +16495,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5358,17 +5803,24 @@
+@@ -5366,17 +5811,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -16512,7 +16520,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5396,10 +5848,13 @@
+@@ -5404,10 +5856,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -16526,7 +16534,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5418,10 +5873,14 @@
+@@ -5426,10 +5881,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -16541,7 +16549,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5456,17 +5915,23 @@
+@@ -5464,17 +5923,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
@@ -16565,7 +16573,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5476,10 +5941,13 @@
+@@ -5484,10 +5949,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
@@ -16579,7 +16587,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5497,10 +5965,13 @@
+@@ -5505,10 +5973,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -16593,7 +16601,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5508,10 +5979,13 @@
+@@ -5516,10 +5987,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -16607,7 +16615,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5552,10 +6026,13 @@
+@@ -5560,10 +6034,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
@@ -16621,7 +16629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5578,10 +6055,15 @@
+@@ -5586,10 +6063,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16637,7 +16645,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5606,10 +6088,13 @@
+@@ -5614,10 +6096,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16651,7 +16659,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["field"] = field
  
      @builtins.property
-@@ -5685,10 +6170,13 @@
+@@ -5693,10 +6178,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -16665,7 +16673,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5700,10 +6188,13 @@
+@@ -5708,10 +6196,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
@@ -16679,7 +16687,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5725,10 +6216,14 @@
+@@ -5733,10 +6224,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -16694,7 +16702,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5758,10 +6253,15 @@
+@@ -5766,10 +6261,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -16710,7 +16718,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5814,10 +6314,13 @@
+@@ -5822,10 +6322,13 @@
          scope: _scope_jsii_calc_lib_c61f082f.Number,
      ) -> _scope_jsii_calc_lib_c61f082f.Number:
          '''
@@ -16724,7 +16732,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5828,10 +6331,13 @@
+@@ -5836,10 +6339,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -16738,7 +16746,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5886,10 +6392,15 @@
+@@ -5894,10 +6400,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -16754,7 +16762,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5904,10 +6415,13 @@
+@@ -5912,10 +6423,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16768,7 +16776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5924,10 +6438,14 @@
+@@ -5932,10 +6446,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -16783,7 +16791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -6150,10 +6668,13 @@
+@@ -6158,10 +6676,13 @@
          value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
      ) -> None:
          '''
@@ -16797,7 +16805,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6164,10 +6685,13 @@
+@@ -6172,10 +6693,13 @@
      @foo.setter
      def foo(
          self,
@@ -16811,7 +16819,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6209,10 +6733,14 @@
+@@ -6217,10 +6741,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -16826,7 +16834,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6279,17 +6807,25 @@
+@@ -6287,17 +6815,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16852,7 +16860,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6301,10 +6837,15 @@
+@@ -6309,10 +6845,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -16868,7 +16876,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6323,10 +6864,14 @@
+@@ -6331,10 +6872,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -16883,7 +16891,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6388,10 +6933,13 @@
+@@ -6396,10 +6941,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -16897,7 +16905,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6410,10 +6958,13 @@
+@@ -6418,10 +6966,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -16911,7 +16919,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6437,10 +6988,14 @@
+@@ -6445,10 +6996,14 @@
      ) -> None:
          '''
          :param property: 
@@ -16926,7 +16934,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6491,10 +7046,14 @@
+@@ -6499,10 +7054,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -16941,7 +16949,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6509,10 +7068,13 @@
+@@ -6517,10 +7076,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16955,7 +16963,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6528,10 +7090,13 @@
+@@ -6536,10 +7098,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -16969,7 +16977,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6568,10 +7133,13 @@
+@@ -6576,10 +7141,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -16983,7 +16991,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6601,19 +7169,25 @@
+@@ -6609,19 +7177,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -17009,7 +17017,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6650,19 +7224,25 @@
+@@ -6658,19 +7232,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -17035,7 +17043,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6685,10 +7265,13 @@
+@@ -6693,10 +7273,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -17049,7 +17057,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6711,10 +7294,15 @@
+@@ -6719,10 +7302,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -17065,7 +17073,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6772,10 +7360,15 @@
+@@ -6780,10 +7368,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -17081,7 +17089,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6827,10 +7420,14 @@
+@@ -6835,10 +7428,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -17096,7 +17104,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -6873,10 +7470,14 @@
+@@ -6881,10 +7478,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -17111,7 +17119,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6891,10 +7492,13 @@
+@@ -6899,10 +7500,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17125,7 +17133,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6911,10 +7515,13 @@
+@@ -6919,10 +7523,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17139,7 +17147,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6922,18 +7529,24 @@
+@@ -6930,18 +7537,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17164,7 +17172,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6947,10 +7560,13 @@
+@@ -6955,10 +7568,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -17178,7 +17186,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6987,10 +7603,14 @@
+@@ -6995,10 +7611,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -17193,7 +17201,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -7046,10 +7666,16 @@
+@@ -7054,10 +7674,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -17210,7 +17218,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7119,10 +7745,13 @@
+@@ -7127,10 +7753,13 @@
      @parts.setter
      def parts(
          self,
@@ -17224,7 +17232,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7138,10 +7767,14 @@
+@@ -7146,10 +7775,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -17239,7 +17247,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -7190,10 +7823,13 @@
+@@ -7198,10 +7831,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -17253,7 +17261,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7231,17 +7867,23 @@
+@@ -7239,17 +7875,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -17277,7 +17285,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7261,17 +7903,23 @@
+@@ -7269,17 +7911,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -17301,7 +17309,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7282,46 +7930,61 @@
+@@ -7290,46 +7938,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -17363,7 +17371,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7404,10 +8067,15 @@
+@@ -7412,10 +8075,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17379,7 +17387,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7498,10 +8166,13 @@
+@@ -7506,10 +8174,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17393,7 +17401,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -7532,10 +8203,14 @@
+@@ -7540,10 +8211,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -17408,7 +17416,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7572,10 +8247,13 @@
+@@ -7580,10 +8255,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -17422,7 +17430,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
-@@ -7618,10 +8296,13 @@
+@@ -7626,10 +8304,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
@@ -17436,7 +17444,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7632,17 +8313,23 @@
+@@ -7640,17 +8321,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
@@ -17460,7 +17468,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7652,25 +8339,34 @@
+@@ -7660,25 +8347,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -17495,7 +17503,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7679,10 +8375,14 @@
+@@ -7687,10 +8383,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -17510,7 +17518,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7690,19 +8390,25 @@
+@@ -7698,19 +8398,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
@@ -17536,7 +17544,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7714,38 +8420,53 @@
+@@ -7722,38 +8428,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -17590,7 +17598,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7807,10 +8528,13 @@
+@@ -7815,10 +8536,13 @@
          '''
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "dontReadMe"))
  
@@ -17604,7 +17612,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class WithPrivatePropertyInConstructor(
      metaclass=jsii.JSIIMeta,
-@@ -7820,10 +8544,13 @@
+@@ -7828,10 +8552,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -17618,7 +17626,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7864,10 +8591,13 @@
+@@ -7872,10 +8599,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -17632,7 +17640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7883,10 +8613,14 @@
+@@ -7891,10 +8621,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -17647,7 +17655,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7930,10 +8664,13 @@
+@@ -7938,10 +8672,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -17661,7 +17669,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7944,10 +8681,14 @@
+@@ -7952,10 +8689,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -17676,7 +17684,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -7988,37 +8729,49 @@
+@@ -7996,37 +8737,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17726,7 +17734,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -8033,37 +8786,49 @@
+@@ -8041,37 +8794,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17776,7 +17784,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -8081,10 +8846,14 @@
+@@ -8089,10 +8854,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -17791,7 +17799,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8095,10 +8864,13 @@
+@@ -8103,10 +8872,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17805,7 +17813,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8213,10 +8985,13 @@
+@@ -8221,10 +8993,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -17819,7 +17827,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8237,10 +9012,13 @@
+@@ -8245,10 +9020,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17833,7 +17841,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8300,10 +9078,16 @@
+@@ -8308,10 +9086,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -17850,7 +17858,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8602,5 +9386,1544 @@
+@@ -8610,5 +9394,1544 @@
  from . import nodirect
  from . import onlystatic
  from . import python_self

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1307,7 +1307,7 @@ exports[`jsii-tree --all 1`] = `
  │   │   │ └── returns: number
  │   │   ├─┬ hola() method (experimental)
  │   │   │ └── returns: void
- │   │   └─┬ moin() method (experimental)
+ │   │   └─┬ moin() method (stable)
  │   │     └── returns: void
  │   ├─┬ class DontComplainAboutVariadicAfterOptional (stable)
  │   │ └─┬ members

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1305,7 +1305,9 @@ exports[`jsii-tree --all 1`] = `
  │   │   │ │ └─┬ greetee
  │   │   │ │   └── type: Optional<jsii-calc.Greetee>
  │   │   │ └── returns: number
- │   │   └─┬ hola() method (experimental)
+ │   │   ├─┬ hola() method (experimental)
+ │   │   │ └── returns: void
+ │   │   └─┬ moin() method (experimental)
  │   │     └── returns: void
  │   ├─┬ class DontComplainAboutVariadicAfterOptional (stable)
  │   │ └─┬ members
@@ -4849,7 +4851,8 @@ exports[`jsii-tree --members 1`] = `
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer
  │   │   ├── greet(greetee) method
- │   │   └── hola() method
+ │   │   ├── hola() method
+ │   │   └── moin() method
  │   ├─┬ class DontComplainAboutVariadicAfterOptional
  │   │ └─┬ members
  │   │   ├── <initializer>() initializer

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -1482,7 +1482,9 @@ exports[`showAll 1`] = `
  │   │   │ │ └─┬ greetee
  │   │   │ │   └── type: Optional<jsii-calc.Greetee>
  │   │   │ └── returns: number
- │   │   └─┬ hola() method
+ │   │   ├─┬ hola() method
+ │   │   │ └── returns: void
+ │   │   └─┬ moin() method
  │   │     └── returns: void
  │   ├─┬ class DontComplainAboutVariadicAfterOptional
  │   │ └─┬ members


### PR DESCRIPTION
When a comment contains `*/` (for any reason, in our case because the escaped version is unescaped within JSII) it should be escaped to not make the file invalid