### PR TITLE
fix(java-runtime): org.jetbrains:annotations leaks onto consumers' runtime classpath

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -94,6 +94,8 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>\${jetbrains-annotations.version}</version>
+            <!-- Compile-only: CLASS/SOURCE retention, no runtime behavior, not needed in consumers' runtime closure -->
+            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->


### PR DESCRIPTION
The `jsii-runtime` Maven artifact declared `org.jetbrains:annotations` at the default `compile` scope. Because `compile` dependencies are transitive, the annotations jar was exposed to everything that depends on `jsii-runtime`.

It does not belong on the runtime classpath at all. The runtime only uses `@Nullable` and `@VisibleForTesting`, which have CLASS and SOURCE retention respectively. They carry no runtime behavior, the JVM does not need the annotation classes present to load classes that reference them, and nothing in the runtime reflects on them at runtime (the only annotation-driven behavior reads jsii's own `software.amazon.jsii.Jsii` annotation). They are purely a compile-time concern for IDEs and static analysis.

This changes the dependency to `provided` scope so it remains available for the runtime's own compilation and tests but is no longer propagated to anything that depends on the runtime. The full `yarn build` was run: all 33 sources compile and the 14 tests pass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
