### PR TITLE
fix(kernel): unsafe JSON.stringify on circular arguments hides original error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Each one of these scripts can be executed either from the root of the repo using
 `npx lerna run <script> --scope <package>` or from individual modules using
 `yarn <script>`.
 
-#### Reproducting Bugs (Test-Driven Solving)
+#### Reproducing Bugs (Test-Driven Solving)
 
 Troubleshooting bugs usually starts with adding a new test that demonstrates the
 faulty behavior, then modifying implementations until the test passes.

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs-extra';
 import { createRequire } from 'module';
 import * as os from 'os';
 import * as path from 'path';
+import { inspect } from 'util';
 
 import * as api from './api';
 import { TOKEN_REF } from './api';
@@ -1376,9 +1377,10 @@ export class Kernel {
     }
     if (xs.length > parametersCopy.length) {
       throw new JsiiFault(
-        `Argument list (${JSON.stringify(
-          xs,
-        )}) not same size as expected argument list (length ${
+        `Argument list (${inspect(xs, {
+          depth: 2,
+          breakLength: Infinity,
+        })}) not same size as expected argument list (length ${
           parametersCopy.length
         })`,
       );

--- a/packages/@jsii/kernel/src/objects.ts
+++ b/packages/@jsii/kernel/src/objects.ts
@@ -1,5 +1,6 @@
 import * as spec from '@jsii/spec';
 import * as assert from 'assert';
+import { inspect } from 'util';
 
 import * as api from './api';
 import { JsiiFault } from './kernel';
@@ -105,9 +106,10 @@ function tagObject(obj: unknown, objid: string, interfaces?: string[]) {
   // writable.
   if (Object.prototype.hasOwnProperty.call(obj, OBJID_SYMBOL)) {
     console.error(
-      `[jsii/kernel] WARNING: object ${JSON.stringify(
-        obj as any,
-      )} was already tagged as ${(obj as any)[OBJID_SYMBOL]}!`,
+      `[jsii/kernel] WARNING: object ${inspect(obj, {
+        depth: 2,
+        breakLength: Infinity,
+      })} was already tagged as ${(obj as any)[OBJID_SYMBOL]}!`,
     );
   }
 


### PR DESCRIPTION
### Why

A jsii user implementing `IStableAnyProducer` in Python and passing it to `cdk.Lazy.any(...)` saw the following confusing error from `cdk synth`:

```
TypeError: Resolution error: Converting circular structure to JSON
    --> starting at object with constructor 'Stack'
    |     property 'node' -> object with constructor 'Node'
    --- property 'host' closes the circle.
```

The actual problem in their code is unrelated to JSON: the JS-side `Lazy.any` invokes `producer.produce(context)` with a single argument, but the Python `IStableAnyProducer.produce()` declares zero parameters. The kernel correctly detects this argument-count mismatch and tries to throw an actionable `JsiiFault` describing it. However, the error message construction calls `JSON.stringify(xs)` on the raw JS argument list, and `xs[0]` is the `IResolveContext` whose `scope` is a `Stack` containing cycles. `JSON.stringify` blows up on the cycles, the original error is never raised, and the user gets a stringification crash they cannot debug.

The same pattern existed in the `tagObject` re-tagging warning (`packages/@jsii/kernel/src/objects.ts`) where `obj` is also an arbitrary user JS value — anything from CDK with a back-reference to a parent construct would crash that warning the same way.

### What

Both diagnostic sites now use `util.inspect(value, { depth: 2, breakLength: Infinity })`, which renders cycles as `[Circular]` markers and never throws. `util.inspect` is already the established convention for diagnostic formatting elsewhere in `@jsii/kernel` (`serialization.ts`).

After the fix the same `cdk synth` repro yields the actionable error the kernel intended to raise:

```
Resolution error: Argument list ([ { preparing: false, scope: Stack { ... }, documentPath: [...], registerPostProcessor: [Function: registerPostProcessor], resolve: [Function: resolve] } ]) not same size as expected argument list (length 0).
```

### Verification

I verified the fix against a minimal CDK Python repro by setting `JSII_RUNTIME` to point at the locally built `bin/jsii-runtime` per the contributing guide. The existing `sync overrides` kernel tests still pass.

I considered adding a dedicated regression test, but the buggy code paths are not reachable from the public sandbox API (`#validateMethodArguments` runs before `#boxUnboxParameters` for incoming calls; the bug only fires on outgoing override callbacks invoked by JS-internal code with extra args). Reaching it from a test would require a new fixture class in `jsii-calc` whose method body deliberately calls a virtual method with the wrong number of args, which felt disproportionate for a one-line formatting change. The realistic regression vector is someone reverting back to `JSON.stringify`, which a code reviewer can catch.

### Notes

The second commit is a drive-by typo fix in `CONTRIBUTING.md` ("Reproducting" → "Reproducing").
