### PR TITLE
feat: prepare support for intersection types

### DIFF
--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
+import { Assembly, SchemaVersion } from '@jsii/spec';
 import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as os from 'os';
@@ -1337,6 +1338,36 @@ defineTest('loading a module twice idepotently succeeds', async (sandbox) => {
 });
 
 defineTest(
+  'loading an assembly with unsupported features fails',
+  async (sandbox) => {
+    const testAssembly: Assembly = {
+      author: {
+        name: 'Me',
+        roles: ['owner'],
+      },
+      description: 'Test',
+      fingerprint: 'asdf',
+      homepage: 'www.example.com',
+      jsiiVersion: '1.20.3',
+      license: 'MIT',
+      name: 'test',
+      repository: { type: 'other', url: 'www.example.com' },
+      schema: SchemaVersion.LATEST,
+      version: '1.2.3',
+      usedFeatures: ['will-never-be-used' as any],
+    };
+
+    await expect(async () =>
+      sandbox.load({
+        tarball: await makeJsiiTarball(testAssembly),
+        name: testAssembly.name,
+        version: testAssembly.version,
+      }),
+    ).rejects.toThrow(/will-never-be-used/);
+  },
+);
+
+defineTest(
   'fails if trying to load two different versions of the same module',
   async (sandbox) => {
     const tarball = await preparePackage('jsii-calc', false);
@@ -2275,9 +2306,42 @@ async function preparePackage(module: string, useCache = true) {
   }
 
   const packageRoot = findPackageRoot(module);
-  await new Promise<void>((ok, ko) => {
-    const child = childProcess.spawn('npm', ['pack', packageRoot], {
-      cwd: staging,
+
+  await runNpm(['pack', packageRoot], staging);
+
+  const dir = path.join(staging, (await fs.readdir(staging))[0]);
+  cache.set(module, dir);
+  return dir;
+}
+
+async function makeJsiiTarball(assembly: Assembly) {
+  const staging = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'jsii-kernel-tests-'),
+  );
+
+  // clean up only if we are not recording, so playback can refer to these
+  if (!recordingOutput) {
+    process.on('exit', () => fs.removeSync(staging)); // cleanup
+  }
+
+  await fs.writeJson(path.join(staging, 'package.json'), {
+    name: assembly.name,
+    version: assembly.version,
+  });
+
+  await fs.writeJson(path.join(staging, '.jsii'), assembly);
+
+  await runNpm(['pack'], staging);
+
+  const tarballs = (await fs.readdir(staging)).filter((x) => x.endsWith('gz'));
+
+  return path.join(staging, tarballs[0]);
+}
+
+async function runNpm(args: string[], cwd: string): Promise<string> {
+  return new Promise<string>((ok, ko) => {
+    const child = childProcess.spawn('npm', args, {
+      cwd,
       shell: true,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
@@ -2285,7 +2349,7 @@ async function preparePackage(module: string, useCache = true) {
     child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
     child.once('close', (code, signal) => {
       if (code === 0) {
-        return ok();
+        return ok(Buffer.concat(stdout).toString());
       }
       if (code != null) {
         return ko(`'npm pack' exited with code ${code}`);
@@ -2293,9 +2357,6 @@ async function preparePackage(module: string, useCache = true) {
       return ko(`'npm pack' killed by signal ${signal}`);
     });
   });
-  const dir = path.join(staging, (await fs.readdir(staging))[0]);
-  cache.set(module, dir);
-  return dir;
 }
 
 function findPackageRoot(pkg: string) {

--- a/packages/@jsii/kernel/src/kernel.test.ts
+++ b/packages/@jsii/kernel/src/kernel.test.ts
@@ -1337,7 +1337,7 @@ defineTest('loading a module twice idepotently succeeds', async (sandbox) => {
   });
 });
 
-defineTest(
+defineTest.skipIf(!!recordingOutput)(
   'loading an assembly with unsupported features fails',
   async (sandbox) => {
     const testAssembly: Assembly = {

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -34,6 +34,7 @@ export class RuntimeError extends Error implements JsiiError {
     super(message);
   }
 }
+
 export class Kernel {
   /**
    * Set to true for verbose debugging.

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -941,6 +941,10 @@ export function serializationType(
     );
   }
 
+  if (spec.isIntersectionTypeReference(typeRef.type)) {
+    throw new Error(`Intersection types cannot be serialized`);
+  }
+
   // The next part of the conversion is lookup-dependent
   const type = lookup(typeRef.type.fqn);
 

--- a/packages/jsii-pacmak/lib/index.ts
+++ b/packages/jsii-pacmak/lib/index.ts
@@ -6,6 +6,7 @@ import { cwd } from 'process';
 import * as logging from './logging';
 import { findJsiiModules, updateAllNpmIgnores } from './npm-modules';
 import { JsiiModule } from './packaging';
+import { assertSpecIsRosettaCompatible } from './rosetta-assembly';
 import { ALL_BUILDERS, TargetName } from './targets';
 import { Timers } from './timer';
 import { Toposorted } from './toposort';
@@ -84,6 +85,9 @@ export async function pacmak({
     return Promise.all(
       modulesToPackageFlat.map(async (m) => {
         await m.load(system, validateAssemblies);
+
+        assertSpecIsRosettaCompatible(m.assembly.spec);
+
         return rosetta.addAssembly(m.assembly.spec, m.moduleDirectory);
       }),
     );

--- a/packages/jsii-pacmak/lib/rosetta-assembly.ts
+++ b/packages/jsii-pacmak/lib/rosetta-assembly.ts
@@ -1,0 +1,30 @@
+import * as spec from '@jsii/spec';
+import { JsiiFeature } from '@jsii/spec';
+import { RosettaTabletReader } from 'jsii-rosetta';
+
+/**
+ * Assert that the given spec is safe to give to Rosetta
+ *
+ * We have to do it like this, because Rosetta has its own internal copy of the
+ * spec and new schema additions may make it technically illegal to assign our
+ * Assembly instance to Rosetta's Assembly type.
+ *
+ * We do runtime validation here to make sure that assignment is safe,
+ * and then assert it in the type system.
+ *
+ * The check should be cheap, this gets called quite a lot.
+ */
+export function assertSpecIsRosettaCompatible(
+  x: spec.Assembly,
+): asserts x is Parameters<RosettaTabletReader['addAssembly']>[0] {
+  const rosettaSupportedFeatures: JsiiFeature[] = [];
+
+  const unsupported = (x.usedFeatures ?? []).filter(
+    (f) => !rosettaSupportedFeatures.includes(f),
+  );
+  if (unsupported.length > 0) {
+    throw new Error(
+      `This assembly uses features Rosetta doesn't support yet: ${unsupported.join(', ')}`,
+    );
+  }
+}

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnetdocgenerator.ts
@@ -11,6 +11,7 @@ import * as xmlbuilder from 'xmlbuilder';
 
 import { renderSummary } from '../_utils';
 import { DotNetNameUtils } from './nameutils';
+import { assertSpecIsRosettaCompatible } from '../../rosetta-assembly';
 
 /**
  * Generates the Jsii attributes and calls for the .NET runtime
@@ -160,6 +161,7 @@ export class DotNetDocGenerator {
   }
 
   private convertExample(example: string, apiLocation: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     const translated = this.rosetta.translateExample(
       apiLocation,
       example,
@@ -170,6 +172,7 @@ export class DotNetDocGenerator {
   }
 
   private convertSamplesInMarkdown(markdown: string, api: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     return this.rosetta.translateSnippetsInMarkdown(
       api,
       markdown,

--- a/packages/jsii-pacmak/lib/targets/dotnet/dotnettyperesolver.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet/dotnettyperesolver.ts
@@ -134,7 +134,7 @@ export class DotNetTypeResolver {
       return this.toDotNetCollection(typeref);
     } else if (spec.isNamedTypeReference(typeref)) {
       return this.toNativeFqn(typeref.fqn);
-    } else if (typeref.union) {
+    } else if (spec.isUnionTypeReference(typeref)) {
       return 'object';
     }
     throw new Error(`Invalid type reference: ${JSON.stringify(typeref)}`);
@@ -150,7 +150,7 @@ export class DotNetTypeResolver {
       return this.toDotNetCollectionName(typeref);
     } else if (spec.isNamedTypeReference(typeref)) {
       return `typeof(${this.toNativeFqn(typeref.fqn)}).FullName`;
-    } else if (typeref.union) {
+    } else if (spec.isUnionTypeReference(typeref)) {
       return '"object"';
     }
     throw new Error(`Invalid type reference: ${JSON.stringify(typeref)}`);

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -30,6 +30,7 @@ import { shell, Scratch, slugify, setExtend } from '../util';
 import { VERSION, VERSION_DESC } from '../version';
 import { stabilityPrefixFor, renderSummary } from './_utils';
 import { toMavenVersionRange, toReleaseVersion } from './version-utils';
+import { assertSpecIsRosettaCompatible } from '../rosetta-assembly';
 
 import { TargetName } from './index';
 
@@ -2920,7 +2921,7 @@ class JavaGenerator extends Generator {
       return [this.toJavaCollection(typeref, { forMarshalling, covariant })];
     } else if (spec.isNamedTypeReference(typeref)) {
       return [this.toNativeFqn(typeref.fqn)];
-    } else if (typeref.union) {
+    } else if (spec.isUnionTypeReference(typeref)) {
       const types = new Array<string>();
       for (const subtype of typeref.union.types) {
         for (const t of this.toJavaTypes(subtype, {
@@ -3369,6 +3370,7 @@ class JavaGenerator extends Generator {
   }
 
   private convertExample(example: string, api: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     const translated = this.rosetta.translateExample(
       api,
       example,
@@ -3379,6 +3381,7 @@ class JavaGenerator extends Generator {
   }
 
   private convertSamplesInMarkdown(markdown: string, api: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     return this.rosetta.translateSnippetsInMarkdown(
       api,
       markdown,

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -29,6 +29,7 @@ import {
 } from './python/type-name';
 import { die, toPythonIdentifier } from './python/util';
 import { toPythonVersionRange, toReleaseVersion } from './version-utils';
+import { assertSpecIsRosettaCompatible } from '../rosetta-assembly';
 
 import { TargetName } from './index';
 
@@ -2589,6 +2590,7 @@ class PythonGenerator extends Generator {
   }
 
   public convertExample(example: string, apiLoc: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     const translated = this.rosetta.translateExample(
       apiLoc,
       example,
@@ -2599,6 +2601,7 @@ class PythonGenerator extends Generator {
   }
 
   public convertMarkdown(markdown: string, apiLoc: ApiLocation): string {
+    assertSpecIsRosettaCompatible(this.assembly);
     return this.rosetta.translateSnippetsInMarkdown(
       apiLoc,
       markdown,

--- a/packages/jsii-reflect/lib/type-ref.ts
+++ b/packages/jsii-reflect/lib/type-ref.ts
@@ -31,6 +31,11 @@ export class TypeReference {
       union.sort();
       return union.join(' | ');
     }
+    if (this.intersectionOfTypes) {
+      const inter = this.intersectionOfTypes.map((x) => x.toString());
+      inter.sort();
+      return inter.join(' & ');
+    }
 
     throw new Error('Invalid type reference');
   }
@@ -93,5 +98,15 @@ export class TypeReference {
     }
 
     return this.spec.union.types.map((t) => new TypeReference(this.system, t));
+  }
+
+  public get intersectionOfTypes(): TypeReference[] | undefined {
+    if (!jsii.isIntersectionTypeReference(this.spec)) {
+      return undefined;
+    }
+
+    return this.spec.intersection.types.map(
+      (t) => new TypeReference(this.system, t),
+    );
   }
 }


### PR DESCRIPTION
This is a preparatory PR for adding support for intersection types (`A & B`) to jsii.

That feature might land or might not, but to figure it out we first need to update `@jsii/spec` to allow modeling intersection types to begin with, as other jsii packages live outside this repo so we can't do an atomic commit adding the feature everywhere; we have to release an updated version of the spec first.

To this end, we're doing the following:

- Add the necessary fields to the spec to express the new feature.
- Add a `usedFeatures` field to assemblies to indicate whether or not a "new feature" is being used, so that tools can reject an assembly if it's using a feature they don't support.
- Wherever we call Rosetta directly from `jsii-pacmak`, we have to do runtime type assertions to make sure the types conversion is valid.

The `usedFeatures` field is chosen rather than a schema version field, to maximize compatibility: we want to gate loading an assembly on whether or not the assembly actually *uses* the new feature, not on whether or not the producing tool *knows about* the new feature.  JSON Schema validation would do the same thing (albeit with a worse error message), but for example the kernel doesn't do JSON Schema validation because it is a slow process.

Proper support for type intersections is added to `@jsii/kernel` already (because it's trivial), but `jsii-pacmak` only has pro-forma type support; it will fail at runtime.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
