### PR TITLE
fix(jsii-reflect): statically guarantee JsiiFeature subset

### DIFF
--- a/packages/jsii-reflect/lib/type-system.ts
+++ b/packages/jsii-reflect/lib/type-system.ts
@@ -26,6 +26,12 @@ export const JSII_REFLECT_SUPPORTED_ASSEMBLY_FEATURES: JsiiFeature[] = [
   'class-covariant-overrides',
 ];
 
+/**
+ * All supported features as a type
+ */
+export type JsiiReflectSupportedAssemblyFeatures =
+  (typeof JSII_REFLECT_SUPPORTED_ASSEMBLY_FEATURES)[number];
+
 export class TypeSystem {
   /**
    * The "root" assemblies (ones that loaded explicitly via a "load" call).
@@ -368,7 +374,7 @@ export class TypeSystem {
   private loadAssembly(
     file: string,
     validate = true,
-    supportedFeatures?: JsiiFeature[],
+    supportedFeatures?: JsiiReflectSupportedAssemblyFeatures[],
   ) {
     validateFeatureSubset(supportedFeatures);
     const contents = loadAssemblyFromFile(file, validate, supportedFeatures);


### PR DESCRIPTION
When new a tool is using `jsii-reflect` to read a jsii assembly, it must declare what JSII features it supports. If the assembly uses new features that the tool doesn't support yet, the load will fail.

However, `jsii-reflect` *itself* must also support those features, so the set of features that the tool declares must be a subset of the set of features that `jsii-reflect` itself supports.

This used to be checked dynamically, but that is easy to get wrong. We can lift this information into the TypeScript type system, so that it becomes a type error to call `jsii-reflect` with features that it doesn't know about yet.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
