### PR TITLE
chore: use Node 18 in yarn upgrade workflow

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 16
+          node-version: 18
 
       - name: Install Tools
         run: |-


### PR DESCRIPTION
Workflow currently fails due to the Node version being incompatible with used packages.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
