### PR TITLE
feat: switch to python 3.8 (#4239)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           cache: yarn
           node-version: '18'
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           cache: pip
       - name: Install python3-venv
         run: sudo apt install -y python3-venv
@@ -130,10 +130,10 @@ jobs:
         with:
           cache: yarn
           node-version: '18'
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           cache: pip
       - name: Install python3-venv
         run: sudo apt install -y python3-venv
@@ -197,7 +197,7 @@ jobs:
         java: ['8']
         node: ['18'] # EOL 2025-04-30
         os: [ubuntu-latest]
-        python: ['3.7']
+        python: ['3.8']
         # Add specific combinations to be tested against (to restrict cardinality)
         include:
           # Test using Windows
@@ -207,7 +207,7 @@ jobs:
             go: '1.18'
             java: '8'
             node: '18'
-            python: '3.7'
+            python: '3.8'
           # Test using macOS
           - title: 'macOS'
             os: macos-latest
@@ -215,7 +215,7 @@ jobs:
             go: '1.18'
             java: '8'
             node: '18'
-            python: '3.7'
+            python: '3.8'
           # Test alternate Nodes
           - title: 'Node 18'
             java: '8'
@@ -223,14 +223,14 @@ jobs:
             go: '1.18'
             node: '18' # EOL 2025-04-30
             os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
           - title: 'Node 20'
             java: '8'
             dotnet: '6.0.x'
             go: '1.18'
             node: '20' # EOL 2026-04-30
             os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
           # Test alternate .NETs
           - title: '.NET 7.0'
             java: '8'
@@ -238,7 +238,7 @@ jobs:
             go: '1.18'
             node: '18'
             os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
           # Test alternate Gos
           - title: 'Go 1.19'
             java: '8'
@@ -246,7 +246,7 @@ jobs:
             go: '1.19'
             node: '18'
             os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
           # Test alternate Javas
           - title: 'Java 11'
             java: '11'
@@ -254,7 +254,7 @@ jobs:
             go: '1.18'
             node: '18'
             os: ubuntu-latest
-            python: '3.7'
+            python: '3.8'
           # Test alternate Pythons
           - title: 'Python 3.8'
             python: '3.8'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ in your development environment.
   + [`maven >= 3.0.5`](https://maven.apache.org)
 - [.NET `6.0`] or later
   + *Recommended:* [`mono >= 6`](https://www.mono-project.com)
-- [Python `3.7.3`] or later
+- [Python `3.8.10`] or later
   + [`pip`](https://pip.pypa.io/en/stable/installing/)
   + [`setuptools >= 38.6.0`](https://pypi.org/project/setuptools/)
   + [`wheel`](https://pypi.org/project/wheel/)
@@ -57,7 +57,7 @@ in your development environment.
 [Oracle's OpenJDK8]: http://openjdk.java.net/install/
 [Amazon Corretto 8]: https://aws.amazon.com/corretto/
 [.NET `6.0`]: https://www.microsoft.com/net/download
-[Python `3.7.3`]: https://www.python.org/downloads/release/python-373/
+[Python `3.8.10`]: https://www.python.org/downloads/release/python-3810/
 [Go]: https://go.dev/dl/
 
 ## Getting Started

--- a/gh-pages/content/user-guides/language-support/index.md
+++ b/gh-pages/content/user-guides/language-support/index.md
@@ -69,7 +69,7 @@ in significant re-engineering effort:
   - How are dependencies modeled? If [semantic versioning] is not the norm, what is the strategy to correctly represent
     semantic version ranges?
 - What are the toolchain and platform requirements?
-  - For example, **Java** requires an OpenJDK 8 distribution and `maven`, **Python** requires `python` 3.7 or above,
+  - For example, **Java** requires an OpenJDK 8 distribution and `maven`, **Python** requires `python` 3.8 or above,
     etc...
 
 ## Code Generation

--- a/gh-pages/content/user-guides/lib-author/configuration/targets/python.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/targets/python.md
@@ -16,7 +16,6 @@ The `python` target requires two configuration entries:
   - Additionally, the following `Programming Language ::` classifiers are already set (more could be added by the user
     if relevant):
     - `Programming Language :: Python :: 3 :: Only`
-    - `Programming Language :: Python :: 3.7`
     - `Programming Language :: Python :: 3.8`
     - `Programming Language :: Python :: 3.9`
     - `Programming Language :: Python :: 3.10`

--- a/gh-pages/content/user-guides/lib-author/index.md
+++ b/gh-pages/content/user-guides/lib-author/index.md
@@ -19,7 +19,7 @@ to produce releasable artifacts.
 | .NET              | .NET ≥ 6.0                   |
 | Go                | Go ≥ 1.18                    |
 | Java              | JDK ≥ 8 *and* Maven ≥ 3.6    |
-| Python            | Python ≥ 3.7                 |
+| Python            | Python ≥ 3.8                 |
 
 
 ## :octicons-desktop-download-24: Download Locations

--- a/packages/@jsii/python-runtime/pyproject.toml
+++ b/packages/@jsii/python-runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools~=62.2", "wheel~=0.37"]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '\.(git|mypy_cache|env)'
 
@@ -11,6 +11,6 @@ exclude = '\.(git|mypy_cache|env)'
 ignore_missing_imports = true
 
 [tool.pyright]
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 venv = ".env"
 venvPath = "."

--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -36,16 +36,15 @@ setuptools.setup(
         "publication>=0.0.3",  # This is used by all generated code.
         "typeguard~=2.13.3",  # This is used by all generated code.
         "python-dateutil",
-        "typing_extensions>=3.7,<5.0",
+        "typing_extensions>=3.8,<5.0",
     ],
-    python_requires="~=3.7",
+    python_requires="~=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -2102,7 +2102,7 @@ class Package {
       package_dir: { '': 'src' },
       packages: modules.map((m) => m.pythonName),
       package_data: packageData,
-      python_requires: '~=3.7',
+      python_requires: '~=3.8',
       install_requires: [
         `jsii${toPythonVersionRange(`^${VERSION}`)}`,
         'publication>=0.0.3',
@@ -2115,7 +2115,6 @@ class Package {
         'Operating System :: OS Independent',
         'Programming Language :: JavaScript',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -2236,7 +2235,7 @@ class Package {
     code.line();
     code.line('[tool.pyright]');
     code.line('defineConstant = { DEBUG = true }');
-    code.line('pythonVersion = "3.7"');
+    code.line('pythonVersion = "3.8"');
     code.line('pythonPlatform = "All"');
     code.line('reportSelfClsParameterName = false');
     code.closeFile('pyproject.toml');

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -1225,7 +1225,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -1266,7 +1266,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -1277,7 +1277,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -2647,7 +2646,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -2688,7 +2687,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -2699,7 +2698,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -417,7 +417,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -454,7 +454,7 @@ kwargs = json.loads(
             "foo@1.2.3.jsii.tgz"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "bar>=2.0.0.rc42, <3.0.0",
         "jsii<0.0.1",
@@ -466,7 +466,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -932,7 +931,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -969,7 +968,7 @@ kwargs = json.loads(
             "foo@1.2.3.jsii.tgz"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "bar>=4.5.6.dev1337, <5.0.0",
         "jsii<0.0.1",
@@ -981,7 +980,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -1427,7 +1425,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -1464,7 +1462,7 @@ kwargs = json.loads(
             "foo@2.0.0-rc.42.jsii.tgz"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -1475,7 +1473,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -1919,7 +1916,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -1956,7 +1953,7 @@ kwargs = json.loads(
             "foo@4.5.6-pre.1337.jsii.tgz"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -1967,7 +1964,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -248,7 +248,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -289,7 +289,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -301,7 +301,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -803,7 +802,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -844,7 +843,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -855,7 +854,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -1331,7 +1329,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -1374,7 +1372,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -1387,7 +1385,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -2992,7 +2989,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 defineConstant = { DEBUG = true }
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 pythonPlatform = "All"
 reportSelfClsParameterName = false
 
@@ -3072,7 +3069,7 @@ kwargs = json.loads(
             "py.typed"
         ]
     },
-    "python_requires": "~=3.7",
+    "python_requires": "~=3.8",
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
@@ -3085,7 +3082,6 @@ kwargs = json.loads(
         "Operating System :: OS Independent",
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Python 3.7 has been end-of-life since 2023-06-27, and an increasing amount of our dependencies are dropping support for it as a consequence.

We introduced a warning to users that are still using Python 3.7 with release v1.86.0 around August 1, 2023.

We are now effectively dropping support for Python 3.7.

Related: https://github.com/aws/jsii/commit/0ef7acef765690f99075888d6c3e6f03d7cc2d59

Re-roll of #4239, which was reverted because the build & release pipeline failed. After some investigation this was because the job used a superchain image with python3.7. However after this change a minimum version of python 3.8 is required.

BREAKING CHANGE: jsii-pacmak and the libraries it generates for Python targets now require a minimum Python version of 3.8, instead of 3.7 previously. We recommend users upgrade to the latest supported Python release (Python 3.11).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0

