### PR TITLE
Include the error message when the go runtime observes a @jsii/kernel.Fault

### DIFF
--- a/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/process/process.go
+++ b/packages/@jsii/go-runtime/jsii-runtime-go/internal/kernel/process/process.go
@@ -227,7 +227,7 @@ func (p *Process) readResponse(into interface{}) error {
 		json.Unmarshal(raw, &errResp)
 
 		if errResp.Name != nil && *errResp.Name == "@jsii/kernel.Fault" {
-			return fmt.Errorf("JsiiError: %s", *errResp.Name)
+			return fmt.Errorf("JsiiError: %s %s", *errResp.Name, errResp.Error)
 		}
 
 		return errors.New(errResp.Error)


### PR DESCRIPTION
I ran into this error message when developing a JSII compatible construct.

```
panic: JsiiError: @jsii/kernel.Fault
```

Including the de-serialized error message into the wrapped error helped me debug that I was missing the `.jsii` file in my distribution! (eg: I needed to add `".jsii"` to the `"files"` list in my construct's `package.json`)

```
panic: JsiiError: @jsii/kernel.Fault Error for package tarball /var/folders/<redacted>.tgz: Expected to find .jsii file in /var/folders/<redacted>/node_modules/<redacted>, but no such file found
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
