### PR TITLE
fix(jsii-pacmak): remove GOSUMDB=off from Go target

### DIFF
--- a/packages/jsii-pacmak/lib/targets/go.ts
+++ b/packages/jsii-pacmak/lib/targets/go.ts
@@ -271,9 +271,6 @@ async function go(command: string, args: string[], options: { cwd: string }) {
   const { cwd } = options;
   return subprocess('go', [command, ...args], {
     cwd,
-    env: {
-      // disable the use of sumdb to reduce eventual consistency issues when new modules are published
-      GOSUMDB: 'off',
-    },
+    env: {},
   });
 }


### PR DESCRIPTION
The `GOSUMDB=off` environment variable was added in #2616 back in February 2021 as a workaround to reduce eventual consistency issues when newly published Go modules were not yet available in the Go checksum database. At the time, this was a pragmatic fix to avoid transient failures during `go mod download`.

However, disabling the checksum database prevents the Go toolchain from using `sum.golang.org` which is required for newer features like automatic toolchain management via the `go` directive in `go.mod`. Specifically, `GOSUMDB=off` breaks the ability of `go work use` and related commands to download and verify the correct Go runtime version automatically. This is an increasingly important feature as the Go ecosystem moves towards self-managing toolchains.

Beyond the functional issue, the Go module ecosystem has matured significantly since 2021. The checksum database is stable and eventual consistency is no longer a practical concern for published modules. Keeping `GOSUMDB=off` is both an unnecessary security trade-off (skipping module integrity verification) and now actively prevents useful toolchain features from working.

This change removes the `GOSUMDB=off` setting from the `go()` helper function in jsii-pacmak, restoring default Go behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
