### PR TITLE
chore: upgrade `actions/upload-artifact` to v4

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,7 +40,7 @@ jobs:
             --site-dir ${{ runner.temp }}/site
         working-directory: gh-pages
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-site
           path: ${{ runner.temp }}/site/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
             .
       # Upload artifact (we'll tar it up to save time)
       - name: 'Upload Artifact: built-tree'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-tree
           path: ${{ runner.temp }}/built-tree.tgz
@@ -173,7 +173,7 @@ jobs:
           yarn package
       # Upload artifacts
       - name: 'Upload Artifact: release-package'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-package
           path: ${{ github.workspace }}/dist/

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -106,7 +106,7 @@ jobs:
           git add .
           git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
       - name: Upload Patch
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: upgrade.patch
           path: ${{ runner.temp }}/upgrade.patch


### PR DESCRIPTION
Version 3 is now [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
