### PR TITLE
fix: revert "chore: fix the Python build for Python >= 3.12"

### DIFF
--- a/packages/@jsii/python-runtime/pyproject.toml
+++ b/packages/@jsii/python-runtime/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=80.3", "wheel~=0.45"]
+requires = ["setuptools~=62.2", "wheel~=0.37"]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]

--- a/packages/@jsii/python-runtime/requirements.txt
+++ b/packages/@jsii/python-runtime/requirements.txt
@@ -3,7 +3,7 @@ mypy==1.15.0
 pip~=25.1
 pytest~=8.3
 pytest-mypy~=1.0
-setuptools~=80.3
+setuptools~=75.3.2
 types-python-dateutil~=2.9
 wheel~=0.45
 


### PR DESCRIPTION
Reverts aws/jsii#4827