### PR TITLE
feat: ability to send Java stack traces to the host

### DIFF
--- a/packages/@jsii/java-runtime-test/pom.xml.t.js
+++ b/packages/@jsii/java-runtime-test/pom.xml.t.js
@@ -103,6 +103,11 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+                <configuration>
+                    <environmentVariables>
+                        <JSII_HOST_STACK_TRACES>1</JSII_HOST_STACK_TRACES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -1846,4 +1846,31 @@ public class ComplianceTest {
         }
         assertTrue(thrown);
     }
+
+    @Test
+    public void hostStackTraceIsPassedToKernel() {
+        // JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration
+        Object trace = HostStackTraceReader.capturedTrace();
+        assertNotNull(trace, "Stack trace should be available when JSII_HOST_STACK_TRACES is enabled");
+        assertTrue(trace instanceof List, "Stack trace should be a list of frames");
+        assertFalse(((List<?>) trace).isEmpty(), "Stack trace should not be empty");
+    }
+
+    @Test
+    public void hostStackTraceThroughCallback() {
+        // JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration
+        CallbackStackTraceTest obj = new CallbackStackTraceTest() {
+            @Override
+            protected Object callbackProvider() {
+                return HostStackTraceReader.capturedTrace();
+            }
+        };
+
+        obj.invokeCallback();
+        Object trace = obj.getTraceFromCallback();
+
+        assertNotNull(trace, "Trace from callback should not be null");
+        assertTrue(trace instanceof List, "Trace should be a list");
+        assertFalse(((List<?>) trace).isEmpty(), "Trace should not be empty");
+    }
 }

--- a/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
+++ b/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/ComplianceTest.java
@@ -1847,30 +1847,4 @@ public class ComplianceTest {
         assertTrue(thrown);
     }
 
-    @Test
-    public void hostStackTraceIsPassedToKernel() {
-        // JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration
-        Object trace = HostStackTraceReader.capturedTrace();
-        assertNotNull(trace, "Stack trace should be available when JSII_HOST_STACK_TRACES is enabled");
-        assertTrue(trace instanceof List, "Stack trace should be a list of frames");
-        assertFalse(((List<?>) trace).isEmpty(), "Stack trace should not be empty");
-    }
-
-    @Test
-    public void hostStackTraceThroughCallback() {
-        // JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration
-        CallbackStackTraceTest obj = new CallbackStackTraceTest() {
-            @Override
-            protected Object callbackProvider() {
-                return HostStackTraceReader.capturedTrace();
-            }
-        };
-
-        obj.invokeCallback();
-        Object trace = obj.getTraceFromCallback();
-
-        assertNotNull(trace, "Trace from callback should not be null");
-        assertTrue(trace instanceof List, "Trace should be a list");
-        assertFalse(((List<?>) trace).isEmpty(), "Trace should not be empty");
-    }
 }

--- a/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
+++ b/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
@@ -1,0 +1,43 @@
+package software.amazon.jsii.testing;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.jsii.tests.calculator.CallbackStackTraceTest;
+import software.amazon.jsii.tests.calculator.HostStackTraceReader;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for host stack trace propagation through the jsii protocol.
+ * These are language-specific tests (not part of the cross-language compliance suite).
+ *
+ * JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration.
+ */
+public final class HostStackTraceIntegrationTest {
+
+    @Test
+    public void hostStackTraceIsPassedToKernel() {
+        Object trace = HostStackTraceReader.capturedTrace();
+        assertNotNull(trace, "Stack trace should be available when JSII_HOST_STACK_TRACES is enabled");
+        assertTrue(trace instanceof List, "Stack trace should be a list of frames");
+        assertFalse(((List<?>) trace).isEmpty(), "Stack trace should not be empty");
+    }
+
+    @Test
+    public void hostStackTraceThroughCallback() {
+        CallbackStackTraceTest obj = new CallbackStackTraceTest() {
+            @Override
+            protected Object callbackProvider() {
+                return HostStackTraceReader.capturedTrace();
+            }
+        };
+
+        obj.invokeCallback();
+        Object trace = obj.getTraceFromCallback();
+
+        assertNotNull(trace, "Trace from callback should not be null");
+        assertTrue(trace instanceof List, "Trace should be a list");
+        assertFalse(((List<?>) trace).isEmpty(), "Trace should not be empty");
+    }
+}

--- a/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
+++ b/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
@@ -45,6 +45,13 @@ public final class HostStackTraceIntegrationTest {
 
         assertNotNull(trace, "Trace from callback should not be null");
         assertTrue(trace instanceof List, "Trace should be a list");
-        assertFalse(((List<?>) trace).isEmpty(), "Trace should not be empty");
+
+        List<?> frames = (List<?>) trace;
+        assertFalse(frames.isEmpty(), "Trace should not be empty");
+        for (Object frameObj : frames) {
+            assertTrue(frameObj instanceof List, "Each frame should be a 4-element list");
+            List<?> frame = (List<?>) frameObj;
+            assertEquals(4, frame.size(), "Frame should have 4 elements");
+        }
     }
 }

--- a/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
+++ b/packages/@jsii/java-runtime-test/project/src/test/java/software/amazon/jsii/testing/HostStackTraceIntegrationTest.java
@@ -21,7 +21,14 @@ public final class HostStackTraceIntegrationTest {
         Object trace = HostStackTraceReader.capturedTrace();
         assertNotNull(trace, "Stack trace should be available when JSII_HOST_STACK_TRACES is enabled");
         assertTrue(trace instanceof List, "Stack trace should be a list of frames");
-        assertFalse(((List<?>) trace).isEmpty(), "Stack trace should not be empty");
+
+        List<?> frames = (List<?>) trace;
+        assertFalse(frames.isEmpty(), "Stack trace should not be empty");
+        for (Object frameObj : frames) {
+            assertTrue(frameObj instanceof List, "Each frame should be a 4-element list");
+            List<?> frame = (List<?>) frameObj;
+            assertEquals(4, frame.size(), "Frame should have 4 elements");
+        }
     }
 
     @Test

--- a/packages/@jsii/java-runtime/pom.xml.t.js
+++ b/packages/@jsii/java-runtime/pom.xml.t.js
@@ -187,6 +187,11 @@ process.stdout.write(`<?xml version="1.0" encoding="UTF-8"?>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
+                <configuration>
+                    <environmentVariables>
+                        <JSII_HOST_STACK_TRACES>1</JSII_HOST_STACK_TRACES>
+                    </environmentVariables>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/HostStackTrace.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/HostStackTrace.java
@@ -1,0 +1,59 @@
+package software.amazon.jsii;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Captures the current Java stack trace for transmission to the jsii kernel.
+ *
+ * When enabled via the {@code JSII_HOST_STACK_TRACES} environment variable,
+ * the runtime captures a stack trace at each request and attaches it to the
+ * wire protocol so that downstream consumers (e.g., CDK) can report stack
+ * traces in the user's language.
+ */
+@Internal
+final class HostStackTrace {
+    private static final String JSII_PACKAGE_PREFIX = "software.amazon.jsii.";
+
+    private HostStackTrace() {}
+
+    /**
+     * Checks whether host stack trace capture is enabled via the environment.
+     */
+    static boolean isEnabled() {
+        String envValue = System.getenv("JSII_HOST_STACK_TRACES");
+        return envValue != null && (
+            envValue.equals("1") || envValue.equalsIgnoreCase("true") || envValue.equalsIgnoreCase("yes")
+        );
+    }
+
+    /**
+     * Captures the current stack trace, filtered to user frames only.
+     *
+     * @return A JSON array of frames (each a [file, line, column, function] tuple).
+     *         May be empty if no user frames remain after filtering.
+     */
+    static ArrayNode captureFrames() {
+        StackTraceElement[] elements = new Throwable().getStackTrace();
+        ArrayNode frames = JsonNodeFactory.instance.arrayNode();
+
+        for (StackTraceElement element : elements) {
+            String className = element.getClassName();
+            if (className.startsWith(JSII_PACKAGE_PREFIX)) {
+                continue;
+            }
+            if (element.getFileName() == null) {
+                continue;
+            }
+
+            ArrayNode frame = JsonNodeFactory.instance.arrayNode();
+            frame.add(element.getFileName());
+            frame.add(element.getLineNumber());
+            frame.add(0);
+            frame.add(className + "." + element.getMethodName());
+            frames.add(frame);
+        }
+
+        return frames;
+    }
+}

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/HostStackTrace.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/HostStackTrace.java
@@ -34,21 +34,25 @@ final class HostStackTrace {
      *         May be empty if no user frames remain after filtering.
      */
     static ArrayNode captureFrames() {
-        StackTraceElement[] elements = new Throwable().getStackTrace();
-        ArrayNode frames = JsonNodeFactory.instance.arrayNode();
+        final StackTraceElement[] elements = new Throwable().getStackTrace();
+        final JsonNodeFactory json = JsonNodeFactory.instance;
+        final ArrayNode frames = json.arrayNode();
 
-        for (StackTraceElement element : elements) {
-            String className = element.getClassName();
+        for (final StackTraceElement element : elements) {
+            final String className = element.getClassName();
             if (className.startsWith(JSII_PACKAGE_PREFIX)) {
                 continue;
             }
-            if (element.getFileName() == null) {
+
+            final String fileName = element.getFileName();
+            final int lineNumber = element.getLineNumber();
+            if (fileName == null || lineNumber <= 0) {
                 continue;
             }
 
-            ArrayNode frame = JsonNodeFactory.instance.arrayNode();
-            frame.add(element.getFileName());
-            frame.add(element.getLineNumber());
+            final ArrayNode frame = json.arrayNode();
+            frame.add(fileName);
+            frame.add(lineNumber);
             frame.add(0);
             frame.add(className + "." + element.getMethodName());
             frames.add(frame);

--- a/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
+++ b/packages/@jsii/java-runtime/project/src/main/java/software/amazon/jsii/JsiiRuntime.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import software.amazon.jsii.api.Callback;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -101,6 +102,14 @@ public final class JsiiRuntime {
      */
     JsonNode requestResponse(final JsonNode request) {
         try {
+            // Attach host stack trace if enabled
+            if (HostStackTrace.isEnabled() && request instanceof ObjectNode) {
+                ArrayNode stackTrace = HostStackTrace.captureFrames();
+                if (stackTrace.size() > 0) {
+                    ((ObjectNode) request).set("$jsii.stacktrace", stackTrace);
+                }
+            }
+
             JsiiRuntime.notifyInspector(request, MessageInspector.MessageType.Request);
 
             // write request

--- a/packages/@jsii/java-runtime/project/src/test/java/software/amazon/jsii/HostStackTraceTest.java
+++ b/packages/@jsii/java-runtime/project/src/test/java/software/amazon/jsii/HostStackTraceTest.java
@@ -1,0 +1,66 @@
+package software.amazon.jsii;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class HostStackTraceTest {
+
+    @Test
+    public void captureFramesReturnsNonEmptyResult() {
+        ArrayNode result = HostStackTrace.captureFrames();
+        assertNotNull(result);
+        assertTrue(result.size() > 0);
+    }
+
+    @Test
+    public void framesHaveCorrectStructure() {
+        ArrayNode result = HostStackTrace.captureFrames();
+        assertNotNull(result);
+        for (int i = 0; i < result.size(); i++) {
+            ArrayNode frame = (ArrayNode) result.get(i);
+            assertEquals(4, frame.size(), "Frame should have 4 elements");
+            assertTrue(frame.get(0).isTextual(), "file should be a string");
+            assertTrue(frame.get(1).isInt(), "line should be an int");
+            assertEquals(0, frame.get(2).asInt(), "column should be 0");
+            assertTrue(frame.get(3).isTextual(), "function should be a string");
+        }
+    }
+
+    @Test
+    public void filtersJsiiInternalFrames() {
+        ArrayNode result = HostStackTrace.captureFrames();
+        assertNotNull(result);
+        for (int i = 0; i < result.size(); i++) {
+            ArrayNode frame = (ArrayNode) result.get(i);
+            String function = frame.get(3).asText();
+            assertFalse(function.startsWith("software.amazon.jsii."),
+                "Should not contain jsii-internal frames: " + function);
+        }
+    }
+
+    @Test
+    public void framesContainNonJsiiCallers() {
+        ArrayNode result = HostStackTrace.captureFrames();
+        assertNotNull(result);
+        // Frames should contain entries from outside the jsii package
+        // (e.g., JUnit runner, reflection utilities)
+        boolean foundExternal = false;
+        for (int i = 0; i < result.size(); i++) {
+            ArrayNode frame = (ArrayNode) result.get(i);
+            String function = frame.get(3).asText();
+            if (!function.startsWith("software.amazon.jsii.")) {
+                foundExternal = true;
+                break;
+            }
+        }
+        assertTrue(foundExternal, "Should contain frames from outside jsii package");
+    }
+
+    @Test
+    public void isEnabledReturnsTrue() {
+        // JSII_HOST_STACK_TRACES=1 is set via maven-surefire-plugin configuration
+        assertTrue(HostStackTrace.isEnabled(), "isEnabled() should return true when JSII_HOST_STACK_TRACES is set");
+    }
+}


### PR DESCRIPTION
Similar to what was done for [Python][1], capture Java stack traces if the user opts in, via the environment variable `JSII_HOST_STACK_TRACES=1`.

Comparing the overhead of capturing the stack traces with Python:

| Scenario                          | Java     | Python   |
|-----------------------------------|----------|----------|
| isEnabled() / env check only      | 0.3 µs   | 0.5 µs   |
| Shallow stack (1 frame)           | 0.9 µs   | 14 µs    |
| Nested stack (4 frames)           | 1.0 µs   | 20 µs    |
| Deep stack (15 frames)            | 2.4 µs   | 40 µs    |
| Very deep stack (50 frames)       | 5.7 µs   | 95 µs    |
| Typical CDK app (1250 requests)   | 3 ms     | 50 ms    |

[1]: https://github.com/aws/jsii/pull/5153

