### PR TITLE
fix: intersection types cannot be deserialized

### DIFF
--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -942,7 +942,13 @@ export function serializationType(
   }
 
   if (spec.isIntersectionTypeReference(typeRef.type)) {
-    throw new Error(`Intersection types cannot be serialized`);
+    return serializationType(
+      {
+        optional: typeRef.optional,
+        type: typeRef.type.intersection.types[0],
+      },
+      lookup,
+    );
   }
 
   // The next part of the conversion is lookup-dependent


### PR DESCRIPTION
In the previous PR I made `serializationType()` throw an error for intersection types, under the assumption it would be used only for *serialization*.

In fact, it returns the type that will be used for both serialization and deserialization, so this was incorrect and now intersection types cannot be deserialized at all.

Instead, treat them like the first type of the intersection (which must be a reference type anyway because of the restrictions placed on the type by jsii).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
