### PR TITLE
fix(jsii-pacmak): Python interfaces sometimes violate MRO

### DIFF
--- a/packages/jsii-pacmak/lib/toposort.ts
+++ b/packages/jsii-pacmak/lib/toposort.ts
@@ -79,4 +79,4 @@ interface TopoElement<T> {
  * We do declare the type `Toposorted<A>` here so that if we ever change
  * the type, we can find all usage sites quickly.
  */
-export type Toposorted<A> = readonly A[][];
+export type Toposorted<A> = A[][];

--- a/packages/jsii-pacmak/lib/util.ts
+++ b/packages/jsii-pacmak/lib/util.ts
@@ -464,3 +464,9 @@ export function zip<A, B>(xs: A[], ys: B[]): Array<[A, B]> {
   }
   return ret;
 }
+
+export function setAdd<T>(setA: Set<T>, setB: Iterable<T>) {
+  for (const b of setB) {
+    setA.add(b);
+  }
+}


### PR DESCRIPTION
The Method Resolution Order (MRO) rules for Python state (in brief) that all classes and interfaces in an inheritance declaration must be listed subclass-before-superclass, and in the same order on all classes.

`jsii-pacmak` was not guaranteeing order, leading to sometimes producing an order that violates MRO.

Update `jsii-pacmak` to update base classes and sort them in the right order.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
