### PR TITLE
fix(java-runtime): javax.annotation-api leaks onto consumers' runtime classpath

### DIFF
--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -135,6 +135,8 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>\${javax-annotations.version}</version>
+            <!-- Compile-only: only provides @javax.annotation.Generated (SOURCE retention), not present in bytecode -->
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The `jsii-runtime` Maven artifact declared `javax.annotation-api` at the default `compile` scope. Because `compile` dependencies are transitive, the jar was exposed to everything that depends on `jsii-runtime`.

It does not belong on the runtime classpath. No hand-written runtime code uses it; it is declared only to supply `@javax.annotation.Generated`, which the generated `JsiiVersion` and `BundledRuntime` classes carry. That annotation has SOURCE retention, so the compiler discards it and it never appears in the bytecode at all — nothing can read it at runtime.

This follows the same reasoning as #5136 (the JetBrains annotations) and changes the dependency to `provided` scope so it remains available for the runtime's own compilation but is no longer propagated to anything that depends on the runtime. The full `yarn build` was run: the generated classes compile and all 14 tests pass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
