### PR TITLE
feat(jsii-reflect): add parent assembly reference to Submodule

### DIFF
--- a/packages/jsii-reflect/lib/assembly.ts
+++ b/packages/jsii-reflect/lib/assembly.ts
@@ -331,7 +331,7 @@ export class Assembly extends ModuleLike {
     )) {
       ret.set(
         submoduleName,
-        new SubmoduleBuilder(system, submoduleSpec, submoduleName, ret),
+        new SubmoduleBuilder(this, system, submoduleSpec, submoduleName, ret),
       );
     }
     return ret;
@@ -352,6 +352,7 @@ class SubmoduleBuilder {
   private _built?: Submodule;
 
   public constructor(
+    private readonly parent: Assembly,
     private readonly system: TypeSystem,
     private readonly spec: jsii.Submodule,
     private readonly fullName: string,
@@ -375,6 +376,7 @@ class SubmoduleBuilder {
       this.fullName,
       mapValues(this.findSubmoduleBuilders(), (b) => b.build()),
       this.types,
+      this.parent,
     );
     return this._built;
   }

--- a/packages/jsii-reflect/lib/submodule.ts
+++ b/packages/jsii-reflect/lib/submodule.ts
@@ -1,5 +1,6 @@
 import * as jsii from '@jsii/spec';
 
+import { Assembly } from './assembly';
 import { ModuleLike } from './module-like';
 import { Type } from './type';
 import { TypeSystem } from './type-system';
@@ -10,16 +11,23 @@ export class Submodule extends ModuleLike {
    */
   public readonly name: string;
 
+  /**
+   * The parent assembly of the submodule.
+   */
+  public readonly parent: Assembly;
+
   public constructor(
     system: TypeSystem,
     public readonly spec: jsii.Submodule,
     public readonly fqn: string,
     protected readonly submoduleMap: ReadonlyMap<string, Submodule>,
     protected readonly typeMap: ReadonlyMap<string, Type>,
+    parent: Assembly,
   ) {
     super(system);
 
     this.name = fqn.split('.').pop()!;
+    this.parent = parent;
   }
 
   /**


### PR DESCRIPTION
This PR adds a `parent` property to the `Submodule` class that references the parent `Assembly`. This enables submodules to access their parent assembly context, which is useful for navigating the module hierarchy.

### Changes
- Added `parent: Assembly` property to `Submodule` class
- Updated `SubmoduleBuilder` to accept and pass the parent assembly reference
- Added import for `Assembly` in `submodule.ts`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
