### PR TITLE
fix(jsii): replace `@link` tags with Markdown code blocks

### DIFF
--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -59,9 +59,9 @@ export function parseSymbolDocumentation(
   sym: ts.Symbol,
   typeChecker: ts.TypeChecker,
 ): DocsParsingResult {
-  const comment = ts
-    .displayPartsToString(sym.getDocumentationComment(typeChecker))
-    .trim();
+  const comment = replaceLinkTags(
+    ts.displayPartsToString(sym.getDocumentationComment(typeChecker)).trim(),
+  );
   const tags = reabsorbExampleTags(sym.getJsDocTags());
 
   // Right here we'll just guess that the first declaration site is the most important one.
@@ -314,4 +314,15 @@ function reabsorbExampleTags(tags: ts.JSDocTagInfo[]): ts.JSDocTagInfo[] {
   }
 
   return ret;
+}
+
+/**
+ * Replace {\@link foo} tags with `foo` to make them Markdown compatible
+ *
+ * Ideally, we'd replace them with something like `[foo](#foo)`,
+ * but that link is not always relative,
+ * and would require linking between documentation pages
+ */
+function replaceLinkTags(comment: string): string {
+  return comment.replace(/\{\s*@link\s+([^}\s]+)\s*\}/g, '`$1`');
 }

--- a/packages/jsii/lib/docs.ts
+++ b/packages/jsii/lib/docs.ts
@@ -105,7 +105,7 @@ function parseDocParts(
       if (tagNames.has(name)) {
         const ret = tagNames.get(name);
         tagNames.delete(name);
-        return ret ?? '';
+        return replaceLinkTags(ret ?? '');
       }
     }
     return undefined;

--- a/packages/jsii/test/docs.test.ts
+++ b/packages/jsii/test/docs.test.ts
@@ -379,14 +379,40 @@ test('replace @link tags with inline code blocks', () => {
     /**
      * Hello this is the documentation for {@link Foo},
      * which implements { @link    IFoo    }.
+     * 
+     * @deprecated - Use {@link Bar} instead.
      */
     export class Foo implements IFoo {
-      public bar() { }
+      /**
+       * Do the {@link Foo}
+       *
+       * @param arg First argument is best argument, {@link Bar} none
+       */
+      public bar(arg: string) { Array.isArray(arg); }
     }
+
+    export class Bar { }
   `);
 
-  expect(assembly.types!['testpkg.Foo'].docs).toEqual({
+  const classType = assembly.types!['testpkg.Foo'] as spec.ClassType;
+  expect(classType.docs).toEqual({
     summary:
       'Hello this is the documentation for `Foo`, which implements `IFoo`.',
+    stability: 'deprecated',
+    deprecated: '- Use `Bar` instead.',
+  });
+
+  console.log(classType.methods);
+
+  expect(classType.methods![0]).toMatchObject({
+    docs: { summary: 'Do the `Foo`.' },
+    parameters: [
+      {
+        name: 'arg',
+        docs: {
+          summary: 'First argument is best argument, `Bar` none.',
+        },
+      },
+    ],
   });
 });

--- a/packages/jsii/test/docs.test.ts
+++ b/packages/jsii/test/docs.test.ts
@@ -370,3 +370,23 @@ test('@example can contain @ sign', () => {
   const classType = assembly.types!['testpkg.Foo'] as spec.ClassType;
   expect(classType.docs!.example).toBe("import * as x from '@banana';");
 });
+
+// ----------------------------------------------------------------------
+test('replace @link tags with inline code blocks', () => {
+  const assembly = compile(`
+    export interface IFoo { }
+
+    /**
+     * Hello this is the documentation for {@link Foo},
+     * which implements { @link    IFoo    }.
+     */
+    export class Foo implements IFoo {
+      public bar() { }
+    }
+  `);
+
+  expect(assembly.types!['testpkg.Foo'].docs).toEqual({
+    summary:
+      'Hello this is the documentation for `Foo`, which implements `IFoo`.',
+  });
+});


### PR DESCRIPTION
Out of habit, I've been using `@link` JSDoc tags in my CDK contributions to reference other entities. I just realized that it might be an issue with the generated Markdown documentation, which it is, see for example:

https://github.com/aws/aws-cdk/blob/58ebabc73d026e78f5804560ce2f23e112a38a66/packages/aws-cdk-lib/aws-cloudwatch/lib/variable.ts#L54-L57

<img width="378" alt="image" src="https://github.com/aws/jsii/assets/2505696/d3dadaae-fa99-41b4-87a5-f7483c794a91">

Which is currently interpreted in the [docs](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.SearchComponents.html) as:

<img width="547" alt="image" src="https://github.com/aws/jsii/assets/2505696/00748f53-f50d-4f0d-81b7-d0d8a0076f87">

This PR is just a basic readability fix to replace `{@link Values.fromSearchComponents}` with `Values.fromSearchComponents` in the generated Markdown. 

The end goal here should be to replace them with proper hash or relative links, e.g. `[Values.fromSearchComponents](aws-cdk-lib.aws_cloudwatch.Values.html#static-fromwbrsearchwbrcomponentscomponents)`, but I can't see an easy way of accomplishing this given my current lack of visibility with JSII

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
