### PR TITLE
fix(jsii-pacmak): show custom pack-command in timer label

### DIFF
--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -77,9 +77,7 @@ export async function pacmak({
   const packCommand = argv['pack-command'];
   await timers.recordAsync(packCommand, () => {
     logging.info('Packaging NPM bundles');
-    return Promise.all(
-      modulesToPackageFlat.map((m) => m.npmPack(packCommand)),
-    );
+    return Promise.all(modulesToPackageFlat.map((m) => m.npmPack(packCommand)));
   });
 
   await timers.recordAsync('load jsii', () => {

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -74,10 +74,11 @@ export async function pacmak({
     await updateAllNpmIgnores(modulesToPackageFlat);
   }
 
-  await timers.recordAsync('npm pack', () => {
+  const packCommand = argv['pack-command'];
+  await timers.recordAsync(packCommand, () => {
     logging.info('Packaging NPM bundles');
     return Promise.all(
-      modulesToPackageFlat.map((m) => m.npmPack(argv['pack-command'])),
+      modulesToPackageFlat.map((m) => m.npmPack(packCommand)),
     );
   });
 


### PR DESCRIPTION
Currently 'npm pack' is shown in the logs regardless of the custom command.  Like in:
```log
[jsii-pacmak] [INFO] Packaged. npm pack (42.4s) | cleanup (3.8s) | load jsii (0.0s) | js (0.0s)
```

This behaviour is confusing because it leaves doubt about which command was actually applied. This PR passes the value of the pack-command option to the timer label.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
