### PR TITLE
docs: update documentation for jsii 6.0

### DIFF
--- a/gh-pages/content/overview/features.md
+++ b/gh-pages/content/overview/features.md
@@ -30,7 +30,7 @@ To determine the version of **TypeScript** that is in use by the installed relea
 
 ```console
 # jsii --version
-5.1.6 (build d8f400c), typescript 5.1.6
+6.0.0 (build abc1234), typescript 6.0.0
 ```
 
 You can then refer to the [TypeScript] documentation to determine which language features are available in that specific
@@ -38,12 +38,11 @@ You can then refer to the [TypeScript] documentation to determine which language
 
 !!! warning
     The `jsii` compiler imposes some restrictions on what **TypeScript** features can be used to declare the APIs
-    exported by a *jsii module*, in order to ensure those APIs can be consistently represented in other languages. For
+    exported by a _jsii module_, in order to ensure those APIs can be consistently represented in other languages. For
     more information, refer to the [TypeScript Restrictions page][restrictions].
 
-    [restrictions]: ../user-guides/lib-author/typescript-restrictions.md
-
-[typescript]: https://www.typescriptlang.org
+[restrictions]: ../user-guides/lib-author/typescript-restrictions.md
+[TypeScript]: https://www.typescriptlang.org
 
 ## Target Languages
 
@@ -55,7 +54,6 @@ The following target languages are currently offered by `jsii-pacmak`, or are cu
 | Go         | :octicons-check-circle-24: Generally Available |
 | Java       | :octicons-check-circle-24: Generally Available |
 | JavaScript | :octicons-check-circle-24: Generally Available |
-| Kotlin     | :octicons-tools-24:        Development         |
 | Python     | :octicons-check-circle-24: Generally Available |
 | TypeScript | :octicons-check-circle-24: Generally Available |
 

--- a/gh-pages/content/overview/toolchain.md
+++ b/gh-pages/content/overview/toolchain.md
@@ -5,18 +5,20 @@
 !!! info
     We are considering creating an "umbrella entrypoint" to make it easier to consume.
 
-| Name            | Release | Stability     | Description                                                           |
-| --------------- | ------- | ------------- | --------------------------------------------------------------------- |
-| [jsii1]         | `1.x`   | [Maintenance] | Compiles TypeScript to jsii module (TypeScript 3.9 Syntax)            |
-| [jsii]          | `5.x`   | GA            | Compiles TypeScript to jsii module (TypeScript 5.x Syntax)            |
-| [jsii-pacmak]   | `1.x`   | GA            | Creates ready-to-publish language-specific packages from jsii modules |
-| [jsii-reflect]  | `1.x`   | GA            | Strong-typed reflection library for jsii type systems                 |
-| [jsii-diff]     | `1.x`   | GA            | API backwards compatibility checker                                   |
-| [jsii-rosetta1] | `1.x`   | [Maintenance] | Transpile code snippets (in docs) from TypeScript to jsii languages   |
-| [jsii-rosetta]  | `5.x`   | GA            | Transpile code snippets (in docs) from TypeScript to jsii languages   |
-| [jsii-config]   | `1.x`   | Experimental  | Interactive tool for generating jsii configuration                    |
-| [jsii-srcmak]   | `1.x`   | Community     | Generates relocatable source code in jsii languages from typescript   |
-| [jsii-docgen]   | *any*   | Community     | Generates markdown API documentation for jsii modules                 |
+| Name           | Release | Stability     | Description                                                           |
+| -------------- | ------- | ------------- | --------------------------------------------------------------------- |
+| [jsii]         | `6.x`   | GA            | Compiles TypeScript to jsii module (TypeScript 6.x)                   |
+|                | `5.x`   | [Maintenance] | Compiles TypeScript to jsii module (TypeScript 5.x)                   |
+|                | `1.x`   | [Maintenance] | Compiles TypeScript to jsii module (TypeScript 3.9)                   |
+| [jsii-pacmak]  | `1.x`   | GA            | Creates ready-to-publish language-specific packages from jsii modules |
+| [jsii-reflect] | `1.x`   | GA            | Strong-typed reflection library for jsii type systems                 |
+| [jsii-diff]    | `1.x`   | GA            | API backwards compatibility checker                                   |
+| [jsii-rosetta] | `6.x`   | GA            | Transpile code snippets (in docs) from TypeScript to jsii languages   |
+|                | `5.x`   | [Maintenance] | (as above but for TypeScript 5.x)                                     |
+|                | `1.x`   | [Maintenance] | (as above but for TypeScript 3.9)                                     |
+| [jsii-config]  | `1.x`   | Experimental  | Interactive tool for generating jsii configuration                    |
+| [jsii-srcmak]  | `1.x`   | Community     | Generates relocatable source code in jsii languages from typescript   |
+| [jsii-docgen]  | *any*   | Community     | Generates markdown API documentation for jsii modules                 |
 
 ??? question "Stability Definitions"
     - **GA**: Projects that are deemed *Generally Available* and for which customers can expect full support, including
@@ -32,13 +34,11 @@
     [semver]: https://semver.org/spec/v2.0.0.html
 
 [Maintenance]: ../compiler-and-rosetta-maintenance.md
-[jsii1]: https://github.com/aws/jsii/tree/main/packages/jsii
 [jsii]: https://github.com/aws/jsii-compiler#readme
 [jsii-pacmak]: https://github.com/aws/jsii/tree/main/packages/jsii-pacmak
 [jsii-reflect]: https://github.com/aws/jsii/tree/main/packages/jsii-reflect
 [jsii-config]: https://github.com/aws/jsii/tree/main/packages/jsii-config
 [jsii-diff]: https://github.com/aws/jsii/tree/main/packages/jsii-diff
-[jsii-rosetta1]: https://github.com/aws/jsii/tree/main/packages/jsii-rosetta
 [jsii-rosetta]: https://github.com/aws/jsii-rosetta#readme
 [jsii-srcmak]: https://github.com/cdklabs/jsii-srcmak
 [jsii-docgen]: https://github.com/cdklabs/jsii-docgen

--- a/gh-pages/content/user-guides/lib-author/configuration/index.md
+++ b/gh-pages/content/user-guides/lib-author/configuration/index.md
@@ -209,7 +209,7 @@ are set in the `jsii.tsc` section of the `package.json` file, but use the same n
   default, all visible `@types/*` packages will be loaded, which can be undesirable (in particular in monorepos, where
   some type libraries are not compatible with the TypeScript compiler version that `jsii` uses). The value specified
   here will be forwarded as-is to the TypeScript compiler.
-- `baseUrl` and `paths` can be used to configure TypeScript path mappings, and are copied verbatim to `tsconfig.json`.
+- `paths` can be used to configure TypeScript path mappings, and is copied verbatim to `tsconfig.json`.
 
 Refer to the [TypeScript compiler options reference][ts-options] for more information about those options.
 
@@ -219,10 +219,6 @@ Refer to the [TypeScript compiler options reference][ts-options] for more inform
 #### `tsconfig`
 
 _Available from jsii >= 5.2_
-
-!!! warn
-    :test_tube: This features is experimental. Behavior may change as bugs are addressed, and requirements are clarified
-    through early adopters. Use at your own risk, and please any [report bugs].
 
 Provide this setting, to use a user-provided typescript configuration with `jsii`. Set to the name of the tsconfig
 file that should be used. Usually this will be `"tsconfig.json"`, but can be set to any filename.
@@ -239,10 +235,6 @@ The provided tsconfig is subject to validation rules, see below for more details
 #### `validateTsconfig`
 
 _Available from jsii >= 5.2_
-
-!!! warn
-    :test_tube: This features is experimental. Behavior may change as bugs are addressed, and requirements are clarified
-    through early adopters. Use at your own risk, and please any [report bugs].
 
 A user-provider typescript config must follow certain rules to be a valid config for use with jsii.
 By default the tsconfig is validated against the `strict` rule set.
@@ -334,4 +326,3 @@ modules, **must** also be referenced in the [`bundledDependencies`][npm-bundled]
 within the NPM package.
 
 [npm-bundled]: https://docs.npmjs.com/files/package.json#bundleddependencies
-[report bugs]: https://github.com/aws/jsii/issues/new/choose

--- a/gh-pages/content/user-guides/lib-author/toolchain/jsii.md
+++ b/gh-pages/content/user-guides/lib-author/toolchain/jsii.md
@@ -49,17 +49,9 @@ reserved words in an identifier.
     option to only warn about reserved words of languages that are configured
     for the current project.
 
-### :test_tube: Experimental Features
+### `--tsconfig`, `--validate-tsconfig`
 
-!!! danger
-    The features discussed in this section are experimental. Their behavior may
-    change as bugs are addressed, and requirements are clarified through early
-    adopters. Use at your own risk, and don't forget to [report bugs] you
-    encounter while doing so!
-
-    [report bugs]: https://github.com/aws/jsii/issues/new/choose
-
-#### `--tsconfig`, `--validate-tsconfig` _(available from jsii >= 5.2)_
+_Available from jsii >= 5.2_
 
 By default, jsii will generate a `tsconfig.json` for you, using best practice
 settings that are optimized for widespread support and backwards compatibility.
@@ -74,6 +66,16 @@ config for use with jsii. These rules are enforced by the `--validate-tsconfig`
 option. You may choose the level of validation to suit your use case.
 
 --8<-- "partials/tsconfig-rulesets.md"
+
+### :test_tube: Experimental Features
+
+!!! danger
+    The features discussed in this section are experimental. Their behavior may
+    change as bugs are addressed, and requirements are clarified through early
+    adopters. Use at your own risk, and don't forget to [report bugs] you
+    encounter while doing so!
+
+    [report bugs]: https://github.com/aws/jsii/issues/new/choose
 
 #### `--strip-deprecated`
 
@@ -91,7 +93,7 @@ erased from the visible API of the module:
   types)
 
 However, in order to ensure the underlying code continues to work as designed,
-the *implementation* of such declarations will remain in the **JavaScript**
+the _implementation_ of such declarations will remain in the **JavaScript**
 (`.js`) files produced by the compilation. This is, in fact, similar to marking
 all `@deprecated` members `@internal`.
 

--- a/gh-pages/partials/tsconfig-rulesets.md
+++ b/gh-pages/partials/tsconfig-rulesets.md
@@ -5,7 +5,7 @@
 | `minimal` :warning: | Only reject options that are known to be incompatible with jsii. This rule set is likely to be incomplete and new rules will be added without notice as incompatibilities are discovered. |
 | `off` :warning:     | Disables all config validation, including options that are known to be incompatible with jsii. Intended for experimentation only. Use at your own risk.                                   |
 
-:star: Recommended setting\
+:star: Recommended setting  
 :warning: Resulting jsii assembly/package may be incompatible with wider ecosystem
 
 There is currently no easy way to inspect these rule sets, however detailed error messages are returned if a provided tsconfig fails validation.


### PR DESCRIPTION
Updates the documentation site (gh-pages) to reflect the upcoming jsii-compiler 6.0 release (aws/jsii-compiler#2659).

The toolchain table now shows `jsii@6.x` and `jsii-rosetta@6.x` as GA, with the 5.x lines moved to Maintenance. The `--tsconfig` and `--validate-tsconfig` options have graduated from experimental to stable, so the experimental warnings and danger boxes are removed from both the CLI reference and configuration pages. The `baseUrl` option is removed from the documented `tsc` settings since TypeScript 6.0 deprecates it. The tsconfig rule sets partial now documents the full list of options rejected since jsii 6.0. Finally, the `jsii --version` example in the features page is updated to show a 6.0 version string.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
