### PR TITLE
fix: jsii-pacmak errors if new targets in package.json

### DIFF
--- a/packages/jsii-pacmak/lib/npm-modules.ts
+++ b/packages/jsii-pacmak/lib/npm-modules.ts
@@ -8,7 +8,7 @@ import { findDependencyDirectory, isBuiltinModule } from './util';
 import * as logging from '../lib/logging';
 
 /**
- * Find all modules that need to be packagerd
+ * Find all modules that need to be packaged
  *
  * If the input list is empty, include the current directory.
  *
@@ -93,14 +93,12 @@ export async function findJsiiModules(
     // outdir is either by package.json/jsii.outdir (relative to package root) or via command line (relative to cwd)
     const outputDirectory =
       pkg.jsii.outdir && path.resolve(realPath, pkg.jsii.outdir);
-    const targets = [...Object.keys(pkg.jsii.targets), 'js']; // "js" is an implicit target.
 
     ret.push(
       new JsiiModule({
         name: pkg.name,
         moduleDirectory: realPath,
         defaultOutputDirectory: outputDirectory,
-        availableTargets: targets,
         dependencyNames,
       }),
     );

--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -19,11 +19,6 @@ export interface JsiiModuleOptions {
   moduleDirectory: string;
 
   /**
-   * Identifier of the targets to build
-   */
-  availableTargets: string[];
-
-  /**
    * Output directory where to package everything
    */
   defaultOutputDirectory: string;
@@ -37,7 +32,6 @@ export class JsiiModule {
   public readonly name: string;
   public readonly dependencyNames: string[];
   public readonly moduleDirectory: string;
-  public readonly availableTargets: string[];
   public outputDirectory: string;
 
   private _tarball?: Scratch<string>;
@@ -46,7 +40,6 @@ export class JsiiModule {
   public constructor(options: JsiiModuleOptions) {
     this.name = options.name;
     this.moduleDirectory = options.moduleDirectory;
-    this.availableTargets = options.availableTargets;
     this.outputDirectory = options.defaultOutputDirectory;
     this.dependencyNames = options.dependencyNames ?? [];
   }
@@ -114,6 +107,11 @@ export class JsiiModule {
       throw new Error('Assembly not available yet, call load() first');
     }
     return this._assembly;
+  }
+
+  public get availableTargets(): string[] {
+    // "js" is an implicit target
+    return [...Object.keys(this.assembly.targets ?? {}), 'js'];
   }
 
   public async cleanup() {


### PR DESCRIPTION
If there are jsii targets in `package.json` that are not in the `.jsii` file (if the package hasn't been recompiled since targets were added) then pacmak explodes with a `reading properties from undefined` error.

Make pacmak consistently read targets from `.jsii` instead of sometimes from `package.json` and sometimes from `.jsii`.

Closes https://github.com/aws/jsii/issues/4913

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
