### PR TITLE
fix(reflect): additional type predicates for `isXyzType` methods

### DIFF
--- a/packages/jsii-reflect/lib/enum.ts
+++ b/packages/jsii-reflect/lib/enum.ts
@@ -18,7 +18,7 @@ export class EnumType extends Type {
     return this.spec.members.map((m) => new EnumMember(this, m));
   }
 
-  public isEnumType() {
+  public isEnumType(): this is EnumType {
     return true;
   }
 }

--- a/packages/jsii-reflect/lib/interface.ts
+++ b/packages/jsii-reflect/lib/interface.ts
@@ -72,11 +72,11 @@ export class InterfaceType extends ReferenceType {
     return Object.fromEntries(this._getMethods(inherited, this));
   }
 
-  public isDataType() {
+  public isDataType(): this is InterfaceType {
     return !!this.spec.datatype;
   }
 
-  public isInterfaceType() {
+  public isInterfaceType(): this is InterfaceType {
     return true;
   }
 


### PR DESCRIPTION
This helps downstream consumers to not have to add type annotations themselves when using these methods.

Before:

```ts
function needsInterface(type: reflect.InterfaceType) {}

if (type.isInterfaceType()) {
  needsInterface(type as reflect.InterfaceType);
}
```

After:

```ts
function needsInterface(type: reflect.InterfaceType) {}

if (type.isInterfaceType()) {
  needsInterface(type);
}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
