### PR TITLE
chore: bump mkdocs-material

### DIFF
--- a/gh-pages/requirements-dev.txt
+++ b/gh-pages/requirements-dev.txt
@@ -1,4 +1,4 @@
 mkdocs~=1.6.0
 mkdocs-awesome-pages-plugin~=2.9.2
-mkdocs-material~=9.5.18
+mkdocs-material~=9.5.19
 mkdocs-git-revision-date-plugin~=0.3.2


### PR DESCRIPTION
The most recent Dependabot update updated `mkdocs` in such a way that our dependencies are now incompatible.

Bumping `mkdocs-material` as well seems to solve it.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
