### PR TITLE
fix(jsii-pacmak): Maven resolve-ranges command is missing repo settings

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -4077,6 +4077,7 @@ async function resolveMavenVersions(directory: string) {
     'mvn',
     [
       `org.codehaus.mojo:versions-maven-plugin:${versionsPluginVersion}:resolve-ranges`,
+      '--settings=user.xml',
     ],
     {
       cwd: directory,


### PR DESCRIPTION
In https://github.com/aws/jsii/pull/5006 we added a command to make Maven resolve all the wide open version ranges to the latest version, under the motivation that Maven doesn't have a distinction between a dependency declaration file and a lockfile, and ranges don't have the effect that we want (but DO contribute to long build times).

In that PR we forgot to pass the settings file that has repository configuration information.

Add that.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
