### PR TITLE
fix(kernel): improve performance by ~10% by deferring error-context and cache serialization values

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -9,6 +9,7 @@ queue_rules:
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     merge_conditions:
+      - label!=pr/no-squash
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     commit_message_template: |-
@@ -24,6 +25,7 @@ queue_rules:
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     merge_conditions:
+      - label=pr/no-squash
       - status-success=Unit Tests
       - status-success=Integration test (jsii-pacmak)
     commit_message_template: |-

--- a/packages/@jsii/kernel/src/kernel.ts
+++ b/packages/@jsii/kernel/src/kernel.ts
@@ -69,7 +69,7 @@ export class Kernel {
   readonly #serializerHost: wire.SerializerHost;
 
   #nextid = 20000; // incrementing counter for objid, cbid, promiseid
-  #syncInProgress?: string; // forbids async calls (begin) while processing sync calls (get/set/invoke)
+  #syncInProgress?: string | (() => string); // forbids async calls (begin) while processing sync calls (get/set/invoke)
   #installDir?: string;
   /** The internal require function, used instead of the global "require" so that webpack does not transform it... */
   #require?: typeof require;
@@ -311,11 +311,15 @@ export class Kernel {
     // make the actual "get", and block any async calls that might be performed
     // by jsii overrides.
     const value = this.#ensureSync(
-      `property '${objref[TOKEN_REF]}.${propertyToGet}'`,
+      () => `property '${objref[TOKEN_REF]}.${propertyToGet}'`,
       () => instance[propertyToGet],
     );
     this.#debug('value:', value);
-    const ret = this.#fromSandbox(value, ti, `of property ${fqn}.${property}`);
+    const ret = this.#fromSandbox(
+      value,
+      ti,
+      () => `of property ${fqn}.${property}`,
+    );
     this.#debug('ret:', ret);
     return { value: ret };
   }
@@ -336,12 +340,12 @@ export class Kernel {
     const propertyToSet = this.#findPropertyTarget(instance, property);
 
     this.#ensureSync(
-      `property '${objref[TOKEN_REF]}.${propertyToSet}'`,
+      () => `property '${objref[TOKEN_REF]}.${propertyToSet}'`,
       () =>
         (instance[propertyToSet] = this.#toSandbox(
           value,
           propInfo,
-          `assigned to property ${fqn}.${property}`,
+          () => `assigned to property ${fqn}.${property}`,
         )),
     );
 
@@ -362,13 +366,13 @@ export class Kernel {
 
     const fqn = jsiiTypeFqn(obj, this.#isVisibleType.bind(this));
     const ret = this.#ensureSync(
-      `method '${objref[TOKEN_REF]}.${method}'`,
+      () => `method '${objref[TOKEN_REF]}.${method}'`,
       () => {
         return fn.apply(
           obj,
           this.#toSandboxValues(
             args,
-            `method ${fqn ? `${fqn}#` : ''}${method}`,
+            () => `method ${fqn ? `${fqn}#` : ''}${method}`,
             ti.parameters,
           ),
         );
@@ -378,7 +382,7 @@ export class Kernel {
     const result = this.#fromSandbox(
       ret,
       ti.returns ?? 'void',
-      `returned by method ${fqn ? `${fqn}#` : ''}${method}`,
+      () => `returned by method ${fqn ? `${fqn}#` : ''}${method}`,
     );
     this.#debug('invoke result', result);
 
@@ -433,8 +437,12 @@ export class Kernel {
     this.#debug('begin', objref, method, args);
 
     if (this.#syncInProgress) {
+      const inProgress =
+        typeof this.#syncInProgress === 'function'
+          ? this.#syncInProgress()
+          : this.#syncInProgress;
       throw new JsiiFault(
-        `Cannot invoke async method '${req.objref[TOKEN_REF]}.${req.method}' while sync ${this.#syncInProgress} is being processed`,
+        `Cannot invoke async method '${req.objref[TOKEN_REF]}.${req.method}' while sync ${inProgress} is being processed`,
       );
     }
 
@@ -682,7 +690,7 @@ export class Kernel {
     const obj = new ctor(
       ...this.#toSandboxValues(
         requestArgs,
-        `new ${fqn}`,
+        () => `new ${fqn}`,
         ctorResult.parameters,
       ),
     );
@@ -1120,24 +1128,42 @@ export class Kernel {
   }
 
   #typeInfoForFqn(fqn: spec.FQN): spec.Type {
+    const fqnInfo = this.#tryTypeInfoForFqn(fqn);
+    if (!fqnInfo) {
+      // Reproduce the more specific error messages on the (cold) failure path.
+      const moduleName = fqn.split('.')[0];
+      if (!this.#assemblies.has(moduleName)) {
+        throw new JsiiFault(`Module '${moduleName}' not found`);
+      }
+      throw new JsiiFault(`Type '${fqn}' not found`);
+    }
+    return fqnInfo;
+  }
+
+  /**
+   * Like {@link #typeInfoForFqn}, but returns `undefined` instead of throwing
+   * when the FQN does not correspond to a known exported type. This lets
+   * callers that only need to test for existence (e.g. {@link #isVisibleType})
+   * avoid the cost of throwing and catching exceptions on the hot path.
+   */
+  #tryTypeInfoForFqn(fqn: spec.FQN): spec.Type | undefined {
     // Check cache first for O(1) lookup
     const cached = this.#typeCache.get(fqn);
     if (cached) {
       return cached;
     }
 
-    const components = fqn.split('.');
-    const moduleName = components[0];
+    const moduleName = fqn.split('.')[0];
 
     const assembly = this.#assemblies.get(moduleName);
     if (!assembly) {
-      throw new JsiiFault(`Module '${moduleName}' not found`);
+      return undefined;
     }
 
     const types = assembly.metadata.types ?? {};
     const fqnInfo = types[fqn];
     if (!fqnInfo) {
-      throw new JsiiFault(`Type '${fqn}' not found`);
+      return undefined;
     }
 
     // Cache for subsequent lookups (callers must not mutate returned objects)
@@ -1154,15 +1180,7 @@ export class Kernel {
    * @returns `true` IIF the FQN corresponds to a know exported type.
    */
   #isVisibleType(fqn: spec.FQN): boolean {
-    try {
-      /* ignored */ this.#typeInfoForFqn(fqn);
-      return true;
-    } catch (e) {
-      if (e instanceof JsiiFault) {
-        return false;
-      }
-      throw e;
-    }
+    return this.#tryTypeInfoForFqn(fqn) !== undefined;
   }
 
   #typeInfoForMethod(
@@ -1309,7 +1327,7 @@ export class Kernel {
   #toSandbox(
     v: any,
     expectedType: wire.OptionalValueOrVoid,
-    context: string,
+    context: string | (() => string),
   ): any {
     return wire.process(
       this.#serializerHost,
@@ -1323,7 +1341,7 @@ export class Kernel {
   #fromSandbox(
     v: any,
     targetType: wire.OptionalValueOrVoid,
-    context: string,
+    context: string | (() => string),
   ): any {
     return wire.process(
       this.#serializerHost,
@@ -1336,7 +1354,7 @@ export class Kernel {
 
   #toSandboxValues(
     xs: readonly unknown[],
-    methodContext: string,
+    methodContext: string | (() => string),
     parameters: readonly spec.Parameter[] | undefined,
   ) {
     return this.#boxUnboxParameters(
@@ -1349,7 +1367,7 @@ export class Kernel {
 
   #fromSandboxValues(
     xs: readonly unknown[],
-    methodContext: string,
+    methodContext: string | (() => string),
     parameters: readonly spec.Parameter[] | undefined,
   ) {
     return this.#boxUnboxParameters(
@@ -1362,9 +1380,13 @@ export class Kernel {
 
   #boxUnboxParameters(
     xs: readonly unknown[],
-    methodContext: string,
+    methodContext: string | (() => string),
     parameters: readonly spec.Parameter[] = [],
-    boxUnbox: (x: any, t: wire.OptionalValueOrVoid, context: string) => any,
+    boxUnbox: (
+      x: any,
+      t: wire.OptionalValueOrVoid,
+      context: string | (() => string),
+    ) => any,
   ) {
     const parametersCopy = [...parameters];
     const variadic =
@@ -1401,7 +1423,12 @@ export class Kernel {
       boxUnbox(
         x,
         parametersCopy[i],
-        `passed to parameter ${parametersCopy[i].name} of ${methodContext}`,
+        () =>
+          `passed to parameter ${parametersCopy[i].name} of ${
+            typeof methodContext === 'function'
+              ? methodContext()
+              : methodContext
+          }`,
       ),
     );
   }
@@ -1430,7 +1457,7 @@ export class Kernel {
    * Ensures that `fn` is called and defends against beginning to invoke
    * async methods until fn finishes (successfully or not).
    */
-  #ensureSync<T>(desc: string, fn: () => T): T {
+  #ensureSync<T>(desc: string | (() => string), fn: () => T): T {
     this.#syncInProgress = desc;
     try {
       return fn();

--- a/packages/@jsii/kernel/src/serialization.ts
+++ b/packages/@jsii/kernel/src/serialization.ts
@@ -279,7 +279,8 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           toMap,
           { type: { primitive: spec.PrimitiveType.Json } },
-          typeof key === 'string' ? `key ${inspect(key)}` : `index ${key}`,
+          () =>
+            typeof key === 'string' ? `key ${inspect(key)}` : `index ${key}`,
         );
       }
     },
@@ -354,7 +355,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'serialize',
           x,
           { type: arrayType.collection.elementtype },
-          `index ${inspect(idx)}`,
+          () => `index ${inspect(idx)}`,
         ),
       );
     },
@@ -376,7 +377,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
           'deserialize',
           x,
           { type: arrayType.collection.elementtype },
-          `index ${inspect(idx)}`,
+          () => `index ${inspect(idx)}`,
         ),
       );
     },
@@ -400,7 +401,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
               'serialize',
               v,
               { type: mapType.collection.elementtype },
-              `key ${inspect(key)}`,
+              () => `key ${inspect(key)}`,
             ),
           host,
         ),
@@ -431,7 +432,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
                 optional: allowNullishMapValue,
                 type: mapType.collection.elementtype,
               },
-              `key ${inspect(key)}`,
+              () => `key ${inspect(key)}`,
             ),
           host,
         );
@@ -447,7 +448,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
               optional: allowNullishMapValue,
               type: mapType.collection.elementtype,
             },
-            `key ${inspect(key)}`,
+            () => `key ${inspect(key)}`,
           ),
         host,
       );
@@ -572,7 +573,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'deserialize',
             v,
             props[key],
-            `key ${inspect(key)}`,
+            () => `key ${inspect(key)}`,
           );
         },
         host,
@@ -674,7 +675,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'serialize',
             e,
             { type: spec.CANONICAL_ANY },
-            `index ${inspect(idx)}`,
+            () => `index ${inspect(idx)}`,
           ),
         );
       }
@@ -758,7 +759,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'serialize',
             v,
             { type: spec.CANONICAL_ANY },
-            `key ${inspect(key)}`,
+            () => `key ${inspect(key)}`,
           ),
         host,
       );
@@ -785,7 +786,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'deserialize',
             e,
             { type: spec.CANONICAL_ANY },
-            `index ${inspect(idx)}`,
+            () => `index ${inspect(idx)}`,
           ),
         );
       }
@@ -836,7 +837,7 @@ export const SERIALIZERS: { [k: string]: Serializer } = {
             'deserialize',
             v,
             { type: spec.CANONICAL_ANY },
-            `key ${inspect(key)}`,
+            () => `key ${inspect(key)}`,
           ),
         host,
       );
@@ -888,6 +889,30 @@ export interface TypeSerialization {
  * There can be multiple, because the type can be a type union.
  */
 export function serializationType(
+  typeRef: OptionalValueOrVoid,
+  lookup: LookupType,
+): TypeSerialization[] {
+  // The serialization shape of a given declared type is stable, and the type
+  // references coming from assembly metadata (method parameters, property and
+  // return types) are long-lived objects. Cache by object identity so we don't
+  // recompute (and re-allocate) the wire-type array on every (de)serialization.
+  // `void` is a string sentinel and inline type references are short-lived, so
+  // those simply don't benefit (the WeakMap reclaims throwaway keys).
+  if (typeRef !== VOID && typeRef != null) {
+    const cached = SERIALIZATION_TYPE_CACHE.get(typeRef);
+    if (cached) {
+      return cached;
+    }
+    const computed = computeSerializationType(typeRef, lookup);
+    SERIALIZATION_TYPE_CACHE.set(typeRef, computed);
+    return computed;
+  }
+  return computeSerializationType(typeRef, lookup);
+}
+
+const SERIALIZATION_TYPE_CACHE = new WeakMap<object, TypeSerialization[]>();
+
+function computeSerializationType(
   typeRef: OptionalValueOrVoid,
   lookup: LookupType,
 ): TypeSerialization[] {
@@ -1183,12 +1208,14 @@ export function process(
   serde: keyof Serializer,
   value: unknown,
   type: OptionalValueOrVoid,
-  context: string,
+  context: string | (() => string),
 ) {
   const wireTypes = serializationType(type, host.lookupType);
   host.debug(serde, value, ...wireTypes);
 
-  const errors = new Array<any>();
+  // Allocated lazily: on the (common) success path the first serializer
+  // returns and we never create this array.
+  let errors: any[] | undefined;
   for (const { serializationClass, typeRef } of wireTypes) {
     try {
       return SERIALIZERS[serializationClass][serde](value, typeRef, host);
@@ -1196,7 +1223,7 @@ export function process(
       error.context = `as ${
         typeRef === VOID ? VOID : spec.describeTypeReference(typeRef.type)
       }`;
-      errors.push(error);
+      (errors ??= []).push(error);
     }
   }
 
@@ -1204,11 +1231,14 @@ export function process(
     type === VOID ? type : spec.describeTypeReference(type.type);
   const optionalTypeDescr =
     type !== VOID && type.optional ? `${typeDescr} | undefined` : typeDescr;
+  // `context` is only consumed to render this error, so callers may pass a
+  // thunk to avoid building the string on the (common) success path.
+  const contextStr = typeof context === 'function' ? context() : context;
   throw new SerializationError(
-    `${titleize(context)}: Unable to ${serde} value as ${optionalTypeDescr}`,
+    `${titleize(contextStr)}: Unable to ${serde} value as ${optionalTypeDescr}`,
     value,
     host,
-    errors,
+    errors ?? [],
     { renderValue: true },
   );
 


### PR DESCRIPTION
This speeds up the jsii kernel by removing per-message work that only matters when an operation fails. Replaying the recorded protocol stream of a large (~2200 resource) CDK synthesis shows kernel CPU time down ~16% and wall-clock time down ~11%. End-to-end synth gains are smaller, since the rest of a synth is dominated by one-time assembly loading and the construct library's own code.

<img width="646" height="215" alt="image" src="https://github.com/user-attachments/assets/b9611113-1b40-4e82-87a2-eb9ce81ca4db" />

_Benchmark runs against an app with 1000 constructs_

The kernel did a fixed amount of bookkeeping on every protocol message—every property get/set, method call, object creation, and serialized value—and much of it produced information only consumed on failure. This change defers that work to the error path instead of the happy path.

The change is behaviour preserving. Kernel snapshot tests assert exact error and fault message text and pass unchanged, confirming the deferred context produces identical output when an error does occur.

## Technical details

- **Lazy error context:** Error context (descriptive strings, plus `util.inspect` on every array index, map key, and struct key in the serializer) is now threaded as a thunk that is only materialized when an error is thrown, instead of being eagerly built and discarded on success.
- **Lazy errors array:** `process()` no longer allocates an errors array for every value; it allocates lazily, so the common case where the first candidate serializer succeeds avoids the allocation.
- **Memoized wire types:** `serializationType()` recomputed and re-allocated the wire types for a declared type on every (de)serialization. Since assembly type references are immutable once loaded, the result is now memoized by reference identity.
- **Non-throwing visibility check:** `isVisibleType()` used a throwing `typeInfoForFqn()` inside `try`/`catch`; it now uses a non-throwing lookup so a routine visibility check no longer drives control flow through the exception machinery.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
