### PR TITLE
fix(kernel): invokeBinScript fails when using symlinked cache

### DIFF
--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -1371,13 +1371,20 @@ export class Kernel {
         throw new JsiiFault(`Script with name ${req.script} was not defined.`);
       }
 
+      // Make sure the current NODE_OPTIONS are honored if we shell out to node
+      const nodeOptions = [...process.execArgv];
+
+      // When we are using the symlinked version of the cache, we need to preserve both symlink settings for binaries
+      if (nodeOptions.includes('--preserve-symlinks')) {
+        nodeOptions.push('--preserve-symlinks-main');
+      }
+
       return {
         command: path.join(packageDir, scriptPath),
         args: req.args ?? [],
         env: {
           ...process.env,
-          // Make sure the current NODE_OPTIONS are honored if we shell out to node
-          NODE_OPTIONS: process.execArgv.join(' '),
+          NODE_OPTIONS: nodeOptions.join(' '),
           // Make sure "this" node is ahead of $PATH just in case
           PATH: `${path.dirname(process.execPath)}:${process.env.PATH}`,
         },

--- a/packages/@jsii/kernel/src/tar-cache/index.ts
+++ b/packages/@jsii/kernel/src/tar-cache/index.ts
@@ -15,7 +15,7 @@ export interface ExtractResult {
    * When `'hit'`, the data was already present in cache and was returned from
    * cache.
    *
-   * When `'miss'`, the data was extracted into the caache and returned from
+   * When `'miss'`, the data was extracted into the cache and returned from
    * cache.
    *
    * When `undefined`, the cache is not enabled.

--- a/packages/jsii-calc/bin/run.ts
+++ b/packages/jsii-calc/bin/run.ts
@@ -2,10 +2,15 @@
 
 /* eslint-disable no-console */
 
+import * as calcLib from '@scope/jsii-calc-lib';
+
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const runCommand = async () => {
   console.info('Hello World!');
+
+  // Make sure this binary depends on an external package to test dependencies with invokeBinScript
+  new calcLib.Number(1);
 
   const args = process.argv.slice(2);
   if (args.length > 0) {


### PR DESCRIPTION
Invoking bin scripts from jsii packages would fail if the symlinked cache was enabled and the invoked script depended on an other package. The reason for this was that scripts were only invoked with `--preserve-symlinks`, however for "main scripts" (like standalone binaries), we also need to call `--preserve-symlinks-main` on the node process.

Note this cannot be tested in the kernel package itself, as it's not possible to invoke the test process with the correct options. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
