### PR TITLE
feat(spec): export list of all jsii features

### DIFF
--- a/packages/@jsii/spec/src/assembly.ts
+++ b/packages/@jsii/spec/src/assembly.ts
@@ -1090,9 +1090,9 @@ export function describeTypeReference(type?: TypeReference): string {
 }
 
 /**
- * The internal list of all jsii extension features
+ * A list of all jsii extension features
  */
-const ALL_FEATURES = [
+export const ALL_SPEC_FEATURES = [
   'intersection-types',
   'class-covariant-overrides',
 ] as const;
@@ -1100,12 +1100,7 @@ const ALL_FEATURES = [
 /**
  * Predefined type constants of available jsii extension features
  */
-export type JsiiFeature = (typeof ALL_FEATURES)[number];
-
-/**
- * A list of all jsii extension features
- */
-export const ALL_SPEC_FEATURES: JsiiFeature[] = [...ALL_FEATURES];
+export type JsiiFeature = (typeof ALL_SPEC_FEATURES)[number];
 
 /**
  * Determines whether an entity is deprecated.


### PR DESCRIPTION
Exports a new constant `ALL_SPEC_FEATURES` containing all available jsii extension features. This allows consumers of the `@jsii/spec` package to programmatically access the complete list of features without having to maintain their own copy.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
