### PR TITLE
chore: update DockerHub README daily

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -229,7 +229,7 @@ jobs:
         with:
           username: ${{ steps.credentials.outputs.username }}
           password: ${{ steps.credentials.outputs.password }}
-          repository: peterevans/dockerhub-description
+          repository: jsii/superchain
           readme-filepath: ./superchain/README.md
 
       - name: Publish (latest)

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -95,14 +95,21 @@ jobs:
           aws ecr-public get-login-password --region=us-east-1                  \
           | docker login --username AWS --password-stdin public.ecr.aws
 
+      - name: Slice DockerHub credentials
+        id: credentials
+        run: |-
+          echo "username=$(cut -d: -f1 <<< '${{ secrets.DOCKER_CREDENTIALS }}')" >> "$GITHUB_OUTPUT"
+          echo "password=$(cut -d: -f2 <<< '${{ secrets.DOCKER_CREDENTIALS }}')" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$(cut -d: -f2 <<< '${{ secrets.DOCKER_CREDENTIALS }}')"
+
       # We only authenticate to Docker on the 'aws/jsii' repo, as forks will not have the secret
       - name: Login to Docker Hub
         if: steps.should-run.outputs.result == 'true' && github.repository == 'aws/jsii'
         # The DOCKER_CREDENTIALS secret is expected to contain a username:token pair
         run: |-
           docker login                                                          \
-            --username=$(cut -d: -f1 <<< '${{ secrets.DOCKER_CREDENTIALS }}')   \
-            --password=$(cut -d: -f2 <<< '${{ secrets.DOCKER_CREDENTIALS }}')
+            --username=${{ steps.credentials.outputs.username }}                \
+            --password=${{ steps.credentials.outputs.password }}
         # Ensure we run with bash, because that's the syntax we're using here...
         shell: bash
 
@@ -215,6 +222,15 @@ jobs:
               -f superchain/Dockerfile                                                                                  \
               .
           fi
+
+      - name: Update README (nightly)
+        if: steps.should-run.outputs.result == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ steps.credentials.outputs.username }}
+          password: ${{ steps.credentials.outputs.password }}
+          repository: peterevans/dockerhub-description
+          readme-filepath: ./superchain/README.md
 
       - name: Publish (latest)
         if: steps.should-run.outputs.result == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/release'


### PR DESCRIPTION
Add a GitHub action to update the DockerHub README of the superchain image every day.

Needed to to refactor the steps a little bit to get the credentials out in a way the Action needs them.

(Of course, no way to test this except in production :/ )


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
