### PR TITLE
chore(spec): pin typescript-json-schema to 0.67.1

### DIFF
--- a/packages/@jsii/spec/package.json
+++ b/packages/@jsii/spec/package.json
@@ -37,6 +37,6 @@
     "jest": "^30.3.0",
     "jsii-build-tools": "^0.0.0",
     "typescript": "5.9.x",
-    "typescript-json-schema": "^0.67.1"
+    "typescript-json-schema": "0.67.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,7 +1861,7 @@ __metadata:
     jest: "npm:^30.3.0"
     jsii-build-tools: "npm:^0.0.0"
     typescript: "npm:5.9.x"
-    typescript-json-schema: "npm:^0.67.1"
+    typescript-json-schema: "npm:0.67.1"
   languageName: unknown
   linkType: soft
 
@@ -11794,7 +11794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-json-schema@npm:^0.67.1":
+"typescript-json-schema@npm:0.67.1":
   version: 0.67.1
   resolution: "typescript-json-schema@npm:0.67.1"
   dependencies:


### PR DESCRIPTION
## Summary

Pin `typescript-json-schema` to exactly `0.67.1` in `packages/@jsii/spec/package.json` to prevent the broken `0.67.2` from being picked up by dependency update automation.

## Root Cause

Version `0.67.2` of `typescript-json-schema` upgrades its `yargs` dependency from v17 to `^18.0.0`. Yargs v18 contains a breaking change that removes the `.usage()` API. The `typescript-json-schema` CLI (`typescript-json-schema-cli.js:9`) calls `require(...).usage(helpText)` which throws:

```
TypeError: require(...).usage is not a function
    at Object.run (node_modules/typescript-json-schema/dist/typescript-json-schema-cli.js:9:10)
```

This fails the `@jsii/spec:build` task and cascades to block the entire Main workflow.

## Context

- PR #5114 (automated dependency bump) has been stuck for 6 days due to this breakage
- Failed CI run: https://github.com/aws/jsii/actions/runs/25805522889

## What was changed

Changed `"typescript-json-schema": "^0.67.1"` → `"typescript-json-schema": "0.67.1"` to remove the caret and prevent semver-compatible upgrades to the broken 0.67.2.