### PR TITLE
chore(mergify): move deprecated parameters from `pull_request_rules` to `queue_rules`

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -1,6 +1,6 @@
 # See https://doc.mergify.io
 queue_rules:
-  - name: default
+  - name: default-squash
     conditions:
       - status-success~=^jsii/superchain
       - status-success=Unit Tests
@@ -9,6 +9,16 @@ queue_rules:
 
       {{ body }}
     merge_method: squash
+
+  - name: default-merge
+    conditions:
+      - status-success~=^jsii/superchain
+      - status-success=Unit Tests
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
+    merge_method: merge
 
 pull_request_rules:
   - name: label core
@@ -47,7 +57,7 @@ pull_request_rules:
         approved: true
         changes_requested: false
       queue:
-        name: default
+        name: default-squash
       comment:
         message: Merging (with squash)...
     conditions:
@@ -73,7 +83,7 @@ pull_request_rules:
         approved: true
         changes_requested: false
       queue:
-        name: default
+        name: default-merge
       comment:
         message: Merging (no-squash)...
     conditions:

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -4,6 +4,11 @@ queue_rules:
     conditions:
       - status-success~=^jsii/superchain
       - status-success=Unit Tests
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
+    merge_method: squash
 
 pull_request_rules:
   - name: label core
@@ -43,11 +48,6 @@ pull_request_rules:
         changes_requested: false
       queue:
         name: default
-        method: squash
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
       comment:
         message: Merging (with squash)...
     conditions:
@@ -74,11 +74,6 @@ pull_request_rules:
         changes_requested: false
       queue:
         name: default
-        method: merge
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
       comment:
         message: Merging (no-squash)...
     conditions:


### PR DESCRIPTION
We are using deprecated parameters that are about to be removed (October 21st, 2024).

Ideally we should move away from Mergify and use GitHub merge queues. But the config for this repository is more complex, with many pull request rules. Let's avoid breaking the PRs for now and then we can come back and migrate to merge queues.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
