### PR TITLE
fix(java-runtime): raise Jackson version bound to 2.19.0

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -60,7 +60,7 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions of the dependencies -->
         <hamcrest.version>[1.3,1.4-a0)</hamcrest.version>
-        <jackson.version>[2.11.3,2.14-a0)</jackson.version>
+        <jackson.version>[2.11.3,2.19.0)</jackson.version>
         <javax-annotations.version>[1.3.2,1.4.0)</javax-annotations.version>
         <jetbrains-annotations.version>[13.0.0,24.0-a0)</jetbrains-annotations.version>
         <junit.version>[5.8.0,5.10-a0)</junit.version>


### PR DESCRIPTION
2.13 has issues, so we should support newer versions as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
