### PR TITLE
chore: updgrade go version in test to 1.25.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6.0.x'
-      - name: Set up Go 1.23
+      - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Set up Java 8
         uses: actions/setup-java@v5
         with:
@@ -111,10 +111,10 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6.0.x'
-      - name: Set up Go 1.23
+      - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Set up Java 8
         uses: actions/setup-java@v5
         with:
@@ -187,7 +187,7 @@ jobs:
       matrix:
         title: ['baseline']
         dotnet: ['6.0.x']
-        go: ['1.23']
+        go: ['1.25']
         java: ['8']
         node: ['20'] # EOS 2026-10-30
         os: [ubuntu-latest]
@@ -198,7 +198,7 @@ jobs:
           - title: 'Windows'
             os: windows-latest
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             python: '3.9'
@@ -206,7 +206,7 @@ jobs:
           - title: 'macOS'
             os: macos-latest
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             python: '3.9'
@@ -214,28 +214,28 @@ jobs:
           - title: 'Node 18'
             java: '8'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '18' # EOS 2025-11-30
             os: ubuntu-latest
             python: '3.9'
           - title: 'Node 20'
             java: '8'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20' # EOL 2026-04-30
             os: ubuntu-latest
             python: '3.9'
           - title: 'Node 22'
             java: '8'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '22' # EOL 2027-04-30
             os: ubuntu-latest
             python: '3.9'
           - title: 'Node 24'
             java: '8'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '24' # EOL 2028-04-30
             os: ubuntu-latest
             python: '3.9'
@@ -243,28 +243,28 @@ jobs:
           - title: '.NET 7.0'
             java: '8'
             dotnet: '7.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20'
             os: ubuntu-latest
             python: '3.9'
           - title: '.NET 8.0'
             java: '8'
             dotnet: '7.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20'
             os: ubuntu-latest
             python: '3.9'
           - title: '.NET 9.0'
             java: '8'
             dotnet: '9.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20'
             os: ubuntu-latest
             python: '3.9'
           - title: '.NET 10.0'
             java: '8'
             dotnet: '10.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20'
             os: ubuntu-latest
             python: '3.9'
@@ -287,7 +287,7 @@ jobs:
           - title: 'Java 11'
             java: '11'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             node: '20'
             os: ubuntu-latest
             python: '3.9'
@@ -295,35 +295,35 @@ jobs:
           - title: 'Python 3.9'
             python: '3.9'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             os: ubuntu-latest
           - title: 'Python 3.10'
             python: '3.10'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             os: ubuntu-latest
           - title: 'Python 3.11'
             python: '3.11'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             os: ubuntu-latest
           - title: 'Python 3.12'
             python: '3.12'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             os: ubuntu-latest
           - title: 'Python 3.13'
             python: '3.13'
             dotnet: '6.0.x'
-            go: '1.23'
+            go: '1.25'
             java: '8'
             node: '20'
             os: ubuntu-latest
@@ -440,10 +440,10 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '7.0.x'
-      - name: Set up Go 1.23
+      - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
       - name: Set up Java 20
         uses: actions/setup-java@v5
         with:

--- a/packages/@jsii/go-runtime-test/project/go.mod
+++ b/packages/@jsii/go-runtime-test/project/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/jsii/go-runtime-test
 
-go 1.23.0
+go 1.25.0
 
 toolchain go1.24.5
 


### PR DESCRIPTION
Our other upgrade workflows are failing because it needs a more up-to-date version of go. This updates all testing versions of go to 1.25, except for the test that specifically targets 1.24.

Failing workflow: https://github.com/aws/jsii/actions/runs/18220712427/job/52396760165?pr=4941
```
@jsii/go-runtime: @jsii/go-runtime: $ cd jsii-runtime-go && go test ./...
@jsii/go-runtime: go: go.mod requires go >= 1.24.0 (running go 1.23.12; GOTOOLCHAIN=local)
@jsii/go-runtime: 
@jsii/go-runtime: error Command failed with exit code 1.
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
