### PR TITLE
fix(spec): pre-compile JSON schema validators at build time

### DIFF
--- a/packages/@jsii/spec/.eslintrc.yaml
+++ b/packages/@jsii/spec/.eslintrc.yaml
@@ -1,2 +1,5 @@
 ---
 extends: ../../../eslint-config.yaml
+
+ignorePatterns:
+  - build-tools/generate-validators.js

--- a/packages/@jsii/spec/build-tools/generate-json-schema.sh
+++ b/packages/@jsii/spec/build-tools/generate-json-schema.sh
@@ -40,3 +40,7 @@ set -euo pipefail
         --strictNullChecks true              \
         --topRef           true
 }
+
+# Generate standalone validation code from schemas
+echo "Generating standalone validation code"
+node build-tools/generate-validators.js

--- a/packages/@jsii/spec/build-tools/generate-validators.js
+++ b/packages/@jsii/spec/build-tools/generate-validators.js
@@ -1,0 +1,21 @@
+const Ajv = require('ajv');
+const standaloneCode = require('ajv/dist/standalone').default;
+const { readFileSync, writeFileSync } = require('fs');
+
+const ajv = new Ajv({ code: { source: true, esm: false }, allErrors: true });
+
+// Load and compile schemas
+const assemblySchema = JSON.parse(readFileSync('schema/jsii-spec.schema.json', 'utf8'));
+const redirectSchema = JSON.parse(readFileSync('schema/assembly-redirect.schema.json', 'utf8'));
+
+ajv.addSchema(assemblySchema, 'assembly');
+ajv.addSchema(redirectSchema, 'redirect');
+
+// Generate standalone code
+const code = standaloneCode(ajv, {
+  validateAssembly: 'assembly',
+  validateRedirect: 'redirect',
+});
+
+writeFileSync('lib/validators.js', code);
+console.log('Generated lib/validators.js');

--- a/packages/@jsii/spec/jest.config.mjs
+++ b/packages/@jsii/spec/jest.config.mjs
@@ -1,9 +1,12 @@
 import { overriddenConfig } from '../../../jest.config.mjs';
 
 export default overriddenConfig({
+  coveragePathIgnorePatterns: [
+    'lib/validators.js'
+  ],
   coverageThreshold: {
     global: {
-      branches: 28,
+      branches: 60,
     },
   },
 });

--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -30,11 +30,8 @@
     "test:update": "jest -u",
     "package": "package-js"
   },
-  "dependencies": {
-    "ajv": "^8.17.1"
-  },
   "devDependencies": {
-    "fs-extra": "^10.1.0",
+    "ajv": "^8.17.1",
     "jsii-build-tools": "^0.0.0",
     "typescript-json-schema": "^0.65.1"
   }

--- a/packages/@jsii/spec/src/format-errors.ts
+++ b/packages/@jsii/spec/src/format-errors.ts
@@ -1,0 +1,10 @@
+import type { ErrorObject } from 'ajv';
+
+export function formatErrors(errors: ErrorObject[], dataVar: string): string {
+  if (!errors || errors.length === 0) {
+    return 'No errors';
+  }
+  return errors
+    .map((e) => `${dataVar}${e.instancePath} ${e.message}`)
+    .join('\n * ');
+}

--- a/packages/@jsii/spec/src/redirect.ts
+++ b/packages/@jsii/spec/src/redirect.ts
@@ -1,7 +1,10 @@
-import Ajv from 'ajv';
+import { formatErrors } from './format-errors';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 export const assemblyRedirectSchema = require('../schema/assembly-redirect.schema.json');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const { validateRedirect: validateSchema } = require('../lib/validators');
 
 const SCHEMA = 'jsii/file-redirect';
 
@@ -43,18 +46,9 @@ export function isAssemblyRedirect(obj: unknown): obj is AssemblyRedirect {
  * @returns the validated value.
  */
 export function validateAssemblyRedirect(obj: unknown): AssemblyRedirect {
-  const ajv = new Ajv({
-    allErrors: true,
-  });
-  const validate = ajv.compile(assemblyRedirectSchema);
-  validate(obj);
-
-  if (validate.errors) {
+  if (!validateSchema(obj)) {
     throw new Error(
-      `Invalid assembly redirect:\n * ${ajv.errorsText(validate.errors, {
-        separator: '\n * ',
-        dataVar: 'redirect',
-      })}`,
+      `Invalid assembly redirect:\n * ${formatErrors(validateSchema.errors, 'redirect')}`,
     );
   }
 

--- a/packages/@jsii/spec/src/validate-assembly.ts
+++ b/packages/@jsii/spec/src/validate-assembly.ts
@@ -1,18 +1,14 @@
-import Ajv from 'ajv';
-
 import { Assembly } from './assembly';
+import { formatErrors } from './format-errors';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 export const schema = require('../schema/jsii-spec.schema.json');
 
-export function validateAssembly(obj: any): Assembly {
-  const ajv = new Ajv({
-    allErrors: true,
-  });
-  const validate = ajv.compile(schema);
-  validate(obj);
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const { validateAssembly: validateSchema } = require('../lib/validators');
 
-  if (validate.errors) {
+export function validateAssembly(obj: any): Assembly {
+  if (!validateSchema(obj)) {
     let descr = '';
     if (typeof obj.name === 'string' && obj.name !== '') {
       descr =
@@ -21,10 +17,7 @@ export function validateAssembly(obj: any): Assembly {
           : ` ${obj.name}`;
     }
     throw new Error(
-      `Invalid assembly${descr}:\n * ${ajv.errorsText(validate.errors, {
-        separator: '\n * ',
-        dataVar: 'assembly',
-      })}`,
+      `Invalid assembly${descr}:\n * ${formatErrors(validateSchema.errors, 'assembly')}`,
     );
   }
   return obj;


### PR DESCRIPTION
The `@jsii/spec` package currently compiles JSON schemas into validators at runtime using `ajv`. This happens every time the validators are called, which adds unnecessary overhead during jsii compilation and when loading assemblies.

Every now and then we are also seeing users getting the following error. While I am not entirely clear on what is causing it (maybe some confused dependency tree?), getting rid of `ajv` completely will solve this.
```
TypeError: ajv_1.default is not a constructor
  at loadAssemblyFromFile (node_modules\@jsii\spec\lib\assembly-utils.js:139:15)
```

This change pre-compiles the validators during the build process using [Ajv's standalone code generation feature](https://ajv.js.org/standalone.html). The generated JavaScript code is a self-contained validator that doesn't require the `ajv` library at runtime. This approach has two benefits: it eliminates the schema compilation overhead at runtime, and it allows us to move `ajv` from a runtime dependency to a dev dependency, reducing the package's footprint.

While making these changes, I also noticed that `fs-extra` was only used in tests for convenience methods like `readJsonSync` and `removeSync`. Since Node.js 14+ provides `fs.rmSync` with recursive support, and JSON parsing is trivial with `JSON.parse(fs.readFileSync(...))`, the `fs-extra` dependency is no longer needed and has been removed entirely.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
