### PR TITLE
release: v1.86.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.86.1](https://github.com/aws/jsii/compare/v1.86.0...v1.86.1) (2023-08-02)
+
+
+### Bug Fixes
+
+* **kernel:** incorrectly scoped FQN resolutions ([#4204](https://github.com/aws/jsii/pull/4204)) ([ed667c7](https://github.com/aws/jsii/commit/ed667c76be73c43f969a1b7acc0b4b93a7a00889))
+
 ## [1.86.0](https://github.com/aws/jsii/compare/v1.85.0...v1.86.0) (2023-08-01)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -12,6 +12,6 @@
       "rejectCycles": true
     }
   },
-  "version": "1.86.0",
+  "version": "1.86.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/@jsii/kernel/src/objects.test.ts
+++ b/packages/@jsii/kernel/src/objects.test.ts
@@ -1,4 +1,4 @@
-import { ObjectTable } from './objects';
+import { ObjectTable, jsiiTypeFqn } from './objects';
 
 const mockResolve = jest.fn();
 
@@ -23,4 +23,21 @@ test('registered objects have clean JSON.Stringify', () => {
   subject.registerObject(obj, 'Object');
 
   expect(JSON.stringify(obj)).toEqual(expected);
+});
+
+test('FQN resolution is not broken by inheritance relationships', () => {
+  const rtti = Symbol.for('jsii.rtti');
+
+  class Parent {
+    public static readonly [rtti] = { fqn: 'phony.Parent' };
+  }
+  class Child extends Parent {
+    public static readonly [rtti] = { fqn: 'phony.Child' };
+  }
+
+  const parent = new Parent();
+  expect(jsiiTypeFqn(parent, () => true)).toBe(Parent[rtti].fqn);
+
+  const child = new Child();
+  expect(jsiiTypeFqn(child, () => true)).toBe(Child[rtti].fqn);
 });


### PR DESCRIPTION
See CHANGELOG.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
