### PR TITLE
fix(pacmak): Improve error message where scripts have interfered with npm pack

### DIFF
--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -90,7 +90,14 @@ export class JsiiModule {
         );
       }
 
-      return path.resolve(tmpdir, lastLine);
+      const tarballLocation = path.resolve(tmpdir, lastLine);
+
+      if (!fs.pathExistsSync(tarballLocation)) {
+        throw new Error(
+          `${packCommand} reported a tarball that doesn't exist. This can happen if '${packCommand}' is printing additional output from scripts (tarball output was: ${JSON.stringify(lines)}, and final path was ${tarballLocation})`,
+        );
+      }
+      return tarballLocation;
     });
   }
 


### PR DESCRIPTION
It took me a while to spot the quoting in the error reported [here](https://github.com/aws/jsii/issues/4793).

This PR adds a more explicit error for the case where the generated tar appears not to exist, which would have helped find the issue quicker.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
