### PR TITLE
revert(deps): Update pytest requirement from ~=8.1 to ~=8.0 in /packages/@jsii/python-runtime

### DIFF
--- a/packages/@jsii/python-runtime/requirements.txt
+++ b/packages/@jsii/python-runtime/requirements.txt
@@ -1,7 +1,7 @@
 black~=24.2
 mypy==1.8.0
 pip~=24.0
-pytest~=8.1
+pytest~=8.0
 pytest-mypy~=0.10
 setuptools~=69.1.1
 types-python-dateutil~=2.8


### PR DESCRIPTION
Reverts aws/jsii#4439

Apparently version 8.1.0 has been [yanked](https://pypi.org/project/pytest/8.1.0/) and is now causing builds to [fail](https://github.com/aws/jsii/actions/runs/8153733563/job/22285706848?pr=4443):

```console
@jsii/python-runtime: ERROR: No matching distribution found for pytest~=8.1
```