### PR TITLE
perf(kernel): ~15% faster loading of cached assemblies

### DIFF
--- a/packages/@jsii/kernel/src/tar-cache/index.ts
+++ b/packages/@jsii/kernel/src/tar-cache/index.ts
@@ -1,5 +1,8 @@
-import { mkdirSync, rmSync } from 'fs';
+import { SPEC_FILE_NAME, isAssemblyRedirect } from '@jsii/spec';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import * as tar from 'tar';
+import { gunzipSync } from 'zlib';
 
 import { DiskCache } from '../disk-cache';
 import { link } from '../link';
@@ -75,11 +78,48 @@ function extractViaCache(
       cwd: path,
       file,
     });
+    // Resolve a (gzipped) assembly redirect once, at cache-population time, so
+    // that every subsequent load of this cached package reads the assembly
+    // directly instead of paying decompression on each load.
+    inlineAssemblyRedirect(path);
   });
 
   link(path, outDir);
 
   return { cache };
+}
+
+/**
+ * If the freshly-extracted package's assembly file ({@link SPEC_FILE_NAME}) is
+ * a redirect to a (possibly compressed) file, resolve it in place: replace the
+ * redirect with the decompressed assembly contents. This is done once, while
+ * populating the cache, so that loading a cached package never has to gunzip
+ * the assembly again.
+ *
+ * Any failure here is non-fatal: the redirect is left untouched and the
+ * assembly loader resolves it as usual.
+ */
+function inlineAssemblyRedirect(dir: string): void {
+  const specPath = join(dir, SPEC_FILE_NAME);
+
+  let contents: unknown;
+  try {
+    contents = JSON.parse(readFileSync(specPath, 'utf-8'));
+  } catch {
+    return;
+  }
+
+  if (!isAssemblyRedirect(contents)) {
+    return;
+  }
+
+  try {
+    const raw = readFileSync(join(dir, contents.filename));
+    const resolved = contents.compression === 'gzip' ? gunzipSync(raw) : raw;
+    writeFileSync(specPath, resolved);
+  } catch {
+    // Leave the redirect in place; the loader will handle it.
+  }
 }
 
 /**

--- a/packages/@jsii/kernel/src/tar-cache/inline-redirect.test.ts
+++ b/packages/@jsii/kernel/src/tar-cache/inline-redirect.test.ts
@@ -1,0 +1,86 @@
+import { SPEC_FILE_NAME, isAssemblyRedirect } from '@jsii/spec';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as tar from 'tar';
+import { gzipSync } from 'zlib';
+
+import {
+  extract,
+  getPackageCacheEnabled,
+  setPackageCacheEnabled,
+} from './index';
+
+describe('extract resolves assembly redirects while populating the cache', () => {
+  let workdir: string;
+  let previousCacheRoot: string | undefined;
+  let previousCacheEnabled: boolean;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'jsii-tar-cache-test-'));
+    previousCacheRoot = process.env.JSII_RUNTIME_PACKAGE_CACHE_ROOT;
+    process.env.JSII_RUNTIME_PACKAGE_CACHE_ROOT = join(workdir, 'cache');
+    previousCacheEnabled = getPackageCacheEnabled();
+    setPackageCacheEnabled(true);
+  });
+
+  afterEach(() => {
+    setPackageCacheEnabled(previousCacheEnabled);
+    if (previousCacheRoot == null) {
+      delete process.env.JSII_RUNTIME_PACKAGE_CACHE_ROOT;
+    } else {
+      process.env.JSII_RUNTIME_PACKAGE_CACHE_ROOT = previousCacheRoot;
+    }
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  test('a gzip assembly redirect is decompressed in place so loads read it directly', () => {
+    const assembly = {
+      schema: 'jsii/0.10.0',
+      name: 'test-pkg',
+      version: '1.0.0',
+      types: {},
+      marker: 'decompressed-content',
+    };
+
+    // Build a package whose `.jsii` is a gzip redirect to a `.jsii.gz` file,
+    // mirroring how large assemblies (e.g. aws-cdk-lib) are published.
+    const sourceRoot = join(workdir, 'src');
+    const packageDir = join(sourceRoot, 'package');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, `${SPEC_FILE_NAME}.gz`),
+      gzipSync(Buffer.from(JSON.stringify(assembly))),
+    );
+    writeFileSync(
+      join(packageDir, SPEC_FILE_NAME),
+      JSON.stringify({
+        schema: 'jsii/file-redirect',
+        compression: 'gzip',
+        filename: `${SPEC_FILE_NAME}.gz`,
+      }),
+    );
+
+    const tarball = join(workdir, 'pkg.tgz');
+    tar.create({ file: tarball, cwd: sourceRoot, sync: true, gzip: true }, [
+      'package',
+    ]);
+
+    const outDir = join(workdir, 'out');
+    extract(tarball, outDir, { strict: true, strip: 1 }, 'test-pkg', '1.0.0');
+
+    // The assembly file in the (cached) extraction must now be the resolved
+    // assembly itself, not a redirect -- so loading never has to decompress it.
+    const contents = JSON.parse(
+      readFileSync(join(outDir, SPEC_FILE_NAME), 'utf-8'),
+    );
+    expect(isAssemblyRedirect(contents)).toBe(false);
+    expect(contents).toEqual(assembly);
+  });
+});


### PR DESCRIPTION
Loading assemblies is part of the fixed startup cost paid by every jsii host, and for large libraries such as aws-cdk-lib it is a significant share of a CDK synthesis. With a warm package cache, this change makes that loading roughly 15% faster, so every synth spends less time before it does any real work.

## Benchmark

<!-- Replace this with a hyperfine screenshot comparing this branch against main, with a warm package cache. -->

_TODO: hyperfine screenshot (before vs after, warm cache)._

## Technical details

Large assemblies publish their `.jsii` as a small redirect to a gzip-compressed file. Previously the kernel read that redirect and decompressed the target on every load, including when the package was already present in the on-disk cache. Because the decompressed assembly is identical for a given cached package, the redirect is now resolved once, while the cache entry is being populated, by replacing the redirect with the decompressed assembly contents. Subsequent loads read the assembly directly and never decompress it again. Resolving the redirect is best-effort: on any failure the redirect is left in place and the assembly loader handles it exactly as before.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
