### PR TITLE
fix(jsii-reflect): advertise `jsii-query` via `bin` entry of `package.json`

### DIFF
--- a/packages/jsii-reflect/package.json
+++ b/packages/jsii-reflect/package.json
@@ -22,7 +22,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "bin": {
-    "jsii-tree": "bin/jsii-tree"
+    "jsii-tree": "bin/jsii-tree",
+    "jsii-query": "bin/jsii-query"
   },
   "scripts": {
     "build": "tsc --build && chmod +x bin/jsii-tree && yarn lint",


### PR DESCRIPTION

Without this entry it will not be symlinked into the right spot.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
