### PR TITLE
feat: declare support for new feature `class-covariant-overrides`

### DIFF
--- a/packages/@jsii/spec/src/assembly.ts
+++ b/packages/@jsii/spec/src/assembly.ts
@@ -1082,7 +1082,7 @@ export function describeTypeReference(type?: TypeReference): string {
 /**
  * Predefined constants for a set of jsii extension features
  */
-export type JsiiFeature = 'intersection-types';
+export type JsiiFeature = 'intersection-types' | 'class-covariant-overrides';
 
 /**
  * For every feature, is it enforced by the type system?
@@ -1096,6 +1096,7 @@ export type JsiiFeature = 'intersection-types';
  */
 const IS_FEATURE_TYPESYSTEM_ENFORCED: Record<JsiiFeature, boolean> = {
   'intersection-types': true,
+  'class-covariant-overrides': false,
 };
 
 /**


### PR DESCRIPTION
This adds support for the new `class-covariant-overrides` feature into `@jsii/spec`.

`class-covariant-overrides` relaxes the existing restriction on covariant overrides [^1]. With the feature it is now allowed to override the `type of readonly class properties` and the `return type of class methods` when extending other classes, as long as the changes are covariant [^2] [^3] to the superclass. Importantly, covariant overrides are still not allowed when implementing interfaces.

Compilers that are producing assemblies with covariant class overrides MUST include `class-covariant-overrides` in the `usedFeatures` set.

This feature does not require any changes to the kernels, runtimes or packmak. All generated code already is already correct when given an appropriate assembly. We can now add support for this feature due to the upgrade to `net6.0` [^4] which was the only thing blocking it.

Proof all of this is working together: https://github.com/aws/jsii/pull/4925

[^1]: https://aws.github.io/jsii/user-guides/lib-author/typescript-restrictions/#covariant-overrides-parameter-list-changes
[^2]: https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
[^3]: As of today this feature strictly applies to class and interface types, event though some built-in types like lists might also be technically covariant.
[^4]: https://github.com/aws/jsii/pull/4916

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
