### PR TITLE
feat: make node 18 the default

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         debian:
-          - 'buster'   # 10
-        node: ['16', '18', '20']
+          - 'buster' # 10
+        node: ['18', '20']
         include:
           - debian: 'bullseye' # 11
             node: '20'
@@ -31,7 +31,7 @@ jobs:
             node: '20'
     env:
       # Node version whose images will be aliased without the -nodeXX segment
-      DEFAULT_NODE_MAJOR_VERSION: 16
+      DEFAULT_NODE_MAJOR_VERSION: 18
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Set up Node 16
+      - name: Set up Node 18
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: '16'
+          node-version: '18'
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:
@@ -125,11 +125,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Set up Node 16
+      - name: Set up Node 18
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: '16'
+          node-version: '18'
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:
@@ -195,10 +195,10 @@ jobs:
         dotnet: ['6.0.x']
         go: ['1.18']
         java: ['8']
-        node: ['16'] # EOL 2023-09-11
+        node: ['18'] # EOL 2025-04-30
         os: [ubuntu-latest]
         python: ['3.7']
-        # Add specific combinations to be tested against "node 14" (to restrict cardinality)
+        # Add specific combinations to be tested against (to restrict cardinality)
         include:
           # Test using Windows
           - title: 'Windows'
@@ -206,7 +206,7 @@ jobs:
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             python: '3.7'
           # Test using macOS
           - title: 'macOS'
@@ -214,16 +214,9 @@ jobs:
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             python: '3.7'
           # Test alternate Nodes
-          - title: 'Node 16'
-            java: '8'
-            dotnet: '6.0.x'
-            go: '1.18'
-            node: '16' # EOL 2023-09-11
-            os: ubuntu-latest
-            python: '3.7'
           - title: 'Node 18'
             java: '8'
             dotnet: '6.0.x'
@@ -243,7 +236,7 @@ jobs:
             java: '8'
             dotnet: '7.0.x'
             go: '1.18'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
             python: '3.7'
           # Test alternate Gos
@@ -251,7 +244,7 @@ jobs:
             java: '8'
             dotnet: '6.0.x'
             go: '1.19'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
             python: '3.7'
           # Test alternate Javas
@@ -259,7 +252,7 @@ jobs:
             java: '11'
             dotnet: '6.0.x'
             go: '1.18'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
             python: '3.7'
           # Test alternate Pythons
@@ -268,28 +261,28 @@ jobs:
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
           - title: 'Python 3.9'
             python: '3.9'
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
           - title: 'Python 3.10'
             python: '3.10'
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
           - title: 'Python 3.11'
             python: '3.11'
             dotnet: '6.0.x'
             go: '1.18'
             java: '8'
-            node: '16'
+            node: '18'
             os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -479,4 +472,3 @@ jobs:
         with:
           name: integtest_aws-cdk-lib
           path: ./node_modules/aws-cdk-lib/dist/
-

--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -35,9 +35,6 @@ export class NodeRelease {
       endOfLife: new Date('2022-04-30'),
       supportedRange: '^12.7.0',
     }),
-    new NodeRelease(19, { endOfLife: new Date('2023-06-01') }),
-
-    // Currently active releases (as of last edit to this file...)
     new NodeRelease(16, {
       endOfLife: new Date('2023-09-11'),
       supportedRange: '^16.3.0',
@@ -46,8 +43,12 @@ export class NodeRelease {
       endOfLife: new Date('2022-06-01'),
       supportedRange: '^17.3.0',
     }),
+    new NodeRelease(19, { endOfLife: new Date('2023-06-01') }),
+
+    // Currently active releases (as of last edit to this file...)
     new NodeRelease(18, { endOfLife: new Date('2025-04-30') }),
     new NodeRelease(20, { endOfLife: new Date('2026-04-30') }),
+    new NodeRelease(21, { endOfLife: new Date('2024-06-01') }),
 
     // Future (planned releases)
   ];

--- a/packages/@jsii/check-node/src/index.test.ts
+++ b/packages/@jsii/check-node/src/index.test.ts
@@ -11,7 +11,7 @@ test('tested node releases are correctly registered & supported', () => {
 
 // This test is there to ensure house-keeping happens when it should. If we are
 // testing a given node release, it must not have been EOL for over 60 days.
-test(`tested node release (${process.version}) has not ben EOL for more than 60 days`, () => {
+test(`tested node release (${process.version}) has not been EOL for more than 60 days`, () => {
   const { nodeRelease } = NodeRelease.forThisRuntime();
   expect(nodeRelease?.endOfLifeDate?.getTime()).toBeGreaterThan(
     Date.now() - 60 * 86_400_000,

--- a/packages/@jsii/check-node/src/index.ts
+++ b/packages/@jsii/check-node/src/index.ts
@@ -22,12 +22,13 @@ export function checkNode(envPrefix = 'JSII'): void {
 
   if (nodeRelease?.endOfLife) {
     const silenceVariable = `${envPrefix}_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`;
-    const acknowledgeNodeEol =
-      'Node14 is now end of life (EOL) as of April 30, 2023. Support of EOL runtimes are only guaranteed for 30 days after EOL. By silencing this warning you acknowledge that you are using an EOL version of Node and will upgrade to a supported version as soon as possible.';
+    const silencedVersions = (process.env[silenceVariable] ?? '')
+      .split(',')
+      .map((v) => v.trim());
     const qualifier = nodeRelease.endOfLifeDate
       ? ` on ${nodeRelease.endOfLifeDate.toISOString().slice(0, 10)}`
       : '';
-    if (!(process.env[silenceVariable] === acknowledgeNodeEol))
+    if (!silencedVersions.includes(nodeRelease.majorVersion.toString()))
       veryVisibleMessage(
         bgRed.white.bold,
         `Node ${nodeRelease.majorVersion} has reached end-of-life${qualifier} and is not supported.`,

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -24,7 +24,9 @@ def silence_node_deprecation_warnings():
         environ[var] = "1"
 
     # silence this for the next decades
-    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "14,16,18,20,22,24,26,28,30,32,34"
+    environ[
+        "JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"
+    ] = "14,16,18,20,22,24,26,28,30,32,34"
 
     # Execute the test
     yield

--- a/packages/@jsii/python-runtime/tests/test_invoke_bin.py
+++ b/packages/@jsii/python-runtime/tests/test_invoke_bin.py
@@ -23,8 +23,8 @@ def silence_node_deprecation_warnings():
     for var in variables:
         environ[var] = "1"
 
-    nodeEolAcknowledgement = "Node14 is now end of life (EOL) as of April 30, 2023. Support of EOL runtimes are only guaranteed for 30 days after EOL. By silencing this warning you acknowledge that you are using an EOL version of Node and will upgrade to a supported version as soon as possible."
-    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = nodeEolAcknowledgement
+    # silence this for the next decades
+    environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "14,16,18,20,22,24,26,28,30,32,34"
 
     # Execute the test
     yield

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -40,7 +40,7 @@ ARG DEBIAN_VERSION="bookworm"
 
 # We require a couple of tools to be available in order to work here...
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_VERSION}-backports main"                                            \
-    > "/etc/apt/sources.list.d/${DEBIAN_VERSION}-backports.list"                                                        \
+  > "/etc/apt/sources.list.d/${DEBIAN_VERSION}-backports.list"                                                        \
   && apt-get update                                                                                                     \
   && apt-get install -y gpg tar zsh                                                                                     \
   # We need a "recent" (>= 7.71) version of curl for --retry-all-errors, so we get it from backports...
@@ -54,9 +54,9 @@ ARG M2_VERSION="3.9.4"
 ENV M2_DISTRO="https://www.apache.org/dist/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                             \
-    -o /tmp/apache-maven.tar.gz                                                                                         \
+  -o /tmp/apache-maven.tar.gz                                                                                         \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz.asc"                         \
-    -o /tmp/apache-maven.tar.gz.asc                                                                                     \
+  -o /tmp/apache-maven.tar.gz.asc                                                                                     \
   && mkdir -p /tmp/gpg-maven && chmod go-rwx /tmp/gpg-maven                                                             \
   && curl -fSsL "https://www.apache.org/dist/maven/KEYS" | gpg --homedir /tmp/gpg-maven --import                        \
   && gpg --homedir /tmp/gpg-maven --verify /tmp/apache-maven.tar.gz.asc /tmp/apache-maven.tar.gz                        \
@@ -75,11 +75,11 @@ RUN DOTNET_VERSION=$(curl -fSsL "${DOTNET_FEED}/Sdk/${DOTNET_CHANNEL}/latest.ver
 # Prepare PowerShell LTS distribution
 ENV POWERSHELL_RELEASES="https://github.com/PowerShell/PowerShell/releases"
 RUN POWERSHELL_RELEASE=$(curl -X GET -fSsIL "https://aka.ms/powershell-release?tag=lts" -o /dev/null                    \
-    --retry 5 --retry-all-errors -w %{url_effective})                                                                   \
+  --retry 5 --retry-all-errors -w %{url_effective})                                                                   \
   && POWERSHELL_VERSION=${POWERSHELL_RELEASE#${POWERSHELL_RELEASES}/tag/v}                                              \
   && ASSET="powershell-${POWERSHELL_VERSION}-linux-${${TARGETPLATFORM#linux/}/amd64/x64}.tar.gz"                        \
   && curl -fSsL "${POWERSHELL_RELEASES}/download/v${POWERSHELL_VERSION}/${ASSET}" --retry 5 --retry-all-errors          \
-    -o /tmp/powershell.tar.gz                                                                                           \
+  -o /tmp/powershell.tar.gz                                                                                           \
   && mkdir -p /opt/microsoft/powershell                                                                                 \
   && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell                                                        \
   && chmod +x /opt/microsoft/powershell/pwsh
@@ -125,24 +125,24 @@ ENV LANG="C.UTF-8"                                                              
 RUN apt-get update                                                                                                      \
   && apt-get -y upgrade                                                                                                 \
   && apt-get -y install --no-install-recommends                                                                         \
-    apt-transport-https                                                                                                 \
-    build-essential                                                                                                     \
-    ca-certificates                                                                                                     \
-    curl                                                                                                                \
-    dirmngr                                                                                                             \
-    git                                                                                                                 \
-    gnupg                                                                                                               \
-    gzip                                                                                                                \
-    libffi-dev                                                                                                          \
-    libicu-dev                                                                                                          \
-    libssl-dev                                                                                                          \
-    openssh-client                                                                                                      \
-    openssl                                                                                                             \
-    rsync                                                                                                               \
-    sudo                                                                                                                \
-    unzip                                                                                                               \
-    zip                                                                                                                 \
-    acl                                                                                                                 \
+  apt-transport-https                                                                                                 \
+  build-essential                                                                                                     \
+  ca-certificates                                                                                                     \
+  curl                                                                                                                \
+  dirmngr                                                                                                             \
+  git                                                                                                                 \
+  gnupg                                                                                                               \
+  gzip                                                                                                                \
+  libffi-dev                                                                                                          \
+  libicu-dev                                                                                                          \
+  libssl-dev                                                                                                          \
+  openssh-client                                                                                                      \
+  openssl                                                                                                             \
+  rsync                                                                                                               \
+  sudo                                                                                                                \
+  unzip                                                                                                               \
+  zip                                                                                                                 \
+  acl                                                                                                                 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono
@@ -150,7 +150,7 @@ COPY superchain/gpg/mono.asc /tmp/mono.asc
 RUN apt-key add /tmp/mono.asc && rm /tmp/mono.asc                                                                       \
   # Mono only provides a Debian Buster (10) distribution point, but it works with subsequent debians, too...
   && echo "deb https://download.mono-project.com/repo/debian stable-buster main"                                        \
-    > /etc/apt/sources.list.d/mono-official-stable.list                                                                 \
+  > /etc/apt/sources.list.d/mono-official-stable.list                                                                 \
   && apt-get update                                                                                                     \
   && apt-get -y install mono-devel                                                                                      \
   && rm -rf /var/lib/apt/lists/*
@@ -213,7 +213,7 @@ ARG GITHUB_CLI_VERSION="1.13.1"
 RUN BASE="https://github.com/cli/cli/releases/download"                                                                 \
   && echo "${BASE}/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETPLATFORM#linux/}.deb"                  \
   && curl -fSsL "${BASE}/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETPLATFORM#linux/}.deb"            \
-    -o /tmp/gh.deb                                                                                                      \
+  -o /tmp/gh.deb                                                                                                      \
   && apt-get update                                                                                                     \
   && apt-get -y install /tmp/gh.deb                                                                                     \
   && rm /tmp/gh.deb                                                                                                     \
@@ -232,15 +232,15 @@ COPY superchain/m2-settings.xml /root/.m2/settings.xml
 # Install Go
 COPY --from=bindist /opt/golang/go ${GOROOT}
 
-# Install Node 14+ (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
+# Install Node (configurable with '--build-arg NODE_MAJOR_VERSION=xxx') and yarn
 # (Put this as late as possible in the Dockerfile so we get to reuse the layer cache
 # for most of the multiple builds).
-ARG NODE_MAJOR_VERSION="16"
+ARG NODE_MAJOR_VERSION="18"
 COPY superchain/gpg/nodesource.asc /tmp/nodesource.asc
 COPY superchain/gpg/yarn.asc /tmp/yarn.asc
 RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                                                           \
   && echo "deb https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x ${DEBIAN_VERSION} main"                          \
-    > /etc/apt/sources.list.d/nodesource.list                                                                           \
+  > /etc/apt/sources.list.d/nodesource.list                                                                           \
   # Reduce priority of the "standard" nodejs package, so that the one from nodesource is always preferred...
   && echo "Package: nodejs" > /etc/apt/preferences.d/nodejs                                                             \
   && echo 'Pin: origin "deb.debian.org"' >> /etc/apt/preferences.d/nodejs                                               \
@@ -256,7 +256,7 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 RUN apt-get update                                                                                                      \
   && apt-get -y install --no-install-recommends curl                                                                    \
   && curl -fSsL "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${TARGETPLATFORM#linux/}/amazon-ssm-agent.deb"\
-    -o /tmp/amazon-ssm-agent.deb                                                                                        \
+  -o /tmp/amazon-ssm-agent.deb                                                                                        \
   && dpkg -i /tmp/amazon-ssm-agent.deb                                                                                  \
   && systemctl enable amazon-ssm-agent                                                                                  \
   && rm -rf /var/lib/apt/lists/*

--- a/superchain/Dockerfile
+++ b/superchain/Dockerfile
@@ -40,7 +40,7 @@ ARG DEBIAN_VERSION="bookworm"
 
 # We require a couple of tools to be available in order to work here...
 RUN echo "deb http://deb.debian.org/debian ${DEBIAN_VERSION}-backports main"                                            \
-  > "/etc/apt/sources.list.d/${DEBIAN_VERSION}-backports.list"                                                        \
+    > "/etc/apt/sources.list.d/${DEBIAN_VERSION}-backports.list"                                                        \
   && apt-get update                                                                                                     \
   && apt-get install -y gpg tar zsh                                                                                     \
   # We need a "recent" (>= 7.71) version of curl for --retry-all-errors, so we get it from backports...
@@ -54,9 +54,9 @@ ARG M2_VERSION="3.9.4"
 ENV M2_DISTRO="https://www.apache.org/dist/maven/maven-3"
 RUN set -eo pipefail                                                                                                    \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz"                             \
-  -o /tmp/apache-maven.tar.gz                                                                                         \
+    -o /tmp/apache-maven.tar.gz                                                                                         \
   && curl -fSsL "${M2_DISTRO}/${M2_VERSION}/binaries/apache-maven-${M2_VERSION}-bin.tar.gz.asc"                         \
-  -o /tmp/apache-maven.tar.gz.asc                                                                                     \
+    -o /tmp/apache-maven.tar.gz.asc                                                                                     \
   && mkdir -p /tmp/gpg-maven && chmod go-rwx /tmp/gpg-maven                                                             \
   && curl -fSsL "https://www.apache.org/dist/maven/KEYS" | gpg --homedir /tmp/gpg-maven --import                        \
   && gpg --homedir /tmp/gpg-maven --verify /tmp/apache-maven.tar.gz.asc /tmp/apache-maven.tar.gz                        \
@@ -75,11 +75,11 @@ RUN DOTNET_VERSION=$(curl -fSsL "${DOTNET_FEED}/Sdk/${DOTNET_CHANNEL}/latest.ver
 # Prepare PowerShell LTS distribution
 ENV POWERSHELL_RELEASES="https://github.com/PowerShell/PowerShell/releases"
 RUN POWERSHELL_RELEASE=$(curl -X GET -fSsIL "https://aka.ms/powershell-release?tag=lts" -o /dev/null                    \
-  --retry 5 --retry-all-errors -w %{url_effective})                                                                   \
+    --retry 5 --retry-all-errors -w %{url_effective})                                                                   \
   && POWERSHELL_VERSION=${POWERSHELL_RELEASE#${POWERSHELL_RELEASES}/tag/v}                                              \
   && ASSET="powershell-${POWERSHELL_VERSION}-linux-${${TARGETPLATFORM#linux/}/amd64/x64}.tar.gz"                        \
   && curl -fSsL "${POWERSHELL_RELEASES}/download/v${POWERSHELL_VERSION}/${ASSET}" --retry 5 --retry-all-errors          \
-  -o /tmp/powershell.tar.gz                                                                                           \
+    -o /tmp/powershell.tar.gz                                                                                           \
   && mkdir -p /opt/microsoft/powershell                                                                                 \
   && tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell                                                        \
   && chmod +x /opt/microsoft/powershell/pwsh
@@ -125,24 +125,24 @@ ENV LANG="C.UTF-8"                                                              
 RUN apt-get update                                                                                                      \
   && apt-get -y upgrade                                                                                                 \
   && apt-get -y install --no-install-recommends                                                                         \
-  apt-transport-https                                                                                                 \
-  build-essential                                                                                                     \
-  ca-certificates                                                                                                     \
-  curl                                                                                                                \
-  dirmngr                                                                                                             \
-  git                                                                                                                 \
-  gnupg                                                                                                               \
-  gzip                                                                                                                \
-  libffi-dev                                                                                                          \
-  libicu-dev                                                                                                          \
-  libssl-dev                                                                                                          \
-  openssh-client                                                                                                      \
-  openssl                                                                                                             \
-  rsync                                                                                                               \
-  sudo                                                                                                                \
-  unzip                                                                                                               \
-  zip                                                                                                                 \
-  acl                                                                                                                 \
+    apt-transport-https                                                                                                 \
+    build-essential                                                                                                     \
+    ca-certificates                                                                                                     \
+    curl                                                                                                                \
+    dirmngr                                                                                                             \
+    git                                                                                                                 \
+    gnupg                                                                                                               \
+    gzip                                                                                                                \
+    libffi-dev                                                                                                          \
+    libicu-dev                                                                                                          \
+    libssl-dev                                                                                                          \
+    openssh-client                                                                                                      \
+    openssl                                                                                                             \
+    rsync                                                                                                               \
+    sudo                                                                                                                \
+    unzip                                                                                                               \
+    zip                                                                                                                 \
+    acl                                                                                                                 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mono
@@ -150,7 +150,7 @@ COPY superchain/gpg/mono.asc /tmp/mono.asc
 RUN apt-key add /tmp/mono.asc && rm /tmp/mono.asc                                                                       \
   # Mono only provides a Debian Buster (10) distribution point, but it works with subsequent debians, too...
   && echo "deb https://download.mono-project.com/repo/debian stable-buster main"                                        \
-  > /etc/apt/sources.list.d/mono-official-stable.list                                                                 \
+    > /etc/apt/sources.list.d/mono-official-stable.list                                                                 \
   && apt-get update                                                                                                     \
   && apt-get -y install mono-devel                                                                                      \
   && rm -rf /var/lib/apt/lists/*
@@ -213,7 +213,7 @@ ARG GITHUB_CLI_VERSION="1.13.1"
 RUN BASE="https://github.com/cli/cli/releases/download"                                                                 \
   && echo "${BASE}/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETPLATFORM#linux/}.deb"                  \
   && curl -fSsL "${BASE}/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_${TARGETPLATFORM#linux/}.deb"            \
-  -o /tmp/gh.deb                                                                                                      \
+    -o /tmp/gh.deb                                                                                                      \
   && apt-get update                                                                                                     \
   && apt-get -y install /tmp/gh.deb                                                                                     \
   && rm /tmp/gh.deb                                                                                                     \
@@ -240,7 +240,7 @@ COPY superchain/gpg/nodesource.asc /tmp/nodesource.asc
 COPY superchain/gpg/yarn.asc /tmp/yarn.asc
 RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                                                           \
   && echo "deb https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x ${DEBIAN_VERSION} main"                          \
-  > /etc/apt/sources.list.d/nodesource.list                                                                           \
+    > /etc/apt/sources.list.d/nodesource.list                                                                           \
   # Reduce priority of the "standard" nodejs package, so that the one from nodesource is always preferred...
   && echo "Package: nodejs" > /etc/apt/preferences.d/nodejs                                                             \
   && echo 'Pin: origin "deb.debian.org"' >> /etc/apt/preferences.d/nodejs                                               \
@@ -256,7 +256,7 @@ RUN apt-key add /tmp/nodesource.asc && rm /tmp/nodesource.asc                   
 RUN apt-get update                                                                                                      \
   && apt-get -y install --no-install-recommends curl                                                                    \
   && curl -fSsL "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${TARGETPLATFORM#linux/}/amazon-ssm-agent.deb"\
-  -o /tmp/amazon-ssm-agent.deb                                                                                        \
+    -o /tmp/amazon-ssm-agent.deb                                                                                        \
   && dpkg -i /tmp/amazon-ssm-agent.deb                                                                                  \
   && systemctl enable amazon-ssm-agent                                                                                  \
   && rm -rf /var/lib/apt/lists/*

--- a/superchain/README.md
+++ b/superchain/README.md
@@ -8,15 +8,15 @@ required in order to package [jsii] projects in all supported languages.
 
 ## Included Language SDKs
 
-SDK             | Version
-----------------|-------------------------------------------
-`OpenJDK 20`    | Amazon Corretto `>= 20.0.0`
-`.NET SDK`      | `>= 6.0.14`
-`mono`          | `>= 6.8.0.105`
-`Javascript`    | see [NodeJS and NPM](#nodejs-and-npm)
-`PowerShell`    | `pwsh >= 7.1.3`
-`Python 3`      | `python3 >= 3.7.4` with `pip3 >= 20.0.2`
-`Go`            | `go >= 1.18`
+| SDK          | Version                                  |
+| ------------ | ---------------------------------------- |
+| `OpenJDK 20` | Amazon Corretto `>= 20.0.0`              |
+| `.NET SDK`   | `>= 6.0.14`                              |
+| `mono`       | `>= 6.8.0.105`                           |
+| `Javascript` | see [NodeJS and NPM](#nodejs-and-npm)    |
+| `PowerShell` | `pwsh >= 7.1.3`                          |
+| `Python 3`   | `python3 >= 3.7.4` with `pip3 >= 20.0.2` |
+| `Go`         | `go >= 1.18`                             |
 
 ## Image tags
 
@@ -31,9 +31,7 @@ public.ecr.aws/jsii/superchain:<JSII-MAJOR>-<BASE>(-node<NODE-MAJOR>)(-nightly)
 - `<BASE>` is the base image tag (e.g: `buster-slim`, `bullseye-slim`, `bookworm-slim`)
   - The only supported value is `buster-slim`
 - `<NODE-MAJOR>` is the major version of node contained in the image
-  - `14` corresponds to node 14.x, this is the default
-  - `16` corresponds to node 16.x
-  - `18` corresponds to node 18.x
+  - `18` corresponds to node 18.x, this is the default
   - `20` corresponds to node 20.x
 - `-nightly` images are released from the `HEAD` of the [`aws/jsii`][jsii]
   repository and should typically not be used for production workloads
@@ -42,12 +40,14 @@ The previous image tags have been discontinued:
 
 - `:latest` (users should migrate to `:1-buster-slim`)
 - `:nightly` (users should migrate to `:1-buster-slim-nightly`)
-- `:node10` (users should migrate to `:1-buster-slim-node14`)
-- `:node10-nightly` (users should migrate to `:1-buster-slim-node14-nightly`)
-- `:node12` (users shoudl migrate to `:1-buster-slim-node14`)
-- `:node12-nightly` (users shoudl migrate to `:1-buster-slim-node14-nightly`)
-- `:node14` (users shoudl migrate to `:1-buster-slim-node14`)
-- `:node14-nightly` (users shoudl migrate to `:1-buster-slim-node14-nightly`)
+- `:node10` (users should migrate to `:1-buster-slim-node18`)
+- `:node10-nightly` (users should migrate to `:1-buster-slim-node18-nightly`)
+- `:node12` (users should migrate to `:1-buster-slim-node18`)
+- `:node12-nightly` (users shoudl migrate to `:1-buster-slim-node18-nightly`)
+- `:node14` (users should migrate to `:1-buster-slim-node18`)
+- `:node14-nightly` (users shoudl migrate to `:1-buster-slim-node18-nightly`)
+- `:node16` (users should migrate to `:1-buster-slim-node18`)
+- `:node16-nightly` (users shoudl migrate to `:1-buster-slim-node18-nightly`)
 
 ## Building
 
@@ -82,20 +82,20 @@ jsii$ docker build [...] --build-arg NODE_MAJOR_VERSION=16
 
 ## Included Tools & Utilities
 
-Tool / Utility | Version
----------------|--------------------------------------------
-`aws`          | `>= 2.11.17`
-`bundler`      | `>= 1.17.3` and `>= 2.1.4`
-`docker`       | `>= 18.09.9-ce`
-`git`          | `>= 2.23.1`
-`make`         | `>= 3.82`
-`maven`        | `>= 3.6.3`
-`openssl`      | `>= 1.0.2k-fips`
-`rsync`        | `>= 3.1.2`
-`yarn`         | `>= 1.21.1`
-`zip` & `unzip`| `>= 6.0-19`
-`gh`           | `>= 1.9.2`
-`sam`          | `>= 1.37.0`
+| Tool / Utility  | Version                    |
+| --------------- | -------------------------- |
+| `aws`           | `>= 2.11.17`               |
+| `bundler`       | `>= 1.17.3` and `>= 2.1.4` |
+| `docker`        | `>= 18.09.9-ce`            |
+| `git`           | `>= 2.23.1`                |
+| `make`          | `>= 3.82`                  |
+| `maven`         | `>= 3.6.3`                 |
+| `openssl`       | `>= 1.0.2k-fips`           |
+| `rsync`         | `>= 3.1.2`                 |
+| `yarn`          | `>= 1.21.1`                |
+| `zip` & `unzip` | `>= 6.0-19`                |
+| `gh`            | `>= 1.9.2`                 |
+| `sam`           | `>= 1.37.0`                |
 
 ## License
 


### PR DESCRIPTION
Removes testing and superchain releases for EOL Node 16

Deprecation and EOL messages of node versions are automated, so no need to announce or wait.
We are well past the promised 30 days support after Node 16 went EOL.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
