### PR TITLE
fix(java-runtime): `ErrorStreamSink` no longer fails with a `NullPointerException`

### DIFF
--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -530,8 +530,11 @@ public final class JsiiRuntime {
                 final JsonNode tree = objectMapper.readTree(line);
                 final ConsoleOutput consoleOutput = objectMapper.treeToValue(tree, ConsoleOutput.class);
                 if(consoleOutput == null) {
-                    // this means the line was empty, but the above objectMapper calls will return null
-                    throw new JsonProcessingException();
+                    // null means the line was empty, but the above objectMapper calls will return null
+                    // We would throw JsonProcessingException to avoid duplication, but the constructors
+                    // are protected, and the subclasses need too much information
+                    System.err.println(line);
+                    return;
                 }
                 if (consoleOutput.stderr != null) {
                     System.err.write(consoleOutput.stderr, 0, consoleOutput.stderr.length);

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -516,7 +516,10 @@ public final class JsiiRuntime {
                     this.buffer.write(read);
                 }
                 if (read == '\n' || this.eof) {
-                    processLine(new String(buffer.toByteArray(), StandardCharsets.UTF_8));
+                    // don't print an empty line if we're at the end of the file and the buffer is empty.
+                    if(!this.eof || buffer.size() > 0) {
+                        processLine(new String(buffer.toByteArray(), StandardCharsets.UTF_8));
+                    }
                     buffer.reset();
                 }
             }

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -529,6 +529,10 @@ public final class JsiiRuntime {
             try {
                 final JsonNode tree = objectMapper.readTree(line);
                 final ConsoleOutput consoleOutput = objectMapper.treeToValue(tree, ConsoleOutput.class);
+                if(consoleOutput == null) {
+                    // this means the line was empty, but the above objectMapper calls will return null
+                    throw new JsonProcessingException();
+                }
                 if (consoleOutput.stderr != null) {
                     System.err.write(consoleOutput.stderr, 0, consoleOutput.stderr.length);
                 }


### PR DESCRIPTION
I believe this fixes https://github.com/aws/jsii/issues/4801

I'm unable to run the full test suite locally due to unrelated python and dotnet errors (I suspect I don't have the right versions of something it needs), and unfortunately it doesn't get up to the java-runtime tests.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
