### PR TITLE
fix(superchain): add openssh-client back

### DIFF
--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -136,6 +136,7 @@ RUN apt-get update                                                              
     libffi-dev                                                                                                          \
     libicu-dev                                                                                                          \
     libssl-dev                                                                                                          \
+    openssh-client                                                                                                      \
     openssl                                                                                                             \
     rsync                                                                                                               \
     sudo                                                                                                                \


### PR DESCRIPTION
This was erroneously deleted and is necessary because we want the `ssh-keyscan` command.

Added: https://github.com/aws/jsii/commit/f95f88c861fb2336a88339a4cf45cb5671b79fe4
Deleted: https://github.com/aws/jsii/pull/4219/files 

```
/codebuild/output/tmp/script.sh: ssh-keyscan: not found
```

At least I think this is the solution because stack overflow tells me that `openssh-client` has `ssh-keyscan`: https://stackoverflow.com/questions/32665746/ssh-keyscan-not-found-in-dockerfile

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
