### PR TITLE
fix(python): type object 'InterfaceDynamicProxy' has no attribute '__jsii_type__'

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_reference_map.py
+++ b/packages/@jsii/python-runtime/src/jsii/_reference_map.py
@@ -1,7 +1,7 @@
 # This module exists to break an import cycle between jsii.runtime and jsii.kernel
 import inspect
 
-from typing import Any, Iterable, Mapping, MutableMapping, Type
+from typing import Any, Iterable, List, Mapping, MutableMapping, Type
 from ._kernel.types import ObjRef
 
 
@@ -133,7 +133,7 @@ class _ReferenceMap:
     def resolve_id(self, id: str) -> Any:
         return self._refs[id]
 
-    def build_interface_proxies_for_ref(self, ref: ObjRef) -> Iterable[Any]:
+    def build_interface_proxies_for_ref(self, ref: ObjRef) -> List[Any]:
         ifaces = [_interfaces[fqn] for fqn in ref.interfaces or []]
         classes = [iface.__jsii_proxy_class__() for iface in ifaces]
 

--- a/packages/@jsii/python-runtime/src/jsii/_reference_map.py
+++ b/packages/@jsii/python-runtime/src/jsii/_reference_map.py
@@ -2,7 +2,7 @@
 import inspect
 
 from typing import Any, Iterable, Mapping, MutableMapping, Type
-from ._kernel.types  import ObjRef
+from ._kernel.types import ObjRef
 
 
 _types = {}
@@ -151,8 +151,8 @@ class _ReferenceMap:
 class Opaque:
     def __init__(self, ref: ObjRef) -> None:
         # Set the __jsii_type__ property on the class if it's not there already
-        if getattr(self.__class__, '__jsii_type__', None) is None:
-            setattr(self.__class__, '__jsii_type__', "Object")
+        if getattr(self.__class__, "__jsii_type__", None) is None:
+            setattr(self.__class__, "__jsii_type__", "Object")
 
         # Track the jsii reference
         self.__jsii_ref__ = ref


### PR DESCRIPTION
In the odd case where an opaque reference is returned (FQN is `Object`) and no interfaces are registered, the `InterfaceDynamicProxy` instance created to represent the value in Python did not have any delegate, resulting it in not having any visible properties; including a `__jsii_type__` value on the `__class__`, or the `__jsii_ref__` property, both of which are required for the vlaue to be able to correctly make it back to JavaScript.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
