### PR TITLE
docs(contributing): provide example instruction for using jsii-superchain docker image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,11 @@ our own CI/CD: the ["superchain" image][superchain] from.
 
 [superchain]: https://github.com/aws/jsii-superchain
 
-Please see the superchain repo for usage instructions.
+Once built locally, you can launch a shell from your root project directory in a self-removing container like so:  
+```bash
+# runs the built container, creates a volume mount to /project inside the container
+docker run --rm -it -v "$(pwd)":/project -w /project jsii/superchain:local
+```
 
 ### Alternative: Manually install the toolchain
 


### PR DESCRIPTION
The [jsii-superchain](https://github.com/aws/jsii-superchain) repo does not give a step-by-step for actually running the container for development. I have added a sample instruction that will work for most development use-cases.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
