### PR TITLE
docs: replace "Javascript" with "JavaScript" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [cdk]: https://github.com/aws/aws-cdk
 
-A class library written in **TypeScript** can be used in projects authored in **TypeScript** or **Javascript** (as
+A class library written in **TypeScript** can be used in projects authored in **TypeScript** or **JavaScript** (as
 usual), but also in **Python**, **Java**, **C#** (and other languages from the _.NET_ family), ...
 
 ## :question: Documentation


### PR DESCRIPTION
Replaced "Javascript" with "JavaScript".
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
