### PR TITLE
fix(java-runtime): dependency ranges make Maven download too many files

### DIFF
--- a/packages/@jsii/java-runtime/generate.sh
+++ b/packages/@jsii/java-runtime/generate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 project="./project"
+versions_plugin_version=2.20.1
 
 mkdir -p conf
 
@@ -14,3 +15,11 @@ mkdir -p ${project}/src/main/resources/software/amazon/jsii
 rsync -av $(node -p 'require("path").dirname(require.resolve("@jsii/runtime/package.json"))')/webpack/ ${project}/src/main/resources/software/amazon/jsii
 
 /usr/bin/env node ./BundledRuntime.t.js > ${project}/src/main/java/software/amazon/jsii/BundledRuntime.java
+
+# Use the Maven 'versions' plugin to resolve our wide ranges to point versions.
+# We want the "latest matching" version anyway (*), and if we don't the resolution
+# now (which downloads the .poms of all possible versions) it will happen during
+# every single build.
+#
+# (*) Consumers can still override versions in their own poms.
+(cd $project && mvn org.codehaus.mojo:versions-maven-plugin:${versions_plugin_version}:resolve-ranges)


### PR DESCRIPTION
Given a dependency version range, Maven will download metadata for all possible versions before every (uncached) build. This takes a long time, before finally resolving to the latest version anyway.

Instead, we use the Maven 'versions' plugin to resolve our wide ranges to point versions.  We want the "latest matching" version anyway, and if we don't the resolution now (which downloads the .poms of all possible versions) it will happen during every single build.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
