### PR TITLE
chore: fix build problems

### DIFF
--- a/packages/@jsii/kernel/package.json
+++ b/packages/@jsii/kernel/package.json
@@ -31,7 +31,7 @@
     "package": "package-js"
   },
   "dependencies": {
-    "@jsii/spec": "^0.0.0",
+    "@jsii/spec": "0.0.0",
     "fs-extra": "^10.1.0",
     "lockfile": "^1.0.4",
     "tar": "^6.2.1"

--- a/packages/@jsii/runtime/package.json
+++ b/packages/@jsii/runtime/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@jsii/kernel": "^0.0.0",
     "@jsii/check-node": "0.0.0",
-    "@jsii/spec": "^0.0.0"
+    "@jsii/spec": "0.0.0"
   },
   "devDependencies": {
     "@scope/jsii-calc-base": "^0.0.0",

--- a/packages/jsii-config/package.json
+++ b/packages/jsii-config/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@jsii/check-node": "0.0.0",
-    "@jsii/spec": "^0.0.0",
+    "@jsii/spec": "0.0.0",
     "inquirer": "^8.2.7",
     "yargs": "^17.7.2"
   }

--- a/packages/jsii-diff/package.json
+++ b/packages/jsii-diff/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@jsii/check-node": "0.0.0",
-    "@jsii/spec": "^0.0.0",
+    "@jsii/spec": "0.0.0",
     "fs-extra": "^10.1.0",
     "jsii-reflect": "^0.0.0",
     "log4js": "^6.9.1",

--- a/packages/jsii-pacmak/package.json
+++ b/packages/jsii-pacmak/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@jsii/check-node": "0.0.0",
-    "@jsii/spec": "^0.0.0",
+    "@jsii/spec": "0.0.0",
     "clone": "^2.1.2",
     "codemaker": "^0.0.0",
     "commonmark": "^0.31.2",

--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jsii/check-node": "0.0.0",
-    "@jsii/spec": "^0.0.0",
+    "@jsii/spec": "0.0.0",
     "chalk": "^4",
     "fs-extra": "^10.1.0",
     "oo-ascii-tree": "^0.0.0",


### PR DESCRIPTION
The build in the main pipeline fails. I don't quite understand the reason, but it has to do with the `align-version` script:

* After the versions have been "aligned", all package versions in this repo have a dependency on `1.113.0` (which is an actually existing package)
* All of a sudden, the TypeScript compilation of `jsii-pacmak` starts picking up the types from the `1.113.0` version of `@jsii/spec`, rather than the local workspace version. 
  * This might sound logical, but mind you that no files on disk have changed and no symlinks have been created. The Node.js place that `@jsii/spec` resolves to is still the local working copy, but TypeScript picks another version, from somewhere, for some reason.

Solve this by bumping to an unreleased version before doing the pipeline build. That way, the bumped version number can never match an actual published version.

Also change all caret dependencies `^` on `@jsii/spec` into point version dependencies. We don't accidentally want a newer version substituted in, because that has implications for the `usedFeatures` that a consumer claims to support.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
