### PR TITLE
chore: fix mergify conditions

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -4,7 +4,10 @@ merge_queue:
   max_parallel_checks: 1
 queue_rules:
   - name: default-squash
-    conditions:
+    queue_conditions:
+      - status-success=Unit Tests
+      - status-success=Integration test (jsii-pacmak)
+    merge_conditions:
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     commit_message_template: |-
@@ -15,7 +18,10 @@ queue_rules:
     batch_size: 1
 
   - name: default-merge
-    conditions:
+    queue_conditions:
+      - status-success=Unit Tests
+      - status-success=Integration test (jsii-pacmak)
+    merge_conditions:
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     commit_message_template: |-


### PR DESCRIPTION
Mergify is currently refusing to do any work with the following error:

> The branch protection setting `Require branches to be up to date before merging` is not compatible with draft PR checks. To keep this branch protection enabled, update your Mergify configuration to enable in-place checks: set `merge_queue.max_parallel_checks: 1`, set every queue rule `batch_size: 1`, and avoid two-step CI (make `merge_conditions` identical to `queue_conditions`). Otherwise, disable this branch protection.

While already have fulfilled the first two settings, we previously used a single `conditions` key. I'm guessing this is a legacy configuration that is not supported anymore by this check. This PR updates the config to see if that works.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
