### PR TITLE
chore: fix typo in error message - `delcaration`

### DIFF
--- a/gh-pages/content/specification/2-type-system.md
+++ b/gh-pages/content/specification/2-type-system.md
@@ -325,7 +325,7 @@ Typescript allows grouping declarations together in _namespaces_, which are inte
 _Submodules_ names are the fully qualified name of the namespace from the package's root (if a package `foo` defines a
 namespace `ns1`, which itself contains `ns2`, the submodule for `ns2` will be named `foo.ns1.ns2`).
 
-_Submodules_ are delcared in the _jsii_ assembly under the `submodules` key. This is also where specific
+_Submodules_ are declared in the _jsii_ assembly under the `submodules` key. This is also where specific
 [configuration](#submodule-configuration) is registered, if different from the parent submodule or package.
 
 _Submodules_ are hierarchical, and their fully qualified name is representative of the relationship. For example the

--- a/gh-pages/content/specification/3-kernel-api.md
+++ b/gh-pages/content/specification/3-kernel-api.md
@@ -246,7 +246,7 @@ Sometimes, the _host_ app will extend a _jsii_ class and implement new _jsii_ in
 original type. Such interfaces must be declared by providing their _jsii_ fully qualified name as an entry in the
 `interfaces` list.
 
-Providing interfaces in this list that are implicitly present from another delcaration (either because they are already
+Providing interfaces in this list that are implicitly present from another declaration (either because they are already
 implemented by the class denoted by the `fqn` field, or because another entry in the `interfaces` list extends it) is
 valid, but not necessary. The `@jsii/kernel` is responsible for correctly handling redundant declarations.
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -64,7 +64,7 @@ export function overriddenConfig(overrides) {
       ]);
 
       // TypeScript appears to choke if we do the "as any" in the same
-      // expression as the key access, so we delcare surrogate varibales...
+      // expression as the key access, so we declare surrogate variables...
       for (const key of Array.from(allKeys).sort()) {
         const originalValue = original[key];
         const overrideValue = override[key];

--- a/packages/jsii-rosetta/lib/languages/go.ts
+++ b/packages/jsii-rosetta/lib/languages/go.ts
@@ -36,7 +36,7 @@ interface GoLanguageContext {
   isPtrAssignmentRValue: boolean;
 
   /**
-   * Whether the current element is a parameter delcaration name.
+   * Whether the current element is a parameter declaration name.
    */
   isParameterName: boolean;
 
@@ -46,7 +46,7 @@ interface GoLanguageContext {
   isStruct: boolean;
 
   /**
-   * Whether the context is within an interface delcaration.
+   * Whether the context is within an interface declaration.
    */
   isInterface: boolean;
 

--- a/packages/jsii-rosetta/lib/submodule-reference.ts
+++ b/packages/jsii-rosetta/lib/submodule-reference.ts
@@ -81,7 +81,7 @@ export class SubmoduleReference {
 
 /**
  * Determines what symbols are imported by the given TypeScript import
- * delcaration, in the context of the specified file, using the provided type
+ * declaration, in the context of the specified file, using the provided type
  * checker.
  *
  * @param decl        an import declaration.

--- a/packages/jsii/lib/assembler.ts
+++ b/packages/jsii/lib/assembler.ts
@@ -853,7 +853,7 @@ export class Assembler implements Emitter {
       }
       this._submoduleMap.set(symbol, ns);
 
-      // If the exported symbol has any declaration, and that delcaration is of
+      // If the exported symbol has any declaration, and that declaration is of
       // an entity that can have nested declarations of interest to jsii
       // (classes, interfaces, enums, modules), we need to also associate those
       // nested symbols to the submodule (or they won't be named correctly!)

--- a/packages/jsii/lib/jsii-diagnostic.ts
+++ b/packages/jsii/lib/jsii-diagnostic.ts
@@ -575,7 +575,7 @@ export class JsiiDiagnostic implements ts.Diagnostic {
   public static readonly JSII_5013_STATIC_INSTANCE_CONFLICT = Code.error({
     code: 5013,
     formatter: (member: string, type: spec.ClassType) =>
-      `Member "${member}" of class "${type.fqn}" has both a static and an instance delcaration`,
+      `Member "${member}" of class "${type.fqn}" has both a static and an instance declaration`,
     name: 'language-compatibility/static-instance-conflict',
   });
 

--- a/packages/jsii/lib/validator.ts
+++ b/packages/jsii/lib/validator.ts
@@ -523,7 +523,7 @@ function _defaultValidations(): ValidationFunction[] {
                 mod.kind === ts.SyntaxKind.PublicKeyword ||
                 mod.kind === ts.SyntaxKind.ProtectedKeyword,
             ) ?? declarationName(expectedNode),
-            'The implemented delcaration is here.',
+            'The implemented declaration is here.',
           ),
         );
       }
@@ -537,7 +537,7 @@ function _defaultValidations(): ValidationFunction[] {
             expected.type,
           ).maybeAddRelatedInformation(
             expectedNode?.type ?? declarationName(expectedNode),
-            'The implemented delcaration is here.',
+            'The implemented declaration is here.',
           ),
         );
       }
@@ -555,7 +555,7 @@ function _defaultValidations(): ValidationFunction[] {
             expectedNode?.modifiers?.find(
               (mod) => mod.kind === ts.SyntaxKind.ReadonlyKeyword,
             ) ?? declarationName(expectedNode),
-            'The implemented delcaration is here.',
+            'The implemented declaration is here.',
           ),
         );
       }
@@ -573,7 +573,7 @@ function _defaultValidations(): ValidationFunction[] {
             expectedNode?.questionToken ??
               expectedNode?.type ??
               declarationName(expectedNode),
-            'The implemented delcaration is here.',
+            'The implemented declaration is here.',
           ),
         );
       }

--- a/packages/jsii/test/__snapshots__/negatives.test.js.snap
+++ b/packages/jsii/test/__snapshots__/negatives.test.js.snap
@@ -106,7 +106,7 @@ neg.downgrade-to-readonly.ts:8:24 - error JSII5010: "jsii.Implementation#propert
   neg.downgrade-to-readonly.ts:4:5
     4     property: string;
           ~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -277,7 +277,7 @@ neg.implementation-changes-types.4.ts:9:21 - error JSII5004: "jsii.SomethingImpl
   neg.implementation-changes-types.4.ts:5:14
     5   something: Superclass;
                    ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -290,7 +290,7 @@ neg.implementation-changes-types.5.ts:14:21 - error JSII5004: "jsii.ISomethingEl
   neg.implementation-changes-types.5.ts:5:14
     5   something: Superclass;
                    ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -318,7 +318,7 @@ neg.implementing-property-changes-optionality.ts:7:20 - error JSII5009: "jsii.Im
   neg.implementing-property-changes-optionality.ts:3:11
     3   property?: string;
                 ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -331,7 +331,7 @@ neg.implementing-property-changes-optionality.1.ts:7:20 - error JSII5009: "jsii.
   neg.implementing-property-changes-optionality.1.ts:3:27
     3   public abstract property?: string;
                                 ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -344,7 +344,7 @@ neg.implementing-property-changes-optionality.2.ts:7:20 - error JSII5009: "jsii.
   neg.implementing-property-changes-optionality.2.ts:3:18
     3   public property?: string = undefined;
                        ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -388,7 +388,7 @@ neg.inheritance-changes-types.4.ts:9:21 - error JSII5004: "jsii.SomethingSpecifi
   neg.inheritance-changes-types.4.ts:5:10
     5   public something = new Superclass();
                ~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -401,7 +401,7 @@ neg.inheritance-changes-types.5.ts:14:21 - error JSII5004: "jsii.SomethingElse#s
   neg.inheritance-changes-types.5.ts:5:21
     5   public something: Superclass = new Superclass();
                           ~~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -414,7 +414,7 @@ neg.inheritance-changes-types.from-base.ts:6:30 - error JSII5009: "jsii.HasRequi
   neg.inheritance-changes-types.from-base.ts:2:28
     2   readonly optionalProperty?: number;
                                  ~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 
 `;
 
@@ -650,7 +650,7 @@ neg.override-changes-visibility.ts:14:3 - error JSII5002: "jsii.ChildClass#prope
   neg.override-changes-visibility.ts:5:3
     5   protected readonly property?: string;
         ~~~~~~~~~
-    The implemented delcaration is here.
+    The implemented declaration is here.
 error JSII5002: "jsii.ChildClass#method" changes visibility to public when overriding jsii.BaseClass. Change it to protected
 
 `;
@@ -720,7 +720,7 @@ neg.static-member-mixing.1.ts:11:1 - error JSII5014: Instance member "funFunctio
 `;
 
 exports[`static-member-mixing.2 1`] = `
-neg.static-member-mixing.2.ts:1:1 - error JSII5013: Member "funFunction" of class "jsii.TheClass" has both a static and an instance delcaration
+neg.static-member-mixing.2.ts:1:1 - error JSII5013: Member "funFunction" of class "jsii.TheClass" has both a static and an instance declaration
 
   1 export class TheClass {
     ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Observed the error below: `The implemented delcaration is here.`

`delcaration` - I kept looking at this because it hurt my eyes until I finally realized it was a typo.

At the very least, this can be closed as won't fix so that at least there will be a record for the next person that searches for an issue or fix for it.

## Observed Error Message

```
[2024-05-15T12:22:12.636] [ERROR] jsii/compiler - Type model errors prevented the JSII assembly from being created
src/myconstruct.ts:191:31 - error JSII5004: "cdkConstruct.MyConstruct#dynamoDBTable" changes the property type to "aws-cdk-lib.aws_dynamodb.Table" when implementing cdkConstruct.IMyConstruct. Change it to "aws-cdk-lib.aws_dynamodb.ITable"

191   public get dynamoDBTable(): dynamodb.Table | undefined {
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~

  src/myconstruct.ts:174:28
    174   readonly dynamoDBTable?: dynamodb.ITable;
                                   ~~~~~~~~~~~~~~~
    The implemented delcaration is here.
👾 Task "build » compile" failed when executing "jsii --silence-warnings=reserved-word" (cwd: packages/cdk)
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
