### PR TITLE
chore: use node LTS version for workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Set up Node 18
+      - name: Set up Node LTS
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: '18'
+          node-version: 'lts/*'
       - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
@@ -125,11 +125,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-      - name: Set up Node 18
+      - name: Set up Node LTS
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: '18'
+          node-version: 'lts/*'
       - name: Set up Python 3.8
         uses: actions/setup-python@v5
         with:
@@ -400,7 +400,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: '18'
+          node-version: 'lts/*'
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Run Benchmark

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18
+          node-version: 'lts/*'
 
       - name: Install Tools
         run: |-


### PR DESCRIPTION
Updates are failing because new versions of `glob` require Node 20 or higher.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
