### PR TITLE
fix(java-runtime): `ErrorStreamSink` crashes with `NullPointerException`

### DIFF
--- a/packages/@jsii/java-runtime/project/src/test/java/software/amazon/jsii/JsiiRuntimeTest.java
+++ b/packages/@jsii/java-runtime/project/src/test/java/software/amazon/jsii/JsiiRuntimeTest.java
@@ -9,6 +9,29 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 public final class JsiiRuntimeTest {
+
+    @Test
+    public void errorSteamSinkDoesntCrash() {
+
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+
+        // to capture writes to System.err, which happen when the error stream
+        // sink crashes. kind of a silly...but simple, and works.
+        System.setErr(new PrintStream(err));
+
+        try {
+            final JsiiRuntime runtime = new JsiiRuntime(null, null);
+            runtime.getClient().createObject("Object", Collections.emptyList(), Collections.emptyList(),
+                    Collections.emptyList());
+            runtime.terminate();
+            Assertions.assertFalse(err.toString().contains(
+                    "Unexpected error in background thread \"software.amazon.jsii.JsiiRuntime.ErrorStreamSink\""));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
     @Test
     public void withNoCustomization() {
         final JsiiRuntime runtime = new JsiiRuntime(null, null);


### PR DESCRIPTION
All credit for the detection and fix goes to @TimothyJones and his [PR](https://github.com/aws/jsii/pull/4802). This just adds a unit test on top of it.

Thanks @TimothyJones ! 

Fixes https://github.com/aws/jsii/issues/4801

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
