### PR TITLE
fix(pacmak): annotation deps leak onto consumers' runtime classpath

### DIFF
--- a/packages/@jsii/java-runtime-test/pom.xml.t.js
+++ b/packages/@jsii/java-runtime-test/pom.xml.t.js
@@ -32,6 +32,14 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <scope>test</scope>
         </dependency>
 
+        <!-- ComplianceTest uses @NotNull; the runtime no longer leaks it transitively (it is provided-scoped there) -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>[13.0.0,24.0-a0)</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/packages/jsii-pacmak/lib/targets/java.ts
+++ b/packages/jsii-pacmak/lib/targets/java.ts
@@ -1400,20 +1400,21 @@ class JavaGenerator extends Generator {
               toMavenVersionRange(`^${VERSION}`),
       });
 
-      // Provides @org.jetbrains.*
+      // Provides @org.jetbrains.* (compile-only: CLASS retention, no runtime behavior)
       dependencies.push({
         groupId: 'org.jetbrains',
         artifactId: 'annotations',
         version: '[16.0.3,20.0.0)',
+        scope: 'provided',
       });
 
-      // Provides @javax.annotation.Generated for JDKs >= 9
+      // Provides @javax.annotation.Generated for JDKs >= 9 (compile-only: SOURCE retention, not in bytecode)
       dependencies.push({
         '#comment': 'Provides @javax.annotation.Generated for JDKs >= 9',
         groupId: 'javax.annotation',
         artifactId: 'javax.annotation-api',
         version: '[1.3.2,1.4.0)',
-        scope: 'compile',
+        scope: 'provided',
       });
 
       return dependencies;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -603,13 +603,14 @@ exports[`diamond-struct-parameter.ts: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -2260,13 +2261,14 @@ exports[`nested-types.ts: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -206,13 +206,14 @@ exports[`foo@1.2.3 depends on bar@^2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -739,13 +740,14 @@ exports[`foo@1.2.3 depends on bar@^4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -1260,13 +1262,14 @@ exports[`foo@2.0.0-rc.42: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -1770,13 +1773,14 @@ exports[`foo@4.5.6-pre.1337: <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-java.test.js.snap
@@ -292,13 +292,14 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/java/pom.xml 1`] =
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -1022,13 +1023,14 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <outDir>/java/pom.x
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -1735,13 +1737,14 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/java/pom.xml 1`] = 
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -4566,13 +4569,14 @@ exports[`Generated code for "jsii-calc": <outDir>/java/pom.xml 1`] = `
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>[16.0.3,20.0.0)</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- Provides @javax.annotation.Generated for JDKs >= 9 -->
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>[1.3.2,1.4.0)</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Generated Java bindings declared both `org.jetbrains:annotations` and `javax.annotation-api` at the default/explicit `compile` scope. Because `compile` dependencies are transitive, both jars propagated into the runtime dependency closure of every consumer of a jsii-generated Java library.

Neither is needed at runtime. The JetBrains `@Nullable`/`@NotNull` are CLASS-retained — they carry no runtime behavior and nothing reflects on them; they exist purely as static-analysis metadata. `@javax.annotation.Generated` is SOURCE-retained, so it is discarded by the compiler and never even appears in the bytecode.

This scopes both to `provided`, so they remain on the compile classpath when the bindings themselves are built but are no longer propagated to consumers. The nullability metadata stays baked into the bytecode, so IDE and Kotlin null-analysis are unaffected (those read the annotation names from the class files, not from a resolvable dependency). A consumer who compiles with annotation processing and wants to silence the resulting `cannot find annotation method` warning can add `org.jetbrains:annotations` to their own build as `provided`.

This mirrors the same fix already applied to the runtime in #5136 and #5140. Snapshots were updated to reflect the new pom scopes; `yarn test:update` passes (177 tests).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
