### PR TITLE
fix: covariant method overrides break Go compilation

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -56,8 +56,13 @@ export class Golang extends Target {
       return Promise.reject(e);
     }
 
-    if (process.env.JSII_BUILD_GO) {
-      // This step is taken to ensure that the generated code is compilable
+    // This step is taken to ensure that the generated code is compilable
+    // Do it by default, because we didn't use to and that was masking a code generation
+    // problem.
+    const doBuild = !['false', '0', 'no'].includes(
+      process.env.JSII_BUILD_GO ?? '1',
+    );
+    if (doBuild) {
       await go('build', ['-modfile', localGoMod.path, './...'], {
         cwd: pkgDir,
       });

--- a/packages/jsii-pacmak/lib/targets/go/package.ts
+++ b/packages/jsii-pacmak/lib/targets/go/package.ts
@@ -441,6 +441,13 @@ export class RootPackage extends Package {
    * This allows resolving type references from other JSII modules
    */
   public findType(fqn: string): GoType | undefined {
+    // This may happen during initialization
+    if (this.typeCache === undefined) {
+      throw new Error(
+        'This method may not be called during RootPackage construction',
+      );
+    }
+
     if (!this.typeCache.has(fqn)) {
       this.typeCache.set(
         fqn,

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-go.test.js.snap
@@ -19126,7 +19126,7 @@ type Derived interface {
 	SetAddUnrelatedMember(val *float64)
 	List() *[]Superclass
 	Something() SubSubclass
-	CreateSomething() SubSubclass
+	CreateSomething() Superclass
 }
 
 // The jsii proxy struct for Derived
@@ -19197,8 +19197,8 @@ func (j *jsiiProxy_Derived)SetAddUnrelatedMember(val *float64) {
 	)
 }
 
-func (d *jsiiProxy_Derived) CreateSomething() SubSubclass {
-	var returns SubSubclass
+func (d *jsiiProxy_Derived) CreateSomething() Superclass {
+	var returns Superclass
 
 	_jsii_.Invoke(
 		d,

--- a/packages/jsii-reflect/lib/method.ts
+++ b/packages/jsii-reflect/lib/method.ts
@@ -79,4 +79,15 @@ export class Method
   public get static(): boolean {
     return !!this.spec.static;
   }
+
+  /**
+   * The Method that this method overrides, if any
+   */
+  public get overriddenMethod(): Method | undefined {
+    const o = this.overrides;
+    if (o && (o.isClassType() || o.isInterfaceType())) {
+      return o.ownMethods.find((m) => m.name === this.name);
+    }
+    return undefined;
+  }
 }

--- a/packages/jsii-reflect/lib/property.ts
+++ b/packages/jsii-reflect/lib/property.ts
@@ -107,4 +107,15 @@ export class Property
   public get locationInRepository(): SourceLocation | undefined {
     return locationInRepository(this);
   }
+
+  /**
+   * The Property that this property overrides, if any
+   */
+  public get overriddenProperty(): Property | undefined {
+    const o = this.overrides;
+    if (o && (o.isClassType() || o.isInterfaceType())) {
+      return o.ownProperties.find((p) => p.name === this.name);
+    }
+    return undefined;
+  }
 }

--- a/packages/jsii-reflect/test/type-system.test.ts
+++ b/packages/jsii-reflect/test/type-system.test.ts
@@ -236,6 +236,9 @@ test('overridden member knows about both parent types', () => {
   expect(booMethod.parentType).toBe(subType);
   expect(booMethod.definingType).toBe(subType);
   expect(booMethod.overrides).toBe(superType);
+
+  const superBooMethod = superType.allMethods.find((m) => m.name === 'boo')!;
+  expect(booMethod.overriddenMethod).toEqual(superBooMethod);
 });
 
 describe('Stability', () => {


### PR DESCRIPTION
Currently generated Go code is not compiled, which leads to potential codegen mistakes slipping in.

Switch on compilation by default; i.e., make the opt-in environment variable an opt-out environment variable.

This revealed a problem with covariant return types in Go; this concept does not exist. We'll solve that by not emitting the more specific return type. This means Go users will not benefit from the additional typing, but the feature can remain in other languages and the compilation will succeed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
