### PR TITLE
fix(kernel): incorrectly scoped FQN resolutions

### DIFF
--- a/packages/@jsii/kernel/src/objects.test.ts
+++ b/packages/@jsii/kernel/src/objects.test.ts
@@ -1,4 +1,4 @@
-import { ObjectTable } from './objects';
+import { ObjectTable, jsiiTypeFqn } from './objects';
 
 const mockResolve = jest.fn();
 
@@ -23,4 +23,21 @@ test('registered objects have clean JSON.Stringify', () => {
   subject.registerObject(obj, 'Object');
 
   expect(JSON.stringify(obj)).toEqual(expected);
+});
+
+test('FQN resolution is not broken by inheritance relationships', () => {
+  const rtti = Symbol.for('jsii.rtti');
+
+  class Parent {
+    public static readonly [rtti] = { fqn: 'phony.Parent' };
+  }
+  class Child extends Parent {
+    public static readonly [rtti] = { fqn: 'phony.Child' };
+  }
+
+  const parent = new Parent();
+  expect(jsiiTypeFqn(parent, () => true)).toBe(Parent[rtti].fqn);
+
+  const child = new Child();
+  expect(jsiiTypeFqn(child, () => true)).toBe(Child[rtti].fqn);
 });


### PR DESCRIPTION
The registration was done on the object's prototype, and the value from the constructor was always used, even if that was inherited, such that if a parent type had already been resolved previously, all child types would use the parent's FQN instead of their own.

Addressed this by instead storing the associations in an external WeakMap, and added a test case to validate correct behavior.

Fixes aws/aws-cdk#26604
Fixes #4202
Fixes #4203


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
