### PR TITLE
fix: use pypa/build to create Python sdists and wheels

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -95,19 +95,11 @@ export default class Python extends Target {
     );
 
     // Actually package up our code, both as a sdist and a wheel for publishing.
-    await shell(python, ['setup.py', 'sdist', '--dist-dir', outDir], {
+    await shell(python, ['-m', 'build', '--outdir', outDir, sourceDir], {
       cwd: sourceDir,
       env,
+      retry: { maxAttempts: 5 },
     });
-    await shell(
-      python,
-      ['-m', 'pip', 'wheel', '--no-deps', '--wheel-dir', outDir, sourceDir],
-      {
-        cwd: sourceDir,
-        env,
-        retry: { maxAttempts: 5 },
-      },
-    );
     await shell(python, ['-m', 'twine', 'check', path.join(outDir, '*')], {
       cwd: sourceDir,
       env,

--- a/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
+++ b/packages/jsii-pacmak/lib/targets/python/requirements-dev.txt
@@ -4,7 +4,7 @@
 # package (wheel, sdist), but not declared as build-system dependencies.
 
 setuptools~=75.3.2 # build-system
-wheel~=0.42        # build-system
+build~=1.2.2.post1 # build-system
 
 twine~=6.1.0
 


### PR DESCRIPTION
Using wheel directly generates whl files that aren't compliant with
https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode
. Specifically, periods in the distribution name aren't converted to
underscores like setuptools would do. When uploading such a wheel to
PyPi, you get an email notification from them complaining about it and
warning that soon it would be denied.

However, running setup.py directly to do create a `bdist_wheel` now
produces a deprecation warning. The upstream advice is to use the
`pypa/build` module to wrap setuptools, so that's what I implemented
here. The Python target no longer depends on `wheel` directly, so I
removed it.
