### PR TITLE
fix(pacmak): Find the tarball location on windows even if prepack is run

### DIFF
--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -79,14 +79,20 @@ export class JsiiModule {
       // Take only the last line of npm pack which should contain the
       // tarball name. otherwise, there can be a lot of extra noise there
       // from scripts that emit to STDOUT.
-      const lines = out.trim().split(os.EOL);
+      const linesSplitByOs = out.trim().split(os.EOL);
+      const lastLineSplitByOs =
+        linesSplitByOs[linesSplitByOs.length - 1].trim();
+      // on Windows, sometimes `npm pack` might print output with
+      // unix line endings, so we have to split again.
+      // This is safe, because '\n' is never a valid character in a file name.
+      const lines = lastLineSplitByOs.split('\n');
       const lastLine = lines[lines.length - 1].trim();
 
       if (!lastLine.endsWith('.tgz') && !lastLine.endsWith('.tar.gz')) {
         throw new Error(
           `${packCommand} did not produce tarball from ${
             this.moduleDirectory
-          } into ${tmpdir} (output was ${JSON.stringify(lines)})`,
+          } into ${tmpdir} (output was ${JSON.stringify(linesSplitByOs)})`,
         );
       }
 


### PR DESCRIPTION
I believe this fixes [the issue where windows runners with prepack scripts fail](https://github.com/aws/jsii/issues/4793).

The fix is a little clumsy - it might be better to pull the line manipulation out to a function.

Raising for discussion, as testing this is a bit fiddly. I'll report back once tested.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
