### PR TITLE
fix(superchain): image fails because ensurepip is not available

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -146,6 +146,7 @@ RUN apt-get update                                                              
     libxmlsec1-dev                                                                                                      \
     openssh-client                                                                                                      \
     openssl                                                                                                             \
+    python3-venv                                                                                                        \
     rsync                                                                                                               \
     sudo                                                                                                                \
     tk-dev                                                                                                              \


### PR DESCRIPTION
#4201 removed `python3-venv`, which causes superchain build to fail:

```
@jsii/python-runtime: ·[1G@jsii/python-runtime: $ cp ../../../README.md . && rm -f jsii-*.whl && npm run generate && npm run deps && npm run lint
@jsii/python-runtime: > @jsii/python-runtime@0.0.0 generate
@jsii/python-runtime: > ts-node build-tools/gen.ts
@jsii/python-runtime: > @jsii/python-runtime@0.0.0 deps
@jsii/python-runtime: > ts-node build-tools/deps.ts
@jsii/python-runtime: The virtual environment was not created successfully because ensurepip is not
@jsii/python-runtime: available.  On Debian/Ubuntu systems, you need to install the python3-venv
@jsii/python-runtime: package using the following command.
@jsii/python-runtime:     apt-get install python3-venv
@jsii/python-runtime: You may need to use sudo with that command.  After installing the python3-venv
@jsii/python-runtime: package, recreate your virtual environment.
@jsii/python-runtime: Failing command: ['/codebuild/output/src3494011583/src/packages/@jsii/python-runtime/.env/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']
@jsii/python-runtime: /codebuild/output/src3494011583/src/packages/@jsii/python-runtime/build-tools/_constants.ts:25
@jsii/python-runtime:     throw new Error(
@jsii/python-runtime:           ^
@jsii/python-runtime: Error: Command failed with code 1: python3 -m venv /codebuild/output/src3494011583/src/packages/@jsii/python-runtime/.env
```

Seems like #4201 was not tested and the PR build does not build superchain.

I tested locally.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
