### PR TITLE
chore: fix pages build

### DIFF
--- a/gh-pages/mkdocs.yml
+++ b/gh-pages/mkdocs.yml
@@ -58,8 +58,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 plugins:
   - awesome-pages:


### PR DESCRIPTION
Fixes the following error in the pages build workflow ([example](https://github.com/aws/jsii/actions/runs/6720427611)):

```
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
Material emoji logic has been officially moved into mkdocs-material
version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
as mkdocs_material_extensions is deprecated and will no longer be
supported moving forward. This is the last release.
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
