### PR TITLE
fix(check-node): unstable node 21 is incorrectly listed as supported

### DIFF
--- a/packages/@jsii/check-node/src/constants.ts
+++ b/packages/@jsii/check-node/src/constants.ts
@@ -25,16 +25,16 @@ export class NodeRelease {
     ),
 
     // Past end-of-life releases
-    new NodeRelease(13, { endOfLife: new Date('2020-06-01') }),
-    new NodeRelease(14, {
-      endOfLife: new Date('2023-04-30'),
-      supportedRange: '^14.17.0',
-    }),
-    new NodeRelease(15, { endOfLife: new Date('2021-06-01') }),
     new NodeRelease(12, {
       endOfLife: new Date('2022-04-30'),
       supportedRange: '^12.7.0',
     }),
+    new NodeRelease(13, { endOfLife: new Date('2020-06-01'), untested: true }),
+    new NodeRelease(14, {
+      endOfLife: new Date('2023-04-30'),
+      supportedRange: '^14.17.0',
+    }),
+    new NodeRelease(15, { endOfLife: new Date('2021-06-01'), untested: true }),
     new NodeRelease(16, {
       endOfLife: new Date('2023-09-11'),
       supportedRange: '^16.3.0',
@@ -42,13 +42,14 @@ export class NodeRelease {
     new NodeRelease(17, {
       endOfLife: new Date('2022-06-01'),
       supportedRange: '^17.3.0',
+      untested: true,
     }),
-    new NodeRelease(19, { endOfLife: new Date('2023-06-01') }),
+    new NodeRelease(19, { endOfLife: new Date('2023-06-01'), untested: true }),
 
     // Currently active releases (as of last edit to this file...)
     new NodeRelease(18, { endOfLife: new Date('2025-04-30') }),
     new NodeRelease(20, { endOfLife: new Date('2026-04-30') }),
-    new NodeRelease(21, { endOfLife: new Date('2024-06-01') }),
+    new NodeRelease(21, { endOfLife: new Date('2024-06-01'), untested: true }),
 
     // Future (planned releases)
   ];


### PR DESCRIPTION
Any downstream packages that use `NodeRelease.supported` to compute a list of active Node versions currently believe they should test again Node 21, which we don't actually want.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
