### PR TITLE
chore: use nullish coalescing instead of the ternary operator

### DIFF
--- a/packages/jsii-calc/lib/calculator.ts
+++ b/packages/jsii-calc/lib/calculator.ts
@@ -301,7 +301,7 @@ export class Calculator extends composition.CompositeOperation {
 
     props = props ?? {};
 
-    const initialValue = props.initialValue ? props.initialValue : 0;
+    const initialValue = props.initialValue ?? 0;
     this.curr = new Number(initialValue);
     this.maxValue = props.maximumValue;
   }


### PR DESCRIPTION
Required by a new ESLint rule.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
