### PR TITLE
fix(pacmak): python classes are generated out of order

### DIFF
--- a/packages/jsii-calc/lib/index.ts
+++ b/packages/jsii-calc/lib/index.ts
@@ -29,3 +29,4 @@ export * as jsii4894 from './jsii4894';
 export * as anonymous from './anonymous';
 export * as union from './union';
 export * as homonymousForwardReferences from './homonymous';
+export * as pascalCaseName from './pascal-case-name';

--- a/packages/jsii-calc/lib/pascal-case-name/index.ts
+++ b/packages/jsii-calc/lib/pascal-case-name/index.ts
@@ -1,0 +1,13 @@
+/**
+ * This module ensures that language code is generated in correct topological order.
+ *
+ * We deliberately name classes & interfaces so that the ones that must come first in code,
+ * are last in alphabetical order.
+ *
+ * Previously, the generated Python code would miss certain dependencies
+ * and effectively render classes alphabetically. Which then obviously fails.
+ */
+
+export class Superclass {}
+export class Subclass extends Superclass {}
+export class SubSubclass extends Subclass {}

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -399,6 +399,13 @@
       },
       "symbolId": "lib/only-static/index:"
     },
+    "jsii-calc.pascalCaseName": {
+      "locationInModule": {
+        "filename": "lib/index.ts",
+        "line": 32
+      },
+      "symbolId": "lib/pascal-case-name/index:"
+    },
     "jsii-calc.submodule": {
       "locationInModule": {
         "filename": "lib/index.ts",
@@ -18347,6 +18354,70 @@
       "namespace": "onlystatic",
       "symbolId": "lib/only-static/index:OnlyStaticMethods"
     },
+    "jsii-calc.pascalCaseName.SubSubclass": {
+      "assembly": "jsii-calc",
+      "base": "jsii-calc.pascalCaseName.Subclass",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.pascalCaseName.SubSubclass",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/pascal-case-name/index.ts",
+        "line": 13
+      },
+      "name": "SubSubclass",
+      "namespace": "pascalCaseName",
+      "symbolId": "lib/pascal-case-name/index:SubSubclass"
+    },
+    "jsii-calc.pascalCaseName.Subclass": {
+      "assembly": "jsii-calc",
+      "base": "jsii-calc.pascalCaseName.Superclass",
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "jsii-calc.pascalCaseName.Subclass",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/pascal-case-name/index.ts",
+        "line": 12
+      },
+      "name": "Subclass",
+      "namespace": "pascalCaseName",
+      "symbolId": "lib/pascal-case-name/index:Subclass"
+    },
+    "jsii-calc.pascalCaseName.Superclass": {
+      "assembly": "jsii-calc",
+      "docs": {
+        "remarks": "We deliberately name classes & interfaces so that the ones that must come first in code,\nare last in alphabetical order.\n\nPreviously, the generated Python code would miss certain dependencies\nand effectively render classes alphabetically. Which then obviously fails.",
+        "stability": "stable",
+        "summary": "This module ensures that language code is generated in correct topological order."
+      },
+      "fqn": "jsii-calc.pascalCaseName.Superclass",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "lib/pascal-case-name/index.ts",
+        "line": 11
+      },
+      "name": "Superclass",
+      "namespace": "pascalCaseName",
+      "symbolId": "lib/pascal-case-name/index:Superclass"
+    },
     "jsii-calc.submodule.Default": {
       "assembly": "jsii-calc",
       "datatype": true,
@@ -19131,5 +19202,5 @@
     }
   },
   "version": "3.20.120",
-  "fingerprint": "Tt3JL7khUypE5masj9ZV7jLcwRzpJ44EvWbxtNaO51E="
+  "fingerprint": "jVJA8GBQfAQWIMVRVjHXZA1xAsJO5WhLdweO7ySlYbs="
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -3485,6 +3485,10 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┃           ┣━ 📄 ParamShadowsScope.cs
        ┃           ┣━ 📄 ParentStruct982.cs
        ┃           ┣━ 📄 PartiallyInitializedThisConsumer.cs
+       ┃           ┣━ 📁 PascalCaseName
+       ┃           ┃  ┣━ 📄 Subclass.cs
+       ┃           ┃  ┣━ 📄 SubSubclass.cs
+       ┃           ┃  ┗━ 📄 Superclass.cs
        ┃           ┣━ 📄 Polymorphism.cs
        ┃           ┣━ 📄 Power.cs
        ┃           ┣━ 📄 PromiseNothing.cs
@@ -17608,6 +17612,128 @@ namespace Amazon.JSII.Tests.CalculatorNamespace
             {
                 return InvokeInstanceMethod<string>(new System.Type[]{typeof(Amazon.JSII.Tests.CalculatorNamespace.ConstructorPassesThisOut), typeof(System.DateTime), typeof(Amazon.JSII.Tests.CalculatorNamespace.AllTypesEnum)}, new object[]{obj, dt, ev})!;
             }
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PascalCaseName/SubSubclass.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName.SubSubclass), fullyQualifiedName: "jsii-calc.pascalCaseName.SubSubclass")]
+    public class SubSubclass : Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName.Subclass
+    {
+        public SubSubclass(): base(_MakeDeputyProps())
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps()
+        {
+            return new DeputyProps(System.Array.Empty<object?>());
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected SubSubclass(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected SubSubclass(DeputyProps props): base(props)
+        {
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PascalCaseName/Subclass.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName
+{
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName.Subclass), fullyQualifiedName: "jsii-calc.pascalCaseName.Subclass")]
+    public class Subclass : Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName.Superclass
+    {
+        public Subclass(): base(_MakeDeputyProps())
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps()
+        {
+            return new DeputyProps(System.Array.Empty<object?>());
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Subclass(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Subclass(DeputyProps props): base(props)
+        {
+        }
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/dotnet/Amazon.JSII.Tests.CalculatorPackageId/Amazon/JSII/Tests/CalculatorNamespace/PascalCaseName/Superclass.cs 1`] = `
+using Amazon.JSII.Runtime.Deputy;
+
+#pragma warning disable CS0672,CS0809,CS1591
+
+namespace Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName
+{
+    /// <summary>This module ensures that language code is generated in correct topological order.</summary>
+    /// <remarks>
+    /// We deliberately name classes &amp; interfaces so that the ones that must come first in code,
+    /// are last in alphabetical order.
+    ///
+    /// Previously, the generated Python code would miss certain dependencies
+    /// and effectively render classes alphabetically. Which then obviously fails.
+    /// </remarks>
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.PascalCaseName.Superclass), fullyQualifiedName: "jsii-calc.pascalCaseName.Superclass")]
+    public class Superclass : DeputyBase
+    {
+        public Superclass(): base(_MakeDeputyProps())
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps()
+        {
+            return new DeputyProps(System.Array.Empty<object?>());
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
+        /// <param name="reference">The Javascript-owned object reference</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Superclass(ByRefValue reference): base(reference)
+        {
+        }
+
+        /// <summary>Used by jsii to construct an instance of this class from DeputyProps</summary>
+        /// <param name="props">The deputy props</param>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        protected Superclass(DeputyProps props): base(props)
+        {
         }
     }
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -3100,6 +3100,11 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
        ┣━ 📄 ParamShadowsScope.go
        ┣━ 📄 ParentStruct982.go
        ┣━ 📄 PartiallyInitializedThisConsumer.go
+       ┣━ 📁 pascalcasename
+       ┃  ┣━ 📄 main.go
+       ┃  ┣━ 📄 Subclass.go
+       ┃  ┣━ 📄 SubSubclass.go
+       ┃  ┗━ 📄 Superclass.go
        ┣━ 📄 Polymorphism.go
        ┣━ 📄 Power.go
        ┣━ 📄 PromiseNothing.go
@@ -24099,6 +24104,186 @@ func init() {
 		nil, // no members
 		func() interface{} {
 			return &jsiiProxy_OnlyStaticMethods{}
+		},
+	)
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pascalcasename/SubSubclass.go 1`] = `
+package pascalcasename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type SubSubclass interface {
+	Subclass
+}
+
+// The jsii proxy struct for SubSubclass
+type jsiiProxy_SubSubclass struct {
+	jsiiProxy_Subclass
+}
+
+func NewSubSubclass() SubSubclass {
+	_init_.Initialize()
+
+	j := jsiiProxy_SubSubclass{}
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.SubSubclass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSubSubclass_Override(s SubSubclass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.SubSubclass",
+		nil, // no parameters
+		s,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pascalcasename/Subclass.go 1`] = `
+package pascalcasename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+type Subclass interface {
+	Superclass
+}
+
+// The jsii proxy struct for Subclass
+type jsiiProxy_Subclass struct {
+	jsiiProxy_Superclass
+}
+
+func NewSubclass() Subclass {
+	_init_.Initialize()
+
+	j := jsiiProxy_Subclass{}
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.Subclass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSubclass_Override(s Subclass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.Subclass",
+		nil, // no parameters
+		s,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pascalcasename/Superclass.go 1`] = `
+package pascalcasename
+
+import (
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+	_init_ "github.com/aws/jsii/jsii-calc/go/jsiicalc/v3/jsii"
+)
+
+// This module ensures that language code is generated in correct topological order.
+//
+// We deliberately name classes & interfaces so that the ones that must come first in code,
+// are last in alphabetical order.
+//
+// Previously, the generated Python code would miss certain dependencies
+// and effectively render classes alphabetically. Which then obviously fails.
+type Superclass interface {
+}
+
+// The jsii proxy struct for Superclass
+type jsiiProxy_Superclass struct {
+	_ byte // padding
+}
+
+func NewSuperclass() Superclass {
+	_init_.Initialize()
+
+	j := jsiiProxy_Superclass{}
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.Superclass",
+		nil, // no parameters
+		&j,
+	)
+
+	return &j
+}
+
+func NewSuperclass_Override(s Superclass) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.pascalCaseName.Superclass",
+		nil, // no parameters
+		s,
+	)
+}
+
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/go/jsiicalc/pascalcasename/main.go 1`] = `
+package pascalcasename
+
+import (
+	"reflect"
+
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+)
+
+func init() {
+	_jsii_.RegisterClass(
+		"jsii-calc.pascalCaseName.SubSubclass",
+		reflect.TypeOf((*SubSubclass)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			j := jsiiProxy_SubSubclass{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_Subclass)
+			return &j
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.pascalCaseName.Subclass",
+		reflect.TypeOf((*Subclass)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			j := jsiiProxy_Subclass{}
+			_jsii_.InitJsiiProxy(&j.jsiiProxy_Superclass)
+			return &j
+		},
+	)
+	_jsii_.RegisterClass(
+		"jsii-calc.pascalCaseName.Superclass",
+		reflect.TypeOf((*Superclass)(nil)).Elem(),
+		nil, // no members
+		func() interface{} {
+			return &jsiiProxy_Superclass{}
 		},
 	)
 }

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -4186,6 +4186,10 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃                 ┣━ 📄 ParamShadowsScope.java
           ┃                 ┣━ 📄 ParentStruct982.java
           ┃                 ┣━ 📄 PartiallyInitializedThisConsumer.java
+          ┃                 ┣━ 📁 pascal_case_name
+          ┃                 ┃  ┣━ 📄 Subclass.java
+          ┃                 ┃  ┣━ 📄 SubSubclass.java
+          ┃                 ┃  ┗━ 📄 Superclass.java
           ┃                 ┣━ 📄 Polymorphism.java
           ┃                 ┣━ 📄 Power.java
           ┃                 ┣━ 📄 PromiseNothing.java
@@ -28007,6 +28011,100 @@ package software.amazon.jsii.tests.calculator;
 
 `;
 
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/pascal_case_name/SubSubclass.java 1`] = `
+package software.amazon.jsii.tests.calculator.pascal_case_name;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.pascalCaseName.SubSubclass")
+public class SubSubclass extends software.amazon.jsii.tests.calculator.pascal_case_name.Subclass {
+
+    protected SubSubclass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected SubSubclass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public SubSubclass() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/pascal_case_name/Subclass.java 1`] = `
+package software.amazon.jsii.tests.calculator.pascal_case_name;
+
+/**
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.pascalCaseName.Subclass")
+public class Subclass extends software.amazon.jsii.tests.calculator.pascal_case_name.Superclass {
+
+    protected Subclass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Subclass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public Subclass() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+}
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/pascal_case_name/Superclass.java 1`] = `
+package software.amazon.jsii.tests.calculator.pascal_case_name;
+
+/**
+ * This module ensures that language code is generated in correct topological order.
+ * <p>
+ * We deliberately name classes &amp; interfaces so that the ones that must come first in code,
+ * are last in alphabetical order.
+ * <p>
+ * Previously, the generated Python code would miss certain dependencies
+ * and effectively render classes alphabetically. Which then obviously fails.
+ */
+@javax.annotation.Generated(value = "jsii-pacmak")
+@software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+@software.amazon.jsii.Jsii(module = software.amazon.jsii.tests.calculator.$Module.class, fqn = "jsii-calc.pascalCaseName.Superclass")
+public class Superclass extends software.amazon.jsii.JsiiObject {
+
+    protected Superclass(final software.amazon.jsii.JsiiObjectRef objRef) {
+        super(objRef);
+    }
+
+    protected Superclass(final software.amazon.jsii.JsiiObject.InitializationMode initializationMode) {
+        super(initializationMode);
+    }
+
+    /**
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public Superclass() {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this);
+    }
+}
+
+`;
+
 exports[`Generated code for "jsii-calc": <outDir>/java/src/main/java/software/amazon/jsii/tests/calculator/python_self/ClassWithSelf.java 1`] = `
 package software.amazon.jsii.tests.calculator.python_self;
 
@@ -29914,6 +30012,9 @@ jsii-calc.module2702.Vpc=software.amazon.jsii.tests.calculator.module2702.Vpc
 jsii-calc.nodirect.sub1.TypeFromSub1=software.amazon.jsii.tests.calculator.nodirect.sub1.TypeFromSub1
 jsii-calc.nodirect.sub2.TypeFromSub2=software.amazon.jsii.tests.calculator.nodirect.sub2.TypeFromSub2
 jsii-calc.onlystatic.OnlyStaticMethods=software.amazon.jsii.tests.calculator.onlystatic.OnlyStaticMethods
+jsii-calc.pascalCaseName.SubSubclass=software.amazon.jsii.tests.calculator.pascal_case_name.SubSubclass
+jsii-calc.pascalCaseName.Subclass=software.amazon.jsii.tests.calculator.pascal_case_name.Subclass
+jsii-calc.pascalCaseName.Superclass=software.amazon.jsii.tests.calculator.pascal_case_name.Superclass
 jsii-calc.submodule.Default=software.amazon.jsii.tests.calculator.submodule.Default
 jsii-calc.submodule.MyClass=software.amazon.jsii.tests.calculator.submodule.MyClass
 jsii-calc.submodule.back_references.MyClassReference=software.amazon.jsii.tests.calculator.submodule.back_references.MyClassReference

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -2938,6 +2938,8 @@ exports[`Generated code for "jsii-calc": <outDir>/ 1`] = `
           ┃     ┗━ 📄 __init__.py
           ┣━ 📁 onlystatic
           ┃  ┗━ 📄 __init__.py
+          ┣━ 📁 pascal_case_name
+          ┃  ┗━ 📄 __init__.py
           ┣━ 📄 py.typed
           ┣━ 📁 python_self
           ┃  ┗━ 📄 __init__.py
@@ -3274,6 +3276,7 @@ kwargs = json.loads(
         "jsii_calc.nodirect.sub1",
         "jsii_calc.nodirect.sub2",
         "jsii_calc.onlystatic",
+        "jsii_calc.pascal_case_name",
         "jsii_calc.python_self",
         "jsii_calc.submodule",
         "jsii_calc.submodule.back_references",
@@ -11942,6 +11945,7 @@ __all__ = [
     "module2702",
     "nodirect",
     "onlystatic",
+    "pascal_case_name",
     "python_self",
     "submodule",
     "union",
@@ -11969,6 +11973,7 @@ from . import module2700
 from . import module2702
 from . import nodirect
 from . import onlystatic
+from . import pascal_case_name
 from . import python_self
 from . import submodule
 from . import union
@@ -14668,6 +14673,85 @@ class OnlyStaticMethods(
 
 __all__ = [
     "OnlyStaticMethods",
+]
+
+publication.publish()
+
+`;
+
+exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/pascal_case_name/__init__.py 1`] = `
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)
+
+import abc
+import builtins
+import datetime
+import enum
+import typing
+
+import jsii
+import publication
+import typing_extensions
+
+import typeguard
+from importlib.metadata import version as _metadata_package_version
+TYPEGUARD_MAJOR_VERSION = int(_metadata_package_version('typeguard').split('.')[0])
+
+def check_type(argname: str, value: object, expected_type: typing.Any) -> typing.Any:
+    if TYPEGUARD_MAJOR_VERSION <= 2:
+        return typeguard.check_type(argname=argname, value=value, expected_type=expected_type) # type:ignore
+    else:
+        if isinstance(value, jsii._reference_map.InterfaceDynamicProxy): # pyright: ignore [reportAttributeAccessIssue]
+           pass
+        else:
+            if TYPEGUARD_MAJOR_VERSION == 3:
+                typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS # type:ignore
+                typeguard.check_type(value=value, expected_type=expected_type) # type:ignore
+            else:
+                typeguard.check_type(value=value, expected_type=expected_type, collection_check_strategy=typeguard.CollectionCheckStrategy.ALL_ITEMS) # type:ignore
+
+from .._jsii import *
+
+
+class Superclass(
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.pascalCaseName.Superclass",
+):
+    '''This module ensures that language code is generated in correct topological order.
+
+    We deliberately name classes & interfaces so that the ones that must come first in code,
+    are last in alphabetical order.
+
+    Previously, the generated Python code would miss certain dependencies
+    and effectively render classes alphabetically. Which then obviously fails.
+    '''
+
+    def __init__(self) -> None:
+        jsii.create(self.__class__, self, [])
+
+
+class Subclass(
+    Superclass,
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.pascalCaseName.Subclass",
+):
+    def __init__(self) -> None:
+        jsii.create(self.__class__, self, [])
+
+
+class SubSubclass(
+    Subclass,
+    metaclass=jsii.JSIIMeta,
+    jsii_type="jsii-calc.pascalCaseName.SubSubclass",
+):
+    def __init__(self) -> None:
+        jsii.create(self.__class__, self, [])
+
+
+__all__ = [
+    "SubSubclass",
+    "Subclass",
+    "Superclass",
 ]
 
 publication.publish()
@@ -18945,9 +19029,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8638,5 +9422,1544 @@
- from . import nodirect
+@@ -8640,5 +9424,1544 @@
  from . import onlystatic
+ from . import pascal_case_name
  from . import python_self
  from . import submodule
  from . import union

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jsii-tree --all 1`] = `
 "assemblies
@@ -526,6 +526,19 @@ exports[`jsii-tree --all 1`] = `
  │ │ │       └─┬ static staticMethod() method (stable)
  │ │ │         ├── static
  │ │ │         └── returns: string
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class SubSubclass (stable)
+ │ │ │   │ ├── base: Subclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer (stable)
+ │ │ │   ├─┬ class Subclass (stable)
+ │ │ │   │ ├── base: Superclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer (stable)
+ │ │ │   └─┬ class Superclass (stable)
+ │ │ │     └─┬ members
+ │ │ │       └── <initializer>() initializer (stable)
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references
@@ -3882,6 +3895,13 @@ exports[`jsii-tree --inheritance 1`] = `
  │ │ ├─┬ onlystatic
  │ │ │ └─┬ types
  │ │ │   └── class OnlyStaticMethods
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class SubSubclass
+ │ │ │   │ └── base: Subclass
+ │ │ │   ├─┬ class Subclass
+ │ │ │   │ └── base: Superclass
+ │ │ │   └── class Superclass
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references
@@ -4557,6 +4577,17 @@ exports[`jsii-tree --members 1`] = `
  │ │ │   └─┬ class OnlyStaticMethods
  │ │ │     └─┬ members
  │ │ │       └── static staticMethod() method
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class SubSubclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer
+ │ │ │   ├─┬ class Subclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer
+ │ │ │   └─┬ class Superclass
+ │ │ │     └─┬ members
+ │ │ │       └── <initializer>() initializer
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references
@@ -6006,6 +6037,7 @@ exports[`jsii-tree --signatures 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references
@@ -6153,6 +6185,11 @@ exports[`jsii-tree --types 1`] = `
  │ │ ├─┬ onlystatic
  │ │ │ └─┬ types
  │ │ │   └── class OnlyStaticMethods
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├── class SubSubclass
+ │ │ │   ├── class Subclass
+ │ │ │   └── class Superclass
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references
@@ -6505,6 +6542,7 @@ exports[`jsii-tree 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`defaults 1`] = `
 "assemblies
@@ -40,6 +40,7 @@ exports[`defaults 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references
@@ -100,6 +101,7 @@ exports[`inheritance 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references
@@ -160,6 +162,7 @@ exports[`members 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references
@@ -706,6 +709,19 @@ exports[`showAll 1`] = `
  │ │ │       └─┬ static staticMethod() method
  │ │ │         ├── static
  │ │ │         └── returns: string
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├─┬ class SubSubclass
+ │ │ │   │ ├── base: Subclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer
+ │ │ │   ├─┬ class Subclass
+ │ │ │   │ ├── base: Superclass
+ │ │ │   │ └─┬ members
+ │ │ │   │   └── <initializer>() initializer
+ │ │ │   └─┬ class Superclass
+ │ │ │     └─┬ members
+ │ │ │       └── <initializer>() initializer
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references
@@ -3946,6 +3962,7 @@ exports[`signatures 1`] = `
  │   │   ├── sub1
  │   │   └── sub2
  │   ├── onlystatic
+ │   ├── pascalCaseName
  │   ├─┬ submodule
  │   │ └─┬ submodules
  │   │   ├── back_references
@@ -4093,6 +4110,11 @@ exports[`types 1`] = `
  │ │ ├─┬ onlystatic
  │ │ │ └─┬ types
  │ │ │   └── class OnlyStaticMethods
+ │ │ ├─┬ pascalCaseName
+ │ │ │ └─┬ types
+ │ │ │   ├── class SubSubclass
+ │ │ │   ├── class Subclass
+ │ │ │   └── class Superclass
  │ │ ├─┬ submodule
  │ │ │ ├─┬ submodules
  │ │ │ │ ├─┬ back_references

--- a/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/type-system.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TypeSystem.assemblies lists all the loaded assemblies 1`] = `
 [
@@ -196,6 +196,9 @@ exports[`TypeSystem.classes lists all the classes in the typesystem 1`] = `
   "jsii-calc.nodirect.sub1.TypeFromSub1",
   "jsii-calc.nodirect.sub2.TypeFromSub2",
   "jsii-calc.onlystatic.OnlyStaticMethods",
+  "jsii-calc.pascalCaseName.SubSubclass",
+  "jsii-calc.pascalCaseName.Subclass",
+  "jsii-calc.pascalCaseName.Superclass",
   "jsii-calc.submodule.MyClass",
   "jsii-calc.submodule.child.InnerClass",
   "jsii-calc.submodule.child.OuterClass",


### PR DESCRIPTION
Fixes #4426

This issue only occurred in submodule using a `pascalCased` name. The reason was that the dependency resolution did not the the same snake_case transformation of the submodule name: When the bases and interfaces of such a type where looked up, an untransformed fqn was used. Consequently the base or interface wasn't found and the type was considered dependency-less. This ultimately led to types being (incorrectly) emitted alphabetically.

The fix was to update the `TypeResolver` to use the same `toPythonFqn()` implementation as elsewhere in the code.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
