### PR TITLE
fix(jsii-diff): `npm:` argument type can be shell-injected

### DIFF
--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -48,6 +48,7 @@ export async function downloadNpmPackage<T>(
       // to not bork when it can find the dependencies.
       await execFile('npm', ['install', '--silent', '--prefix', '.', pkg]);
     } catch (e: any) {
+      console.log(e);
       // If this fails, might be because the package doesn't exist
       if (!isSubprocesFailedError(e)) {
         throw e;

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -7,7 +7,7 @@ import * as util from 'util';
 
 const LOG = log4js.getLogger('jsii-diff');
 
-const exec = util.promisify(childProcess.exec);
+const execFile = util.promisify(childProcess.execFile);
 
 export async function inTempDir<T>(block: () => T | Promise<T>): Promise<T> {
   const origDir = process.cwd();
@@ -46,7 +46,7 @@ export async function downloadNpmPackage<T>(
     try {
       // Need to install package and dependencies in order for jsii-reflect
       // to not bork when it can find the dependencies.
-      await exec(`npm install --silent --prefix . ${pkg}`);
+      await execFile('npm', ['install', '--silent', '--prefix', '.', pkg]);
     } catch (e: any) {
       // If this fails, might be because the package doesn't exist
       if (!isSubprocesFailedError(e)) {
@@ -77,7 +77,7 @@ function isSubprocesFailedError(e: any) {
 async function npmPackageExists(pkg: string): Promise<boolean> {
   try {
     LOG.info(`Checking existence of ${pkg}`);
-    await exec(`npm show --silent ${pkg}`);
+    await execFile('npm', ['show', '--silent', pkg]);
     return true;
   } catch (e) {
     if (!isSubprocesFailedError(e)) {

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -7,7 +7,7 @@ import * as util from 'util';
 
 const LOG = log4js.getLogger('jsii-diff');
 
-const execFile = util.promisify(childProcess.execFile);
+const exec = util.promisify(childProcess.exec);
 
 export async function inTempDir<T>(block: () => T | Promise<T>): Promise<T> {
   const origDir = process.cwd();
@@ -40,15 +40,20 @@ export async function downloadNpmPackage<T>(
   pkg: string,
   block: (dir: string) => Promise<T>,
 ): Promise<NpmDownloadResult<T>> {
+  validateValidPackageSpecifier(pkg);
+
   return inTempDir(async () => {
     LOG.info(`Fetching NPM package ${pkg}`);
 
     try {
       // Need to install package and dependencies in order for jsii-reflect
       // to not bork when it can find the dependencies.
-      await execFile('npm', ['install', '--silent', '--prefix', '.', pkg]);
+      //
+      // This executes the shell, which is necessary: on Windows, npm is a .cmd file,
+      // and only the shell and execute .bat/.cmd files. We have validated the package
+      // name already to make sure it contains only safe characters.
+      await exec(`npm install --silent --prefix . ${pkg}`);
     } catch (e: any) {
-      console.log(e);
       // If this fails, might be because the package doesn't exist
       if (!isSubprocesFailedError(e)) {
         throw e;
@@ -78,7 +83,10 @@ function isSubprocesFailedError(e: any) {
 async function npmPackageExists(pkg: string): Promise<boolean> {
   try {
     LOG.info(`Checking existence of ${pkg}`);
-    await execFile('npm', ['show', '--silent', pkg]);
+    // This executes the shell, which is necessary: on Windows, npm is a .cmd file,
+    // and only the shell and execute .bat/.cmd files. We have validated the package
+    // name already to make sure it contains only safe characters.
+    await exec(`npm show --silent ${pkg}`);
     return true;
   } catch (e) {
     if (!isSubprocesFailedError(e)) {
@@ -95,6 +103,19 @@ function trimVersionString(pkg: string) {
   // The arbitrary char before the @ prevents matching a @ at the start of the
   // string.
   return pkg.replace(/(.)@.*$/, '$1');
+}
+
+/**
+ * Validate a package name against a list of allowed characters
+ *
+ * If we are too strict here, that's not a biggy: script writers are always
+ * able to download their exotically-named NPM package themselves before running
+ * jsii-diff on it.
+ */
+function validateValidPackageSpecifier(pkg: string) {
+  if (pkg.match(/[^a-z0-9@\/._-]/i)) {
+    throw new Error(`Invalid package name, only 'a-z0-9@/._-' are allowed: ${JSON.stringify(pkg)}`);
+  }
 }
 
 export function flatMap<T, U>(xs: T[], fn: (x: T) => U[]): U[] {

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -113,8 +113,8 @@ function trimVersionString(pkg: string) {
  * jsii-diff on it.
  */
 function validateValidPackageSpecifier(pkg: string) {
-  if (pkg.match(/[^a-z0-9@\/._-]/i)) {
-    throw new Error(`Invalid package name, only 'a-z0-9@/._-' are allowed: ${JSON.stringify(pkg)}`);
+  if (pkg.match(/[^a-z0-9@\/:._-]/i)) {
+    throw new Error(`Invalid package name, only 'a-z0-9@/:._-' are allowed: ${JSON.stringify(pkg)}`);
   }
 }
 

--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -113,8 +113,10 @@ function trimVersionString(pkg: string) {
  * jsii-diff on it.
  */
 function validateValidPackageSpecifier(pkg: string) {
-  if (pkg.match(/[^a-z0-9@\/:._-]/i)) {
-    throw new Error(`Invalid package name, only 'a-z0-9@/:._-' are allowed: ${JSON.stringify(pkg)}`);
+  if (pkg.match(/[^a-z0-9@/:._-]/i)) {
+    throw new Error(
+      `Invalid package name, only 'a-z0-9@/:._-' are allowed: ${JSON.stringify(pkg)}`,
+    );
   }
 }
 

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -17,7 +17,7 @@ import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
-import { subprocess, zip } from '../util';
+import { shell, subprocess, zip } from '../util';
 import { VERSION } from '../version';
 import { renderSummary, PropertyDefinition } from './_utils';
 import {
@@ -104,7 +104,7 @@ export default class Python extends Target {
       env,
       retry: { maxAttempts: 5 },
     });
-    await subprocess(python, ['-m', 'twine', 'check', path.join(outDir, '*')], {
+    await shell(`${python} -m twine check ${path.join(outDir, '*')}`, {
       cwd: sourceDir,
       env,
     });

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -17,7 +17,7 @@ import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
-import { shell, subprocess, zip } from '../util';
+import { subprocess, zip } from '../util';
 import { VERSION } from '../version';
 import { renderSummary, PropertyDefinition } from './_utils';
 import {
@@ -104,7 +104,7 @@ export default class Python extends Target {
       env,
       retry: { maxAttempts: 5 },
     });
-    await shell(`${python} -m twine check ${path.join(outDir, '*')}`, {
+    await subprocess(python, ['-m', 'twine', 'check', path.join(outDir, '*')], {
       cwd: sourceDir,
       env,
     });


### PR DESCRIPTION
`jsii-diff` supports downloading packages to compare from NPM:

```
$ jsii-diff aws-cdk-lib npm:aws-cdk-lib
```

The string after `npm:` gets used as part of a subcommand that executes the NPM package manager. This used to be done using a shell, which made it vulnerable to shell injection.

We can't avoid going through the shell though, because we run NPM and on Windows NPM is `npm.cmd`; only the shell can execute batch files on Windows, they are not directly executable. 

Instead, we limit the set of characters we will allow there, to avoid the shell injection that way.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
