### PR TITLE
chore: fix mergify config

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -12,6 +12,7 @@ queue_rules:
 
       {{ body }}
     merge_method: squash
+    batch_size: 1
 
   - name: default-merge
     conditions:
@@ -22,6 +23,7 @@ queue_rules:
 
       {{ body }}
     merge_method: merge
+    batch_size: 1
 
 pull_request_rules:
   - name: label core


### PR DESCRIPTION
Current config leads to the error:

> The branch protection setting Require branches to be up to date before
merging is not compatible with draft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks: set merge_queue.max_parallel_checks: 1, set every queue rule batch_size: 1, and avoid two-step CI (make merge_conditions identical to queue_conditions). Otherwise, disable this branch protection.

Fix it in this commit.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
