### PR TITLE
feat(pacmak): support jsii-rosetta 5.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,10 +371,10 @@ jobs:
       matrix:
         rosetta:
           - latest
-          - 5.4.x
           - 5.5.x
           - 5.6.x
           - 5.7.x
+          - 5.8.x
     steps:
       # Check out the code
       - name: Download Artifact

--- a/packages/@scope/jsii-calc-base-of-base/package.json
+++ b/packages/@scope/jsii-calc-base-of-base/package.json
@@ -30,9 +30,9 @@
     "test:update": "npm run build && UPDATE_DIFF=1 npm run test"
   },
   "devDependencies": {
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-rosetta": "^5.7.0"
+    "jsii-rosetta": "^5.8.0"
   },
   "jsii": {
     "outdir": "dist",

--- a/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base-of-base/test/assembly.jsii
@@ -9,7 +9,7 @@
   },
   "description": "An example transitive dependency for jsii-calc.",
   "homepage": "https://github.com/aws/jsii",
-  "jsiiVersion": "5.7.6",
+  "jsiiVersion": "5.8.0",
   "license": "Apache-2.0",
   "metadata": {
     "jsii": {
@@ -166,5 +166,5 @@
     }
   },
   "version": "2.1.1",
-  "fingerprint": "DT2ow+045qLI08aYhB9Ca5qlQxDIfKyoCeMd3Itjbsk="
+  "fingerprint": "VfnjAv/kKNF0c7yssI920uEZbTr4OrRoFW0hcT57qns="
 }

--- a/packages/@scope/jsii-calc-base/package.json
+++ b/packages/@scope/jsii-calc-base/package.json
@@ -35,9 +35,9 @@
     "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "devDependencies": {
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-rosetta": "^5.7.0"
+    "jsii-rosetta": "^5.8.0"
   },
   "jsii": {
     "metadata": {

--- a/packages/@scope/jsii-calc-base/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-base/test/assembly.jsii
@@ -39,7 +39,7 @@
   },
   "description": "An example direct dependency for jsii-calc.",
   "homepage": "https://github.com/aws/jsii",
-  "jsiiVersion": "5.7.6",
+  "jsiiVersion": "5.8.0",
   "license": "Apache-2.0",
   "metadata": {
     "jsii": {
@@ -207,5 +207,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "nYSD2Fe7M7yIRckvis9UtnquHJz6S+E7SC0Ill34XcQ="
+  "fingerprint": "IZHOxoRL/MXFfl41fiT4CKd440KPwMz5DAPJe7um6JU="
 }

--- a/packages/@scope/jsii-calc-lib/package.json
+++ b/packages/@scope/jsii-calc-lib/package.json
@@ -39,9 +39,9 @@
     "@scope/jsii-calc-base-of-base": "^2.1.1"
   },
   "devDependencies": {
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-rosetta": "^5.7.0"
+    "jsii-rosetta": "^5.8.0"
   },
   "jsii": {
     "outdir": "dist",

--- a/packages/@scope/jsii-calc-lib/test/assembly.jsii
+++ b/packages/@scope/jsii-calc-lib/test/assembly.jsii
@@ -71,7 +71,7 @@
     "stability": "deprecated"
   },
   "homepage": "https://github.com/aws/jsii",
-  "jsiiVersion": "5.7.6",
+  "jsiiVersion": "5.8.0",
   "license": "Apache-2.0",
   "metadata": {
     "jsii": {
@@ -1107,5 +1107,5 @@
     }
   },
   "version": "0.0.0",
-  "fingerprint": "+I8SK68kD/2vEhdmmd3WuO6G03etYpfIjEmQofD8pFk="
+  "fingerprint": "Cj0SprOiSFuu5uOdVNJtUfPpVZxEi7sfDe0BiGEM54M="
 }

--- a/packages/jsii-calc/package.json
+++ b/packages/jsii-calc/package.json
@@ -51,9 +51,9 @@
     "@scope/jsii-calc-lib": "^0.0.0"
   },
   "devDependencies": {
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
-    "jsii-rosetta": "^5.7.0"
+    "jsii-rosetta": "^5.8.0"
   },
   "jsii": {
     "outdir": "dist",

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -146,7 +146,7 @@
     "stability": "stable"
   },
   "homepage": "https://github.com/aws/jsii",
-  "jsiiVersion": "5.7.6",
+  "jsiiVersion": "5.8.0",
   "keywords": [
     "aws",
     "jsii",
@@ -18996,5 +18996,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "sVsKwR2v6RkKF980zycR6kcPCYnjjma0ixi2yS90A+o="
+  "fingerprint": "mWA02D8YACIXtSWosm/bklJEostmUajpRZsZ6tLB3l0="
 }

--- a/packages/jsii-diff/package.json
+++ b/packages/jsii-diff/package.json
@@ -44,7 +44,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/tar-fs": "^2.0.4",
     "jest-expect-message": "^1.1.3",
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0"
   }
 }

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -61,14 +61,14 @@
     "@types/fs-extra": "^9.0.13",
     "@types/semver": "^7.5.8",
     "diff": "^5.2.0",
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
     "jsii-calc": "^3.20.120",
-    "jsii-rosetta": "~5.7.0",
+    "jsii-rosetta": "~5.8.0",
     "pyright": "^1.1.395"
   },
   "peerDependencies": {
-    "jsii-rosetta": ">=5.4.0"
+    "jsii-rosetta": ">=5.5.0"
   },
   "keywords": [
     "jsii",

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@scope/jsii-calc-lib": "^0.0.0",
     "@types/fs-extra": "^9.0.13",
-    "jsii": "^5.7.0",
+    "jsii": "^5.8.0",
     "jsii-build-tools": "^0.0.0",
     "jsii-calc": "^3.20.120"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,18 +811,18 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsii/check-node@1.107.0":
-  version "1.107.0"
-  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.107.0.tgz#359099573cf47e3d2f7be19172fbe49e3e2d11a7"
-  integrity sha512-ud21048xxEVbbzjFlE7GQSuypW7/8P6Dyu+jjTwp6wGFbnbpxZiupIMdp6eSVSqo9M3rC14SyjNq2liXoSYBZg==
+"@jsii/check-node@1.109.0":
+  version "1.109.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.109.0.tgz#d6d988f50f0d11591f6ac7476e6fa1ed9ff43c2e"
+  integrity sha512-KUdmXNeCpOgjwK3QtEnxwMjIbGsPG4YkSwYsU1dmYftOz8x/oTC/D4Bz9uS7f4ARBBVkCWJWtS01l8nQgAZ2jQ==
   dependencies:
     chalk "^4.1.2"
-    semver "^7.6.3"
+    semver "^7.7.1"
 
-"@jsii/spec@^1.107.0":
-  version "1.108.0"
-  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.108.0.tgz#fbcf6785ac7dc62f79aca535a18ecdfa2a8198aa"
-  integrity sha512-YtebmBRy19UT1pKmxqlTqfW1OcFFjuU2zxxi+QFfM8KG1ahBlpcuz+3DE9gG1qTASIJJJI0fd8PaAiZ5gE40sQ==
+"@jsii/spec@^1.109.0":
+  version "1.109.0"
+  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.109.0.tgz#dd5b80014726fc4dce5982ab9c3f2ea4521015f5"
+  integrity sha512-+IQT4DN7/ZjaheFuwKgfpVdDIF+Reb8Hq4nO43Lu0hjeVugelOL0P22cXL229BjQ5yDRr44Fr64FuI/WUNGRKA==
   dependencies:
     ajv "^8.17.1"
 
@@ -1867,10 +1867,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-3.0.1.tgz#bd8b1f824d57e30faa19eb78e4c0951056f72f00"
   integrity sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==
 
-"@xmldom/xmldom@^0.9.7":
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.7.tgz#f21bebdcde4af682a810062b14585c89bb7fab07"
-  integrity sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==
+"@xmldom/xmldom@^0.9.8":
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.8.tgz#1471e82bdff9e8f20ee8bbe60d4ffa8a516e78d8"
+  integrity sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5588,32 +5588,32 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-jsii-rosetta@^5.7.0, jsii-rosetta@~5.7.0:
-  version "5.7.6"
-  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.7.6.tgz#c41612acbc62d95f5e8cd5bbd879d8a28d63cd65"
-  integrity sha512-yimRfvgFM4+ZctGBWadQe3Yplxpp21iSWZzYGncMCV+oaZ1IlTrq4AxGjcoij+bQFdp97hAXoDg66pFmvWOkBg==
+jsii-rosetta@^5.8.0, jsii-rosetta@~5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.8.0.tgz#ed6e473ca2c2c7a7ba29355c7761d0044c7a03e7"
+  integrity sha512-iRqQoGDONPfL6Ga8VnctreQsrYzfWvsFSocKcOctiiHJ+5mbFwWreg/XLMFTz8N3VlblzUbNRnCXfB4XE+3XOg==
   dependencies:
-    "@jsii/check-node" "1.107.0"
-    "@jsii/spec" "^1.107.0"
-    "@xmldom/xmldom" "^0.9.7"
+    "@jsii/check-node" "1.109.0"
+    "@jsii/spec" "^1.109.0"
+    "@xmldom/xmldom" "^0.9.8"
     chalk "^4"
     commonmark "^0.31.2"
     fast-glob "^3.3.3"
-    jsii "~5.7.0"
+    jsii "~5.8.0"
     semver "^7.7.1"
     semver-intersect "^1.5.0"
     stream-json "^1.9.1"
-    typescript "~5.7"
+    typescript "~5.8"
     workerpool "^6.5.1"
     yargs "^17.7.2"
 
-jsii@^5.7.0, jsii@~5.7.0:
-  version "5.7.6"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.7.6.tgz#a60c26854176d80ed7bb9545a3d30f0946f30576"
-  integrity sha512-yh+LxT7tUTs30R5nbmI5hcjHaxqHdrYyd9jjR9uDWbkW4Aj8yvqX7U6eaOzQZPvolnBZ1pvgelIfO/KRqzSfog==
+jsii@^5.8.0, jsii@~5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.8.0.tgz#8dcd83017064ea1c39c516952aa9b33532d5570e"
+  integrity sha512-aFcGir8GAQu5ZNzuvqLxLSvMeSSFsHeh1enoXt7Vp23lvQ7eBvUXMfxmsJ8exq7SuIAVhmx0dWjrJyekOCmAFA==
   dependencies:
-    "@jsii/check-node" "1.107.0"
-    "@jsii/spec" "^1.107.0"
+    "@jsii/check-node" "1.109.0"
+    "@jsii/spec" "^1.109.0"
     case "^1.6.3"
     chalk "^4"
     fast-deep-equal "^3.1.3"
@@ -5622,7 +5622,7 @@ jsii@^5.7.0, jsii@~5.7.0:
     semver-intersect "^1.5.0"
     sort-json "^2.0.1"
     spdx-license-list "^6.9.0"
-    typescript "~5.7"
+    typescript "~5.8"
     yargs "^17.7.2"
 
 json-buffer@3.0.1:
@@ -8231,7 +8231,7 @@ typescript-json-schema@0.64.0:
     typescript "~5.1.0"
     yargs "^17.1.1"
 
-"typescript@>=3 < 6", typescript@~5.7:
+"typescript@>=3 < 6":
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
@@ -8245,6 +8245,11 @@ typescript@~5.1.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
+typescript@~5.8:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
Adds support for jsii-rosetta 5.8 to jsii-pacmak.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
