### PR TITLE
chore: fix the Python build for Python >= 3.12

### DIFF
--- a/packages/@jsii/python-runtime/pyproject.toml
+++ b/packages/@jsii/python-runtime/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.2", "wheel~=0.37"]
+requires = ["setuptools~=80.3", "wheel~=0.45"]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]

--- a/packages/@jsii/python-runtime/requirements.txt
+++ b/packages/@jsii/python-runtime/requirements.txt
@@ -3,7 +3,7 @@ mypy==1.15.0
 pip~=25.1
 pytest~=8.3
 pytest-mypy~=1.0
-setuptools~=75.3.2
+setuptools~=80.3
 types-python-dateutil~=2.9
 wheel~=0.45
 


### PR DESCRIPTION
Since the removal of a class in Python 3.12, we need a more modern version of `setuptools` to work on newer Python versions.

This gets rid of the error:

```
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
