### PR TITLE
fix: Python publishing fails on some Python distributions

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
+++ b/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
@@ -7,3 +7,7 @@ setuptools~=70.0.0 # build-system
 wheel~=0.42        # build-system
 
 twine~=6.1.0
+
+# The dependency on packaging is necessary to work around an incompatibility between
+# what setuptools generates and what twine expects. <https://github.com/pypa/twine/issues/1216>
+packaging >= 24.2


### PR DESCRIPTION
Our recent `jsii-pacmak` release contained an update to `twine` which exhibits a failure when combined with specific versions of `packaging`.

When reading the [bug thread](https://github.com/pypa/twine/issues/1216) the root cause seems to be `setuptools`, but the workaround seems to depend on the installed version of `packaging`.

`twine` declares a dependency on `packaging>=24.0.0` and the bug doesn't appear if `24.2` is installed. As a result, the problem shows on Python distributions that come with `packaging@24.0` or `packaging@24.1` preinstalled.

If an older version or no version of `packaging` is preinstalled then `pip` will install a fresh copy and it will pick `24.2`, but older versions match the declared version range and the pre-existing version will be used, which leads to the problem.

To solve, add the required minimum version of `packaging` to our own dependency file.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
