### PR TITLE
fix(mergify): disable speculative checks to prevent race conditions

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -1,4 +1,7 @@
 # See https://doc.mergify.io
+merge_queue:
+  # Ensure Mergify doesn't use speculative PRs to evaluate mergeability
+  max_parallel_checks: 1
 queue_rules:
   - name: default-squash
     conditions:


### PR DESCRIPTION
This change sets `max_parallel_checks` to 1 in the Mergify configuration to ensure that Mergify doesn't use speculative PRs when evaluating mergeability. 

While these speculative PRs are a good idea in principle, they tend to fail against our PR validation rules, e.g. https://github.com/aws/jsii/pull/4868. The simple fix is to not use them. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0