### PR TITLE
chore: upgrade workflow not producing upgrades under yarn 4

### DIFF
--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -13,13 +13,13 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Set up Node
+      - name: Setup Node
         uses: actions/setup-node@v6
         with:
           cache: yarn
@@ -29,7 +29,7 @@ jobs:
         run: |-
           npm -g install lerna npm-check-updates@^20
 
-      - name: List Mono-Repo Packages
+      - name: List Monorepo Packages
         id: monorepo-packages
         # These need to be ignored from the `ncu` runs!
         run: |-
@@ -99,10 +99,10 @@ jobs:
 
       # This will ensure the current lockfile is up-to-date with the dependency specifications (necessary for "yarn update" to run)
       - name: Run "yarn install"
-        run: yarn install
+        run: yarn install --no-immutable
 
       - name: Run "yarn up"
-        run: yarn up '*'
+        run: yarn up -R '*'
 
       # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
       # Creating a pull request requires write permissions and it's best to keep write privileges isolated.
@@ -124,7 +124,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out
+      - name: Checkout
         uses: actions/checkout@v6
 
       - name: Download patch
@@ -134,7 +134,8 @@ jobs:
           path: ${{ runner.temp }}
 
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp }}/upgrade.patch || echo "Empty patch. Skipping."'
+        run: "[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp
+          }}/upgrade.patch || echo \"Empty patch. Skipping.\""
 
       - name: Make Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
The scheduled `Yarn Upgrade` workflow was not producing upgrades anymore because it was written for yarn 1 semantics. With yarn 4 the default `yarn install` runs in immutable mode inside CI and refuses to update the lockfile, which made the subsequent `yarn up '*'` a no-op for transitive dependencies.

Switching to `yarn install --no-immutable` allows the lockfile refresh step to do its job, and replacing `yarn up '*'` with `yarn up -R '*'` makes the upgrade recursive so transitive dependencies are actually bumped — the original intent of the workflow.

The remaining changes are cosmetic: step names are normalized (`Check Out` → `Checkout`, `Set up Node` → `Setup Node`, `List Mono-Repo Packages` → `List Monorepo Packages`) and the `Apply patch` step's long shell one-liner is folded for readability. No behaviour change there.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
