### PR TITLE
chore(superchain): replace pyenv with pipx

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -164,10 +164,13 @@ RUN set -eo pipefail                                                            
 ENV PATH=$PATH:${CARGO_HOME}/bin
 
 # Install Python 3 and pipx
-# ('apt-get install pipx' only works starting from bookworm, so we need to be forceful with 'pip install')
+# Starting in 'bookworm', 'pip install' needs special coercing (and 'apt-get install pipx' would be recommended)
+# but that flag is not recognized yet in older distros.
 RUN apt-get update                                                                                                      \
   && apt-get -y install python3-dev python3-pip python3-venv                                                            \
-  && python3 -m pip install --break-system-packages pipx                                                                \
+  && coercepip='--break-system-packages'                                                                                \
+  && if [[ ${DEBIAN_VERSION} == "buster" || ${DEBIAN_VERSION} == "bullseye" ]]; then coercepip=''; fi                   \
+  && python3 -m pip install ${coercepip} pipx                                                                           \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Python tools globally using pipx (install globally)

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -125,7 +125,6 @@ ENV LANG="C.UTF-8"                                                              
 RUN apt-get update                                                                                                      \
   && apt-get -y upgrade                                                                                                 \
   && apt-get -y install --no-install-recommends                                                                         \
-    acl                                                                                                                 \
     apt-transport-https                                                                                                 \
     build-essential                                                                                                     \
     ca-certificates                                                                                                     \
@@ -134,25 +133,15 @@ RUN apt-get update                                                              
     git                                                                                                                 \
     gnupg                                                                                                               \
     gzip                                                                                                                \
-    libbz2-dev                                                                                                          \
     libffi-dev                                                                                                          \
     libicu-dev                                                                                                          \
-    liblzma-dev                                                                                                         \
-    libncursesw5-dev                                                                                                    \
-    libreadline-dev                                                                                                     \
-    libsqlite3-dev                                                                                                      \
     libssl-dev                                                                                                          \
-    libxml2-dev                                                                                                         \
-    libxmlsec1-dev                                                                                                      \
-    openssh-client                                                                                                      \
     openssl                                                                                                             \
     rsync                                                                                                               \
     sudo                                                                                                                \
-    tk-dev                                                                                                              \
     unzip                                                                                                               \
-    xz-utils                                                                                                            \
     zip                                                                                                                 \
-    zlib1g-dev                                                                                                          \
+    acl                                                                                                                 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono
@@ -174,17 +163,19 @@ RUN set -eo pipefail                                                            
   && chmod -R a+rw ${CARGO_HOME}
 ENV PATH=$PATH:${CARGO_HOME}/bin
 
-# Install Python 3
-ENV PYENV_ROOT="/opt/pyenv"
-RUN curl -fSsL "https://pyenv.run" | bash                                                                               \
-  && command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"                                                 \
-  && eval "$(pyenv init -)"                                                                                             \
-  && PYTHON_CONFIGURE_OPTS='--enable-optimizations --with-lto' pyenv install 3.8                                        \
-  && pyenv global 3.8                                                                                                   \
-  && python3 -m pip install --no-input --upgrade pip                                                                    \
-  && python3 -m pip install --no-input --upgrade black setuptools twine wheel aws-sam-cli                               \
-  && rm -rf $(pip cache dir)                                                                                            \
+# Install Python 3 and pipx
+# (Can't use 'apt-get install pipx because that's only available starting in bookworm, so we need to be nasty)
+RUN apt-get update                                                                                                      \
+  && apt-get -y install python3-dev python3-pip python3-venv                                                            \
+  && python3 -m pip install --break-system-packages pipx                                                                \
   && rm -rf /var/lib/apt/lists/*
+
+# Install Python tools globally using pipx (install globally)
+ENV PIPX_HOME=/opt/pipx
+ENV PIPX_BIN_DIR=/usr/local/bin
+RUN pipx install black \
+  && pipx install twine \
+  && pipx install aws-sam-cli
 
 # Install AWS CLI v2
 ENV AWS_CLI_V2_URL='https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip'
@@ -410,10 +401,8 @@ ENV LANG="C.UTF-8"                                                              
   \
   GOROOT="/opt/golang/go"                                                                                               \
   RUSTUP_HOME="/usr/local/rustup"                                                                                       \
-  CARGO_HOME="/usr/local/cargo"                                                                                         \
-  \
-  PYENV_ROOT="/opt/pyenv"
-ENV PATH="${PYENV_ROOT}/shims:${PATH}:${CARGO_HOME}/bin:${GOROOT}/bin:${M2}:${PYENV_ROOT}/bin"
+  CARGO_HOME="/usr/local/cargo"
+ENV PATH="${PATH}:${CARGO_HOME}/bin:${GOROOT}/bin:${M2}"
 
 COPY --from=staging / /
 VOLUME /var/lib/docker

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -164,7 +164,7 @@ RUN set -eo pipefail                                                            
 ENV PATH=$PATH:${CARGO_HOME}/bin
 
 # Install Python 3 and pipx
-# (Can't use 'apt-get install pipx because that's only available starting in bookworm, so we need to be nasty)
+# ('apt-get install pipx' only works starting from bookworm, so we need to be forceful with 'pip install')
 RUN apt-get update                                                                                                      \
   && apt-get -y install python3-dev python3-pip python3-venv                                                            \
   && python3 -m pip install --break-system-packages pipx                                                                \

--- a/superchain/build-local.sh
+++ b/superchain/build-local.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+cd $scriptdir
 
 ###
 # This script can be used to build a jsii/superchain:local image from a locally
@@ -24,17 +26,8 @@ if [[ "${PLATFORM}" == "x86_64" ]]; then
   PLATFORM="amd64"
 fi
 
-if command -v docker >/dev/null; then
-  DOCKER=docker
-elif command -v finch >/dev/null; then
-  DOCKER=finch
-else
-  echo "Could not find 'docker' or 'finch' in PATH, aborting..."
-  exit 1
-fi
-
 # Now on to building the image
-${DOCKER} build                                                                 \
+${DOCKER:-docker} build                                                         \
   --target superchain                                                           \
   --build-arg BUILDPLATFORM=linux/${PLATFORM}                                   \
   --build-arg TARGETPLATFORM=linux/${PLATFORM}                                  \


### PR DESCRIPTION
In #4201, we introduced a Python distribution built with `pyenv` in order to safely install some Python packages globally.

However, using pyenv drives the build time of the images up from 30m to 3 hours.

This PR switches back to the distro Python and installs `pipx` to do global installs of Python packages. `pipx` will give each tool its own venv (similar to how `npm install -g` would work).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
