### PR TITLE
fix: type intersections don't work for Java class builders

### DIFF
--- a/packages/jsii-calc/lib/intersection.ts
+++ b/packages/jsii-calc/lib/intersection.ts
@@ -17,5 +17,7 @@ export class ConsumesIntersection {
     void props;
   }
 
-  private constructor() {}
+  public constructor(props: IntersectionProps) {
+    void props;
+  }
 }

--- a/packages/jsii-calc/test/assembly.jsii
+++ b/packages/jsii-calc/test/assembly.jsii
@@ -16937,6 +16937,23 @@
         "stability": "stable"
       },
       "fqn": "jsii-calc.intersection.ConsumesIntersection",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "lib/intersection.ts",
+          "line": 20
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "type": {
+              "fqn": "jsii-calc.intersection.IntersectionProps"
+            }
+          }
+        ]
+      },
       "kind": "class",
       "locationInModule": {
         "filename": "lib/intersection.ts",
@@ -19351,5 +19368,5 @@
     "intersection-types"
   ],
   "version": "3.20.120",
-  "fingerprint": "tO2XUx4QWDYtIzVyIejPr2qHHJX+/TG1lb6O2uWdS78="
+  "fingerprint": "GVwmWxAUwVMUeujfDgP0gEVA7pfU5wIz05Iyw8VL0RE="
 }

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -2301,8 +2301,10 @@ class JavaGenerator extends Generator {
           memberName: prop.name,
         });
         this.emitStabilityAnnotations(prop.spec);
+        // FIXME: generix
+        const renderedType = displayType(javaType, 'covariant');
         this.code.openBlock(
-          `public ${BUILDER_CLASS_NAME} ${fieldName}(final ${displayType(javaType, 'covariant')} ${fieldName})`,
+          `public ${typeVarDeclarations([javaType])}${BUILDER_CLASS_NAME} ${fieldName}(final ${renderedType} ${fieldName})`,
         );
         this.code.line(
           `this.${structParamName}${

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-dotnet.test.js.snap
@@ -13661,9 +13661,19 @@ using Amazon.JSII.Runtime.Deputy;
 
 namespace Amazon.JSII.Tests.CalculatorNamespace.Intersection
 {
-    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Intersection.ConsumesIntersection), fullyQualifiedName: "jsii-calc.intersection.ConsumesIntersection")]
+    [JsiiClass(nativeType: typeof(Amazon.JSII.Tests.CalculatorNamespace.Intersection.ConsumesIntersection), fullyQualifiedName: "jsii-calc.intersection.ConsumesIntersection", parametersJson: "[{\\"name\\":\\"props\\",\\"type\\":{\\"fqn\\":\\"jsii-calc.intersection.IntersectionProps\\"}}]")]
     public class ConsumesIntersection : DeputyBase
     {
+        public ConsumesIntersection(Amazon.JSII.Tests.CalculatorNamespace.Intersection.IIntersectionProps props): base(_MakeDeputyProps(props))
+        {
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static DeputyProps _MakeDeputyProps(Amazon.JSII.Tests.CalculatorNamespace.Intersection.IIntersectionProps props)
+        {
+            return new DeputyProps(new object?[]{props});
+        }
+
         /// <summary>Used by jsii to construct an instance of this class from a Javascript-owned object reference</summary>
         /// <param name="reference">The Javascript-owned object reference</param>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -19537,6 +19537,30 @@ type jsiiProxy_ConsumesIntersection struct {
 	_ byte // padding
 }
 
+func NewConsumesIntersection(props *IntersectionProps) ConsumesIntersection {
+	_init_.Initialize()
+
+	j := jsiiProxy_ConsumesIntersection{}
+
+	_jsii_.Create(
+		"jsii-calc.intersection.ConsumesIntersection",
+		[]interface{}{props},
+		&j,
+	)
+
+	return &j
+}
+
+func NewConsumesIntersection_Override(c ConsumesIntersection, props *IntersectionProps) {
+	_init_.Initialize()
+
+	_jsii_.Create(
+		"jsii-calc.intersection.ConsumesIntersection",
+		[]interface{}{props},
+		c,
+	)
+}
+
 func ConsumesIntersection_AcceptsIntersection(param interface{ ISomething;scopejsiicalclib.IFriendly }) {
 	_init_.Initialize()
 
@@ -35237,7 +35261,21 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/h
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/intersection/ConsumesIntersection.go.diff 1`] = `
 --- go/jsiicalc/intersection/ConsumesIntersection.go	--no-runtime-type-checking
 +++ go/jsiicalc/intersection/ConsumesIntersection.go	--runtime-type-checking
-@@ -14,20 +14,26 @@
+@@ -14,10 +14,13 @@
+ }
+ 
+ func NewConsumesIntersection(props *IntersectionProps) ConsumesIntersection {
+ 	_init_.Initialize()
+ 
++	if err := validateNewConsumesIntersectionParameters(props); err != nil {
++		panic(err)
++	}
+ 	j := jsiiProxy_ConsumesIntersection{}
+ 
+ 	_jsii_.Create(
+ 		"jsii-calc.intersection.ConsumesIntersection",
+ 		[]interface{}{props},
+@@ -38,20 +41,26 @@
  }
  
  func ConsumesIntersection_AcceptsIntersection(param interface{ ISomething;scopejsiicalclib.IFriendly }) {
@@ -35269,7 +35307,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/i
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/intersection/ConsumesIntersection__checks.go.diff 1`] = `
 --- go/jsiicalc/intersection/ConsumesIntersection__checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/intersection/ConsumesIntersection__checks.go	--runtime-type-checking
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,42 @@
 +//go:build !no_runtime_type_checking
 +
 +package intersection
@@ -35301,12 +35339,23 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/i
 +	return nil
 +}
 +
++func validateNewConsumesIntersectionParameters(props *IntersectionProps) error {
++	if props == nil {
++		return fmt.Errorf("parameter props is required, but nil was provided")
++	}
++	if err := _jsii_.ValidateStruct(props, func() string { return "parameter props" }); err != nil {
++		return err
++	}
++
++	return nil
++}
++
 `;
 
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/intersection/ConsumesIntersection__no_checks.go.diff 1`] = `
 --- go/jsiicalc/intersection/ConsumesIntersection__no_checks.go	--no-runtime-type-checking
 +++ go/jsiicalc/intersection/ConsumesIntersection__no_checks.go	--runtime-type-checking
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,18 @@
 +//go:build no_runtime_type_checking
 +
 +package intersection
@@ -35318,6 +35367,10 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/go/jsiicalc/i
 +}
 +
 +func validateConsumesIntersection_AcceptsPropWithIntersectionParameters(props *IntersectionProps) error {
++	return nil
++}
++
++func validateNewConsumesIntersectionParameters(props *IntersectionProps) error {
 +	return nil
 +}
 +

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -25895,6 +25895,15 @@ public class ConsumesIntersection extends software.amazon.jsii.JsiiObject {
     }
 
     /**
+     * @param props This parameter is required.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public ConsumesIntersection(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.intersection.IntersectionProps props) {
+        super(software.amazon.jsii.JsiiObject.InitializationMode.JSII);
+        software.amazon.jsii.JsiiEngine.getInstance().createNewObject(this, new Object[] { java.util.Objects.requireNonNull(props, "props is required") });
+    }
+
+    /**
      * @param param This parameter is required.
      */
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
@@ -25908,6 +25917,47 @@ public class ConsumesIntersection extends software.amazon.jsii.JsiiObject {
     @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
     public static void acceptsPropWithIntersection(final @org.jetbrains.annotations.NotNull software.amazon.jsii.tests.calculator.intersection.IntersectionProps props) {
         software.amazon.jsii.JsiiObject.jsiiStaticCall(software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection.class, "acceptsPropWithIntersection", software.amazon.jsii.NativeType.VOID, new Object[] { java.util.Objects.requireNonNull(props, "props is required") });
+    }
+
+    /**
+     * A fluent builder for {@link software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection}.
+     */
+    @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+    public static final class Builder implements software.amazon.jsii.Builder<software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection> {
+        /**
+         * @return a new instance of {@link Builder}.
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        public static Builder create() {
+            return new Builder();
+        }
+
+        private final software.amazon.jsii.tests.calculator.intersection.IntersectionProps.Builder props;
+
+        private Builder() {
+            this.props = new software.amazon.jsii.tests.calculator.intersection.IntersectionProps.Builder();
+        }
+
+        /**
+         * @return {@code this}
+         * @param param This parameter is required.
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        public <T1 extends software.amazon.jsii.tests.calculator.intersection.ISomething & software.amazon.jsii.tests.calculator.lib.IFriendly> Builder param(final T1 param) {
+            this.props.param(param);
+            return this;
+        }
+
+        /**
+         * @return a newly built instance of {@link software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection}.
+         */
+        @software.amazon.jsii.Stability(software.amazon.jsii.Stability.Level.Stable)
+        @Override
+        public software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection build() {
+            return new software.amazon.jsii.tests.calculator.intersection.ConsumesIntersection(
+                this.props.build()
+            );
+        }
     }
 }
 

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -13156,6 +13156,14 @@ class ConsumesIntersection(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.intersection.ConsumesIntersection",
 ):
+    def __init__(self, *, param: '_ISomething_IFriendly') -> None:
+        '''
+        :param param: 
+        '''
+        props = IntersectionProps(param=param)
+
+        jsii.create(self.__class__, self, [props])
+
     @jsii.member(jsii_name="acceptsIntersection")
     @builtins.classmethod
     def accepts_intersection(cls, param: '_ISomething_IFriendly') -> None:
@@ -21208,7 +21216,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/intersection/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/intersection/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/intersection/__init__.py	--runtime-type-checking
-@@ -41,10 +41,13 @@
+@@ -49,10 +49,13 @@
      @builtins.classmethod
      def accepts_intersection(cls, param: '_ISomething_IFriendly') -> None:
          '''
@@ -21222,7 +21230,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="acceptsPropWithIntersection")
      @builtins.classmethod
      def accepts_prop_with_intersection(cls, *, param: '_ISomething_IFriendly') -> None:
-@@ -82,10 +85,13 @@
+@@ -90,10 +93,13 @@
  class IntersectionProps:
      def __init__(self, *, param: '_ISomething_IFriendly') -> None:
          '''
@@ -21236,7 +21244,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -112,10 +118,23 @@
+@@ -120,10 +126,23 @@
      "IntersectionProps",
  ]
  

--- a/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/jsii-tree.test.js.snap
@@ -225,6 +225,10 @@ exports[`jsii-tree --all 1`] = `
  │ │ │ └─┬ types
  │ │ │   ├─┬ class ConsumesIntersection (stable)
  │ │ │   │ └─┬ members
+ │ │ │   │   ├─┬ <initializer>(props) initializer (stable)
+ │ │ │   │   │ └─┬ parameters
+ │ │ │   │   │   └─┬ props
+ │ │ │   │   │     └── type: jsii-calc.intersection.IntersectionProps
  │ │ │   │   ├─┬ static acceptsIntersection(param) method (stable)
  │ │ │   │   │ ├── static
  │ │ │   │   │ ├─┬ parameters
@@ -4444,6 +4448,7 @@ exports[`jsii-tree --members 1`] = `
  │ │ │ └─┬ types
  │ │ │   ├─┬ class ConsumesIntersection
  │ │ │   │ └─┬ members
+ │ │ │   │   ├── <initializer>(props) initializer
  │ │ │   │   ├── static acceptsIntersection(param) method
  │ │ │   │   └── static acceptsPropWithIntersection(props) method
  │ │ │   ├─┬ interface ISomething

--- a/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
+++ b/packages/jsii-reflect/test/__snapshots__/tree.test.js.snap
@@ -411,6 +411,10 @@ exports[`showAll 1`] = `
  │ │ │ └─┬ types
  │ │ │   ├─┬ class ConsumesIntersection
  │ │ │   │ └─┬ members
+ │ │ │   │   ├─┬ <initializer>(props) initializer
+ │ │ │   │   │ └─┬ parameters
+ │ │ │   │   │   └─┬ props
+ │ │ │   │   │     └── type: jsii-calc.intersection.IntersectionProps
  │ │ │   │   ├─┬ static acceptsIntersection(param) method
  │ │ │   │   │ ├── static
  │ │ │   │   │ ├─┬ parameters


### PR DESCRIPTION
We have two different code paths for struct builders and class builders (where the class constructor takes a props object as an argument).

We were supporting type intersections properly in struct builders, but not yet in class builders.

Fix that.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
