### PR TITLE
feat: upgrade python runtime version of typeguard to >=3.0.2

### DIFF
--- a/packages/@jsii/python-runtime/setup.py
+++ b/packages/@jsii/python-runtime/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "cattrs>=1.8,<23.3",
         "importlib_resources>=5.2.0",
         "publication>=0.0.3",  # This is used by all generated code.
-        "typeguard~=2.13.3",  # This is used by all generated code.
+        "typeguard>=3.0.2",  # This is used by all generated code.
         "python-dateutil",
         "typing_extensions>=3.8,<5.0",
     ],

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1024,6 +1024,7 @@ abstract class BaseProperty implements PythonBase {
 class Interface extends BasePythonClassType {
   public emit(code: CodeMaker, context: EmitContext) {
     context = nestedContext(context, this.fqn);
+    code.line('@typing.runtime_checkable');
     emitList(code, '@jsii.interface(', [`jsii_type="${this.fqn}"`], ')');
 
     // First we do our normal class logic for emitting our members.
@@ -2125,7 +2126,7 @@ class Package {
       install_requires: [
         `jsii${toPythonVersionRange(`^${VERSION}`)}`,
         'publication>=0.0.3',
-        'typeguard~=2.13.3',
+        'typeguard>=3.0.2',
       ]
         .concat(dependencies)
         .sort(),
@@ -3202,9 +3203,7 @@ function emitParameterTypeChecks(
       comment = ' # pyright: ignore [reportGeneralTypeIssues]';
     }
     code.line(
-      `check_type(argname=${JSON.stringify(
-        `argument ${name}`,
-      )}, value=${name}, expected_type=${expectedType})${comment}`,
+      `check_type(value=${name}, expected_type=${expectedType})${comment}`,
     );
   }
   if (openedBlock) {

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -1270,7 +1270,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -1348,7 +1348,7 @@ class Foo:
         '''
         if __debug__:
             type_hints = typing.get_type_hints(_typecheckingstub__bf2f596592c027f75261089e0a96611ccca28179a004c918d9b1057b4e390db5)
-            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
+            check_type(value=foo, expected_type=type_hints["foo"])
         self._values: typing.Dict[builtins.str, typing.Any] = {
             "foo": foo,
         }
@@ -1389,8 +1389,8 @@ class FooBar:
         '''
         if __debug__:
             type_hints = typing.get_type_hints(_typecheckingstub__0cb0385f4239a994a5509c1ac8d143d10f8400893975d4519442a0d7baf1b5d4)
-            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
+            check_type(value=foo, expected_type=type_hints["foo"])
+            check_type(value=bar, expected_type=type_hints["bar"])
         self._values: typing.Dict[builtins.str, typing.Any] = {
             "foo": foo,
         }
@@ -1440,9 +1440,9 @@ class Baz(Foo, FooBar):
         '''
         if __debug__:
             type_hints = typing.get_type_hints(_typecheckingstub__98e5f88ba6c94001e15cc6f3ce78d86bd3610eea1b79954536d33da0dee53b2d)
-            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
-            check_type(argname="argument baz", value=baz, expected_type=type_hints["baz"])
+            check_type(value=foo, expected_type=type_hints["foo"])
+            check_type(value=bar, expected_type=type_hints["bar"])
+            check_type(value=baz, expected_type=type_hints["baz"])
         self._values: typing.Dict[builtins.str, typing.Any] = {
             "foo": foo,
             "baz": baz,
@@ -2697,7 +2697,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -2763,7 +2763,7 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
             '''
             if __debug__:
                 type_hints = typing.get_type_hints(_typecheckingstub__2a8df629360a764124e23427f4b4bb1422fef01e5b6dcd040a2f64d477f476d9)
-                check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
+                check_type(value=bar, expected_type=type_hints["bar"])
             self._values: typing.Dict[builtins.str, typing.Any] = {
                 "bar": bar,
             }
@@ -2785,6 +2785,7 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
                 k + "=" + repr(v) for k, v in self._values.items()
             )
 
+    @typing.runtime_checkable
     @jsii.interface(jsii_type="testpkg.Namespace1.IBar")
     class IBar(typing_extensions.Protocol):
         @builtins.property

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -459,7 +459,7 @@ kwargs = json.loads(
         "bar>=2.0.0.rc42, <3.0.0",
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -976,7 +976,7 @@ kwargs = json.loads(
         "bar>=4.5.6.dev1337, <5.0.0",
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -1472,7 +1472,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -1966,7 +1966,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -294,7 +294,7 @@ kwargs = json.loads(
         "jsii<0.0.1",
         "publication>=0.0.3",
         "scope.jsii-calc-base-of-base>=2.1.1, <3.0.0",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -408,6 +408,7 @@ class BaseProps(_scope_jsii_calc_base_of_base_49fa37fe.VeryBaseProps):
         )
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-base.IBaseInterface")
 class IBaseInterface(
     _scope_jsii_calc_base_of_base_49fa37fe.IVeryBaseInterface,
@@ -517,14 +518,14 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e2d8a566db7d86eb1cb511cb869273dae39a21b3ad7041359aabb7bd283dcfef)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
++            check_type(value=foo, expected_type=type_hints["foo"])
++            check_type(value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
              "bar": bar,
          }
  
-@@ -120,10 +124,13 @@
+@@ -121,10 +125,13 @@
      @builtins.classmethod
      def consume(cls, *args: typing.Any) -> None:
          '''
@@ -532,13 +533,13 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__66400f6ebe2f9a3fbb550342b894bebf4f5368890843f3917e2b903f62d48b38)
-+            check_type(argname="argument args", value=args, expected_type=typing.Tuple[type_hints["args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=args, expected_type=typing.Tuple[type_hints["args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*args]))
  
  
  __all__ = [
      "Base",
-@@ -131,5 +138,19 @@
+@@ -132,5 +139,19 @@
      "IBaseInterface",
      "StaticConsumer",
  ]
@@ -853,7 +854,7 @@ kwargs = json.loads(
     "install_requires": [
         "jsii<0.0.1",
         "publication>=0.0.3",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -899,6 +900,7 @@ from typeguard import check_type
 from ._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-base-of-base.IVeryBaseInterface")
 class IVeryBaseInterface(typing_extensions.Protocol):
     @jsii.member(jsii_name="foo")
@@ -1040,7 +1042,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
 exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base_of_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base_of_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base_of_base/__init__.py	--runtime-type-checking
-@@ -42,10 +42,13 @@
+@@ -43,10 +43,13 @@
      @builtins.classmethod
      def consume(cls, *_args: typing.Any) -> None:
          '''
@@ -1048,13 +1050,13 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__740535cda6ecbc578919a2921dd1fa0b87c5dd735a2acd391963310cdf59f47c)
-+            check_type(argname="argument _args", value=_args, expected_type=typing.Tuple[type_hints["_args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=_args, expected_type=typing.Tuple[type_hints["_args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*_args]))
  
  
  class Very(metaclass=jsii.JSIIMeta, jsii_type="@scope/jsii-calc-base-of-base.Very"):
      '''(experimental) Something here.
-@@ -72,10 +75,13 @@
+@@ -73,10 +76,13 @@
  class VeryBaseProps:
      def __init__(self, *, foo: Very) -> None:
          '''
@@ -1062,13 +1064,13 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c314d9d6951cb6f41a208c5feb55cc9d30da774b67f6d47cb4fa13215b96f2b9)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -102,5 +108,18 @@
+@@ -103,5 +109,18 @@
      "Very",
      "VeryBaseProps",
  ]
@@ -1390,7 +1392,7 @@ kwargs = json.loads(
         "publication>=0.0.3",
         "scope.jsii-calc-base-of-base>=2.1.1, <3.0.0",
         "scope.jsii-calc-base<0.0.1",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -1620,6 +1622,7 @@ class FunctionWithUnderscoreArgument(
         return typing.cast(builtins.str, jsii.invoke(self, "foo", [_]))
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IDoublable")
 class IDoublable(typing_extensions.Protocol):
     '''(deprecated) The general contract for a concrete number.
@@ -1656,6 +1659,7 @@ class _IDoublableProxy:
 typing.cast(typing.Any, IDoublable).__jsii_proxy_class__ = lambda : _IDoublableProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IFriendly")
 class IFriendly(typing_extensions.Protocol):
     '''(deprecated) Applies to classes that are considered friendly.
@@ -1698,6 +1702,7 @@ class _IFriendlyProxy:
 typing.cast(typing.Any, IFriendly).__jsii_proxy_class__ = lambda : _IFriendlyProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.IThreeLevelsInterface")
 class IThreeLevelsInterface(
     _scope_jsii_calc_base_734f0262.IBaseInterface,
@@ -2095,6 +2100,7 @@ from typeguard import check_type
 from .._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.submodule.IReflectable")
 class IReflectable(typing_extensions.Protocol):
     '''
@@ -2306,6 +2312,7 @@ from typeguard import check_type
 from .._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="@scope/jsii-calc-lib.deprecationRemoval.IInterface")
 class IInterface(typing_extensions.Protocol):
     '''
@@ -2415,7 +2422,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__46512218b53da06690990919b41a88d6c2379b11ef0a3243cf6d60add5197ae2)
-+            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
++            check_type(value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
      @jsii.member(jsii_name="foo")
@@ -2427,7 +2434,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e721760a6f0cb2ba909986665323a1f1f880769c379ae1f2ad0dbadf80ee9016)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          return typing.cast(None, jsii.invoke(self, "foo", [obj]))
  
  
@@ -2441,8 +2448,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__969bc4b33aa2d0684b20d440803d81dfda55aa9fa6398ac40f1afafc2114db5a)
-+            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
-+            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
++            check_type(value=hoisted_top, expected_type=type_hints["hoisted_top"])
++            check_type(value=left, expected_type=type_hints["left"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if hoisted_top is not None:
              self._values["hoisted_top"] = hoisted_top
@@ -2456,8 +2463,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__31f7eac552107efa0a4275f6798b003fcc3b6e74e0a463ae709af8b660b91dc4)
-+            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
-+            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
++            check_type(value=hoisted_top, expected_type=type_hints["hoisted_top"])
++            check_type(value=right, expected_type=type_hints["right"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if hoisted_top is not None:
              self._values["hoisted_top"] = hoisted_top
@@ -2471,13 +2478,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9f2d965a28491c2347ed53f3f21b6d1e134bd8c506672f5715c44023bddab720)
-+            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
++            check_type(value=_, expected_type=type_hints["_"])
          return typing.cast(builtins.str, jsii.invoke(self, "foo", [_]))
  
  
+ @typing.runtime_checkable
  @jsii.interface(jsii_type="@scope/jsii-calc-lib.IDoublable")
- class IDoublable(typing_extensions.Protocol):
-@@ -345,10 +362,15 @@
+@@ -348,10 +365,15 @@
          :param astring: (deprecated) A string value.
          :param first_optional: 
  
@@ -2485,15 +2492,15 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__de81edc65427ea9129fd035388008307a6cae942eefc63cb3d9fd8b42956da06)
-+            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
-+            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
-+            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
++            check_type(value=anumber, expected_type=type_hints["anumber"])
++            check_type(value=astring, expected_type=type_hints["astring"])
++            check_type(value=first_optional, expected_type=type_hints["first_optional"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "anumber": anumber,
              "astring": astring,
          }
          if first_optional is not None:
-@@ -505,10 +527,15 @@
+@@ -508,10 +530,15 @@
          :param optional2: 
          :param optional3: 
  
@@ -2501,15 +2508,15 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__82b4e5e8f3b46996124a87aac13a874f61bf9660a45a062bafa08046c027da63)
-+            check_type(argname="argument optional1", value=optional1, expected_type=type_hints["optional1"])
-+            check_type(argname="argument optional2", value=optional2, expected_type=type_hints["optional2"])
-+            check_type(argname="argument optional3", value=optional3, expected_type=type_hints["optional3"])
++            check_type(value=optional1, expected_type=type_hints["optional1"])
++            check_type(value=optional2, expected_type=type_hints["optional2"])
++            check_type(value=optional3, expected_type=type_hints["optional3"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if optional1 is not None:
              self._values["optional1"] = optional1
          if optional2 is not None:
              self._values["optional2"] = optional2
-@@ -568,10 +595,13 @@
+@@ -571,10 +598,13 @@
  
          :param value: The number.
  
@@ -2517,13 +2524,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__adff4f4d0383c32ffdeb0bca92ae1ea2ebe0b2ea8d9bf5f5433287cc06e55e07)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
      @builtins.property
      @jsii.member(jsii_name="doubleValue")
      def double_value(self) -> jsii.Number:
-@@ -612,5 +642,63 @@
+@@ -615,5 +645,63 @@
  publication.publish()
  
  # Loading modules to ensure their types are registered with the jsii runtime library
@@ -2592,7 +2599,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/custom_submodule_name/__init__.py	--runtime-type-checking
-@@ -100,10 +100,13 @@
+@@ -101,10 +101,13 @@
  
              :param name: 
  
@@ -2600,13 +2607,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              '''
 +            if __debug__:
 +                type_hints = typing.get_type_hints(_typecheckingstub__5c03ed6e0d395f6fa262d12c7831dd2893af2098bf580a0c602a20f92c1ad24b)
-+                check_type(argname="argument name", value=name, expected_type=type_hints["name"])
++                check_type(value=name, expected_type=type_hints["name"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
                  "name": name,
              }
  
          @builtins.property
-@@ -138,10 +141,14 @@
+@@ -139,10 +142,14 @@
          :param key: 
          :param value: 
  
@@ -2614,14 +2621,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__301126f287c0bfbbd3cb015833c5e0b2ced77e73d25597215c917612b67c3331)
-+            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=key, expected_type=type_hints["key"])
++            check_type(value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "key": key,
              "value": value,
          }
  
-@@ -197,10 +204,13 @@
+@@ -198,10 +205,13 @@
          '''
          :param reflectable: -
  
@@ -2629,13 +2636,13 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__bed3b5b08c611933987ef5d9dfc131289e09ebcd26286417337c3708ca054e9f)
-+            check_type(argname="argument reflectable", value=reflectable, expected_type=type_hints["reflectable"])
++            check_type(value=reflectable, expected_type=type_hints["reflectable"])
          return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
  
  
  __all__ = [
      "IReflectable",
-@@ -208,5 +218,26 @@
+@@ -209,5 +219,26 @@
      "ReflectableEntry",
      "Reflector",
  ]
@@ -3099,7 +3106,7 @@ kwargs = json.loads(
         "publication>=0.0.3",
         "scope.jsii-calc-base<0.0.1",
         "scope.jsii-calc-lib<0.0.1",
-        "typeguard~=2.13.3"
+        "typeguard>=3.0.2"
     ],
     "classifiers": [
         "Intended Audience :: Developers",
@@ -6001,6 +6008,7 @@ class GreetingAugmenter(
         return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
 class IAnonymousImplementationProvider(typing_extensions.Protocol):
     '''We can return an anonymous interface implementation from an override without losing the interface declarations.'''
@@ -6031,6 +6039,7 @@ class _IAnonymousImplementationProviderProxy:
 typing.cast(typing.Any, IAnonymousImplementationProvider).__jsii_proxy_class__ = lambda : _IAnonymousImplementationProviderProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IAnonymouslyImplementMe")
 class IAnonymouslyImplementMe(typing_extensions.Protocol):
     @builtins.property
@@ -6059,6 +6068,7 @@ class _IAnonymouslyImplementMeProxy:
 typing.cast(typing.Any, IAnonymouslyImplementMe).__jsii_proxy_class__ = lambda : _IAnonymouslyImplementMeProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IAnotherPublicInterface")
 class IAnotherPublicInterface(typing_extensions.Protocol):
     @builtins.property
@@ -6087,6 +6097,7 @@ class _IAnotherPublicInterfaceProxy:
 typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IBell")
 class IBell(typing_extensions.Protocol):
     @jsii.member(jsii_name="ring")
@@ -6105,6 +6116,7 @@ class _IBellProxy:
 typing.cast(typing.Any, IBell).__jsii_proxy_class__ = lambda : _IBellProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IBellRinger")
 class IBellRinger(typing_extensions.Protocol):
     '''Takes the object parameter as an interface.'''
@@ -6133,6 +6145,7 @@ class _IBellRingerProxy:
 typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IConcreteBellRinger")
 class IConcreteBellRinger(typing_extensions.Protocol):
     '''Takes the object parameter as a calss.'''
@@ -6161,6 +6174,7 @@ class _IConcreteBellRingerProxy:
 typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IDeprecatedInterface")
 class IDeprecatedInterface(typing_extensions.Protocol):
     '''
@@ -6229,6 +6243,7 @@ class _IDeprecatedInterfaceProxy:
 typing.cast(typing.Any, IDeprecatedInterface).__jsii_proxy_class__ = lambda : _IDeprecatedInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IExperimentalInterface")
 class IExperimentalInterface(typing_extensions.Protocol):
     '''
@@ -6285,6 +6300,7 @@ class _IExperimentalInterfaceProxy:
 typing.cast(typing.Any, IExperimentalInterface).__jsii_proxy_class__ = lambda : _IExperimentalInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IExtendsPrivateInterface")
 class IExtendsPrivateInterface(typing_extensions.Protocol):
     @builtins.property
@@ -6323,6 +6339,7 @@ class _IExtendsPrivateInterfaceProxy:
 typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IExternalInterface")
 class IExternalInterface(typing_extensions.Protocol):
     '''
@@ -6379,6 +6396,7 @@ class _IExternalInterfaceProxy:
 typing.cast(typing.Any, IExternalInterface).__jsii_proxy_class__ = lambda : _IExternalInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IFriendlier")
 class IFriendlier(_scope_jsii_calc_lib_c61f082f.IFriendly, typing_extensions.Protocol):
     '''Even friendlier classes can implement this interface.'''
@@ -6421,6 +6439,7 @@ class _IFriendlierProxy(
 typing.cast(typing.Any, IFriendlier).__jsii_proxy_class__ = lambda : _IFriendlierProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IIndirectlyImplemented")
 class IIndirectlyImplemented(typing_extensions.Protocol):
     @builtins.property
@@ -6449,6 +6468,7 @@ class _IIndirectlyImplementedProxy:
 typing.cast(typing.Any, IIndirectlyImplemented).__jsii_proxy_class__ = lambda : _IIndirectlyImplementedProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceImplementedByAbstractClass")
 class IInterfaceImplementedByAbstractClass(typing_extensions.Protocol):
     '''awslabs/jsii#220 Abstract return type.'''
@@ -6473,6 +6493,7 @@ class _IInterfaceImplementedByAbstractClassProxy:
 typing.cast(typing.Any, IInterfaceImplementedByAbstractClass).__jsii_proxy_class__ = lambda : _IInterfaceImplementedByAbstractClassProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithInternal")
 class IInterfaceWithInternal(typing_extensions.Protocol):
     @jsii.member(jsii_name="visible")
@@ -6491,6 +6512,7 @@ class _IInterfaceWithInternalProxy:
 typing.cast(typing.Any, IInterfaceWithInternal).__jsii_proxy_class__ = lambda : _IInterfaceWithInternalProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithMethods")
 class IInterfaceWithMethods(typing_extensions.Protocol):
     @builtins.property
@@ -6519,6 +6541,7 @@ class _IInterfaceWithMethodsProxy:
 typing.cast(typing.Any, IInterfaceWithMethods).__jsii_proxy_class__ = lambda : _IInterfaceWithMethodsProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithOptionalMethodArguments")
 class IInterfaceWithOptionalMethodArguments(typing_extensions.Protocol):
     '''awslabs/jsii#175 Interface proxies (and builders) do not respect optional arguments in methods.'''
@@ -6557,6 +6580,7 @@ class _IInterfaceWithOptionalMethodArgumentsProxy:
 typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithProperties")
 class IInterfaceWithProperties(typing_extensions.Protocol):
     @builtins.property
@@ -6595,6 +6619,7 @@ class _IInterfaceWithPropertiesProxy:
 typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceWithPropertiesExtension")
 class IInterfaceWithPropertiesExtension(
     IInterfaceWithProperties,
@@ -6628,6 +6653,7 @@ class _IInterfaceWithPropertiesExtensionProxy(
 typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJSII417PublicBaseOfBase")
 class IJSII417PublicBaseOfBase(typing_extensions.Protocol):
     @builtins.property
@@ -6656,6 +6682,7 @@ class _IJSII417PublicBaseOfBaseProxy:
 typing.cast(typing.Any, IJSII417PublicBaseOfBase).__jsii_proxy_class__ = lambda : _IJSII417PublicBaseOfBaseProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJavaReservedWordsInAnInterface")
 class IJavaReservedWordsInAnInterface(typing_extensions.Protocol):
     @builtins.property
@@ -7084,6 +7111,7 @@ class _IJavaReservedWordsInAnInterfaceProxy:
 typing.cast(typing.Any, IJavaReservedWordsInAnInterface).__jsii_proxy_class__ = lambda : _IJavaReservedWordsInAnInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJsii487External")
 class IJsii487External(typing_extensions.Protocol):
     pass
@@ -7097,6 +7125,7 @@ class _IJsii487ExternalProxy:
 typing.cast(typing.Any, IJsii487External).__jsii_proxy_class__ = lambda : _IJsii487ExternalProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJsii487External2")
 class IJsii487External2(typing_extensions.Protocol):
     pass
@@ -7110,6 +7139,7 @@ class _IJsii487External2Proxy:
 typing.cast(typing.Any, IJsii487External2).__jsii_proxy_class__ = lambda : _IJsii487External2Proxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJsii496")
 class IJsii496(typing_extensions.Protocol):
     pass
@@ -7123,6 +7153,7 @@ class _IJsii496Proxy:
 typing.cast(typing.Any, IJsii496).__jsii_proxy_class__ = lambda : _IJsii496Proxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IMutableObjectLiteral")
 class IMutableObjectLiteral(typing_extensions.Protocol):
     @builtins.property
@@ -7151,6 +7182,7 @@ class _IMutableObjectLiteralProxy:
 typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.INonInternalInterface")
 class INonInternalInterface(IAnotherPublicInterface, typing_extensions.Protocol):
     @builtins.property
@@ -7199,6 +7231,7 @@ class _INonInternalInterfaceProxy(
 typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IObjectWithProperty")
 class IObjectWithProperty(typing_extensions.Protocol):
     '''Make sure that setters are properly called on objects with interfaces.'''
@@ -7239,6 +7272,7 @@ class _IObjectWithPropertyProxy:
 typing.cast(typing.Any, IObjectWithProperty).__jsii_proxy_class__ = lambda : _IObjectWithPropertyProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IOptionalMethod")
 class IOptionalMethod(typing_extensions.Protocol):
     '''Checks that optional result from interface method code generates correctly.'''
@@ -7261,6 +7295,7 @@ class _IOptionalMethodProxy:
 typing.cast(typing.Any, IOptionalMethod).__jsii_proxy_class__ = lambda : _IOptionalMethodProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IPrivatelyImplemented")
 class IPrivatelyImplemented(typing_extensions.Protocol):
     @builtins.property
@@ -7281,6 +7316,7 @@ class _IPrivatelyImplementedProxy:
 typing.cast(typing.Any, IPrivatelyImplemented).__jsii_proxy_class__ = lambda : _IPrivatelyImplementedProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IPublicInterface")
 class IPublicInterface(typing_extensions.Protocol):
     @jsii.member(jsii_name="bye")
@@ -7299,6 +7335,7 @@ class _IPublicInterfaceProxy:
 typing.cast(typing.Any, IPublicInterface).__jsii_proxy_class__ = lambda : _IPublicInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IPublicInterface2")
 class IPublicInterface2(typing_extensions.Protocol):
     @jsii.member(jsii_name="ciao")
@@ -7317,6 +7354,7 @@ class _IPublicInterface2Proxy:
 typing.cast(typing.Any, IPublicInterface2).__jsii_proxy_class__ = lambda : _IPublicInterface2Proxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IRandomNumberGenerator")
 class IRandomNumberGenerator(typing_extensions.Protocol):
     '''Generates random numbers.'''
@@ -7347,6 +7385,7 @@ class _IRandomNumberGeneratorProxy:
 typing.cast(typing.Any, IRandomNumberGenerator).__jsii_proxy_class__ = lambda : _IRandomNumberGeneratorProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IReturnJsii976")
 class IReturnJsii976(typing_extensions.Protocol):
     '''Returns a subclass of a known class which implements an interface.'''
@@ -7371,6 +7410,7 @@ class _IReturnJsii976Proxy:
 typing.cast(typing.Any, IReturnJsii976).__jsii_proxy_class__ = lambda : _IReturnJsii976Proxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IReturnsNumber")
 class IReturnsNumber(typing_extensions.Protocol):
     @builtins.property
@@ -7399,6 +7439,7 @@ class _IReturnsNumberProxy:
 typing.cast(typing.Any, IReturnsNumber).__jsii_proxy_class__ = lambda : _IReturnsNumberProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IStableInterface")
 class IStableInterface(typing_extensions.Protocol):
     @builtins.property
@@ -7435,6 +7476,7 @@ class _IStableInterfaceProxy:
 typing.cast(typing.Any, IStableInterface).__jsii_proxy_class__ = lambda : _IStableInterfaceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IStructReturningDelegate")
 class IStructReturningDelegate(typing_extensions.Protocol):
     '''Verifies that a "pure" implementation of an interface works correctly.'''
@@ -7457,6 +7499,7 @@ class _IStructReturningDelegateProxy:
 typing.cast(typing.Any, IStructReturningDelegate).__jsii_proxy_class__ = lambda : _IStructReturningDelegateProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IWallClock")
 class IWallClock(typing_extensions.Protocol):
     '''Implement this interface.'''
@@ -11249,6 +11292,7 @@ class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCom
     pass
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IFriendlyRandomGenerator")
 class IFriendlyRandomGenerator(
     IRandomNumberGenerator,
@@ -11269,6 +11313,7 @@ class _IFriendlyRandomGeneratorProxy(
 typing.cast(typing.Any, IFriendlyRandomGenerator).__jsii_proxy_class__ = lambda : _IFriendlyRandomGeneratorProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IInterfaceThatShouldNotBeADataType")
 class IInterfaceThatShouldNotBeADataType(
     IInterfaceWithMethods,
@@ -11298,6 +11343,7 @@ class _IInterfaceThatShouldNotBeADataTypeProxy(
 typing.cast(typing.Any, IInterfaceThatShouldNotBeADataType).__jsii_proxy_class__ = lambda : _IInterfaceThatShouldNotBeADataTypeProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.IJSII417Derived")
 class IJSII417Derived(IJSII417PublicBaseOfBase, typing_extensions.Protocol):
     @builtins.property
@@ -11822,6 +11868,7 @@ from typeguard import check_type
 from .._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.anonymous.IOptionA")
 class IOptionA(typing_extensions.Protocol):
     @jsii.member(jsii_name="doSomething")
@@ -11840,6 +11887,7 @@ class _IOptionAProxy:
 typing.cast(typing.Any, IOptionA).__jsii_proxy_class__ = lambda : _IOptionAProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.anonymous.IOptionB")
 class IOptionB(typing_extensions.Protocol):
     @jsii.member(jsii_name="doSomethingElse")
@@ -13439,6 +13487,7 @@ from typeguard import check_type
 from .._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2700.IFoo")
 class IFoo(typing_extensions.Protocol):
     @builtins.property
@@ -13568,6 +13617,7 @@ class Class3(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2702.Class3"):
         return typing.cast(None, jsii.invoke(self, "iBaseInterface", []))
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2702.IBaz")
 class IBaz(_scope_jsii_calc_base_734f0262.IBaseInterface, typing_extensions.Protocol):
     @jsii.member(jsii_name="bazMethod")
@@ -13588,6 +13638,7 @@ class _IBazProxy(
 typing.cast(typing.Any, IBaz).__jsii_proxy_class__ = lambda : _IBazProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2702.IConstruct")
 class IConstruct(typing_extensions.Protocol):
     @jsii.member(jsii_name="constructMethod")
@@ -13606,6 +13657,7 @@ class _IConstructProxy:
 typing.cast(typing.Any, IConstruct).__jsii_proxy_class__ = lambda : _IConstructProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2702.IFoo")
 class IFoo(_scope_jsii_calc_base_734f0262.IBaseInterface, typing_extensions.Protocol):
     @builtins.property
@@ -13628,6 +13680,7 @@ class _IFooProxy(
 typing.cast(typing.Any, IFoo).__jsii_proxy_class__ = lambda : _IFooProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2702.IResource")
 class IResource(IConstruct, typing_extensions.Protocol):
     @jsii.member(jsii_name="resourceMethod")
@@ -13648,6 +13701,7 @@ class _IResourceProxy(
 typing.cast(typing.Any, IResource).__jsii_proxy_class__ = lambda : _IResourceProxy
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.module2702.IVpc")
 class IVpc(IResource, typing_extensions.Protocol):
     @jsii.member(jsii_name="vpcMethod")
@@ -13951,6 +14005,7 @@ class ClassWithSelfKwarg(
         return typing.cast("StructWithSelf", jsii.get(self, "props"))
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.PythonSelf.IInterfaceWithSelf")
 class IInterfaceWithSelf(typing_extensions.Protocol):
     @jsii.member(jsii_name="method")
@@ -14551,6 +14606,7 @@ from typeguard import check_type
 from ...._jsii import *
 
 
+@typing.runtime_checkable
 @jsii.interface(
     jsii_type="jsii-calc.submodule.nested_submodule.deeplyNested.INamespaced"
 )
@@ -14715,6 +14771,7 @@ class ConsumesUnion(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.union.Consumes
         return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))
 
 
+@typing.runtime_checkable
 @jsii.interface(jsii_type="jsii-calc.union.IResolvable")
 class IResolvable(typing_extensions.Protocol):
     @jsii.member(jsii_name="resolve")
@@ -14818,7 +14875,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8348af6419fc01178f78ba59cea59d0c7437626169866d772f4e957d09e6e13a)
-+            check_type(argname="argument seed", value=seed, expected_type=type_hints["seed"])
++            check_type(value=seed, expected_type=type_hints["seed"])
          return typing.cast(builtins.str, jsii.invoke(self, "workItAll", [seed]))
  
      @builtins.property
@@ -14832,7 +14889,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__06c06b97e36be962012901c4c1f542b3f51b377154f91bf1154d1bd475221829)
-+            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
++            check_type(value=str, expected_type=type_hints["str"])
          return typing.cast(builtins.str, jsii.invoke(self, "someMethod", [str]))
  
      @builtins.property
@@ -14844,7 +14901,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def _property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__0f076015f51de68c2d0e6902c0d199c9058ad0bff9c11f58b2aae99578ece6ae)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
@@ -14858,7 +14915,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__81a2d86a9598fa10dde4af8bd70d369967edc6febb332dc788702f6aea07f33c)
-+            check_type(argname="argument inp", value=inp, expected_type=type_hints["inp"])
++            check_type(value=inp, expected_type=type_hints["inp"])
          return typing.cast(None, jsii.invoke(self, "anyIn", [inp]))
  
      @jsii.member(jsii_name="anyOut")
@@ -14872,7 +14929,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__56056c33132184bd4ad46f69c534777112c49b9a987cc7b962d4026cf550998c)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast("StringEnum", jsii.invoke(self, "enumMethod", [value]))
  
      @builtins.property
@@ -14886,7 +14943,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def any_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1ab9ae75c746f751d2bf2ac254bcd1bee8eae7281ec936e222c9f29765fdcfa4)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyArrayProperty", value)
  
      @builtins.property
@@ -14898,7 +14955,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def any_map_property(self, value: typing.Mapping[builtins.str, typing.Any]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f88e356a91a703923e622c02850435cc7f632a66f49ca79f00d42590d2928a5e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyMapProperty", value)
  
      @builtins.property
@@ -14910,7 +14967,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def any_property(self, value: typing.Any) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d81f1a89ccd850ccdb0b96a43000dfcde30f3542bf797051c754610d641f2316)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyProperty", value)
  
      @builtins.property
@@ -14922,7 +14979,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def array_property(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__0c663902e9a8a1db9aff59eb8642a68c944dc2e3385744098d2b51ecf2e2e11f)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "arrayProperty", value)
  
      @builtins.property
@@ -14934,7 +14991,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def boolean_property(self, value: builtins.bool) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__106a83d3c77dbb6dbc6fcd706bca888d57ec37cd4beedf7dcc9d7d4428f44845)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "booleanProperty", value)
  
      @builtins.property
@@ -14946,7 +15003,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def date_property(self, value: datetime.datetime) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5e62ea2f9629943c1138cad77629f47906644279c178b9436e4303e5a5f74c8a)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "dateProperty", value)
  
      @builtins.property
@@ -14958,7 +15015,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def enum_property(self, value: "AllTypesEnum") -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f0d83d5dde352e12690bd34359b2272194b20ad0d4585d4cd235a62a68413cc7)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "enumProperty", value)
  
      @builtins.property
@@ -14970,7 +15027,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def json_property(self, value: typing.Mapping[typing.Any, typing.Any]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8cddc5c03b0b87366a7bf274aedf92ced502b23fe811780c7f8c3da532cba3fc)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "jsonProperty", value)
  
      @builtins.property
@@ -14984,7 +15041,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ce34799b1443789feb28cffe434f5bcbb9cb940065992aa75dbb30eb89cd78e6)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mapProperty", value)
  
      @builtins.property
@@ -14996,7 +15053,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def number_property(self, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c8fb4d044e2e7432d7e661aafdb286ebf21dfe5a82b9908dee57945f6892a63e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "numberProperty", value)
  
      @builtins.property
@@ -15008,7 +15065,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def string_property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4e3dc199e54a9fbd40ceb20cecf887aa2aeca670e9ba223707466d9670eec9b9)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringProperty", value)
  
      @builtins.property
@@ -15022,7 +15079,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4a9e87035008a2c1b649b911c8cfc02f2723230d8ced957948b2948c76caf61a)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionArrayProperty", value)
  
      @builtins.property
@@ -15036,7 +15093,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__62ebee42e1871545bc2e82cfb9c7fe43b5a607c8f662caff89dda0f0ed99a3df)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionMapProperty", value)
  
      @builtins.property
@@ -15050,7 +15107,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c9be2756a18e8a40eb03cf55231201574f76abf02996a73d0d75fefd1393473d)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
      @builtins.property
@@ -15062,7 +15119,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def unknown_array_property(self, value: typing.List[typing.Any]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e49729a44c21aef8c75584ff0991ddba3ee45184cacf816eb1a6a13b99e99ecc)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownArrayProperty", value)
  
      @builtins.property
@@ -15076,7 +15133,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f8de6b30de9bfa884f9de02e2abe57e9394fb7a387b5691f858b7b98817b1db7)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownMapProperty", value)
  
      @builtins.property
@@ -15088,7 +15145,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def unknown_property(self, value: typing.Any) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__901c3574a81e006fdf36f73e34f66b34f65ada4bddcb11cd15a51d6e3d9b59e4)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownProperty", value)
  
      @builtins.property
@@ -15100,7 +15157,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def optional_enum_value(self, value: typing.Optional["StringEnum"]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__705bed55c0dbc20a3a1bad9a21931270f0c285e5b3b276e13bca645ffa7ccb0f)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "optionalEnumValue", value)
  
  
@@ -15114,8 +15171,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__99730dd857f01c8e93755d3e4f1e04f44efd2e63487e37db32f0fae8d36c618e)
-+            check_type(argname="argument _p1", value=_p1, expected_type=type_hints["_p1"])
-+            check_type(argname="argument _p2", value=_p2, expected_type=type_hints["_p2"])
++            check_type(value=_p1, expected_type=type_hints["_p1"])
++            check_type(value=_p2, expected_type=type_hints["_p2"])
          return typing.cast(None, jsii.invoke(self, "getBar", [_p1, _p2]))
  
      @jsii.member(jsii_name="getFoo")
@@ -15126,7 +15183,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7f25304a2274ca1691dbe05a223f32126250948b15187c5095780e5c9af08c2a)
-+            check_type(argname="argument with_param", value=with_param, expected_type=type_hints["with_param"])
++            check_type(value=with_param, expected_type=type_hints["with_param"])
          return typing.cast(builtins.str, jsii.invoke(self, "getFoo", [with_param]))
  
      @jsii.member(jsii_name="setBar")
@@ -15138,9 +15195,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__12f6979e6d88948e4aebfe8c25ed814c21d19b4b549d6bc2db4620794e706238)
-+            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
-+            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
-+            check_type(argname="argument _z", value=_z, expected_type=type_hints["_z"])
++            check_type(value=_x, expected_type=type_hints["_x"])
++            check_type(value=_y, expected_type=type_hints["_y"])
++            check_type(value=_z, expected_type=type_hints["_z"])
          return typing.cast(None, jsii.invoke(self, "setBar", [_x, _y, _z]))
  
      @jsii.member(jsii_name="setFoo")
@@ -15152,8 +15209,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ca978ab380897c8607252c370202d45bc72e8b5cdc52549bb53b870299333d52)
-+            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
-+            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
++            check_type(value=_x, expected_type=type_hints["_x"])
++            check_type(value=_y, expected_type=type_hints["_y"])
          return typing.cast(None, jsii.invoke(self, "setFoo", [_x, _y]))
  
  
@@ -15167,7 +15224,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__35fb7428c2ad70583f7b280c07cec184905b51e8e896efe6cc88eaf83a6f65c3)
-+            check_type(argname="argument scope_", value=scope_, expected_type=type_hints["scope_"])
++            check_type(value=scope_, expected_type=type_hints["scope_"])
          props_ = StructParameterType(scope=scope, props=props)
  
          jsii.create(self.__class__, self, [scope_, props_])
@@ -15181,10 +15238,10 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2e74ece926d1cff82c3a42c02b35b0b5b4427369dfc17caf49b658e36503a986)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
-+            check_type(argname="argument prop_a", value=prop_a, expected_type=type_hints["prop_a"])
-+            check_type(argname="argument prop_b", value=prop_b, expected_type=type_hints["prop_b"])
-+            check_type(argname="argument result_prop", value=result_prop, expected_type=type_hints["result_prop"])
++            check_type(value=obj, expected_type=type_hints["obj"])
++            check_type(value=prop_a, expected_type=type_hints["prop_a"])
++            check_type(value=prop_b, expected_type=type_hints["prop_b"])
++            check_type(value=result_prop, expected_type=type_hints["result_prop"])
          return typing.cast(None, jsii.sinvoke(cls, "mutateProperties", [obj, prop_a, prop_b, result_prop]))
  
  
@@ -15198,7 +15255,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__49537950cbbeb6e2c62cb1b8a079cc9bb5cc6d06d95cf2229128539d2be886a3)
-+            check_type(argname="argument mult", value=mult, expected_type=type_hints["mult"])
++            check_type(value=mult, expected_type=type_hints["mult"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMe", [mult]))
  
      @jsii.member(jsii_name="overrideMeToo")
@@ -15212,8 +15269,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__408890be1949f7684db536e79081b85d00d72250ca9eb19c74db6ad226564784)
-+            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
-+            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
++            check_type(value=lhs, expected_type=type_hints["lhs"])
++            check_type(value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
  
      @jsii.member(jsii_name="hello")
@@ -15227,7 +15284,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__67894f861ef38d2769b440d2fe71f549cb9e333247b385c5d6ae862b2eb04fc5)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Any, jsii.invoke(self, "giveItBack", [value]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
@@ -15241,7 +15298,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__106b87a3d0b194bda7cee057654f752c82d9a92a3775bcc3b2dc5cf7814ba84d)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "add", [value]))
  
      @jsii.member(jsii_name="mul")
@@ -15252,7 +15309,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b0e9a9c8546dd024e1568b2e6d11bd847e53548d624f33afffdffacc77fe01ef)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "mul", [value]))
  
      @jsii.member(jsii_name="neg")
@@ -15266,7 +15323,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c62707f1a80d6bc26c0b74205f8892c1777e6ed97359263df05628018d8ef6fc)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "pow", [value]))
  
      @jsii.member(jsii_name="readUnionValue")
@@ -15280,7 +15337,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def curr(self, value: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c74abb191c66f86aed2c139ec3e50b0442b6d3bdcd41beb06db17c9b3c5d93d0)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "curr", value)
  
      @builtins.property
@@ -15293,7 +15350,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def max_value(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1af5d9bb897bd9bfc2029e92d33fc306fc090e2d0a9bc0bd70fb01762e798fe6)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "maxValue", value)
  
      @builtins.property
@@ -15307,7 +15364,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__349b2a1dce95cb7ff4c5a7772d81772697767c5f4e7e5fd709847ff5e526c3c1)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
@@ -15321,8 +15378,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__21033948ed66f89716ed818c4cf9e5a38a9252e042231e1e8e1672356d403bef)
-+            check_type(argname="argument initial_value", value=initial_value, expected_type=type_hints["initial_value"])
-+            check_type(argname="argument maximum_value", value=maximum_value, expected_type=type_hints["maximum_value"])
++            check_type(value=initial_value, expected_type=type_hints["initial_value"])
++            check_type(value=maximum_value, expected_type=type_hints["maximum_value"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if initial_value is not None:
              self._values["initial_value"] = initial_value
@@ -15336,7 +15393,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9e749834c2e46eee6370de7b60daabbff6e5c16febe9775b98a2b961b0d4e335)
-+            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
++            check_type(value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
@@ -15350,7 +15407,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__80b80f78c4ac7fda46ac2aec7ab826a87bef3eaaba64661c90f346972800baf5)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
@@ -15364,8 +15421,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7eb49cfb1282d7f1bd28096ff0407c0806693194f02f5c053936f99756a2a8fd)
-+            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
-+            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
++            check_type(value=map, expected_type=type_hints["map"])
++            check_type(value=array, expected_type=type_hints["array"])
          jsii.create(self.__class__, self, [map, array])
  
      @jsii.member(jsii_name="createAList")
@@ -15379,7 +15436,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def static_array(cls, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__964903eb68623806c91fc9026cacfdc726cfbb287698530724c5a9938a7bb2ca)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticArray", value)
  
      @jsii.python.classproperty
@@ -15391,7 +15448,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def static_map(cls, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8dd7203701e4915203e4778820ee40fe6bdd6f0bb2855c200f375606277e06c8)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticMap", value)
  
      @builtins.property
@@ -15403,7 +15460,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def array(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c0c76fec28076841e36c26581c26385de1e984d96e91ea434a61c4bf36c9b4d9)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "array", value)
  
      @builtins.property
@@ -15415,7 +15472,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def map(self, value: typing.Mapping[builtins.str, builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5461a3c7bb81040765e4ca2e9effb12cc7f5fb018e5e1b8b21501a3f9cd6a8b3)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "map", value)
  
  
@@ -15429,9 +15486,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__11d94174b1d488125abef65967a384ceb599f4948eca6cb9be3d55e1979fb64f)
-+            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
-+            check_type(argname="argument record", value=record, expected_type=type_hints["record"])
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=array, expected_type=type_hints["array"])
++            check_type(value=record, expected_type=type_hints["record"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          props = ContainerProps(
              array_prop=array_prop, obj_prop=obj_prop, record_prop=record_prop
          )
@@ -15445,7 +15502,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c017a39e0da5d21f3a9acbfd00f6a5c84eb4cad306148504e7c835359d35537e)
-+            check_type(argname="argument int", value=int, expected_type=type_hints["int"])
++            check_type(value=int, expected_type=type_hints["int"])
          jsii.create(self.__class__, self, [int])
  
      @jsii.member(jsii_name="import")
@@ -15455,7 +15512,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7a756cab89b47a2ae4c08f36162482b60fdf963b8ba638917a63c5e110b4d33e)
-+            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
++            check_type(value=assert_, expected_type=type_hints["assert_"])
          return typing.cast(builtins.str, jsii.invoke(self, "import", [assert_]))
  
      @builtins.property
@@ -15469,7 +15526,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_object(self, value: "IMutableObjectLiteral") -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3afbef7e05ef43a18b9260b86660c09b15be66fabeae128c9a9f99b729da7143)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableObject", value)
  
  
@@ -15483,7 +15540,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__0b8f0f729686dad01c8555a3b1bc47509e495bd18f1560ef045b558884b2a1fb)
-+            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
++            check_type(value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
  
      @builtins.property
@@ -15497,7 +15554,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a8a15eb37393d5188c71779e29278367f7b3600c6dd48bdbcd502cdf510c3c15)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
@@ -15511,7 +15568,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ec229cc92e04670f4dca9546759b3b39ee813eb1aa18057135bb155d08971e6a)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value)
  
  
@@ -15525,7 +15582,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__481b1113b85e6dc9d7ba31c3ef5654e3550abac1edef9204348ab0f9554f61c1)
-+            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
++            check_type(value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if union_property is not None:
              self._values["union_property"] = union_property
@@ -15539,7 +15596,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5676fcb3395f1db1a013537fa52220553e5e418c2a9d97aa2f9541c00ffe259e)
-+            check_type(argname="argument consumer", value=consumer, expected_type=type_hints["consumer"])
++            check_type(value=consumer, expected_type=type_hints["consumer"])
          jsii.create(self.__class__, self, [consumer])
  
  
@@ -15553,7 +15610,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5c5defc6d683ee91707f8b7770d8d2fb11d381b9c928d7e5d6e2c5c495395f38)
-+            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
++            check_type(value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="workItBaby")
@@ -15567,7 +15624,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1df814299f3f9720be108d84bdfd61bc591699a79a3c8ac6d450bfb0a9610278)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPrivateClass")
@@ -15581,7 +15638,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2f08bd2d56e856071db5f777b63fe2577f9e96dbfcd91e4044d0eda2d26f9017)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
  
      @jsii.member(jsii_name="staticImplementedByPublicClass")
@@ -15595,7 +15652,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4a2b7f0a05298ddaec112cb088cc71cfa2856aaa1d8414a5157d581b6d5a7293)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
  
      @jsii.member(jsii_name="staticWhenTypedAsClass")
@@ -15609,7 +15666,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f751da3f5766ea4973eb2d89086565259f0a3cd626425a7eec723afd7b64f392)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
  
      @jsii.member(jsii_name="implementedByObjectLiteral")
@@ -15622,7 +15679,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cca04fe4a4c41a0034087ab0c574d1d2f1d0427d87a806fc660446b6a7e5290a)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
  
      @jsii.member(jsii_name="implementedByPrivateClass")
@@ -15635,7 +15692,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7bde53b867de290d21a419baa46b8e833a0d394835a1ce2be3b429179b2ddce5)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
  
      @jsii.member(jsii_name="implementedByPublicClass")
@@ -15648,7 +15705,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__988e53d92b16fb4b7224c654f985a074cbfa7dd5f567df005b41522641ad92ac)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
  
      @jsii.member(jsii_name="whenTypedAsClass")
@@ -15661,7 +15718,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1d786308546ae61deacb465c6f501fe7e0be028973494548b57e0480759ed460)
-+            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
++            check_type(value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
  
  
@@ -15675,7 +15732,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__83037a3f429b90a38d2d9532a347144030578d83f68817b1a5677ebcd1b38e12)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
  
      @jsii.member(jsii_name="consumeNonInternalInterface")
@@ -15688,7 +15745,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__139bf4e63e56bef32e364c5972e055de5cba153d49cc821740fba1d51f73ef70)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
  
  
@@ -15702,9 +15759,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2be181b08e5a2c0e1e3f3a84732a423af31039117701d35431ee251d343ca9d5)
-+            check_type(argname="argument array_prop", value=array_prop, expected_type=type_hints["array_prop"])
-+            check_type(argname="argument obj_prop", value=obj_prop, expected_type=type_hints["obj_prop"])
-+            check_type(argname="argument record_prop", value=record_prop, expected_type=type_hints["record_prop"])
++            check_type(value=array_prop, expected_type=type_hints["array_prop"])
++            check_type(value=obj_prop, expected_type=type_hints["obj_prop"])
++            check_type(value=record_prop, expected_type=type_hints["record_prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "array_prop": array_prop,
              "obj_prop": obj_prop,
@@ -15718,7 +15775,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__dd941dcba8415b4b4dbb95bc3f55ac3404bdaf303822dfc7093fb615dc66b2cf)
-+            check_type(argname="argument data", value=data, expected_type=type_hints["data"])
++            check_type(value=data, expected_type=type_hints["data"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderArbitrary", [data]))
  
      @jsii.member(jsii_name="renderMap")
@@ -15728,7 +15785,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9008dfc97234c0f2895caaa88d20a94de081c3cd97c38f9a012f13cdae75fbd6)
-+            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
++            check_type(value=map, expected_type=type_hints["map"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderMap", [map]))
  
  
@@ -15742,9 +15799,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__019e6ec86ae7ee325dc404a7025eaf0edcb164e166535a831bccf6658adfbb10)
-+            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
-+            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
-+            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
++            check_type(value=arg1, expected_type=type_hints["arg1"])
++            check_type(value=arg2, expected_type=type_hints["arg2"])
++            check_type(value=arg3, expected_type=type_hints["arg3"])
          jsii.create(self.__class__, self, [arg1, arg2, arg3])
  
      @builtins.property
@@ -15758,8 +15815,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f64945b01dd806fcd872f369983e1fa6b3db8811cb0682ac6adf88aebb0aabda)
-+            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
-+            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
++            check_type(value=readonly_string, expected_type=type_hints["readonly_string"])
++            check_type(value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
  
      @jsii.member(jsii_name="method")
@@ -15773,7 +15830,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3aef3220b38be7daf4208453b1766d9eafb6a74bd51dfb351d21235a205afa34)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
@@ -15787,7 +15844,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cdee1d6893b4921a8d7cf0a9c957a543b69f7a98eb3cedd7ece84871fc81c767)
-+            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
++            check_type(value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "readonly_property": readonly_property,
          }
@@ -15801,15 +15858,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c544311353634d5a2f08144f0c184afbcb700d8304b9f49deae99f19e1e7b0af)
-+            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
-+            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
-+            check_type(argname="argument first_optional", value=first_optional, expected_type=type_hints["first_optional"])
-+            check_type(argname="argument another_required", value=another_required, expected_type=type_hints["another_required"])
-+            check_type(argname="argument bool", value=bool, expected_type=type_hints["bool"])
-+            check_type(argname="argument non_primitive", value=non_primitive, expected_type=type_hints["non_primitive"])
-+            check_type(argname="argument another_optional", value=another_optional, expected_type=type_hints["another_optional"])
-+            check_type(argname="argument optional_any", value=optional_any, expected_type=type_hints["optional_any"])
-+            check_type(argname="argument optional_array", value=optional_array, expected_type=type_hints["optional_array"])
++            check_type(value=anumber, expected_type=type_hints["anumber"])
++            check_type(value=astring, expected_type=type_hints["astring"])
++            check_type(value=first_optional, expected_type=type_hints["first_optional"])
++            check_type(value=another_required, expected_type=type_hints["another_required"])
++            check_type(value=bool, expected_type=type_hints["bool"])
++            check_type(value=non_primitive, expected_type=type_hints["non_primitive"])
++            check_type(value=another_optional, expected_type=type_hints["another_optional"])
++            check_type(value=optional_any, expected_type=type_hints["optional_any"])
++            check_type(value=optional_array, expected_type=type_hints["optional_array"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "anumber": anumber,
              "astring": astring,
@@ -15823,10 +15880,10 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__865cdfdd094ca753189170221ee7d6a0e59c2c0bcfdeff3dc37bb87dd39515ca)
-+            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
-+            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
-+            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
-+            check_type(argname="argument bottom", value=bottom, expected_type=type_hints["bottom"])
++            check_type(value=hoisted_top, expected_type=type_hints["hoisted_top"])
++            check_type(value=left, expected_type=type_hints["left"])
++            check_type(value=right, expected_type=type_hints["right"])
++            check_type(value=bottom, expected_type=type_hints["bottom"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if hoisted_top is not None:
              self._values["hoisted_top"] = hoisted_top
@@ -15840,7 +15897,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cfa52ba952c3d4a7e6df7fba3f619bf3ac14c52e829cce862a5fa495e45d0e70)
-+            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
++            check_type(value=base_level_property, expected_type=type_hints["base_level_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "base_level_property": base_level_property,
          }
@@ -15854,8 +15911,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__354311bd3d60d2b3b4ea927d6a96bdf66aa6d1109c29bfcd96266051c7c30a5e)
-+            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
-+            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
++            check_type(value=base_level_property, expected_type=type_hints["base_level_property"])
++            check_type(value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "base_level_property": base_level_property,
              "first_mid_level_property": first_mid_level_property,
@@ -15869,8 +15926,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8074c5f38699399b9e6f8708c125bef5d7c89118c36ffcce8582d66cac2197da)
-+            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
-+            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
++            check_type(value=base_level_property, expected_type=type_hints["base_level_property"])
++            check_type(value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "base_level_property": base_level_property,
              "second_mid_level_property": second_mid_level_property,
@@ -15884,10 +15941,10 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9384691e88dd3ab7e55516762b2076445d94bd6d9348db1b93f79de9f4ae0ea1)
-+            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
-+            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
-+            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
-+            check_type(argname="argument top_level_property", value=top_level_property, expected_type=type_hints["top_level_property"])
++            check_type(value=base_level_property, expected_type=type_hints["base_level_property"])
++            check_type(value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
++            check_type(value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
++            check_type(value=top_level_property, expected_type=type_hints["top_level_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "base_level_property": base_level_property,
              "first_mid_level_property": first_mid_level_property,
@@ -15901,7 +15958,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5ae2124576c295a0c88fc75be0e57258f0f72e63c733e7493367b8558266510e)
-+            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
++            check_type(value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(None, jsii.invoke(self, "changePrivatePropertyValue", [new_value]))
  
      @jsii.member(jsii_name="privateMethodValue")
@@ -15915,9 +15972,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8ffaadb351f5c2c48a7368068d5c88e0c7836deefe0e13aa9fe53ac104052fd5)
-+            check_type(argname="argument _required_any", value=_required_any, expected_type=type_hints["_required_any"])
-+            check_type(argname="argument _optional_any", value=_optional_any, expected_type=type_hints["_optional_any"])
-+            check_type(argname="argument _optional_string", value=_optional_string, expected_type=type_hints["_optional_string"])
++            check_type(value=_required_any, expected_type=type_hints["_required_any"])
++            check_type(value=_optional_any, expected_type=type_hints["_optional_any"])
++            check_type(value=_optional_string, expected_type=type_hints["_optional_string"])
          return typing.cast(None, jsii.invoke(self, "method", [_required_any, _optional_any, _optional_string]))
  
  
@@ -15931,8 +15988,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5af7b38b9b5c170ebd3e05c215e05f10e6843b03868850dad87a5a149b90e790)
-+            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
-+            check_type(argname="argument things", value=things, expected_type=typing.Tuple[type_hints["things"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=optional, expected_type=type_hints["optional"])
++            check_type(value=things, expected_type=typing.Tuple[type_hints["things"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.str, jsii.invoke(self, "optionalAndVariadic", [optional, *things]))
  
  
@@ -15946,7 +16003,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__feb33b34fd05e771c7e47c132104c701042acfdf4eb6753873c4463e01f3cd9c)
-+            check_type(argname="argument dont_set_me", value=dont_set_me, expected_type=type_hints["dont_set_me"])
++            check_type(value=dont_set_me, expected_type=type_hints["dont_set_me"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if dont_set_me is not None:
              self._values["dont_set_me"] = dont_set_me
@@ -15960,7 +16017,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ae5d543014149876cec8b005abbb94c112981cccaf318870c7fe4e8353c2c675)
-+            check_type(argname="argument example", value=example, expected_type=type_hints["example"])
++            check_type(value=example, expected_type=type_hints["example"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "example": example,
          }
@@ -15974,7 +16031,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c0d457497f870b36d210f01af9890c6624684d1e53da833858e801c18baf9fbb)
-+            check_type(argname="argument value_store", value=value_store, expected_type=type_hints["value_store"])
++            check_type(value=value_store, expected_type=type_hints["value_store"])
          jsii.create(self.__class__, self, [value_store])
  
      @builtins.property
@@ -15986,7 +16043,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def dynamic_property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4f40c12fae2ef2673f3f324c0c452f65c187c1b3e6552b86768465a2d20de051)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "dynamicProperty", value)
  
      @builtins.property
@@ -15998,7 +16055,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def value_store(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9106fb2a86e944ce0c61537852ab2d310a8a53448c6946af051de0325a67fa1a)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueStore", value)
  
  
@@ -16012,7 +16069,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ad557fbd0532aa4220227645f5aae3e73ebae6b529cfe074430abf30d18cd5e9)
-+            check_type(argname="argument original_value", value=original_value, expected_type=type_hints["original_value"])
++            check_type(value=original_value, expected_type=type_hints["original_value"])
          jsii.create(self.__class__, self, [original_value])
  
      @jsii.member(jsii_name="overrideValue")
@@ -16025,7 +16082,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a4026611d197b83d9a37b973ba97c69254e674921a7d89d0eb57ac41a19b636e)
-+            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
++            check_type(value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(builtins.str, jsii.invoke(self, "overrideValue", [new_value]))
  
      @builtins.property
@@ -16039,7 +16096,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2a7f203302b2610301f1b36f34453db0f5572f2e02b0bc4c9933fd670e594222)
-+            check_type(argname="argument clock", value=clock, expected_type=type_hints["clock"])
++            check_type(value=clock, expected_type=type_hints["clock"])
          jsii.create(self.__class__, self, [clock])
  
      @jsii.member(jsii_name="increase")
@@ -16053,7 +16110,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a90d161fb7d47a195a192cf987ac6968fc2c6fbe27005bdd7684478a3d956e66)
-+            check_type(argname="argument word", value=word, expected_type=type_hints["word"])
++            check_type(value=word, expected_type=type_hints["word"])
          return typing.cast(builtins.str, jsii.invoke(self, "repeat", [word]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
@@ -16067,8 +16124,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b87cc89f87e9b1c180227625f3aba9395da5a8b258a88e605d466edb9004d709)
-+            check_type(argname="argument opts", value=opts, expected_type=type_hints["opts"])
-+            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
++            check_type(value=opts, expected_type=type_hints["opts"])
++            check_type(value=key, expected_type=type_hints["key"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "doesKeyExist", [opts, key]))
  
      @jsii.member(jsii_name="prop1IsNull")
@@ -16082,8 +16139,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d34e4f5dab670ec3ea298ec2cda50be32700f7f52dcef6a618ca9cb3706062ee)
-+            check_type(argname="argument option1", value=option1, expected_type=type_hints["option1"])
-+            check_type(argname="argument option2", value=option2, expected_type=type_hints["option2"])
++            check_type(value=option1, expected_type=type_hints["option1"])
++            check_type(value=option2, expected_type=type_hints["option2"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if option1 is not None:
              self._values["option1"] = option1
@@ -16097,8 +16154,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6a92c7223d00e7a0a2f0611cbb689671885b835bb26eedc8eb4a4d12e4ed5021)
-+            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
-+            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
++            check_type(value=readonly_string, expected_type=type_hints["readonly_string"])
++            check_type(value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
  
      @jsii.member(jsii_name="method")
@@ -16112,7 +16169,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__52559292c6e04ad49e53e443b1a4c56149833b8f12876d779bb8860fcb231b41)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
@@ -16126,7 +16183,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b0c8f4c6eca5af7072a4a7c737950b39e75c61a56c505deb94edc5cd0995ed7d)
-+            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
++            check_type(value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "readonly_property": readonly_property,
          }
@@ -16140,7 +16197,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__dad018fa707514e8023df185b5e6e0a4b611bec563fe57abd9b81939b8833ebb)
-+            check_type(argname="argument success", value=success, expected_type=type_hints["success"])
++            check_type(value=success, expected_type=type_hints["success"])
          jsii.create(self.__class__, self, [success])
  
      @builtins.property
@@ -16154,8 +16211,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__861a5ec03219f6c9fecd1b039faa2e53075227ff0d28f8eb66929909bc0c3096)
-+            check_type(argname="argument boom", value=boom, expected_type=type_hints["boom"])
-+            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
++            check_type(value=boom, expected_type=type_hints["boom"])
++            check_type(value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "boom": boom,
              "prop": prop,
@@ -16169,8 +16226,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__82149b1f61aca58419f6ba4c74c8bb1c5c241433707e64ea4626937b294d8fe5)
-+            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
-+            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
++            check_type(value=readonly_string, expected_type=type_hints["readonly_string"])
++            check_type(value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
  
      @jsii.member(jsii_name="method")
@@ -16184,7 +16241,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8380ec30b1f8773df7b5b27be8811be79b04f1d17c8eca83f83927eb56cdfd34)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
@@ -16198,7 +16255,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8e8843a5fc914ec2c1e3baccdad526ea4d48eee37296f6812f3c0673ef86794f)
-+            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
++            check_type(value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "readonly_property": readonly_property,
          }
@@ -16212,7 +16269,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3dce87825e36304d54521ce5524aa7e230fa5d505b0abbc79101fd9014f2cbd9)
-+            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
++            check_type(value=name, expected_type=type_hints["name"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if name is not None:
              self._values["name"] = name
@@ -16226,13 +16283,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d17f0544be961cba6cabfbb40f28c196963de107fcaef9c56d8227bdcb359431)
-+            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
++            check_type(value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
  
  
+ @typing.runtime_checkable
  @jsii.interface(jsii_type="jsii-calc.IAnonymousImplementationProvider")
- class IAnonymousImplementationProvider(typing_extensions.Protocol):
-@@ -2946,10 +3296,13 @@
+@@ -2949,10 +3299,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -16240,13 +16297,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3eabfcad9a21b26024f4c1480ca127a3d6c6888067f0ae991d5922a49bfe81d4)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -2992,10 +3345,13 @@
+@@ -2997,10 +3350,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: IBell) -> None:
          '''
@@ -16254,13 +16311,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d127476ce3b6e59ff9f375f547c1b6e1826d7a3969612c0605ebd0017d2b985d)
-+            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
++            check_type(value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -3020,10 +3376,13 @@
+@@ -3026,10 +3382,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -16268,13 +16325,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2c34aaac5945bdc61c4f56492dee5608e1852940835d94d3e991fed377db66f2)
-+            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
++            check_type(value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3079,10 +3438,13 @@
+@@ -3086,10 +3445,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16282,13 +16339,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e4d76200a6c5bdbdd51f208229da8bfd8f6f4c967af28e1e733579780e9d4a0e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3137,10 +3499,13 @@
+@@ -3145,10 +3507,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16296,13 +16353,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6e68d313f3254be7145220b211c66f45749aa8efc15aaf93d96330eb3cb7c6c7)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3182,10 +3547,13 @@
+@@ -3191,10 +3556,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16310,13 +16367,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8199a83e86f8a4cf29ddc53d2b2151c37c7fa10d29562b454127376d1867d6da)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3231,10 +3599,13 @@
+@@ -3241,10 +3609,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16324,13 +16381,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a904d745cb9f037de717ed7a2b1d3a207493564662fdbe1d7c63e60a24f9bace)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3416,10 +3787,14 @@
+@@ -3432,10 +3803,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -16338,14 +16395,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5568c72c746dd5221cb6fb7b741ed7a3346c346d7a30863c5abe3d99ada53098)
-+            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
-+            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
++            check_type(value=arg1, expected_type=type_hints["arg1"])
++            check_type(value=arg2, expected_type=type_hints["arg2"])
          return typing.cast(None, jsii.invoke(self, "hello", [arg1, arg2]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3454,10 +3829,13 @@
+@@ -3471,10 +3846,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -16353,13 +16410,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__858de6e8785f18ad264a158ca83a0fc1e0a6299efa9f77a0b31eaaffaa5b086c)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3487,10 +3865,13 @@
+@@ -3505,10 +3883,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -16367,13 +16424,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def foo(self, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c571c6749392bc04e123a99b926edaf10b88be6b6d6b6a3937cae9893af5119e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -4010,10 +4391,13 @@
+@@ -4034,10 +4415,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -16381,13 +16438,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def value(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e0395944061fad9d5156b633dc20682ff9759ae0acb88df574b159f4919ab3a5)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "value", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -4049,19 +4433,25 @@
+@@ -4074,19 +4458,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -16395,7 +16452,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9d1e4198ba3f4e6b6a6f4ce0a4a185223ec216368c0c3304c69b029aba13ca49)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
      @builtins.property
@@ -16407,13 +16464,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6774e195ab25dab5790e1d187eb30be56997804d5186753a9928f2575f81977b)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4094,10 +4484,13 @@
+@@ -4120,10 +4510,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -16421,13 +16478,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__831f664cd567fd4e707fd175e9c9e13519f3ca587b792d7d5bc79f427589a802)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value)
  
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4290,10 +4683,13 @@
+@@ -4324,10 +4717,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -16435,13 +16492,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__254a58386276f7b7d5a41dddd674375b8942c2cad4deb6c2d24b55d240d14350)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4360,10 +4756,13 @@
+@@ -4396,10 +4792,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -16449,13 +16506,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__10bb8b026d6c8368d479cf0da8b27c049c5f9088f173a63624e515dd36607439)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4409,10 +4808,13 @@
+@@ -4445,10 +4844,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -16463,13 +16520,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def private(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2df4d055b033cdfdf7ad915b451ddc787ad68fb64b7e02386a9d8e591c1657af)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4430,10 +4832,15 @@
+@@ -4466,10 +4868,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -16477,15 +16534,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b70592e4d080897239bf5f8b0de5b6b464cd9e888e39fca1082c04b5cbeca890)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
-+            check_type(argname="argument goo", value=goo, expected_type=type_hints["goo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
++            check_type(value=bar, expected_type=type_hints["bar"])
++            check_type(value=goo, expected_type=type_hints["goo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
              "bar": bar,
              "goo": goo,
          }
-@@ -4508,10 +4915,13 @@
+@@ -4544,10 +4951,13 @@
          count: jsii.Number,
      ) -> typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable]:
          '''
@@ -16493,13 +16550,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1d6e348a61ed27bfc8b7928365798b43e0130ca2b720c1105baca04fa093d194)
-+            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
++            check_type(value=count, expected_type=type_hints["count"])
          return typing.cast(typing.List[_scope_jsii_calc_lib_c61f082f.IDoublable], jsii.sinvoke(cls, "makeInterfaces", [count]))
  
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4616,19 +5026,25 @@
+@@ -4652,19 +5062,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -16507,7 +16564,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def prop_a(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__30ce308abdc1d2462c00bf7a4acc194ec05d61ddee24b2e79c674aa7034e5ffa)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "propA", value)
  
      @builtins.property
@@ -16519,13 +16576,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def prop_b(self, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__eef7c487e6f0c4d81dd633cf70121104ff8f3458fa52a418df64bcab9fe4bd3e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "propB", value)
  
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4850,10 +5266,13 @@
+@@ -4886,10 +5302,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -16533,13 +16590,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def while_(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a7654af9a241e67ad498c3eb33b98e6cdb1558487bb9b02dcce41f75334b76ad)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "while", value)
  
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -4955,10 +5374,13 @@
+@@ -4991,10 +5410,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -16547,13 +16604,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__43f45c49ecee3d08351b82aa5cdc3548d9dafa534cd2d99da8b5c5c9188e9a54)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Optional[builtins.str], jsii.sinvoke(cls, "stringify", [value]))
  
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -4988,10 +5410,13 @@
+@@ -5024,10 +5446,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -16561,13 +16618,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              '''
 +            if __debug__:
 +                type_hints = typing.get_type_hints(_typecheckingstub__ef705a05998260349d35c748c557e65cf539d53e136eb9191250080bdce852c3)
-+                check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++                check_type(value=value, expected_type=type_hints["value"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
                  "value": value,
              }
  
          @builtins.property
-@@ -5025,10 +5450,13 @@
+@@ -5061,10 +5486,13 @@
              '''
              :param prop: 
              '''
@@ -16575,13 +16632,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
                  prop = LevelOne.PropBooleanValue(**prop)
 +            if __debug__:
 +                type_hints = typing.get_type_hints(_typecheckingstub__2a9e65060bf85c3d49b79ada1f9394ae146c380a4212c190065e031098d570b8)
-+                check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
++                check_type(value=prop, expected_type=type_hints["prop"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
                  "prop": prop,
              }
  
          @builtins.property
-@@ -5063,10 +5491,13 @@
+@@ -5099,10 +5527,13 @@
          '''
          :param prop: 
          '''
@@ -16589,13 +16646,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              prop = LevelOne.PropProperty(**prop)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__479be5d5625f656c28cf12ffdc2cef9d6d74aae555551630f440fcb05351d261)
-+            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
++            check_type(value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "prop": prop,
          }
  
      @builtins.property
-@@ -5114,10 +5545,17 @@
+@@ -5150,10 +5581,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -16603,17 +16660,17 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b3d89a25beb0ebd10c196d941aa924197ae9a2def08f1f414c190a2a6d943d9c)
-+            check_type(argname="argument container_port", value=container_port, expected_type=type_hints["container_port"])
-+            check_type(argname="argument cpu", value=cpu, expected_type=type_hints["cpu"])
-+            check_type(argname="argument memory_mib", value=memory_mib, expected_type=type_hints["memory_mib"])
-+            check_type(argname="argument public_load_balancer", value=public_load_balancer, expected_type=type_hints["public_load_balancer"])
-+            check_type(argname="argument public_tasks", value=public_tasks, expected_type=type_hints["public_tasks"])
++            check_type(value=container_port, expected_type=type_hints["container_port"])
++            check_type(value=cpu, expected_type=type_hints["cpu"])
++            check_type(value=memory_mib, expected_type=type_hints["memory_mib"])
++            check_type(value=public_load_balancer, expected_type=type_hints["public_load_balancer"])
++            check_type(value=public_tasks, expected_type=type_hints["public_tasks"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if container_port is not None:
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5244,10 +5682,14 @@
+@@ -5280,10 +5718,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16621,14 +16678,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7e73465ea858e34d4df8697d34f29a53ca3c3a41c47946382e5d49f498e3747d)
-+            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
-+            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
++            check_type(value=lhs, expected_type=type_hints["lhs"])
++            check_type(value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
  
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5295,10 +5737,13 @@
+@@ -5331,10 +5773,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -16636,13 +16693,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__04dae031a5097183ccda93eb91ec51a8a6fa1133134a6a398f1f05c581bc0091)
-+            check_type(argname="argument number_prop", value=number_prop, expected_type=type_hints["number_prop"])
++            check_type(value=number_prop, expected_type=type_hints["number_prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "number_prop": number_prop,
          }
  
      @builtins.property
-@@ -5369,17 +5814,24 @@
+@@ -5405,17 +5850,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -16650,8 +16707,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__218107d38285901ff40e08163f0de0bac5d835bd64c21c0a735e8d72399ebe35)
-+            check_type(argname="argument _param1", value=_param1, expected_type=type_hints["_param1"])
-+            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
++            check_type(value=_param1, expected_type=type_hints["_param1"])
++            check_type(value=optional, expected_type=type_hints["optional"])
          jsii.create(self.__class__, self, [_param1, optional])
  
      @jsii.member(jsii_name="giveMeUndefined")
@@ -16661,13 +16718,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a109cd8429db09172895a3eb04ca7e9d5c92129c7ca7a50f85fa89b6f6ab366b)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "giveMeUndefined", [value]))
  
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5407,10 +5859,13 @@
+@@ -5443,10 +5895,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -16675,13 +16732,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def change_me_to_undefined(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7102c29a709c4297fb88615c74a3e42a584364ac4ccba5c1db42a65e05184d1b)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "changeMeToUndefined", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5429,10 +5884,14 @@
+@@ -5465,10 +5920,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -16689,14 +16746,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ae8d47cabe4d36f88c891d250d7e792432b0d153223789ec3687e714ba92a5f3)
-+            check_type(argname="argument array_with_three_elements_and_undefined_as_second_argument", value=array_with_three_elements_and_undefined_as_second_argument, expected_type=type_hints["array_with_three_elements_and_undefined_as_second_argument"])
-+            check_type(argname="argument this_should_be_undefined", value=this_should_be_undefined, expected_type=type_hints["this_should_be_undefined"])
++            check_type(value=array_with_three_elements_and_undefined_as_second_argument, expected_type=type_hints["array_with_three_elements_and_undefined_as_second_argument"])
++            check_type(value=this_should_be_undefined, expected_type=type_hints["this_should_be_undefined"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "array_with_three_elements_and_undefined_as_second_argument": array_with_three_elements_and_undefined_as_second_argument,
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5467,17 +5926,23 @@
+@@ -5503,17 +5962,23 @@
  
      def __init__(self, generator: IRandomNumberGenerator) -> None:
          '''
@@ -16704,7 +16761,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3c1812783ba0b3b2146a3dd9609a6e12af404502ff5fbb9b9a9be49bf576122b)
-+            check_type(argname="argument generator", value=generator, expected_type=type_hints["generator"])
++            check_type(value=generator, expected_type=type_hints["generator"])
          jsii.create(self.__class__, self, [generator])
  
      @jsii.member(jsii_name="isSameGenerator")
@@ -16714,13 +16771,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__151b90e9765ce9a05ae13e568f4ba7c9e36e34c1cd991c5c1ee0249869fd4cce)
-+            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
++            check_type(value=gen, expected_type=type_hints["gen"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
  
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5487,10 +5952,13 @@
+@@ -5523,10 +5988,13 @@
      def generator(self) -> IRandomNumberGenerator:
          return typing.cast(IRandomNumberGenerator, jsii.get(self, "generator"))
  
@@ -16728,13 +16785,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def generator(self, value: IRandomNumberGenerator) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__0f5a1cc548d3db6e156cec5671bc04b980132e529c77f3bb5aaa58427db35e7c)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "generator", value)
  
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5508,10 +5976,13 @@
+@@ -5544,10 +6012,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -16742,13 +16799,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f5cb9f9511b0248cd4c0c4bec4eed9e75e7690012237fdb1b39b3f7b3bb0392e)
-+            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
++            check_type(value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromArray", [values]))
  
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5519,10 +5990,13 @@
+@@ -5555,10 +6026,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -16756,13 +16813,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ca5199647728e53a1ec89d4fd7dad9aeb7239f8c1213c51b4e2eda734daa4cf4)
-+            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
++            check_type(value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromMap", [values]))
  
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5563,10 +6037,13 @@
+@@ -5599,10 +6073,13 @@
  ):
      def __init__(self, delegate: IInterfaceWithOptionalMethodArguments) -> None:
          '''
@@ -16770,13 +16827,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__da93d15e57e6e2a1857cd7df156fb2a55ec91715c97323f20268def40f72137c)
-+            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
++            check_type(value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5589,10 +6066,15 @@
+@@ -5625,10 +6102,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16784,15 +16841,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5f6c5e5b55379123a8bd2bc457d9a5e9a0d34dd512b2bd2f59c6a5bec2a95f14)
-+            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
-+            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
-+            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
++            check_type(value=arg1, expected_type=type_hints["arg1"])
++            check_type(value=arg2, expected_type=type_hints["arg2"])
++            check_type(value=arg3, expected_type=type_hints["arg3"])
          jsii.create(self.__class__, self, [arg1, arg2, arg3])
  
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5617,10 +6099,13 @@
+@@ -5653,10 +6135,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -16800,13 +16857,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__26ecd0d4ea200acf388a8b91f17bfd3c09b6c7f8e0a84228b89c27ace672d0b1)
-+            check_type(argname="argument field", value=field, expected_type=type_hints["field"])
++            check_type(value=field, expected_type=type_hints["field"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
          if field is not None:
              self._values["field"] = field
  
      @builtins.property
-@@ -5696,10 +6181,13 @@
+@@ -5732,10 +6217,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -16814,13 +16871,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def _override_read_write(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__72ca8c3c148afe2b76dc14b63b8e2baf0bbf28802add3f88490cb5d3792825fb)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "overrideReadWrite", value)
  
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5711,10 +6199,13 @@
+@@ -5747,10 +6235,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: IReturnsNumber) -> jsii.Number:
          '''
@@ -16828,13 +16885,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ca8d417ddf787890441d6903718eebaf7fde3508b3466202724fdac3a17ba79b)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
  
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5736,10 +6227,14 @@
+@@ -5772,10 +6263,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -16842,14 +16899,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__32a51b5d61d5ca58d33e8f6b9d9e1c4f16b39bf431a669250d4c290de0bbf46f)
-+            check_type(argname="argument builtins", value=builtins, expected_type=type_hints["builtins"])
-+            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
++            check_type(value=builtins, expected_type=type_hints["builtins"])
++            check_type(value=str, expected_type=type_hints["str"])
          props = ParamShadowsBuiltinsProps(
              boolean_property=boolean_property,
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5769,10 +6264,15 @@
+@@ -5805,10 +6300,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -16857,15 +16914,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              struct_property = StructA(**struct_property)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c93d69c5c8307eec2d1c6e8d5f9892234fbdd24bb5cce3f5ea1e210276bc58c1)
-+            check_type(argname="argument boolean_property", value=boolean_property, expected_type=type_hints["boolean_property"])
-+            check_type(argname="argument string_property", value=string_property, expected_type=type_hints["string_property"])
-+            check_type(argname="argument struct_property", value=struct_property, expected_type=type_hints["struct_property"])
++            check_type(value=boolean_property, expected_type=type_hints["boolean_property"])
++            check_type(value=string_property, expected_type=type_hints["string_property"])
++            check_type(value=struct_property, expected_type=type_hints["struct_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "boolean_property": boolean_property,
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5825,10 +6325,13 @@
+@@ -5861,10 +6361,13 @@
          scope: _scope_jsii_calc_lib_c61f082f.Number,
      ) -> _scope_jsii_calc_lib_c61f082f.Number:
          '''
@@ -16873,13 +16930,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ae63c91319764cabd02536ac5b03026eb3f4071497b2a04adf93ca02985507ae)
-+            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
++            check_type(value=scope, expected_type=type_hints["scope"])
          return typing.cast(_scope_jsii_calc_lib_c61f082f.Number, jsii.invoke(self, "useScope", [scope]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5839,10 +6342,13 @@
+@@ -5875,10 +6378,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -16887,13 +16944,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f6db465208dd616dc4f171643676a159b21fe5963ec9a3d1fd752e5cb291868d)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
  
      @builtins.property
-@@ -5897,10 +6403,15 @@
+@@ -5933,10 +6439,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -16901,15 +16958,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__85c3ad65f24d8d5af99d7777a0379b793f45ac0e0e39714f279b8f2d58dbcfdb)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
-+            check_type(argname="argument dt", value=dt, expected_type=type_hints["dt"])
-+            check_type(argname="argument ev", value=ev, expected_type=type_hints["ev"])
++            check_type(value=obj, expected_type=type_hints["obj"])
++            check_type(value=dt, expected_type=type_hints["dt"])
++            check_type(value=ev, expected_type=type_hints["ev"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumePartiallyInitializedThis", [obj, dt, ev]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -5915,10 +6426,13 @@
+@@ -5951,10 +6462,13 @@
          friendly: _scope_jsii_calc_lib_c61f082f.IFriendly,
      ) -> builtins.str:
          '''
@@ -16917,13 +16974,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__edbbf85a7c4217635da7418d28aa61c4e11f7a0c1e9c960528ed4e7bee1ad541)
-+            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
++            check_type(value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
  
  
  class Power(
      _CompositeOperation_1c4d123b,
-@@ -5935,10 +6449,14 @@
+@@ -5971,10 +6485,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -16931,14 +16988,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__df4f41b4c003b9ba61f07f4d41a4059f167ea41c03ea29933966d2caeb831d8c)
-+            check_type(argname="argument base", value=base, expected_type=type_hints["base"])
-+            check_type(argname="argument pow", value=pow, expected_type=type_hints["pow"])
++            check_type(value=base, expected_type=type_hints["base"])
++            check_type(value=pow, expected_type=type_hints["pow"])
          jsii.create(self.__class__, self, [base, pow])
  
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -6161,10 +6679,13 @@
+@@ -6197,10 +6715,13 @@
          value: _scope_jsii_calc_lib_c61f082f.EnumFromScopedModule,
      ) -> None:
          '''
@@ -16946,13 +17003,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__235768085718ab33214221cff3145bb2a82c28916350f273995760a428a1aba3)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "saveFoo", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6175,10 +6696,13 @@
+@@ -6211,10 +6732,13 @@
      @foo.setter
      def foo(
          self,
@@ -16960,13 +17017,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__100c679fa10c1938fc087475a1e5fcdf7c2cbff383b1c02b1d09471cb4f23123)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value)
  
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6220,10 +6744,14 @@
+@@ -6256,10 +6780,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -16974,14 +17031,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              nested_struct = NestedStruct(**nested_struct)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cf66d7b4f4a567aefacbafc24f61d33a942afde3d167676ed65ea82da95cd36e)
-+            check_type(argname="argument string_prop", value=string_prop, expected_type=type_hints["string_prop"])
-+            check_type(argname="argument nested_struct", value=nested_struct, expected_type=type_hints["nested_struct"])
++            check_type(value=string_prop, expected_type=type_hints["string_prop"])
++            check_type(value=nested_struct, expected_type=type_hints["nested_struct"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "string_prop": string_prop,
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6290,17 +6818,25 @@
+@@ -6326,17 +6854,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -16989,9 +17046,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6db501e892de783af62ff728e59cc3155afc51ddc2dff77cce61ffe698e2e1f3)
-+            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
-+            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
-+            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
++            check_type(value=arg1, expected_type=type_hints["arg1"])
++            check_type(value=arg2, expected_type=type_hints["arg2"])
++            check_type(value=arg3, expected_type=type_hints["arg3"])
          return typing.cast(None, jsii.invoke(self, "methodWithDefaultedArguments", [arg1, arg2, arg3]))
  
      @jsii.member(jsii_name="methodWithOptionalAnyArgument")
@@ -17001,13 +17058,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5978f09aaa3317742377437d5735571f672119325c2b5d69f26153bae6764c85)
-+            check_type(argname="argument arg", value=arg, expected_type=type_hints["arg"])
++            check_type(value=arg, expected_type=type_hints["arg"])
          return typing.cast(None, jsii.invoke(self, "methodWithOptionalAnyArgument", [arg]))
  
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6312,10 +6848,15 @@
+@@ -6348,10 +6884,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -17015,15 +17072,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c894904fd4904d7e110da91df846a8ec0970051a274bba5ad95c2b7dc1125cc2)
-+            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
-+            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
-+            check_type(argname="argument arg3", value=arg3, expected_type=type_hints["arg3"])
++            check_type(value=arg1, expected_type=type_hints["arg1"])
++            check_type(value=arg2, expected_type=type_hints["arg2"])
++            check_type(value=arg3, expected_type=type_hints["arg3"])
          return typing.cast(None, jsii.invoke(self, "methodWithOptionalArguments", [arg1, arg2, arg3]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6334,10 +6875,14 @@
+@@ -6370,10 +6911,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -17031,14 +17088,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e7383b9a36a10b88815e6c310c7b13c611260f5ccb143b75dac114873643350d)
-+            check_type(argname="argument deeper_required_prop", value=deeper_required_prop, expected_type=type_hints["deeper_required_prop"])
-+            check_type(argname="argument deeper_optional_prop", value=deeper_optional_prop, expected_type=type_hints["deeper_optional_prop"])
++            check_type(value=deeper_required_prop, expected_type=type_hints["deeper_required_prop"])
++            check_type(value=deeper_optional_prop, expected_type=type_hints["deeper_optional_prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "deeper_required_prop": deeper_required_prop,
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6399,10 +6944,13 @@
+@@ -6435,10 +6980,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -17046,13 +17103,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2ccde09a2986c421795069d44c46d9e2d7470609094b8b7177c6b154360f7435)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonInt", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6421,10 +6969,13 @@
+@@ -6457,10 +7005,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -17060,13 +17117,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__76cbdc0bba36d674ab013a40d091c1f3ccb139f10e78844ebc868bfa5d707ef8)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonString", [value]))
  
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6448,10 +6999,14 @@
+@@ -6484,10 +7035,14 @@
      ) -> None:
          '''
          :param property: 
@@ -17074,14 +17131,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1b795ca2a3052da38144d10d87f230e74bcfa497af1262580f53908be48f6710)
-+            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
-+            check_type(argname="argument yet_anoter_one", value=yet_anoter_one, expected_type=type_hints["yet_anoter_one"])
++            check_type(value=property, expected_type=type_hints["property"])
++            check_type(value=yet_anoter_one, expected_type=type_hints["yet_anoter_one"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "property": property,
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6502,10 +7057,14 @@
+@@ -6538,10 +7093,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -17089,14 +17146,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8c577a76d55e32f4b62a2a005d0c321bf9d0784b2f6cea5f10e297f3f79fc4bb)
-+            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
-+            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
++            check_type(value=readonly_string, expected_type=type_hints["readonly_string"])
++            check_type(value=mutable_number, expected_type=type_hints["mutable_number"])
          jsii.create(self.__class__, self, [readonly_string, mutable_number])
  
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6520,10 +7079,13 @@
+@@ -6556,10 +7115,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17104,13 +17161,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__737be2f0376e64bd8c0980aee9fc6afd796bb4d0cb3415eab28d054f15881752)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value)
  
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6539,10 +7101,13 @@
+@@ -6575,10 +7137,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -17118,13 +17175,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4bbf1eebbce12768b1d2ef90968ffdbe749e42ce8bcdaf4c8750314d2160c5ea)
-+            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
++            check_type(value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "readonly_property": readonly_property,
          }
  
      @builtins.property
-@@ -6579,10 +7144,13 @@
+@@ -6615,10 +7180,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -17132,13 +17189,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def static_variable(cls, value: builtins.bool) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cf00e16ec45ebcadc1f7003eb344ecf452096a12a1a76ff0e15fce1066d716d2)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticVariable", value)
  
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6612,19 +7180,25 @@
+@@ -6648,19 +7216,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -17146,7 +17203,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__69df39c5fc3367bba974a46518d9122ce067721f56037ef6e1faedf479222822)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
      @jsii.member(jsii_name="staticMethod")
@@ -17158,13 +17215,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c4597464b7867e98bf0052f7808e080b75874d088aeac980865a4fc19e47a6d1)
-+            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
++            check_type(value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "staticMethod", [name]))
  
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6661,19 +7235,25 @@
+@@ -6697,19 +7271,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -17172,7 +17229,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def instance(cls, value: "Statics") -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__748a4d0813e4a3ab750bd52215b9ff4dee315d39b160d47884780ea7c4b10daf)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "instance", value)
  
      @jsii.python.classproperty
@@ -17184,13 +17241,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def non_const_static(cls, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5d0ed37ae4b7f5bd294a768da342f4735c6636e0197883a5727e46ed81deec69)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "nonConstStatic", value)
  
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6696,10 +7276,13 @@
+@@ -6732,10 +7312,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -17198,13 +17255,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def you_see_me(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__aa3b9a5342b6fe1366fac3279219c5bae15389881ddd050c544c1d0001853482)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "youSeeMe", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6722,10 +7305,15 @@
+@@ -6758,10 +7341,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -17212,15 +17269,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c9e4f6413d6ce49f4a289256d84d0fa97f7abac1877fc8d49f80f4a7d83a4972)
-+            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
-+            check_type(argname="argument optional_number", value=optional_number, expected_type=type_hints["optional_number"])
-+            check_type(argname="argument optional_string", value=optional_string, expected_type=type_hints["optional_string"])
++            check_type(value=required_string, expected_type=type_hints["required_string"])
++            check_type(value=optional_number, expected_type=type_hints["optional_number"])
++            check_type(value=optional_string, expected_type=type_hints["optional_string"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "required_string": required_string,
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -6783,10 +7371,15 @@
+@@ -6819,10 +7407,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -17228,15 +17285,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              optional_struct_a = StructA(**optional_struct_a)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4d335a3a7bbc35ed76509a5e85466d6d29221efebdd6dd4de639ef040628f332)
-+            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
-+            check_type(argname="argument optional_boolean", value=optional_boolean, expected_type=type_hints["optional_boolean"])
-+            check_type(argname="argument optional_struct_a", value=optional_struct_a, expected_type=type_hints["optional_struct_a"])
++            check_type(value=required_string, expected_type=type_hints["required_string"])
++            check_type(value=optional_boolean, expected_type=type_hints["optional_boolean"])
++            check_type(value=optional_struct_a, expected_type=type_hints["optional_struct_a"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "required_string": required_string,
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -6838,10 +7431,14 @@
+@@ -6874,10 +7467,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -17244,14 +17301,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7eb7b6caeb33bbd3740ca0fc027022df9d4fade4a7d1943a334f2869ab44bd98)
-+            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
-+            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
++            check_type(value=scope, expected_type=type_hints["scope"])
++            check_type(value=props, expected_type=type_hints["props"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "scope": scope,
          }
          if props is not None:
              self._values["props"] = props
-@@ -6884,10 +7481,14 @@
+@@ -6920,10 +7517,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -17259,14 +17316,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e3587fc6359e7cd1adf0bb70ed66e1cd69faa462a530e07c8d25a96b942cb943)
-+            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
-+            check_type(argname="argument inputs", value=inputs, expected_type=typing.Tuple[type_hints["inputs"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=_positional, expected_type=type_hints["_positional"])
++            check_type(value=inputs, expected_type=typing.Tuple[type_hints["inputs"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(jsii.Number, jsii.sinvoke(cls, "howManyVarArgsDidIPass", [_positional, *inputs]))
  
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -6902,10 +7503,13 @@
+@@ -6938,10 +7539,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17274,13 +17331,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b60fd8dad9496da93546e0555f2f8a7a34711e7160c06dc64a47f095f1539d02)
-+            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
++            check_type(value=_positional, expected_type=type_hints["_positional"])
          input = TopLevelStruct(
              required=required, second_level=second_level, optional=optional
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -6922,10 +7526,13 @@
+@@ -6958,10 +7562,13 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17288,13 +17345,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1c22dd35a08877498e4c2c0ed61e220c19d83da3b6a1e278dfcb7af4d76d2df8)
-+            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
++            check_type(value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructA", [struct]))
  
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -6933,18 +7540,24 @@
+@@ -6969,18 +7576,24 @@
          struct: typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -17302,7 +17359,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__bfb5d0235b42940b9a17c7bb3182f454c7652fdb031f8993719a701d42833623)
-+            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
++            check_type(value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructB", [struct]))
  
      @jsii.member(jsii_name="provideStruct")
@@ -17313,13 +17370,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e3e3d0b072ef214d95806fb0366dd1f4a92b97932f845c9364616c9348bce502)
-+            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
++            check_type(value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[StructA, StructB], jsii.sinvoke(cls, "provideStruct", [which]))
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -6958,10 +7571,13 @@
+@@ -6994,10 +7607,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union[StructA, typing.Dict[builtins.str, typing.Any]], typing.Union[StructB, typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -17327,13 +17384,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__06173422e8b2a410ef992bee26115592516245e72f1a99397919d18bfebc1259)
-+            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
++            check_type(value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "union_property": union_property,
          }
  
      @builtins.property
-@@ -6998,10 +7614,14 @@
+@@ -7034,10 +7650,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -17341,14 +17398,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9fac60639e71eb35a422d891e6b571b3ba2118da50de35e8ba784bbb73928be9)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
++            check_type(value=foo, expected_type=type_hints["foo"])
++            check_type(value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -7057,10 +7677,16 @@
+@@ -7093,10 +7713,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -17356,16 +17413,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__21b11cdfe2d95237cdddef417a67936ff8529ea3cef4bd7e80fe498f1e27527d)
-+            check_type(argname="argument default", value=default, expected_type=type_hints["default"])
-+            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
-+            check_type(argname="argument result", value=result, expected_type=type_hints["result"])
-+            check_type(argname="argument that", value=that, expected_type=type_hints["that"])
++            check_type(value=default, expected_type=type_hints["default"])
++            check_type(value=assert_, expected_type=type_hints["assert_"])
++            check_type(value=result, expected_type=type_hints["result"])
++            check_type(value=that, expected_type=type_hints["that"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "default": default,
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7130,10 +7756,13 @@
+@@ -7166,10 +7792,13 @@
      @parts.setter
      def parts(
          self,
@@ -17373,13 +17430,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      ) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e2e14d04b1a68f16d9aef0965aa4ffbc51af3cbd2d201ac6e236d861b10c2fbf)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "parts", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7149,10 +7778,14 @@
+@@ -7185,10 +7814,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -17387,14 +17444,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__11e78aa6557af36be636eea7a1a9b1d6ebf38d63d876b270de65a5f23152b605)
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
-+            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
++            check_type(value=bar, expected_type=type_hints["bar"])
++            check_type(value=id, expected_type=type_hints["id"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bar": bar,
          }
          if id is not None:
              self._values["id"] = id
-@@ -7201,10 +7834,13 @@
+@@ -7237,10 +7870,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -17402,13 +17459,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__46b91a4f1b85f01437aa8a6dda82c7c9e02f0b2ae5324f8c1591fa7ff74feaa0)
-+            check_type(argname="argument id_", value=id_, expected_type=type_hints["id_"])
++            check_type(value=id_, expected_type=type_hints["id_"])
          props = SupportsNiceJavaBuilderProps(bar=bar, id=id)
  
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7242,17 +7878,23 @@
+@@ -7278,17 +7914,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -17416,7 +17473,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a961c6dee96c75a70470863d82c09136094c1d72d47aafe7f105c7733536dd4d)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyOtherProperty", [value]))
  
      @jsii.member(jsii_name="modifyValueOfTheProperty")
@@ -17426,13 +17483,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f3d4d3109122672e8fa17c64fb60787d84a098ee0ee0857d4a10ffe5345a1908)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyValueOfTheProperty", [value]))
  
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7272,17 +7914,23 @@
+@@ -7308,17 +7950,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -17440,7 +17497,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ba36c4cb32b9551fe1c3e91bd834b2e97f7ee93d0b5919acfb1c4fd3d6161295)
-+            check_type(argname="argument n", value=n, expected_type=type_hints["n"])
++            check_type(value=n, expected_type=type_hints["n"])
          return typing.cast(jsii.Number, jsii.invoke(self, "virtualMethod", [n]))
  
      @jsii.member(jsii_name="writeA")
@@ -17450,13 +17507,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7118412729d7ec6272cded791897b09f12ee70e1ca550853121f98ceb30ee0e7)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "writeA", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7293,46 +7941,61 @@
+@@ -7329,46 +7977,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -17464,7 +17521,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def a(self, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c361a6694d6564ff5c16af012cfaf94cac0a971928a1d0fb014c27f971287836)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
      @builtins.property
@@ -17476,7 +17533,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def caller_is_property(self, value: jsii.Number) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d5d44f6e3395b0db421bab95a6dd7d1560538c63f136025c6b216ffb01eae179)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "callerIsProperty", value)
  
      @builtins.property
@@ -17488,7 +17545,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def other_property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__64c8c65ae76fcafb4b6d28e75f8fd31efad60ab9e71d11cbd5877c28c45d8f70)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "otherProperty", value)
  
      @builtins.property
@@ -17500,7 +17557,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def the_property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__52ea95020be0094da769c873214a182768aa2de47b1c4c3dff43f1226edfe281)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "theProperty", value)
  
      @builtins.property
@@ -17512,13 +17569,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def value_of_other_property(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__21d6ffe465a7e42c257c8318bf2bee38ecbc6b1959e6e945e769e365afb3e55d)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueOfOtherProperty", value)
  
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7415,10 +8078,15 @@
+@@ -7451,10 +8114,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -17526,15 +17583,15 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__74359fdf4e6a6505a1c0bc4c2c687826dde0a7696de75fc39f9ed57d89137f96)
-+            check_type(argname="argument required", value=required, expected_type=type_hints["required"])
-+            check_type(argname="argument second_level", value=second_level, expected_type=type_hints["second_level"])
-+            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
++            check_type(value=required, expected_type=type_hints["required"])
++            check_type(value=second_level, expected_type=type_hints["second_level"])
++            check_type(value=optional, expected_type=type_hints["optional"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "required": required,
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7509,10 +8177,13 @@
+@@ -7545,10 +8213,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17542,13 +17599,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e31f878fe14747887a58683a15ca9c8ab54ec35cd6e3a665ad70dd53deadb573)
-+            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
++            check_type(value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> _scope_jsii_calc_lib_c61f082f.NumericValue:
-@@ -7543,10 +8214,14 @@
+@@ -7579,10 +8250,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -17556,14 +17613,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__223de5294ccc50da976adb8794cb8556981e31d63a2c8b249f7dfbd9e2d99eac)
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=bar, expected_type=type_hints["bar"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bar": bar,
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7583,10 +8258,13 @@
+@@ -7619,10 +8294,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -17571,13 +17628,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__aaaf822e80c6473bff9b1da58151a278cd846ae0614db9af97bc57ea6f899ce2)
-+            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
++            check_type(value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
  
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(cls) -> _scope_jsii_calc_lib_custom_submodule_name_c61f082f.Reflector:
-@@ -7629,10 +8307,13 @@
+@@ -7665,10 +8343,13 @@
  ):
      def __init__(self, obj: IInterfaceWithProperties) -> None:
          '''
@@ -17585,13 +17642,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__73d1545891c65d400938add489402441cb083c61d214ad7a922b6417d3984732)
-+            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
++            check_type(value=obj, expected_type=type_hints["obj"])
          jsii.create(self.__class__, self, [obj])
  
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7643,17 +8324,23 @@
+@@ -7679,17 +8360,23 @@
          ext: IInterfaceWithPropertiesExtension,
      ) -> builtins.str:
          '''
@@ -17599,7 +17656,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__60f3870a6dceb3773397b75ec3f3b664f38c2cc3d2f37dc055262663d12f41a8)
-+            check_type(argname="argument ext", value=ext, expected_type=type_hints["ext"])
++            check_type(value=ext, expected_type=type_hints["ext"])
          return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
  
      @jsii.member(jsii_name="writeAndRead")
@@ -17609,13 +17666,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__42edcb376aed0b6e6fec7d7df016bda9e3a31df0e47ecabb5465d1c84d16a414)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.str, jsii.invoke(self, "writeAndRead", [value]))
  
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> IInterfaceWithProperties:
-@@ -7663,25 +8350,34 @@
+@@ -7699,25 +8386,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -17623,7 +17680,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6d238d6a2f6e464c570c3176db3d78d62e0be9908b705705c8f6d7b6b2385c54)
-+            check_type(argname="argument method", value=method, expected_type=type_hints["method"])
++            check_type(value=method, expected_type=type_hints["method"])
          jsii.create(self.__class__, self, [method])
  
      @jsii.member(jsii_name="asArray")
@@ -17633,7 +17690,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__43f32dfb73f1a7fe9c86c00bbc381391db4812c13b5b72363ddcfcd57638c368)
-+            check_type(argname="argument values", value=values, expected_type=typing.Tuple[type_hints["values"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=values, expected_type=typing.Tuple[type_hints["values"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [*values]))
  
  
@@ -17644,13 +17701,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a33769c23320f9f6bce3e3a70c594135cf44ca5c9c6d1de1cae8cc62a99d49e9)
-+            check_type(argname="argument prefix", value=prefix, expected_type=typing.Tuple[type_hints["prefix"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=prefix, expected_type=typing.Tuple[type_hints["prefix"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*prefix])
  
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7690,10 +8386,14 @@
+@@ -7726,10 +8422,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -17658,14 +17715,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1c18f2c7d91dcdc13843ff1637ed95a1f1c1ed99384d6276ee493b0ca579b4a4)
-+            check_type(argname="argument first", value=first, expected_type=type_hints["first"])
-+            check_type(argname="argument others", value=others, expected_type=typing.Tuple[type_hints["others"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=first, expected_type=type_hints["first"])
++            check_type(value=others, expected_type=typing.Tuple[type_hints["others"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [first, *others]))
  
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -7701,19 +8401,25 @@
+@@ -7737,19 +8437,25 @@
  ):
      def __init__(self, *union: typing.Union[StructA, StructB]) -> None:
          '''
@@ -17673,7 +17730,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f18ff2aa5c744d99cc2b37e705d6ed44823660f714c20539c148c9e34e123752)
-+            check_type(argname="argument union", value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*union])
  
      @builtins.property
@@ -17685,13 +17742,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def union(self, value: typing.List[typing.Union[StructA, StructB]]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__01944feab2feb5a9fdf3d356f62de139685f520d3bb3a38ddc5c42d0b03963fe)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "union", value)
  
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -7725,38 +8431,53 @@
+@@ -7761,38 +8467,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -17699,7 +17756,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5efa2ef42e261d5c38c59d5e216e587cb3005bbbb5b4a62e926087ee58478a36)
-+            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
++            check_type(value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeAsync", [index]))
  
      @jsii.member(jsii_name="overrideMeSync")
@@ -17709,7 +17766,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ca8f2360b0292d0b5329ac52818673aece7fb01cf2f09567e60ff65b7728c9cc)
-+            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
++            check_type(value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.invoke(self, "overrideMeSync", [index]))
  
      @jsii.member(jsii_name="parallelSumAsync")
@@ -17719,7 +17776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5bc99fd66b59152ee7799cf716c91bec428d7091eb33ece69057f9ca9b9fdb19)
-+            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
++            check_type(value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "parallelSumAsync", [count]))
  
      @jsii.member(jsii_name="serialSumAsync")
@@ -17729,7 +17786,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__58451fb4813d1aa8877a55de41f1ef8bd30300048337edb2bcf16985abbb6f45)
-+            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
++            check_type(value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "serialSumAsync", [count]))
  
      @jsii.member(jsii_name="sumSync")
@@ -17739,13 +17796,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7ac4c09636b11fefb0a54fbd52b88fc2b4c5c356eb07189a0d2545601f3bef9c)
-+            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
++            check_type(value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumSync", [count]))
  
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -7818,10 +8539,13 @@
+@@ -7854,10 +8575,13 @@
          '''
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "dontReadMe"))
  
@@ -17753,13 +17810,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def dont_read_me(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__54f5b2f0a61a7f2fafae719635a1408f7ff0a8f8a503e559bf0d6bc99772471f)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "dontReadMe", value)
  
  
  class WithPrivatePropertyInConstructor(
      metaclass=jsii.JSIIMeta,
-@@ -7831,10 +8555,13 @@
+@@ -7867,10 +8591,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -17767,13 +17824,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__01fcbc911a24b1fa352275e1273526114db562d2c278b742181eba6e8cb11ad4)
-+            check_type(argname="argument private_field", value=private_field, expected_type=type_hints["private_field"])
++            check_type(value=private_field, expected_type=type_hints["private_field"])
          jsii.create(self.__class__, self, [private_field])
  
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -7875,10 +8602,13 @@
+@@ -7911,10 +8638,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -17781,13 +17838,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__af1f574dee5c4eb581961518ccf32b4060094ed2f9b7e60bece1ed48e3fc45a1)
-+            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
++            check_type(value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.invoke(self, "abstractMethod", [name]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -7894,10 +8624,14 @@
+@@ -7930,10 +8660,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -17795,14 +17852,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__c0e59e6ea7e78215051bf4fe6b69de179aefb4116a344decdfaab4b6b15189b8)
-+            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
-+            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
++            check_type(value=lhs, expected_type=type_hints["lhs"])
++            check_type(value=rhs, expected_type=type_hints["rhs"])
          jsii.create(self.__class__, self, [lhs, rhs])
  
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -7941,10 +8675,13 @@
+@@ -7977,10 +8711,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -17810,13 +17867,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def rung(self, value: builtins.bool) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__fa23831ecd0b539d7689616a0557240dc1a45f924fafe58c0d5f0ac464eecf94)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "rung", value)
  
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -7955,10 +8692,14 @@
+@@ -7991,10 +8728,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -17824,14 +17881,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__84a0b7e93c52a4977e9726c1186b64f57ff35c59c5bc0e7250da1d3236e70208)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
-+            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
++            check_type(value=foo, expected_type=type_hints["foo"])
++            check_type(value=bar, expected_type=type_hints["bar"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
              "bar": bar,
          }
  
-@@ -7999,37 +8740,49 @@
+@@ -8035,37 +8776,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17839,7 +17896,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__720d53a768711730e792d129fcff6272627608d1d3942f42e3010e61a3463b31)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
      @builtins.property
@@ -17851,7 +17908,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5236e267a6763b672404dac13a3d5e50c03eb03d35fe2c18cbe7f649933301f1)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
      @builtins.property
@@ -17863,7 +17920,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__1bd3b16d1aaf127e7610a230095bced32c4c3ef1cadc73f6b24c76b3ebffdd8e)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
      @builtins.property
@@ -17875,13 +17932,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def d(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4e685d8185af60a2f5c9bcffe812224568fe893228304e510b4d989f92c19b90)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "d", value)
  
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -8044,37 +8797,49 @@
+@@ -8080,37 +8833,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17889,7 +17946,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def a(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6499a25aa5ac6723e26c4c716dd2d62a1f9ecd75ae2a476d3213fa5fe8792a1d)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value)
  
      @builtins.property
@@ -17901,7 +17958,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def b(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5da75e226d085b0daac7742a86525ea697c77a044896ce80d48677f5fadb2d57)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value)
  
      @builtins.property
@@ -17913,7 +17970,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def c(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__538f9410afd2d028ca599a233896016121b326bd90d69693e949aff75d72caf3)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value)
  
      @builtins.property
@@ -17925,13 +17982,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def e(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ba8bf3471001981f03d1ad5b84a1b0a4a4d7d556c72734d25d96637a60ad2477)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "e", value)
  
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -8092,10 +8857,14 @@
+@@ -8128,10 +8893,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -17939,14 +17996,14 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__71399b17d07223b2b83f0d7b33d5172c49eb3d0cf3fe38d6059d4c9b7f471113)
-+            check_type(argname="argument read_only_string", value=read_only_string, expected_type=type_hints["read_only_string"])
-+            check_type(argname="argument read_write_string", value=read_write_string, expected_type=type_hints["read_write_string"])
++            check_type(value=read_only_string, expected_type=type_hints["read_only_string"])
++            check_type(value=read_write_string, expected_type=type_hints["read_write_string"])
          return typing.cast("ClassWithPrivateConstructorAndAutomaticProperties", jsii.sinvoke(cls, "create", [read_only_string, read_write_string]))
  
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8106,10 +8875,13 @@
+@@ -8142,10 +8911,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17954,13 +18011,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def read_write_string(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e308499c7b9268c91ee3dc9e4a9c975efdfaa0cd72bd877383c6c64e8f2768d0)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value)
  
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8224,10 +8996,13 @@
+@@ -8263,10 +9035,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -17968,13 +18025,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__148cd823b5de47723c8a76d0553f3ff6c880ba8ecec14b9a86bd89025a18f4d3)
-+            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
++            check_type(value=property, expected_type=type_hints["property"])
          jsii.create(self.__class__, self, [property])
  
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8248,10 +9023,13 @@
+@@ -8287,10 +9062,13 @@
  
      def __init__(self, operand: _scope_jsii_calc_lib_c61f082f.NumericValue) -> None:
          '''
@@ -17982,13 +18039,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e7aa949631662ae6f6ab2804e4a231fa264a1c879d86efa8267e53158c50e647)
-+            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
++            check_type(value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
  
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8311,10 +9089,16 @@
+@@ -8350,10 +9128,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -17996,16 +18053,16 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__2f90423a63bd0fc04016022e622b4bf01d35f365e38b15153d0a4d6fa014ee5b)
-+            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
-+            check_type(argname="argument default_bar", value=default_bar, expected_type=type_hints["default_bar"])
-+            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
-+            check_type(argname="argument rest", value=rest, expected_type=typing.Tuple[type_hints["rest"], ...]) # pyright: ignore [reportGeneralTypeIssues]
++            check_type(value=id, expected_type=type_hints["id"])
++            check_type(value=default_bar, expected_type=type_hints["default_bar"])
++            check_type(value=props, expected_type=type_hints["props"])
++            check_type(value=rest, expected_type=typing.Tuple[type_hints["rest"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [id, default_bar, props, *rest])
  
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8613,5 +9397,1544 @@
+@@ -8652,5 +9436,1544 @@
  from . import nodirect
  from . import onlystatic
  from . import python_self
@@ -19555,7 +19612,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/anonymous/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/anonymous/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/anonymous/__init__.py	--runtime-type-checking
-@@ -57,31 +57,58 @@
+@@ -59,31 +59,58 @@
      @builtins.classmethod
      def consume(cls, option: typing.Union[IOptionA, IOptionB]) -> builtins.str:
          '''
@@ -19563,7 +19620,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__132536bffc9129421b4ae0a6539d0bbfdc1c52c3de007c4546d2f2626ba8c31e)
-+            check_type(argname="argument option", value=option, expected_type=type_hints["option"])
++            check_type(value=option, expected_type=type_hints["option"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "consume", [option]))
  
      @jsii.member(jsii_name="privideAsAny")
@@ -19574,7 +19631,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d461fff988e22833dcf37c5193332d48b9e455d605f2a1e708ab0d111a1659c7)
-+            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
++            check_type(value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Any, jsii.sinvoke(cls, "privideAsAny", [which]))
  
      @jsii.member(jsii_name="provide")
@@ -19585,7 +19642,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f841b966136dfd090628b12290eedd178724cc8f332e05aba2b3a035f07dae50)
-+            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
++            check_type(value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union[IOptionA, IOptionB], jsii.sinvoke(cls, "provide", [which]))
  
  
@@ -19627,7 +19684,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b)
-+            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
++            check_type(value=gen, expected_type=type_hints["gen"])
          return typing.cast(jsii.Number, jsii.invoke(self, "unwrap", [gen]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
@@ -19658,7 +19715,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e2659669d69691129e05836f0722a48449fe2efe197706d9d59c10c141470a4b)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
  
      @jsii.member(jsii_name="next")
@@ -19689,7 +19746,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5a067c851774273f33badeac9c167720ebde25d4301ab096dec54b2e615dc8a4)
-+            check_type(argname="argument source_path", value=source_path, expected_type=type_hints["source_path"])
++            check_type(value=source_path, expected_type=type_hints["source_path"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "source_path": source_path,
          }
@@ -19721,7 +19778,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def decoration_postfixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f546e09b5b6c86dfee3f946eff8913ea8feb763a4156fb8aad45ecc179c63e62)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPostfixes", value)
  
      @builtins.property
@@ -19734,7 +19791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def decoration_prefixes(self, value: typing.List[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__abce94053402e9d1fcf1605226fa2c285e1340ec8219cfd1061f917e876a9051)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPrefixes", value)
  
      @builtins.property
@@ -19747,7 +19804,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def string_style(self, value: "CompositeOperation.CompositionStringStyle") -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9dbbc353e0ea03d68edfa3977eadeb5446b56a89ffb921cb8406ba9fca0805b0)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringStyle", value)
  
      @jsii.enum(
@@ -19790,7 +19847,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def prop(self, value: builtins.str) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__4b95d284137921c7cbf29a9e3a15da0a5cf9dda87efad87aa9ed601662f00b2c)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value)
  
  
@@ -19821,7 +19878,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              homonymous = Homonymous(**homonymous)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a201923592702b83e439b8af921b7eae6f1b86b0eeeffb6c2b506d66a57d4c3a)
-+            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
++            check_type(value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "homonymous": homonymous,
          }
@@ -19835,7 +19892,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b7814834f12f5cbacf39dd7bdb11da208ae4c429011eff511d21e10d621cf9d5)
-+            check_type(argname="argument numeric_property", value=numeric_property, expected_type=type_hints["numeric_property"])
++            check_type(value=numeric_property, expected_type=type_hints["numeric_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "numeric_property": numeric_property,
          }
@@ -19874,7 +19931,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              homonymous = Homonymous(**homonymous)
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__56bad81fb024ccb6a97af9b4edcb748a4d5e34e81491c4222bb761bc0e5890b6)
-+            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
++            check_type(value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "homonymous": homonymous,
          }
@@ -19888,7 +19945,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__57e873ae26cc34d45d619900518aa9fbc9f512fa9ca964387f9bcd933e461123)
-+            check_type(argname="argument string_property", value=string_property, expected_type=type_hints["string_property"])
++            check_type(value=string_property, expected_type=type_hints["string_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "string_property": string_property,
          }
@@ -19927,7 +19984,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def bar(self, value: typing.Optional[builtins.str]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3319085b675e83451882dd81f7704e88da2e392266f9d5188ecb22725f3f71bb)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "bar", value)
  
  
@@ -19941,7 +19998,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5c05b45db7e873d4164cc7295b5d2800ba4bed1813d4a2d57aad8cedb292186d)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
@@ -19979,7 +20036,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cc86cfd2ea53d0ae81d6d80ed07db33f3ca7b140e37166ba1d572a8ed2a78d2c)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
@@ -20011,8 +20068,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__9754f0ac616c8a4339db020e52a796e65577c9909ed5e25d0c696417da04377c)
-+            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
-+            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
++            check_type(value=name, expected_type=type_hints["name"])
++            check_type(value=count, expected_type=type_hints["count"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "name": name,
          }
@@ -20026,7 +20083,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__37c9a298f20a606212f074bd150ba5bc37e38a4cc1f9b2672facafd80734afc1)
-+            check_type(argname="argument receiver", value=receiver, expected_type=type_hints["receiver"])
++            check_type(value=receiver, expected_type=type_hints["receiver"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "callAbstract", [receiver]))
  
      @jsii.member(jsii_name="implementMe")
@@ -20065,7 +20122,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d62f783e4108a6327009d506f8ae7f5aca2734de07314ffd120f24d3e918f697)
-+            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
++            check_type(value=_, expected_type=type_hints["_"])
          jsii.create(self.__class__, self, [_])
  
      @jsii.member(jsii_name="bar")
@@ -20076,7 +20133,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f35c91dda02ec538c4e5ee9182aaa01ba14f837c78951f48bb0abd1a866a4d5c)
-+            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
++            check_type(value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.sinvoke(cls, "bar", [_]))
  
      @jsii.member(jsii_name="foo")
@@ -20086,7 +20143,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__dd74e61269fd21c6a0b0983199f27c5d4df8a4447ff77e770890f58f6c9b6969)
-+            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
++            check_type(value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.invoke(self, "foo", [_]))
  
  
@@ -20126,7 +20183,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__3b33906576528227344dbb0f079876c5dccd08a32f3dbaa0acdc3f444c5fe448)
-+            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
++            check_type(value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
  
      @jsii.member(jsii_name="hello")
@@ -20157,7 +20214,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__cfbe1bc46497cbad551fc80c4d304742daa30493dee8c65b7119cafdeb06e9af)
-+            check_type(argname="argument _bar", value=_bar, expected_type=type_hints["_bar"])
++            check_type(value=_bar, expected_type=type_hints["_bar"])
          return typing.cast(None, jsii.invoke(self, "bar", [_bar]))
  
      @jsii.member(jsii_name="foo")
@@ -20170,7 +20227,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__40045f17e26efacbabd3e103d903497e18761a611301d901fcdebc3cf8baaced)
-+            check_type(argname="argument _values", value=_values, expected_type=type_hints["_values"])
++            check_type(value=_values, expected_type=type_hints["_values"])
          return typing.cast(None, jsii.invoke(self, "foo", [_values]))
  
  
@@ -20204,8 +20261,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__71fe496245d27f33a2ded522fdf47757e7fb41b578fd3ec479cd5b45534588fc)
-+            check_type(argname="argument base_map", value=base_map, expected_type=type_hints["base_map"])
-+            check_type(argname="argument numbers", value=numbers, expected_type=type_hints["numbers"])
++            check_type(value=base_map, expected_type=type_hints["base_map"])
++            check_type(value=numbers, expected_type=type_hints["numbers"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "base_map": base_map,
              "numbers": numbers,
@@ -20238,7 +20295,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__6602c05b71ef2e77c650dd283c33ba4543f756dbbca5d1c31752ee29f836b1f5)
-+            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
++            check_type(value=bar1, expected_type=type_hints["bar1"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bar1": bar1,
          }
@@ -20270,7 +20327,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__d9a43a9ecad39319deef77fa38822e65c584450447849fb04c34b767a8c0881d)
-+            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
++            check_type(value=bar2, expected_type=type_hints["bar2"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bar2": bar2,
          }
@@ -20284,9 +20341,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__717272f96a16c5ea04b9406364f96f18d1c2b16b183b81ef7bae856ebd371a43)
-+            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
-+            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
-+            check_type(argname="argument foo2", value=foo2, expected_type=type_hints["foo2"])
++            check_type(value=bar2, expected_type=type_hints["bar2"])
++            check_type(value=bar1, expected_type=type_hints["bar1"])
++            check_type(value=foo2, expected_type=type_hints["foo2"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bar2": bar2,
              "bar1": bar1,
@@ -20327,7 +20384,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__5cc662603963e69f50f446fe7bf40b3f3ccf17842ed59562f45f4eb63848155b)
-+            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
++            check_type(value=self, expected_type=type_hints["self"])
          jsii.create(self_.__class__, self_, [self])
  
      @jsii.member(jsii_name="method")
@@ -20337,13 +20394,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__7085240966e9682f4d0598c65f482b932ae1281420f2cead92f0036488d061d4)
-+            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
++            check_type(value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
      @builtins.property
      @jsii.member(jsii_name="self")
      def self(self) -> builtins.str:
-@@ -73,10 +79,13 @@
+@@ -74,10 +80,13 @@
      @jsii.member(jsii_name="method")
      def method(self_, self: jsii.Number) -> builtins.str:
          '''
@@ -20351,13 +20408,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__8e4a50df1f139ac6d917c0954b0b6346aeeb47f16abae33b345a5aa2aa02fc99)
-+            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
++            check_type(value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
  
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithSelf).__jsii_proxy_class__ = lambda : _IInterfaceWithSelfProxy
  
-@@ -89,10 +98,13 @@
+@@ -90,10 +99,13 @@
  class StructWithSelf:
      def __init__(self_, *, self: builtins.str) -> None:
          '''
@@ -20365,13 +20422,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__796022ef7b07de2b3997ff905b7451854b30a5e8e06145e4cc31e88f0ea8b0d0)
-+            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
++            check_type(value=self, expected_type=type_hints["self"])
          self_._values: typing.Dict[builtins.str, typing.Any] = {
              "self": self,
          }
  
      @builtins.property
-@@ -119,5 +131,30 @@
+@@ -120,5 +132,30 @@
      "IInterfaceWithSelf",
      "StructWithSelf",
  ]
@@ -20415,7 +20472,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__a44c39bd2002b354344d30dcb1ae0e2dc7ef8f604c2d31c61616cbbfc6a6fc40)
-+            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
++            check_type(value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "foo": foo,
          }
@@ -20429,7 +20486,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      def all_types(self, value: typing.Optional[_AllTypes_b08307c5]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          jsii.set(self, "allTypes", value)
  
  
@@ -20467,7 +20524,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__e7f53d1efa418d6ee29ababd1c2660c1d3d9a5d3de3ad874b2d0cd7c6481139b)
-+            check_type(argname="argument reference", value=reference, expected_type=type_hints["reference"])
++            check_type(value=reference, expected_type=type_hints["reference"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "reference": reference,
          }
@@ -20499,7 +20556,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__ce6e4bc4b6c503e757ba9e0640368ea37840d2ca58311e6ec8b98cdcda077f48)
-+            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
++            check_type(value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "prop": prop,
          }
@@ -20513,7 +20570,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__f4dc81f7243c5c317d71ab682231a51bf3c3a189d9be68c17b8d41246c0abef5)
-+            check_type(argname="argument bool", value=bool, expected_type=type_hints["bool"])
++            check_type(value=bool, expected_type=type_hints["bool"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "bool": bool,
          }
@@ -20527,8 +20584,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__b3b6b38208a14cadd94ba787e4091f753debb361ad5dd2ee9d037908f5677d8b)
-+            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
-+            check_type(argname="argument extra", value=extra, expected_type=type_hints["extra"])
++            check_type(value=prop, expected_type=type_hints["prop"])
++            check_type(value=extra, expected_type=type_hints["extra"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "prop": prop,
          }
@@ -20575,7 +20632,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__25c6f5775c01f503690c503a264eb256af186a94c0c65bd43d6a11942ff54b1c)
-+            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
++            check_type(value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
              "value": value,
          }
@@ -20607,13 +20664,13 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__62dfa3c0a0a719fea295807df31fd40fd66b0e76cf44d9f742ffb421f8e4ca77)
-+            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
++            check_type(value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))
  
  
+ @typing.runtime_checkable
  @jsii.interface(jsii_type="jsii-calc.union.IResolvable")
- class IResolvable(typing_extensions.Protocol):
-@@ -61,5 +64,11 @@
+@@ -62,5 +65,11 @@
      "IResolvable",
      "Resolvable",
  ]


### PR DESCRIPTION
---
Closes: #4469

This change upgrades the python runtime's version of `typeguard` to `>=3.0.2` which was a significant breaking change where `argname` was removed. 

- [ ] I am unsure what the impact of removing `argname` is on error messages.

It also adds `@typing.runtime_checkable` to all interfaces (`I*`) because of raised warnings.

- [ ] I am still unclear whether the `runtime_checkable` decorator was required because I can't explain why it wasn't required before. But, my monkey-patch experiments resulted in a ton of warnings such as:
```
/./packyak.config.py:11: UserWarning: Typeguard cannot check the IReusableStackSynthesizer protocol because it is a non-runtime protocol. If you would like to type check this protocol, please use @typing.runtime_checkable
  return old_check_type(*args, **kwargs)
/./packyak.config.py:11: UserWarning: Typeguard cannot check the IStackSynthesizer protocol because it is a non-runtime protocol. If you would like to type check this protocol, please use @typing.runtime_checkable
  return old_check_type(*args, **kwargs)
```
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
