### PR TITLE
fix(dotnet-windows): specify versions for dotnet packages to prevent errors in Windows

### DIFF
--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
@@ -20,12 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-        <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
+        <PackageReference Include="XunitXml.TestLogger" Version="3.1.17" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
+++ b/packages/@jsii/dotnet-runtime-test/test/Amazon.JSII.Runtime.IntegrationTests/Amazon.JSII.Runtime.IntegrationTests.csproj
@@ -20,12 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Newtonsoft.Json" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio" />
-        <PackageReference Include="XunitXml.TestLogger" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+        <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers.UnitTests/Amazon.JSII.Analyzers.UnitTests.csproj
@@ -15,10 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.12.0,)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0,)" />
+    <PackageReference Include="xunit" Version="[2.9.3,)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.1,)" />
     <ProjectReference Include="..\Amazon.JSII.Analyzers\Amazon.JSII.Analyzers.csproj" />
   </ItemGroup>
 

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Analyzers/Amazon.JSII.Analyzers.csproj
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeQuality.Analyzers" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="[3.11.0,)" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.12.0,)" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="[3.3.2,)" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime.UnitTests/Amazon.JSII.Runtime.UnitTests.csproj
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0,)" />
+    <PackageReference Include="NSubstitute" Version="[5.3.0,)" />
+    <PackageReference Include="xunit" Version="[2.9.3,)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
+++ b/packages/@jsii/dotnet-runtime/src/Amazon.JSII.Runtime/Amazon.JSII.Runtime.csproj
@@ -23,10 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[9.0.1,)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[9.0.1,)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="[9.0.1,)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.3,)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes errors preventing Windows environment test from succeeding.

```
@jsii/dotnet-runtime:   Failed to restore D:\a\jsii\jsii\packages\@jsii\dotnet-runtime\src\Amazon.JSII.Analyzers.UnitTests\Amazon.JSII.Analyzers.UnitTests.csproj (in 41.02 sec).
@jsii/dotnet-runtime:   Failed to restore D:\a\jsii\jsii\packages\@jsii\dotnet-runtime\src\Amazon.JSII.Runtime.UnitTests\Amazon.JSII.Runtime.UnitTests.csproj (in 41.02 sec).
```

```
@jsii/dotnet-runtime-test:   Failed to restore D:\a\jsii\jsii\packages\@jsii\dotnet-runtime-test\test\Amazon.JSII.Runtime.IntegrationTests\Amazon.JSII.Runtime.IntegrationTests.csproj (in 18.44 sec).
```

Several instances of NU1604 `Warning as Error`:  
```
@jsii/dotnet-runtime-test: D:\a\jsii\jsii\packages\@jsii\dotnet-runtime-test\test\Amazon.JSII.Runtime.IntegrationTests\Amazon.JSII.Runtime.IntegrationTests.csproj : error NU1604: Warning As Error: Project dependency Microsoft.Extensions.Logging does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
