### PR TITLE
ci: allow manual dispatch of superchain build

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,6 +2,7 @@
 name: Docker Images
 
 on:
+  workflow_dispatch: {}
   merge_group: {}
   pull_request:
     branches: [main, release]
@@ -126,7 +127,7 @@ jobs:
         with:
           # Disable parallelism because IO contention makes it too slow on GitHub
           # workers...
-          config-inline: |-
+          buildkitd-config-inline: |-
             [worker.oci]
               max-parallelism = 1
 


### PR DESCRIPTION
Need this for testing.
Also fixed a deprecated input parameter name in the workflow.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
