### PR TITLE
chore: changelog entry points to non existing release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [1.114.0](https://github.com/aws/jsii/compare/v1.113.0...v1.114.0) (2025-09-04)
+## [1.114.1](https://github.com/aws/jsii/compare/v1.113.0...v1.114.1) (2025-09-04)
 
 
 ### Features


### PR DESCRIPTION
It should be 1.114.1, since we skipped 1.114.0 due to a release glitch.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
