### PR TITLE
chore: prevent dependabot from updating the golang version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,7 @@ updates:
       - language/go
       - auto-approve
     ignore:
+      - dependency-name: "go" # don't upgrad the golang version
       - dependency-name: github.com/aws/jsii-runtime-go
       - dependency-name: github.com/aws/jsii-runtime-go/*
       - dependency-name: github.com/aws/jsii/jsii-calc/go/*


### PR DESCRIPTION
We manage this one manually.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
