### PR TITLE
fix(jsii-pacmak): `--mvn-*` arguments aren't passed through

### DIFF
--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -26,7 +26,14 @@ import {
   findLocalBuildDirs,
   TargetOptions,
 } from '../target';
-import { subprocess, Scratch, slugify, setExtend, zip, ShellOptions } from '../util';
+import {
+  subprocess,
+  Scratch,
+  slugify,
+  setExtend,
+  zip,
+  ShellOptions,
+} from '../util';
 import { VERSION, VERSION_DESC } from '../version';
 import { stabilityPrefixFor, renderSummary } from './_utils';
 import { toMavenVersionRange, toReleaseVersion } from './version-utils';
@@ -451,11 +458,9 @@ export default class Java extends Target {
   public async build(sourceDir: string, outDir: string): Promise<void> {
     const url = `file://${outDir}`;
 
-    await this.invokeMaven(sourceDir,
-      [
-        'deploy',
-        `-D=altDeploymentRepository=local::default::${url}`,
-      ],
+    await this.invokeMaven(
+      sourceDir,
+      ['deploy', `-D=altDeploymentRepository=local::default::${url}`],
       {
         retry: { maxAttempts: 5 },
       },
@@ -479,14 +484,22 @@ export default class Java extends Target {
    */
   public async resolveMavenVersions(directory: string) {
     const versionsPluginVersion = '2.20.1';
-    await this.invokeMaven(directory, [
-      `org.codehaus.mojo:versions-maven-plugin:${versionsPluginVersion}:resolve-ranges`,
-    ], {
-      retry: { maxAttempts: 1 },
-    });
+    await this.invokeMaven(
+      directory,
+      [
+        `org.codehaus.mojo:versions-maven-plugin:${versionsPluginVersion}:resolve-ranges`,
+      ],
+      {
+        retry: { maxAttempts: 1 },
+      },
+    );
   }
 
-  private async invokeMaven(directory: string, args: string[], options?: Omit<ShellOptions, 'cwd'>) {
+  private async invokeMaven(
+    directory: string,
+    args: string[],
+    options?: Omit<ShellOptions, 'cwd'>,
+  ) {
     // Pass through jsii-pacmak --mvn-xyz=... arguments as --xyz=...
     const passThruArgs = new Array<string>();
     for (const arg of Object.keys(this.arguments)) {


### PR DESCRIPTION
This PR is the correct fix for https://github.com/aws/jsii/pull/5015.

`jsii-pacmak` has a feature where `--mvn-settings=X` is passed through as `--settings=X` when calling `mvn`.

This was not being passed through in the call to the new `resolve-ranges` step. This PR factors the entire Maven invocation into a helper that contains that logic, and uses it from 2 call sites.

Not sure about the best way to automatically test this, so for now this doesn't have a test.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
