### PR TITLE
fix(jsii-pacmak): remove deprecation warning DEP0190

### DIFF
--- a/packages/jsii-pacmak/lib/packaging.ts
+++ b/packages/jsii-pacmak/lib/packaging.ts
@@ -49,22 +49,20 @@ export class JsiiModule {
    */
   public async npmPack(packCommand = DEFAULT_PACK_COMMAND) {
     this._tarball = await Scratch.make(async (tmpdir) => {
-      const args = [];
-
       if (packCommand === DEFAULT_PACK_COMMAND) {
         // Quoting (JSON-stringifying) the module directory in order to avoid
         // problems if there are spaces or other special characters in the path.
-        args.push(JSON.stringify(this.moduleDirectory));
+        packCommand += ` ${JSON.stringify(this.moduleDirectory)}`;
 
         if (logging.level.valueOf() >= logging.LEVEL_VERBOSE) {
-          args.push('--loglevel=verbose');
+          packCommand += ' --loglevel=verbose';
         }
       } else {
         // Ensure module is copied to tmpdir to ensure parallel execution does not contend on generated tarballs
         await fs.copy(this.moduleDirectory, tmpdir, { dereference: true });
       }
 
-      const out = await shell(packCommand, args, {
+      const out = await shell(packCommand, {
         cwd: tmpdir,
       });
 

--- a/packages/jsii-pacmak/lib/targets/dotnet.ts
+++ b/packages/jsii-pacmak/lib/targets/dotnet.ts
@@ -12,7 +12,7 @@ import {
   TargetOptions,
   findLocalBuildDirs,
 } from '../target';
-import { shell, Scratch, setExtend, filterAsync } from '../util';
+import { subprocess, Scratch, setExtend, filterAsync } from '../util';
 import { DotNetGenerator } from './dotnet/dotnetgenerator';
 import { toReleaseVersion } from './version-utils';
 
@@ -57,7 +57,7 @@ export class DotnetBuilder implements TargetBuilder {
 
       // Build solution
       logging.debug('Building .NET');
-      await shell(
+      await subprocess(
         'dotnet',
         ['build', '--force', '--configuration', 'Release'],
         {
@@ -104,8 +104,10 @@ export class DotnetBuilder implements TargetBuilder {
       }
 
       // Use 'dotnet' command line tool to build a solution file from these csprojs
-      await shell('dotnet', ['new', 'sln', '-n', 'JsiiBuild'], { cwd: tmpDir });
-      await shell('dotnet', ['sln', 'add', ...csProjs], { cwd: tmpDir });
+      await subprocess('dotnet', ['new', 'sln', '-n', 'JsiiBuild'], {
+        cwd: tmpDir,
+      });
+      await subprocess('dotnet', ['sln', 'add', ...csProjs], { cwd: tmpDir });
 
       await this.generateNuGetConfigForLocalDeps(tmpDir);
 

--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { IGenerator, Legalese } from '../generator';
 import * as logging from '../logging';
 import { findLocalBuildDirs, Target, TargetOptions } from '../target';
-import { shell } from '../util';
+import { subprocess } from '../util';
 import { Documentation } from './go/documentation';
 import { GOMOD_FILENAME, RootPackage } from './go/package';
 import { JSII_INIT_PACKAGE } from './go/runtime';
@@ -264,7 +264,7 @@ function tryFindLocalRuntime():
  */
 async function go(command: string, args: string[], options: { cwd: string }) {
   const { cwd } = options;
-  return shell('go', [command, ...args], {
+  return subprocess('go', [command, ...args], {
     cwd,
     env: {
       // disable the use of sumdb to reduce eventual consistency issues when new modules are published

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -26,7 +26,7 @@ import {
   findLocalBuildDirs,
   TargetOptions,
 } from '../target';
-import { shell, Scratch, slugify, setExtend } from '../util';
+import { subprocess, Scratch, slugify, setExtend } from '../util';
 import { VERSION, VERSION_DESC } from '../version';
 import { stabilityPrefixFor, renderSummary } from './_utils';
 import { toMavenVersionRange, toReleaseVersion } from './version-utils';
@@ -443,7 +443,7 @@ export default class Java extends Target {
       mvnArguments.push(this.arguments[arg].toString());
     }
 
-    await shell(
+    await subprocess(
       'mvn',
       [
         // If we don't run in verbose mode, turn on quiet mode

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -17,7 +17,7 @@ import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
-import { shell } from '../util';
+import { subprocess } from '../util';
 import { VERSION } from '../version';
 import { renderSummary, PropertyDefinition } from './_utils';
 import {
@@ -71,7 +71,7 @@ export default class Python extends Target {
     // shim, but using this actually results in a WinError with Python 3.7 and 3.8 where venv will
     // fail to copy the python binary if it's not invoked as python.exe). More on this particular
     // issue can be read here: https://bugs.python.org/issue43749
-    await shell(process.platform === 'win32' ? 'python' : 'python3', [
+    await subprocess(process.platform === 'win32' ? 'python' : 'python3', [
       '-m',
       'venv',
       '--system-site-packages', // Allow using globally installed packages (saves time & disk space)
@@ -85,7 +85,7 @@ export default class Python extends Target {
     const python = path.join(venvBin, 'python');
 
     // Install the necessary things
-    await shell(
+    await subprocess(
       python,
       ['-m', 'pip', 'install', '--no-input', '-r', requirementsFile],
       {
@@ -96,12 +96,12 @@ export default class Python extends Target {
     );
 
     // Actually package up our code, both as a sdist and a wheel for publishing.
-    await shell(python, ['-m', 'build', '--outdir', outDir, sourceDir], {
+    await subprocess(python, ['-m', 'build', '--outdir', outDir, sourceDir], {
       cwd: sourceDir,
       env,
       retry: { maxAttempts: 5 },
     });
-    await shell(python, ['-m', 'twine', 'check', path.join(outDir, '*')], {
+    await subprocess(python, ['-m', 'twine', 'check', path.join(outDir, '*')], {
       cwd: sourceDir,
       env,
     });

--- a/packages/jsii-pacmak/test/generated-code/harness.ts
+++ b/packages/jsii-pacmak/test/generated-code/harness.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as process from 'process';
 
 import { pacmak, TargetName } from '../../lib';
-import { shell } from '../../lib/util';
+import { subprocess } from '../../lib/util';
 
 export const JSII_TEST_PACKAGES: readonly string[] = [
   '@scope/jsii-calc-base-of-base',
@@ -320,7 +320,7 @@ export async function preparePythonVirtualEnv({
     // shim, but using this actually results in a WinError with Python 3.7 and 3.8 where venv will
     // fail to copy the python binary if it's not invoked as python.exe). More on this particular
     // issue can be read here: https://bugs.python.org/issue43749
-    shell(process.platform === 'win32' ? 'python' : 'python3', [
+    subprocess(process.platform === 'win32' ? 'python' : 'python3', [
       '-m',
       'venv',
       ...(systemSitePackages
@@ -334,7 +334,7 @@ export async function preparePythonVirtualEnv({
 
   // First install dev dependencies
   await expect(
-    shell(
+    subprocess(
       venvPython,
       [
         '-m',
@@ -349,7 +349,7 @@ export async function preparePythonVirtualEnv({
   ).resolves.not.toThrow();
 
   await expect(
-    shell(
+    subprocess(
       venvPython,
       [
         '-m',
@@ -379,7 +379,7 @@ async function runMypy(pythonRoot: string): Promise<void> {
 
   // Now run mypy on the Python code
   return expect(
-    shell(
+    subprocess(
       venvPython,
       [
         '-m',

--- a/packages/jsii-pacmak/test/generated-code/python-pyright.test.ts
+++ b/packages/jsii-pacmak/test/generated-code/python-pyright.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { JSII_TEST_PACKAGES, preparePythonVirtualEnv } from './harness';
 import { pacmak, TargetName } from '../../lib';
-import { shell } from '../../lib/util';
+import { subprocess } from '../../lib/util';
 
 jest.setTimeout(3_600_000);
 
@@ -83,7 +83,7 @@ afterAll(async () => {
 
 test('generated code passes pyright', async () => {
   await expect(
-    shell(
+    subprocess(
       process.execPath,
       [
         ...process.execArgv,


### PR DESCRIPTION
DEP0190 is complaining that when you pass an array to `spawn()` in combination with `{ shell: true }`, you would *expect* the underlying library to escape the arguments for you (like Python does), but in fact it doesn't.

The options are:

- Pass a string that you pre-escaped yourself.
- Don't use `shell: true`.

Because pacmak uses both subshells with hardcoded string arrays, as well as allows users to pass an arbitrary string to be used as a shell command, we make a distinction and introduce two functions:

- `subprocess()`, for when we are invoking a process with an array of strings.
- `shell()`, for when we have a string that needs executin'



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
