### PR TITLE
fix: sibling module dependencies are eagerly loaded even if only for type annotations

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -25,6 +25,7 @@ import {
   toTypeName,
   PythonImports,
   mergePythonImports,
+  hasImports,
   toPackageName,
   toPythonFqn,
   IntersectionTypesRegistry,
@@ -1777,6 +1778,15 @@ class PythonModule implements PythonType {
     // Before we write anything else, we need to write out our module headers, this
     // is where we handle stuff like imports, any required initialization, etc.
 
+    // Emit PEP 563 (from __future__ import annotations) if this module has
+    // cross-module imports. This makes all annotations strings at definition
+    // time, preventing lazy proxy resolution during module load.
+    // Must be the first statement in the file (after docstring) per Python rules.
+    if (hasImports(this.requiredImports(context))) {
+      code.line('from __future__ import annotations');
+      code.line();
+    }
+
     // If multiple packages use the same namespace (in Python, a directory) it
     // depends on how they are laid out on disk if deep imports of multiple packages
     // will succeed. `pip` merges all packages into the same directory, and deep
@@ -2114,6 +2124,67 @@ class PythonModule implements PythonType {
   }
 
   /**
+   * Emit the `_LazyImport` helper class that defers `importlib.import_module()`
+   * until first attribute access via `__getattr__`.
+   *
+   * The class is emitted once per module that has cross-module imports. It wraps
+   * a module name string and caches the imported module after first access.
+   * Failed imports are NOT cached, allowing retry on subsequent access.
+   */
+  private emitLazyImportClass(code: CodeMaker) {
+    code.line();
+    code.openBlock('class _LazyImport');
+    // __init__
+    code.openBlock('def __init__(self, module_name: str) -> None');
+    code.line('self._module_name = module_name');
+    code.line('self._module: typing.Any = None');
+    code.closeBlock();
+    // __getattr__
+    code.openBlock('def __getattr__(self, name: str) -> typing.Any');
+    code.openBlock('if self._module is None');
+    code.line('import importlib');
+    code.line('self._module = importlib.import_module(self._module_name)');
+    code.closeBlock();
+    code.line('return getattr(self._module, name)');
+    code.closeBlock();
+    code.closeBlock();
+  }
+
+  /**
+   * Emit `_LazyImport(...)` assignments for all cross-module imports.
+   *
+   * Only processes entries where the items set contains '' (empty string),
+   * indicating a full module import. Parses the sourcePackage string which
+   * has the format "module.name as _alias" to extract the module name and alias.
+   * Sorts assignments by alias for deterministic output.
+   */
+  private emitLazyProxyAssignments(code: CodeMaker, imports: PythonImports) {
+    const assignments = Object.entries(imports)
+      .filter(([, items]) => items.has('')) // Only full module imports (empty string = import the whole module)
+      .map(([sourcePackage]) => {
+        // sourcePackage is like "aws_cdk.aws_iam as _aws_cdk_aws_iam_abcd1234"
+        const match = sourcePackage.match(/^(.+)\s+as\s+(.+)$/);
+        if (match) {
+          const [, moduleName, alias] = match;
+          return { moduleName, alias };
+        }
+        // Fallback: no alias
+        return {
+          moduleName: sourcePackage,
+          alias: `_${sourcePackage.replace(/\./g, '_')}`,
+        };
+      })
+      .sort((a, b) => a.alias.localeCompare(b.alias));
+
+    if (assignments.length > 0) {
+      code.line();
+      for (const { moduleName, alias } of assignments) {
+        code.line(`${alias} = _LazyImport("${moduleName}")`);
+      }
+    }
+  }
+
+  /**
    * Emit a mapping from submodule FQNs to their Python module paths.
    *
    * This allows the Python runtime to deterministically resolve a jsii FQN
@@ -2142,8 +2213,28 @@ class PythonModule implements PythonType {
   }
 
   private emitRequiredImports(code: CodeMaker, context: EmitContext) {
-    const requiredImports = this.requiredImports(context);
-    const statements = Object.entries(requiredImports)
+    const allImports = this.requiredImports(context);
+    if (!hasImports(allImports)) {
+      return;
+    }
+
+    // Emit _LazyImport class definition
+    this.emitLazyImportClass(code);
+
+    // Emit TYPE_CHECKING block with original import statements for static type checkers,
+    // and lazy proxy assignments in the else branch for runtime.
+    // This structure ensures pyright/mypy see the real module types while runtime uses lazy proxies.
+    code.line();
+    code.openBlock('if typing.TYPE_CHECKING');
+    this.emitImportStatements(code, allImports);
+    code.closeBlock();
+    code.openBlock('else');
+    this.emitLazyProxyAssignments(code, allImports);
+    code.closeBlock();
+  }
+
+  private emitImportStatements(code: CodeMaker, imports: PythonImports) {
+    const statements = Object.entries(imports)
       .map(([sourcePackage, items]) => toImportStatements(sourcePackage, items))
       .reduce(
         (acc, elt) => [...acc, ...elt],

--- a/packages/jsii-pacmak/lib/targets/python/type-name.ts
+++ b/packages/jsii-pacmak/lib/targets/python/type-name.ts
@@ -152,6 +152,13 @@ export function mergePythonImports(
   return result;
 }
 
+/**
+ * Check if a PythonImports object has any entries.
+ */
+export function hasImports(imports: PythonImports): boolean {
+  return Object.keys(imports).length > 0;
+}
+
 function isOptionalValue(
   type: OptionalValue | TypeReference,
 ): type is OptionalValue {
@@ -398,20 +405,18 @@ class UserType implements TypeName {
         .split('.');
       const aliasSuffix = createHash('sha256')
         .update(typeSubmodulePythonName)
-        .update('.')
-        .update(toImport)
+        .update('.*')
         .digest('hex')
         .substring(0, 8);
-      const alias = `_${toImport}_${aliasSuffix}`;
+      const moduleAlias = `_${lastComponent(typeSubmodulePythonName)}_${aliasSuffix}`;
 
       return {
-        pythonType: wrapType([alias, ...nested].join('.')),
+        pythonType: wrapType(
+          `${moduleAlias}.${toImport}${nested.length > 0 ? `.${nested.join('.')}` : ''}`,
+        ),
         requiredImport: {
-          sourcePackage: relativeImportPath(
-            submodulePythonName,
-            typeSubmodulePythonName,
-          ),
-          item: `${toImport} as ${alias}`,
+          sourcePackage: `${typeSubmodulePythonName} as ${moduleAlias}`,
+          item: '',
         },
       };
 
@@ -488,7 +493,7 @@ export function toPythonFqn(fqn: string, rootAssm: Assembly) {
  *  relativeImportPath('A.B.C', 'A.B')     === '..';
  *  relativeImportPath('A.B', 'A.B.C')     === '.C';
  */
-function relativeImportPath(fromPkg: string, toPkg: string): string {
+export function relativeImportPath(fromPkg: string, toPkg: string): string {
   if (toPkg.startsWith(fromPkg)) {
     // from A.B to A.B.C === .C
     return `.${toPkg.substring(fromPkg.length + 1)}`;

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -324,6 +324,8 @@ exports[`Generated code for "@scope/jsii-calc-base": <outDir>/python/src/scope/j
 r'''
 # @scope/jsii-calc-base
 '''
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -342,7 +344,22 @@ from jsii._type_checking import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+else:
+
+    _scope_jsii_calc_base_of_base_49fa37fe = _LazyImport("scope.jsii_calc_base_of_base")
 
 
 class Base(metaclass=jsii.JSIIAbstractClass, jsii_type="@scope/jsii-calc-base.Base"):
@@ -516,7 +533,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/ 
 exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/python/src/scope/jsii_calc_base/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_base/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_base/__init__.py	--runtime-type-checking
-@@ -57,10 +57,14 @@
+@@ -74,10 +74,14 @@
      ) -> None:
          '''
          :param foo: -
@@ -531,7 +548,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
              "bar": bar,
          }
  
-@@ -124,10 +128,13 @@
+@@ -141,10 +145,13 @@
      @builtins.classmethod
      def consume(cls, *args: typing.Any) -> None:
          '''
@@ -545,7 +562,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
  
  __all__ = [
      "Base",
-@@ -136,7 +143,21 @@
+@@ -153,7 +160,21 @@
      "StaticConsumer",
  ]
  
@@ -1439,6 +1456,8 @@ exports[`Generated code for "@scope/jsii-calc-lib": <outDir>/python/src/scope/js
 r'''
 # @scope/jsii-calc-lib
 '''
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -1458,8 +1477,24 @@ from jsii._type_checking import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_base_of_base_49fa37fe = _LazyImport("scope.jsii_calc_base_of_base")
 
 
 class BaseFor2647(
@@ -2520,7 +2555,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/ 1
 exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/python/src/scope/jsii_calc_lib/__init__.py.diff 1`] = `
 --- python/src/scope/jsii_calc_lib/__init__.py	--no-runtime-type-checking
 +++ python/src/scope/jsii_calc_lib/__init__.py	--runtime-type-checking
-@@ -42,19 +42,25 @@
+@@ -60,19 +60,25 @@
          '''
          :param very: -
  
@@ -2546,7 +2581,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
  @jsii.data_type(
      jsii_type="@scope/jsii-calc-lib.DiamondLeft",
-@@ -72,10 +78,14 @@
+@@ -90,10 +96,14 @@
          :param hoisted_top: 
          :param left: 
  
@@ -2561,7 +2596,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -124,10 +134,14 @@
+@@ -142,10 +152,14 @@
          :param hoisted_top: 
          :param right: 
  
@@ -2576,7 +2611,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["hoisted_top"] = hoisted_top
          if right is not None:
              self._values["right"] = right
-@@ -199,10 +213,13 @@
+@@ -217,10 +231,13 @@
          '''
          :param _: -
  
@@ -2590,7 +2625,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
  @jsii.interface(jsii_type="@scope/jsii-calc-lib.IDoublable")
  class IDoublable(typing_extensions.Protocol):
-@@ -350,10 +367,15 @@
+@@ -368,10 +385,15 @@
          :param astring: (deprecated) A string value.
          :param first_optional: 
  
@@ -2606,7 +2641,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              "astring": astring,
          }
          if first_optional is not None:
-@@ -510,10 +532,15 @@
+@@ -528,10 +550,15 @@
          :param optional2: 
          :param optional3: 
  
@@ -2622,7 +2657,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
              self._values["optional1"] = optional1
          if optional2 is not None:
              self._values["optional2"] = optional2
-@@ -573,10 +600,13 @@
+@@ -591,10 +618,13 @@
  
          :param value: The number.
  
@@ -2636,7 +2671,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
      @builtins.property
      @jsii.member(jsii_name="doubleValue")
      def double_value(self) -> jsii.Number:
-@@ -639,7 +669,65 @@
+@@ -657,7 +687,65 @@
  
  import sys as _sys
  setattr(_sys.modules[__name__], "__getattr__", __getattr__)
@@ -3310,6 +3345,8 @@ calculator.add(10)
 foo = "bar"
 \`\`\`
 '''
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -3329,11 +3366,30 @@ from jsii._type_checking import check_type
 
 from ._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
-import scope.jsii_calc_lib.custom_submodule_name as _scope_jsii_calc_lib_custom_submodule_name_c61f082f
-from .composition import CompositeOperation as _CompositeOperation_1c4d123b
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.composition as _composition_4f38e801
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+    import scope.jsii_calc_lib.custom_submodule_name as _scope_jsii_calc_lib_custom_submodule_name_c61f082f
+else:
+
+    _composition_4f38e801 = _LazyImport("jsii_calc.composition")
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_base_of_base_49fa37fe = _LazyImport("scope.jsii_calc_base_of_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
+    _scope_jsii_calc_lib_custom_submodule_name_c61f082f = _LazyImport("scope.jsii_calc_lib.custom_submodule_name")
 
 
 class AbstractClassBase(
@@ -3931,7 +3987,7 @@ typing.cast(typing.Any, BurriedAnonymousObject).__jsii_proxy_class__ = lambda : 
 
 
 class Calculator(
-    _CompositeOperation_1c4d123b,
+    _composition_4f38e801.CompositeOperation,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Calculator",
 ):
@@ -9344,7 +9400,7 @@ class Polymorphism(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Polymorphism"):
 
 
 class Power(
-    _CompositeOperation_1c4d123b,
+    _composition_4f38e801.CompositeOperation,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Power",
 ):
@@ -10653,7 +10709,7 @@ class StructWithJavaReservedWords:
 
 
 class Sum(
-    _CompositeOperation_1c4d123b,
+    _composition_4f38e801.CompositeOperation,
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.Sum",
 ):
@@ -12472,6 +12528,8 @@ for cls in [IOptionA, IOptionB]:
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/cdk16625/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -12491,7 +12549,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-from .. import IRandomNumberGenerator as _IRandomNumberGenerator_9643a8b9
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc as _jsii_calc_e856c20f
+else:
+
+    _jsii_calc_e856c20f = _LazyImport("jsii_calc")
 
 
 class Cdk16625(
@@ -12508,7 +12581,7 @@ class Cdk16625(
 
     @jsii.member(jsii_name="unwrap")
     @abc.abstractmethod
-    def _unwrap(self, gen: "_IRandomNumberGenerator_9643a8b9") -> jsii.Number:
+    def _unwrap(self, gen: "_jsii_calc_e856c20f.IRandomNumberGenerator") -> jsii.Number:
         '''Implement this functin to return \`\`gen.next()\`\`. It is extremely important that the \`\`donotimport\`\` submodule is NEVER explicitly loaded in the testing application (otherwise this test is void).
 
         :param gen: a VERY pseudo random number generator.
@@ -12518,7 +12591,7 @@ class Cdk16625(
 
 class _Cdk16625Proxy(Cdk16625):
     @jsii.member(jsii_name="unwrap")
-    def _unwrap(self, gen: "_IRandomNumberGenerator_9643a8b9") -> jsii.Number:
+    def _unwrap(self, gen: "_jsii_calc_e856c20f.IRandomNumberGenerator") -> jsii.Number:
         '''Implement this functin to return \`\`gen.next()\`\`. It is extremely important that the \`\`donotimport\`\` submodule is NEVER explicitly loaded in the testing application (otherwise this test is void).
 
         :param gen: a VERY pseudo random number generator.
@@ -12562,6 +12635,8 @@ setattr(_sys.modules[__name__], "__dir__", __dir__)
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/cdk16625/donotimport/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -12580,10 +12655,25 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from ... import IRandomNumberGenerator as _IRandomNumberGenerator_9643a8b9
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc as _jsii_calc_e856c20f
+else:
+
+    _jsii_calc_e856c20f = _LazyImport("jsii_calc")
 
 
-@jsii.implements(_IRandomNumberGenerator_9643a8b9)
+@jsii.implements(_jsii_calc_e856c20f.IRandomNumberGenerator)
 class UnimportedSubmoduleType(
     metaclass=jsii.JSIIMeta,
     jsii_type="jsii-calc.cdk16625.donotimport.UnimportedSubmoduleType",
@@ -12693,6 +12783,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/composition/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -12711,7 +12803,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class CompositeOperation(
@@ -13567,6 +13674,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/intersection/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -13585,7 +13694,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class ConsumesIntersection(
@@ -13810,6 +13934,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/jsii4894/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -13828,7 +13954,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib.custom_submodule_name as _scope_jsii_calc_lib_custom_submodule_name_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_lib.custom_submodule_name as _scope_jsii_calc_lib_custom_submodule_name_c61f082f
+else:
+
+    _scope_jsii_calc_lib_custom_submodule_name_c61f082f = _LazyImport("scope.jsii_calc_lib.custom_submodule_name")
 
 
 class NonPascalCaseTest(
@@ -14023,6 +14164,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2647/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14041,8 +14184,24 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base_of_base as _scope_jsii_calc_base_of_base_49fa37fe
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_base_of_base_49fa37fe = _LazyImport("scope.jsii_calc_base_of_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 @jsii.implements(_scope_jsii_calc_lib_c61f082f.IFriendly)
@@ -14143,6 +14302,8 @@ setattr(_sys.modules[__name__], "__dir__", __dir__)
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2689/methods/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14161,8 +14322,24 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class MyClass(
@@ -14202,6 +14379,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2689/props/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14220,8 +14399,24 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.props.MyClass"):
@@ -14250,6 +14445,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2689/retval/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14268,8 +14465,24 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.module2689.retval.MyClass"):
@@ -14296,6 +14509,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2689/structs/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14314,8 +14529,24 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 @jsii.data_type(
@@ -14488,6 +14719,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2692/submodule2/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14506,7 +14739,22 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from ..submodule1 import Bar as _Bar_ec7eccad
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.module2692.submodule1 as _submodule1_382c143d
+else:
+
+    _submodule1_382c143d = _LazyImport("jsii_calc.module2692.submodule1")
 
 
 @jsii.data_type(
@@ -14543,10 +14791,10 @@ class Bar:
 
 @jsii.data_type(
     jsii_type="jsii-calc.module2692.submodule2.Foo",
-    jsii_struct_bases=[Bar, _Bar_ec7eccad],
+    jsii_struct_bases=[Bar, _submodule1_382c143d.Bar],
     name_mapping={"bar2": "bar2", "bar1": "bar1", "foo2": "foo2"},
 )
-class Foo(Bar, _Bar_ec7eccad):
+class Foo(Bar, _submodule1_382c143d.Bar):
     def __init__(
         self,
         *,
@@ -14691,6 +14939,8 @@ for cls in [IFoo]:
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/module2702/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -14709,7 +14959,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_base as _scope_jsii_calc_base_734f0262
+else:
+
+    _scope_jsii_calc_base_734f0262 = _LazyImport("scope.jsii_calc_base")
 
 
 class Class1(
@@ -15311,6 +15576,8 @@ r'''
 
 This is the readme of the \`jsii-calc.submodule\` module.
 '''
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -15330,15 +15597,28 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-from .. import AllTypes as _AllTypes_b08307c5
-from .child import (
-    Awesomeness as _Awesomeness_d37a24df,
-    Goodness as _Goodness_2df26737,
-    SomeEnum as _SomeEnum_b2e41d92,
-    SomeStruct as _SomeStruct_91627123,
-)
-from .nested_submodule.deeply_nested import INamespaced as _INamespaced_e2f386ad
-from .param import SpecialParameter as _SpecialParameter_5bbf34a2
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc as _jsii_calc_e856c20f
+    import jsii_calc.submodule.child as _child_05c7385e
+    import jsii_calc.submodule.nested_submodule.deeply_nested as _deeply_nested_66202a01
+    import jsii_calc.submodule.param as _param_532223cc
+else:
+
+    _child_05c7385e = _LazyImport("jsii_calc.submodule.child")
+    _deeply_nested_66202a01 = _LazyImport("jsii_calc.submodule.nested_submodule.deeply_nested")
+    _jsii_calc_e856c20f = _LazyImport("jsii_calc")
+    _param_532223cc = _LazyImport("jsii_calc.submodule.param")
 
 
 @jsii.data_type(
@@ -15376,13 +15656,13 @@ class Default:
         )
 
 
-@jsii.implements(_INamespaced_e2f386ad)
+@jsii.implements(_deeply_nested_66202a01.INamespaced)
 class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.MyClass"):
-    def __init__(self, *, prop: "_SomeEnum_b2e41d92") -> None:
+    def __init__(self, *, prop: "_child_05c7385e.SomeEnum") -> None:
         '''
         :param prop: 
         '''
-        props = _SomeStruct_91627123(prop=prop)
+        props = _child_05c7385e.SomeStruct(prop=prop)
 
         jsii.create(self.__class__, self, [props])
 
@@ -15391,14 +15671,14 @@ class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.MyClass"):
         '''
         :param value: 
         '''
-        param = _SpecialParameter_5bbf34a2(value=value)
+        param = _param_532223cc.SpecialParameter(value=value)
 
         return typing.cast(builtins.str, jsii.invoke(self, "methodWithSpecialParam", [param]))
 
     @builtins.property
     @jsii.member(jsii_name="awesomeness")
-    def awesomeness(self) -> "_Awesomeness_d37a24df":
-        return typing.cast("_Awesomeness_d37a24df", jsii.get(self, "awesomeness"))
+    def awesomeness(self) -> "_child_05c7385e.Awesomeness":
+        return typing.cast("_child_05c7385e.Awesomeness", jsii.get(self, "awesomeness"))
 
     @builtins.property
     @jsii.member(jsii_name="definedAt")
@@ -15407,21 +15687,21 @@ class MyClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.MyClass"):
 
     @builtins.property
     @jsii.member(jsii_name="goodness")
-    def goodness(self) -> "_Goodness_2df26737":
-        return typing.cast("_Goodness_2df26737", jsii.get(self, "goodness"))
+    def goodness(self) -> "_child_05c7385e.Goodness":
+        return typing.cast("_child_05c7385e.Goodness", jsii.get(self, "goodness"))
 
     @builtins.property
     @jsii.member(jsii_name="props")
-    def props(self) -> "_SomeStruct_91627123":
-        return typing.cast("_SomeStruct_91627123", jsii.get(self, "props"))
+    def props(self) -> "_child_05c7385e.SomeStruct":
+        return typing.cast("_child_05c7385e.SomeStruct", jsii.get(self, "props"))
 
     @builtins.property
     @jsii.member(jsii_name="allTypes")
-    def all_types(self) -> typing.Optional["_AllTypes_b08307c5"]:
-        return typing.cast(typing.Optional["_AllTypes_b08307c5"], jsii.get(self, "allTypes"))
+    def all_types(self) -> typing.Optional["_jsii_calc_e856c20f.AllTypes"]:
+        return typing.cast(typing.Optional["_jsii_calc_e856c20f.AllTypes"], jsii.get(self, "allTypes"))
 
     @all_types.setter
-    def all_types(self, value: typing.Optional["_AllTypes_b08307c5"]) -> None:
+    def all_types(self, value: typing.Optional["_jsii_calc_e856c20f.AllTypes"]) -> None:
         jsii.set(self, "allTypes", value) # pyright: ignore[reportArgumentType]
 
 
@@ -15474,6 +15754,8 @@ setattr(_sys.modules[__name__], "__dir__", __dir__)
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/submodule/back_references/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -15492,7 +15774,22 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from .. import MyClass as _MyClass_a2fdc0b6
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.submodule as _submodule_f946ba2c
+else:
+
+    _submodule_f946ba2c = _LazyImport("jsii_calc.submodule")
 
 
 @jsii.data_type(
@@ -15501,7 +15798,7 @@ from .. import MyClass as _MyClass_a2fdc0b6
     name_mapping={"reference": "reference"},
 )
 class MyClassReference:
-    def __init__(self, *, reference: "_MyClass_a2fdc0b6") -> None:
+    def __init__(self, *, reference: "_submodule_f946ba2c.MyClass") -> None:
         '''
         :param reference: 
         '''
@@ -15510,10 +15807,10 @@ class MyClassReference:
         }
 
     @builtins.property
-    def reference(self) -> "_MyClass_a2fdc0b6":
+    def reference(self) -> "_submodule_f946ba2c.MyClass":
         result = self._values.get("reference")
         assert result is not None, "Required property 'reference' is missing"
-        return typing.cast("_MyClass_a2fdc0b6", result)
+        return typing.cast("_submodule_f946ba2c.MyClass", result)
 
     def __eq__(self, rhs: typing.Any) -> builtins.bool:
         return isinstance(rhs, self.__class__) and rhs._values == self._values
@@ -15737,6 +16034,8 @@ r'''
 
 This is the readme of the \`jsii-calc.submodule.isolated\` module.
 '''
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -15755,9 +16054,22 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from ..child import (
-    KwargsProps as _KwargsProps_c7855dcf, SomeEnum as _SomeEnum_b2e41d92
-)
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.submodule.child as _child_05c7385e
+else:
+
+    _child_05c7385e = _LazyImport("jsii_calc.submodule.child")
 
 
 class Kwargs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.isolated.Kwargs"):
@@ -15769,13 +16081,13 @@ class Kwargs(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.submodule.isolated.Kw
         cls,
         *,
         extra: typing.Optional[builtins.str] = None,
-        prop: "_SomeEnum_b2e41d92",
+        prop: "_child_05c7385e.SomeEnum",
     ) -> builtins.bool:
         '''
         :param extra: 
         :param prop: 
         '''
-        props = _KwargsProps_c7855dcf(extra=extra, prop=prop)
+        props = _child_05c7385e.KwargsProps(extra=extra, prop=prop)
 
         return typing.cast(builtins.bool, jsii.sinvoke(cls, "method", [props]))
 
@@ -15789,6 +16101,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/submodule/nested_submodule/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -15808,11 +16122,27 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from ..child import Goodness as _Goodness_2df26737
-from .deeply_nested import INamespaced as _INamespaced_e2f386ad
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.submodule.child as _child_05c7385e
+    import jsii_calc.submodule.nested_submodule.deeply_nested as _deeply_nested_66202a01
+else:
+
+    _child_05c7385e = _LazyImport("jsii_calc.submodule.child")
+    _deeply_nested_66202a01 = _LazyImport("jsii_calc.submodule.nested_submodule.deeply_nested")
 
 
-@jsii.implements(_INamespaced_e2f386ad)
+@jsii.implements(_deeply_nested_66202a01.INamespaced)
 class Namespaced(
     metaclass=jsii.JSIIAbstractClass,
     jsii_type="jsii-calc.submodule.nested_submodule.Namespaced",
@@ -15825,15 +16155,15 @@ class Namespaced(
     @builtins.property
     @jsii.member(jsii_name="goodness")
     @abc.abstractmethod
-    def goodness(self) -> "_Goodness_2df26737":
+    def goodness(self) -> "_child_05c7385e.Goodness":
         ...
 
 
 class _NamespacedProxy(Namespaced):
     @builtins.property
     @jsii.member(jsii_name="goodness")
-    def goodness(self) -> "_Goodness_2df26737":
-        return typing.cast("_Goodness_2df26737", jsii.get(self, "goodness"))
+    def goodness(self) -> "_child_05c7385e.Goodness":
+        return typing.cast("_child_05c7385e.Goodness", jsii.get(self, "goodness"))
 
 # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
 typing.cast(typing.Any, Namespaced).__jsii_proxy_class__ = lambda : _NamespacedProxy
@@ -15985,6 +16315,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/submodule/returnsparam/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -16003,7 +16335,22 @@ from jsii._type_checking import check_type
 
 from ..._jsii import *
 
-from ..param import SpecialParameter as _SpecialParameter_5bbf34a2
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import jsii_calc.submodule.param as _param_532223cc
+else:
+
+    _param_532223cc = _LazyImport("jsii_calc.submodule.param")
 
 
 class ReturnsSpecialParameter(
@@ -16014,8 +16361,8 @@ class ReturnsSpecialParameter(
         jsii.create(self.__class__, self, [])
 
     @jsii.member(jsii_name="returnsSpecialParam")
-    def returns_special_param(self) -> "_SpecialParameter_5bbf34a2":
-        return typing.cast("_SpecialParameter_5bbf34a2", jsii.invoke(self, "returnsSpecialParam", []))
+    def returns_special_param(self) -> "_param_532223cc.SpecialParameter":
+        return typing.cast("_param_532223cc.SpecialParameter", jsii.invoke(self, "returnsSpecialParam", []))
 
 
 __all__ = [
@@ -16027,6 +16374,8 @@ publication.publish()
 `;
 
 exports[`Generated code for "jsii-calc": <outDir>/python/src/jsii_calc/union/__init__.py 1`] = `
+from __future__ import annotations
+
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
@@ -16045,7 +16394,22 @@ from jsii._type_checking import check_type
 
 from .._jsii import *
 
-import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+class _LazyImport:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = module_name
+        self._module: typing.Any = None
+    def __getattr__(self, name: str) -> typing.Any:
+        if self._module is None:
+            import importlib
+            self._module = importlib.import_module(self._module_name)
+        return getattr(self._module, name)
+
+if typing.TYPE_CHECKING:
+
+    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
+else:
+
+    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
 
 
 class ConsumesUnion(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.union.ConsumesUnion"):
@@ -16166,7 +16530,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/ 1`] = `
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/__init__.py	--runtime-type-checking
-@@ -116,10 +116,13 @@
+@@ -137,10 +137,13 @@
      def work_it_all(self, seed: builtins.str) -> builtins.str:
          '''Sets \`\`seed\`\` to \`\`this.property\`\`, then calls \`\`someMethod\`\` with \`\`this.property\`\` and returns the result.
  
@@ -16180,7 +16544,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="property")
      @abc.abstractmethod
-@@ -136,19 +139,25 @@
+@@ -157,19 +160,25 @@
      @jsii.member(jsii_name="someMethod")
      def _some_method(self, str: builtins.str) -> builtins.str:
          '''
@@ -16206,7 +16570,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractSuite).__jsii_proxy_class__ = lambda : _AbstractSuiteProxy
  
-@@ -166,10 +175,13 @@
+@@ -187,10 +196,13 @@
      @jsii.member(jsii_name="anyIn")
      def any_in(self, inp: typing.Any) -> None:
          '''
@@ -16220,7 +16584,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="anyOut")
      def any_out(self) -> typing.Any:
          return typing.cast(typing.Any, jsii.invoke(self, "anyOut", []))
-@@ -177,10 +189,13 @@
+@@ -198,10 +210,13 @@
      @jsii.member(jsii_name="enumMethod")
      def enum_method(self, value: "StringEnum") -> "StringEnum":
          '''
@@ -16234,7 +16598,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="enumPropertyValue")
      def enum_property_value(self) -> jsii.Number:
-@@ -191,73 +206,97 @@
+@@ -212,73 +227,97 @@
      def any_array_property(self) -> typing.List[typing.Any]:
          return typing.cast(typing.List[typing.Any], jsii.get(self, "anyArrayProperty"))
  
@@ -16332,7 +16696,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="mapProperty")
      def map_property(
-@@ -268,28 +307,37 @@
+@@ -289,28 +328,37 @@
      @map_property.setter
      def map_property(
          self,
@@ -16370,7 +16734,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionArrayProperty")
      def union_array_property(
-@@ -300,10 +348,13 @@
+@@ -321,10 +369,13 @@
      @union_array_property.setter
      def union_array_property(
          self,
@@ -16384,7 +16748,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionMapProperty")
      def union_map_property(
-@@ -314,10 +365,13 @@
+@@ -335,10 +386,13 @@
      @union_map_property.setter
      def union_map_property(
          self,
@@ -16398,7 +16762,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -328,19 +382,25 @@
+@@ -349,19 +403,25 @@
      @union_property.setter
      def union_property(
          self,
@@ -16424,7 +16788,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unknownMapProperty")
      def unknown_map_property(self) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -349,28 +409,37 @@
+@@ -370,28 +430,37 @@
      @unknown_map_property.setter
      def unknown_map_property(
          self,
@@ -16462,7 +16826,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.AllTypesEnum")
  class AllTypesEnum(enum.Enum):
-@@ -390,36 +459,52 @@
+@@ -411,36 +480,52 @@
      def get_bar(self, _p1: builtins.str, _p2: jsii.Number) -> None:
          '''
          :param _p1: -
@@ -16515,7 +16879,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class AmbiguousParameters(
      metaclass=jsii.JSIIMeta,
-@@ -435,10 +520,13 @@
+@@ -456,10 +541,13 @@
          '''
          :param scope_: -
          :param scope: 
@@ -16529,7 +16893,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [scope_, props_])
  
      @builtins.property
-@@ -470,10 +558,16 @@
+@@ -491,10 +579,16 @@
          :param obj: the receiver object.
          :param prop_a: the first property to read.
          :param prop_b: the second property to read.
@@ -16546,7 +16910,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class AsyncVirtualMethods(
      metaclass=jsii.JSIIMeta,
-@@ -508,10 +602,13 @@
+@@ -529,10 +623,13 @@
      @jsii.member(jsii_name="overrideMe")
      def override_me(self, mult: jsii.Number) -> jsii.Number:
          '''
@@ -16560,7 +16924,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="overrideMeToo")
      def override_me_too(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeToo", []))
-@@ -572,10 +669,14 @@
+@@ -593,10 +690,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -16575,7 +16939,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
-@@ -636,10 +737,13 @@
+@@ -657,10 +758,13 @@
  
          :param value: the value that should be returned.
  
@@ -16589,7 +16953,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, BurriedAnonymousObject).__jsii_proxy_class__ = lambda : _BurriedAnonymousObjectProxy
  
-@@ -687,18 +791,24 @@
+@@ -708,18 +812,24 @@
      def add(self, value: jsii.Number) -> None:
          '''Adds a number to the current value.
  
@@ -16614,7 +16978,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="neg")
      def neg(self) -> None:
          '''Negates the current value.'''
-@@ -708,10 +818,13 @@
+@@ -729,10 +839,13 @@
      def pow(self, value: jsii.Number) -> None:
          '''Raises the current value by a power.
  
@@ -16628,7 +16992,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readUnionValue")
      def read_union_value(self) -> jsii.Number:
          '''Returns teh value of the union property (if defined).'''
-@@ -745,20 +858,26 @@
+@@ -766,20 +879,26 @@
          '''The current value.'''
          return typing.cast("_scope_jsii_calc_lib_c61f082f.NumericValue", jsii.get(self, "curr"))
  
@@ -16655,7 +17019,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -770,10 +889,13 @@
+@@ -791,10 +910,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -16669,7 +17033,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.CalculatorProps",
-@@ -790,10 +912,14 @@
+@@ -811,10 +933,14 @@
          '''Properties for Calculator.
  
          :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
@@ -16684,7 +17048,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["initial_value"] = initial_value
          if maximum_value is not None:
              self._values["maximum_value"] = maximum_value
-@@ -894,10 +1020,13 @@
+@@ -915,10 +1041,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -16698,7 +17062,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticMethodWithMapOfUnionsParam")
      @builtins.classmethod
      def static_method_with_map_of_unions_param(
-@@ -905,20 +1034,26 @@
+@@ -926,20 +1055,26 @@
          param: typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]],
      ) -> None:
          '''
@@ -16725,7 +17089,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -929,10 +1064,13 @@
+@@ -950,10 +1085,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -16739,7 +17103,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithCollections(
      metaclass=jsii.JSIIMeta,
-@@ -945,10 +1083,14 @@
+@@ -966,10 +1104,14 @@
      ) -> None:
          '''
          :param map: -
@@ -16754,7 +17118,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="createAList")
      @builtins.classmethod
      def create_a_list(cls) -> typing.List[builtins.str]:
-@@ -964,37 +1106,49 @@
+@@ -985,37 +1127,49 @@
      def static_array(cls) -> typing.List[builtins.str]:  # pyright: ignore [reportGeneralTypeIssues,reportRedeclaration]
          return typing.cast(typing.List[builtins.str], jsii.sget(cls, "staticArray"))
  
@@ -16804,7 +17168,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithContainerTypes(
      metaclass=jsii.JSIIMeta,
-@@ -1016,10 +1170,15 @@
+@@ -1037,10 +1191,15 @@
          :param obj: -
          :param array_prop: 
          :param obj_prop: 
@@ -16820,7 +17184,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          jsii.create(self.__class__, self, [array, record, obj, props])
-@@ -1069,17 +1228,23 @@
+@@ -1090,17 +1249,23 @@
  ):
      def __init__(self, int: builtins.str) -> None:
          '''
@@ -16844,7 +17208,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="int")
      def int(self) -> builtins.str:
-@@ -1098,10 +1263,13 @@
+@@ -1119,10 +1284,13 @@
      def mutable_object(self) -> "IMutableObjectLiteral":
          return typing.cast("IMutableObjectLiteral", jsii.get(self, "mutableObject"))
  
@@ -16858,7 +17222,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ClassWithNestedUnion(
      metaclass=jsii.JSIIMeta,
-@@ -1112,10 +1280,13 @@
+@@ -1133,10 +1301,13 @@
          union_property: typing.Sequence[typing.Union[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]], typing.Sequence[typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]]]],
      ) -> None:
          '''
@@ -16872,7 +17236,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="unionProperty")
      def union_property(
-@@ -1126,10 +1297,13 @@
+@@ -1147,10 +1318,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -16886,7 +17250,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ConfusingToJackson(
      metaclass=jsii.JSIIMeta,
-@@ -1160,10 +1334,13 @@
+@@ -1181,10 +1355,13 @@
      @union_property.setter
      def union_property(
          self,
@@ -16900,7 +17264,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ConfusingToJacksonStruct",
-@@ -1177,10 +1354,13 @@
+@@ -1198,10 +1375,13 @@
          union_property: typing.Optional[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", typing.Sequence[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", "AbstractClass"]]]] = None,
      ) -> None:
          '''
@@ -16914,7 +17278,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["union_property"] = union_property
  
      @builtins.property
-@@ -1208,10 +1388,13 @@
+@@ -1229,10 +1409,13 @@
  ):
      def __init__(self, consumer: "PartiallyInitializedThisConsumer") -> None:
          '''
@@ -16928,7 +17292,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Constructors(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Constructors"):
      def __init__(self) -> None:
-@@ -1259,10 +1442,13 @@
+@@ -1280,10 +1463,13 @@
  ):
      def __init__(self, delegate: "IStructReturningDelegate") -> None:
          '''
@@ -16942,7 +17306,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="workItBaby")
      def work_it_baby(self) -> "StructB":
          return typing.cast("StructB", jsii.invoke(self, "workItBaby", []))
-@@ -1291,10 +1477,13 @@
+@@ -1312,10 +1498,13 @@
  
          Returns whether the bell was rung.
  
@@ -16956,7 +17320,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticImplementedByPrivateClass")
      @builtins.classmethod
      def static_implemented_by_private_class(
-@@ -1305,10 +1494,13 @@
+@@ -1326,10 +1515,13 @@
  
          Return whether the bell was rung.
  
@@ -16970,7 +17334,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticImplementedByPublicClass")
      @builtins.classmethod
      def static_implemented_by_public_class(cls, ringer: "IBellRinger") -> builtins.bool:
-@@ -1316,10 +1508,13 @@
+@@ -1337,10 +1529,13 @@
  
          Return whether the bell was rung.
  
@@ -16984,7 +17348,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="staticWhenTypedAsClass")
      @builtins.classmethod
      def static_when_typed_as_class(cls, ringer: "IConcreteBellRinger") -> builtins.bool:
-@@ -1327,50 +1522,65 @@
+@@ -1348,50 +1543,65 @@
  
          Return whether the bell was rung.
  
@@ -17050,7 +17414,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ConsumersOfThisCrazyTypeSystem(
      metaclass=jsii.JSIIMeta,
-@@ -1385,20 +1595,26 @@
+@@ -1406,20 +1616,26 @@
          obj: "IAnotherPublicInterface",
      ) -> builtins.str:
          '''
@@ -17077,7 +17441,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ContainerProps",
-@@ -1420,10 +1636,15 @@
+@@ -1441,10 +1657,15 @@
          '''
          :param array_prop: 
          :param obj_prop: 
@@ -17093,7 +17457,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "obj_prop": obj_prop,
              "record_prop": record_prop,
          }
-@@ -1489,17 +1710,23 @@
+@@ -1510,17 +1731,23 @@
          data: typing.Mapping[builtins.str, typing.Any],
      ) -> builtins.str:
          '''
@@ -17117,7 +17481,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Default(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Default"):
      '''A class named "Default".
-@@ -1528,10 +1755,15 @@
+@@ -1549,10 +1776,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -17133,7 +17497,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -1589,10 +1821,14 @@
+@@ -1610,10 +1842,14 @@
  
          :deprecated: this constructor is "just" okay
  
@@ -17148,7 +17512,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -1622,10 +1858,13 @@
+@@ -1643,10 +1879,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17162,7 +17526,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.DeprecatedEnum")
  class DeprecatedEnum(enum.Enum):
-@@ -1661,10 +1900,13 @@
+@@ -1682,10 +1921,13 @@
  
          :deprecated: it just wraps a string
  
@@ -17176,7 +17540,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -1729,10 +1971,21 @@
+@@ -1750,10 +1992,21 @@
          :param non_primitive: An example of a non primitive property.
          :param another_optional: This is optional.
          :param optional_any: 
@@ -17198,7 +17562,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "astring": astring,
              "another_required": another_required,
              "bool": bool,
-@@ -1853,10 +2106,16 @@
+@@ -1874,10 +2127,16 @@
          :param hoisted_top: 
          :param left: 
          :param right: 
@@ -17215,7 +17579,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["hoisted_top"] = hoisted_top
          if left is not None:
              self._values["left"] = left
-@@ -1914,10 +2173,13 @@
+@@ -1935,10 +2194,13 @@
  class DiamondInheritanceBaseLevelStruct:
      def __init__(self, *, base_level_property: builtins.str) -> None:
          '''
@@ -17229,7 +17593,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -1955,10 +2217,14 @@
+@@ -1976,10 +2238,14 @@
      ) -> None:
          '''
          :param base_level_property: 
@@ -17244,7 +17608,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
          }
  
-@@ -2003,10 +2269,14 @@
+@@ -2024,10 +2290,14 @@
      ) -> None:
          '''
          :param base_level_property: 
@@ -17259,7 +17623,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_mid_level_property": second_mid_level_property,
          }
  
-@@ -2062,10 +2332,16 @@
+@@ -2083,10 +2353,16 @@
          :param base_level_property: 
          :param first_mid_level_property: 
          :param second_mid_level_property: 
@@ -17276,7 +17640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "first_mid_level_property": first_mid_level_property,
              "second_mid_level_property": second_mid_level_property,
              "top_level_property": top_level_property,
-@@ -2145,10 +2421,13 @@
+@@ -2166,10 +2442,13 @@
      @jsii.member(jsii_name="changePrivatePropertyValue")
      def change_private_property_value(self, new_value: builtins.str) -> None:
          '''
@@ -17290,7 +17654,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="privateMethodValue")
      def private_method_value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "privateMethodValue", []))
-@@ -2177,10 +2456,15 @@
+@@ -2198,10 +2477,15 @@
          '''
          :param _required_any: -
          :param _optional_any: -
@@ -17306,7 +17670,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DocumentedClass(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.DocumentedClass"):
      '''Here's the first line of the TSDoc comment.
-@@ -2252,10 +2536,14 @@
+@@ -2273,10 +2557,14 @@
      ) -> builtins.str:
          '''
          :param optional: -
@@ -17321,7 +17685,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.DontUseMe",
-@@ -2268,10 +2556,13 @@
+@@ -2289,10 +2577,13 @@
  
     Don't use this interface An interface that shouldn't be used, with the annotation in a weird place.
  
@@ -17335,7 +17699,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["dont_set_me"] = dont_set_me
  
      @builtins.property
-@@ -2305,10 +2596,13 @@
+@@ -2326,10 +2617,13 @@
  class DummyObj:
      def __init__(self, *, example: builtins.str) -> None:
          '''
@@ -17349,7 +17713,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2337,28 +2631,37 @@
+@@ -2358,28 +2652,37 @@
  
      def __init__(self, value_store: builtins.str) -> None:
          '''
@@ -17387,7 +17751,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class DynamicPropertyBearerChild(
      DynamicPropertyBearer,
-@@ -2367,20 +2670,26 @@
+@@ -2388,20 +2691,26 @@
  ):
      def __init__(self, original_value: builtins.str) -> None:
          '''
@@ -17414,7 +17778,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="originalValue")
      def original_value(self) -> builtins.str:
-@@ -2393,10 +2702,13 @@
+@@ -2414,10 +2723,13 @@
      def __init__(self, clock: "IWallClock") -> None:
          '''Creates a new instance of Entropy.
  
@@ -17428,7 +17792,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="increase")
      def increase(self) -> builtins.str:
          '''Increases entropy by consuming time from the clock (yes, this is a long shot, please don't judge).
-@@ -2424,10 +2736,13 @@
+@@ -2445,10 +2757,13 @@
  
          :param word: the value to return.
  
@@ -17442,7 +17806,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Entropy).__jsii_proxy_class__ = lambda : _EntropyProxy
  
-@@ -2464,10 +2779,14 @@
+@@ -2485,10 +2800,14 @@
          are being erased when sending values from native code to JS.
  
          :param opts: -
@@ -17457,7 +17821,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="prop1IsNull")
      @builtins.classmethod
      def prop1_is_null(cls) -> typing.Mapping[builtins.str, typing.Any]:
-@@ -2495,10 +2814,14 @@
+@@ -2516,10 +2835,14 @@
      ) -> None:
          '''
          :param option1: 
@@ -17472,7 +17836,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["option1"] = option1
          if option2 is not None:
              self._values["option2"] = option2
-@@ -2542,10 +2865,14 @@
+@@ -2563,10 +2886,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -17487,7 +17851,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2569,10 +2896,13 @@
+@@ -2590,10 +2917,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17501,7 +17865,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExperimentalEnum")
  class ExperimentalEnum(enum.Enum):
-@@ -2600,10 +2930,13 @@
+@@ -2621,10 +2951,13 @@
          '''
          :param readonly_property: 
  
@@ -17515,7 +17879,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2633,10 +2966,13 @@
+@@ -2654,10 +2987,13 @@
  ):
      def __init__(self, success: builtins.bool) -> None:
          '''
@@ -17529,7 +17893,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -2652,10 +2988,14 @@
+@@ -2673,10 +3009,14 @@
      def __init__(self, *, boom: builtins.bool, prop: builtins.str) -> None:
          '''
          :param boom: 
@@ -17544,7 +17908,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "prop": prop,
          }
  
-@@ -2697,10 +3037,14 @@
+@@ -2718,10 +3058,14 @@
          :param readonly_string: -
          :param mutable_number: -
  
@@ -17559,7 +17923,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -2724,10 +3068,13 @@
+@@ -2745,10 +3089,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17573,7 +17937,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.ExternalEnum")
  class ExternalEnum(enum.Enum):
-@@ -2755,10 +3102,13 @@
+@@ -2776,10 +3123,13 @@
          '''
          :param readonly_property: 
  
@@ -17587,7 +17951,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -2901,10 +3251,13 @@
+@@ -2922,10 +3272,13 @@
      def __init__(self, *, name: typing.Optional[builtins.str] = None) -> None:
          '''These are some arguments you can pass to a method.
  
@@ -17601,7 +17965,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["name"] = name
  
      @builtins.property
-@@ -2941,10 +3294,13 @@
+@@ -2962,10 +3315,13 @@
          friendly: "_scope_jsii_calc_lib_c61f082f.IFriendly",
      ) -> builtins.str:
          '''
@@ -17615,7 +17979,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class HostStackTraceReader(
      metaclass=jsii.JSIIMeta,
-@@ -3049,10 +3405,13 @@
+@@ -3070,10 +3426,13 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -17629,7 +17993,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IAnotherPublicInterface).__jsii_proxy_class__ = lambda : _IAnotherPublicInterfaceProxy
  
-@@ -3095,10 +3454,13 @@
+@@ -3116,10 +3475,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "IBell") -> None:
          '''
@@ -17643,7 +18007,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IBellRinger).__jsii_proxy_class__ = lambda : _IBellRingerProxy
  
-@@ -3123,10 +3485,13 @@
+@@ -3144,10 +3506,13 @@
      @jsii.member(jsii_name="yourTurn")
      def your_turn(self, bell: "Bell") -> None:
          '''
@@ -17657,7 +18021,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IConcreteBellRinger).__jsii_proxy_class__ = lambda : _IConcreteBellRingerProxy
  
-@@ -3182,10 +3547,13 @@
+@@ -3203,10 +3568,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17671,7 +18035,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3240,10 +3608,13 @@
+@@ -3261,10 +3629,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17685,7 +18049,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3285,10 +3656,13 @@
+@@ -3306,10 +3677,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -17699,7 +18063,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IExtendsPrivateInterface).__jsii_proxy_class__ = lambda : _IExtendsPrivateInterfaceProxy
  
-@@ -3334,10 +3708,13 @@
+@@ -3355,10 +3729,13 @@
          '''
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17713,7 +18077,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          '''
-@@ -3519,10 +3896,14 @@
+@@ -3540,10 +3917,14 @@
      ) -> None:
          '''
          :param arg1: -
@@ -17728,7 +18092,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithOptionalMethodArguments).__jsii_proxy_class__ = lambda : _IInterfaceWithOptionalMethodArgumentsProxy
  
-@@ -3557,10 +3938,13 @@
+@@ -3578,10 +3959,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -17742,7 +18106,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithProperties).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesProxy
  
-@@ -3590,10 +3974,13 @@
+@@ -3611,10 +3995,13 @@
      def foo(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "foo"))
  
@@ -17756,7 +18120,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IInterfaceWithPropertiesExtension).__jsii_proxy_class__ = lambda : _IInterfaceWithPropertiesExtensionProxy
  
-@@ -4113,10 +4500,13 @@
+@@ -4134,10 +4521,13 @@
      def value(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "value"))
  
@@ -17770,7 +18134,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, IMutableObjectLiteral).__jsii_proxy_class__ = lambda : _IMutableObjectLiteralProxy
  
-@@ -4152,19 +4542,25 @@
+@@ -4173,19 +4563,25 @@
      def b(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "b"))
  
@@ -17796,7 +18160,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the interface
  typing.cast(typing.Any, INonInternalInterface).__jsii_proxy_class__ = lambda : _INonInternalInterfaceProxy
  
-@@ -4197,10 +4593,13 @@
+@@ -4218,10 +4614,13 @@
      def property(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "property"))
  
@@ -17810,7 +18174,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="wasSet")
      def was_set(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.invoke(self, "wasSet", []))
-@@ -4393,10 +4792,13 @@
+@@ -4414,10 +4813,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -17824,7 +18188,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -4497,10 +4899,13 @@
+@@ -4518,10 +4920,13 @@
      def prop(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "prop"))
  
@@ -17838,7 +18202,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Implementation(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Implementation"):
      def __init__(self) -> None:
-@@ -4546,10 +4951,13 @@
+@@ -4567,10 +4972,13 @@
      def private(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "private"))
  
@@ -17852,7 +18216,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ImplictBaseOfBase",
-@@ -4567,10 +4975,15 @@
+@@ -4588,10 +4996,15 @@
          '''
          :param foo: -
          :param bar: -
@@ -17868,7 +18232,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
              "goo": goo,
          }
-@@ -4645,10 +5058,13 @@
+@@ -4666,10 +5079,13 @@
          count: jsii.Number,
      ) -> typing.List["_scope_jsii_calc_lib_c61f082f.IDoublable"]:
          '''
@@ -17882,7 +18246,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class Isomorphism(metaclass=jsii.JSIIAbstractClass, jsii_type="jsii-calc.Isomorphism"):
      '''Checks the "same instance" isomorphism is preserved within the constructor.
-@@ -4753,19 +5169,25 @@
+@@ -4774,19 +5190,25 @@
      def prop_a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "propA"))
  
@@ -17908,7 +18272,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class JavaReservedWords(
      metaclass=jsii.JSIIMeta,
-@@ -4987,10 +5409,13 @@
+@@ -5008,10 +5430,13 @@
      def while_(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "while"))
  
@@ -17922,7 +18286,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IJsii487External2, IJsii487External)
  class Jsii487Derived(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Jsii487Derived"):
-@@ -5092,10 +5517,13 @@
+@@ -5113,10 +5538,13 @@
      @builtins.classmethod
      def stringify(cls, value: typing.Any = None) -> typing.Optional[builtins.str]:
          '''
@@ -17936,7 +18300,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class LevelOne(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.LevelOne"):
      '''Validates that nested classes get correct code generation for the occasional forward reference.'''
-@@ -5125,10 +5553,13 @@
+@@ -5146,10 +5574,13 @@
      class PropBooleanValue:
          def __init__(self, *, value: builtins.bool) -> None:
              '''
@@ -17950,7 +18314,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5162,10 +5593,13 @@
+@@ -5183,10 +5614,13 @@
              '''
              :param prop: 
              '''
@@ -17964,7 +18328,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -5200,10 +5634,13 @@
+@@ -5221,10 +5655,13 @@
          '''
          :param prop: 
          '''
@@ -17978,7 +18342,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5251,10 +5688,17 @@
+@@ -5272,10 +5709,17 @@
          :param cpu: The number of cpu units used by the task. Valid values, which determines your range of valid values for the memory parameter: 256 (.25 vCPU) - Available memory values: 0.5GB, 1GB, 2GB 512 (.5 vCPU) - Available memory values: 1GB, 2GB, 3GB, 4GB 1024 (1 vCPU) - Available memory values: 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB 2048 (2 vCPU) - Available memory values: Between 4GB and 16GB in 1GB increments 4096 (4 vCPU) - Available memory values: Between 8GB and 30GB in 1GB increments This default is set in the underlying FargateTaskDefinition construct. Default: 256
          :param memory_mib: The amount (in MiB) of memory used by the task. This field is required and you must use one of the following values, which determines your range of valid values for the cpu parameter: 0.5GB, 1GB, 2GB - Available cpu values: 256 (.25 vCPU) 1GB, 2GB, 3GB, 4GB - Available cpu values: 512 (.5 vCPU) 2GB, 3GB, 4GB, 5GB, 6GB, 7GB, 8GB - Available cpu values: 1024 (1 vCPU) Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU) Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU) This default is set in the underlying FargateTaskDefinition construct. Default: 512
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
@@ -17996,7 +18360,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["container_port"] = container_port
          if cpu is not None:
              self._values["cpu"] = cpu
-@@ -5381,10 +5825,14 @@
+@@ -5402,10 +5846,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -18011,7 +18375,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -5432,10 +5880,13 @@
+@@ -5453,10 +5901,13 @@
  class NestedStruct:
      def __init__(self, *, number_prop: jsii.Number) -> None:
          '''
@@ -18025,7 +18389,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -5506,17 +5957,24 @@
+@@ -5527,17 +5978,24 @@
      def __init__(self, _param1: builtins.str, optional: typing.Any = None) -> None:
          '''
          :param _param1: -
@@ -18050,7 +18414,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="giveMeUndefinedInsideAnObject")
      def give_me_undefined_inside_an_object(
          self,
-@@ -5544,10 +6002,13 @@
+@@ -5565,10 +6023,13 @@
      def change_me_to_undefined(self) -> typing.Optional[builtins.str]:
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "changeMeToUndefined"))
  
@@ -18064,7 +18428,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.NullShouldBeTreatedAsUndefinedData",
-@@ -5566,10 +6027,14 @@
+@@ -5587,10 +6048,14 @@
      ) -> None:
          '''
          :param array_with_three_elements_and_undefined_as_second_argument: 
@@ -18079,7 +18443,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if this_should_be_undefined is not None:
              self._values["this_should_be_undefined"] = this_should_be_undefined
-@@ -5604,17 +6069,23 @@
+@@ -5625,17 +6090,23 @@
  
      def __init__(self, generator: "IRandomNumberGenerator") -> None:
          '''
@@ -18103,7 +18467,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="nextTimes100")
      def next_times100(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "nextTimes100", []))
-@@ -5624,10 +6095,13 @@
+@@ -5645,10 +6116,13 @@
      def generator(self) -> "IRandomNumberGenerator":
          return typing.cast("IRandomNumberGenerator", jsii.get(self, "generator"))
  
@@ -18117,7 +18481,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectRefsInCollections(
      metaclass=jsii.JSIIMeta,
-@@ -5645,10 +6119,13 @@
+@@ -5666,10 +6140,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values.
  
@@ -18131,7 +18495,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="sumFromMap")
      def sum_from_map(
          self,
-@@ -5656,10 +6133,13 @@
+@@ -5677,10 +6154,13 @@
      ) -> jsii.Number:
          '''Returns the sum of all values in a map.
  
@@ -18145,7 +18509,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ObjectWithPropertyProvider(
      metaclass=jsii.JSIIMeta,
-@@ -5700,10 +6180,13 @@
+@@ -5721,10 +6201,13 @@
  ):
      def __init__(self, delegate: "IInterfaceWithOptionalMethodArguments") -> None:
          '''
@@ -18159,7 +18523,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="invokeWithOptional")
      def invoke_with_optional(self) -> None:
          return typing.cast(None, jsii.invoke(self, "invokeWithOptional", []))
-@@ -5726,10 +6209,15 @@
+@@ -5747,10 +6230,15 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -18175,7 +18539,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="arg1")
      def arg1(self) -> jsii.Number:
-@@ -5754,10 +6242,13 @@
+@@ -5775,10 +6263,13 @@
  class OptionalStruct:
      def __init__(self, *, field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -18189,7 +18553,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              self._values["field"] = field
  
      @builtins.property
-@@ -5833,10 +6324,13 @@
+@@ -5854,10 +6345,13 @@
      def _override_read_write(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "overrideReadWrite"))
  
@@ -18203,7 +18567,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class OverrideReturnsObject(
      metaclass=jsii.JSIIMeta,
-@@ -5848,10 +6342,13 @@
+@@ -5869,10 +6363,13 @@
      @jsii.member(jsii_name="test")
      def test(self, obj: "IReturnsNumber") -> jsii.Number:
          '''
@@ -18217,7 +18581,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ParamShadowsBuiltins(
      metaclass=jsii.JSIIMeta,
-@@ -5873,10 +6370,14 @@
+@@ -5894,10 +6391,14 @@
          :param str: should be set to something that is NOT a valid expression in Python (e.g: "\${NOPE}"").
          :param boolean_property: 
          :param string_property: 
@@ -18232,7 +18596,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              string_property=string_property,
              struct_property=struct_property,
          )
-@@ -5906,10 +6407,15 @@
+@@ -5927,10 +6428,15 @@
          :param string_property: 
          :param struct_property: 
          '''
@@ -18248,7 +18612,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "string_property": string_property,
              "struct_property": struct_property,
          }
-@@ -5962,10 +6468,13 @@
+@@ -5983,10 +6489,13 @@
          scope: "_scope_jsii_calc_lib_c61f082f.Number",
      ) -> "_scope_jsii_calc_lib_c61f082f.Number":
          '''
@@ -18262,7 +18626,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ParentStruct982",
-@@ -5976,10 +6485,13 @@
+@@ -5997,10 +6506,13 @@
      def __init__(self, *, foo: builtins.str) -> None:
          '''https://github.com/aws/jsii/issues/982.
  
@@ -18276,7 +18640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6034,10 +6546,15 @@
+@@ -6055,10 +6567,15 @@
          '''
          :param obj: -
          :param dt: -
@@ -18292,7 +18656,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, PartiallyInitializedThisConsumer).__jsii_proxy_class__ = lambda : _PartiallyInitializedThisConsumerProxy
  
-@@ -6052,10 +6569,13 @@
+@@ -6073,10 +6590,13 @@
          friendly: "_scope_jsii_calc_lib_c61f082f.IFriendly",
      ) -> builtins.str:
          '''
@@ -18305,8 +18669,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  
  class Power(
-     _CompositeOperation_1c4d123b,
-@@ -6072,10 +6592,14 @@
+     _composition_4f38e801.CompositeOperation,
+@@ -6093,10 +6613,14 @@
          '''Creates a Power operation.
  
          :param base: The base of the power.
@@ -18321,7 +18685,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="base")
      def base(self) -> "_scope_jsii_calc_lib_c61f082f.NumericValue":
-@@ -6298,10 +6822,13 @@
+@@ -6319,10 +6843,13 @@
          value: "_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule",
      ) -> None:
          '''
@@ -18335,7 +18699,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="foo")
      def foo(
-@@ -6312,10 +6839,13 @@
+@@ -6333,10 +6860,13 @@
      @foo.setter
      def foo(
          self,
@@ -18349,7 +18713,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class ReturnsPrivateImplementationOfInterface(
      metaclass=jsii.JSIIMeta,
-@@ -6357,10 +6887,14 @@
+@@ -6378,10 +6908,14 @@
          :param string_prop: May not be empty.
          :param nested_struct: 
          '''
@@ -18364,7 +18728,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if nested_struct is not None:
              self._values["nested_struct"] = nested_struct
-@@ -6427,17 +6961,25 @@
+@@ -6448,17 +6982,25 @@
          '''
          :param arg1: -
          :param arg2: -
@@ -18390,7 +18754,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="methodWithOptionalArguments")
      def method_with_optional_arguments(
          self,
-@@ -6449,10 +6991,15 @@
+@@ -6470,10 +7012,15 @@
  
          :param arg1: -
          :param arg2: -
@@ -18406,7 +18770,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SecondLevelStruct",
-@@ -6471,10 +7018,14 @@
+@@ -6492,10 +7039,14 @@
      ) -> None:
          '''
          :param deeper_required_prop: It's long and required.
@@ -18421,7 +18785,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if deeper_optional_prop is not None:
              self._values["deeper_optional_prop"] = deeper_optional_prop
-@@ -6536,10 +7087,13 @@
+@@ -6557,10 +7108,13 @@
      @jsii.member(jsii_name="isSingletonInt")
      def is_singleton_int(self, value: jsii.Number) -> builtins.bool:
          '''
@@ -18435,7 +18799,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonIntEnum")
  class SingletonIntEnum(enum.Enum):
-@@ -6558,10 +7112,13 @@
+@@ -6579,10 +7133,13 @@
      @jsii.member(jsii_name="isSingletonString")
      def is_singleton_string(self, value: builtins.str) -> builtins.bool:
          '''
@@ -18449,7 +18813,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.SingletonStringEnum")
  class SingletonStringEnum(enum.Enum):
-@@ -6585,10 +7142,14 @@
+@@ -6606,10 +7163,14 @@
      ) -> None:
          '''
          :param property: 
@@ -18464,7 +18828,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "yet_anoter_one": yet_anoter_one,
          }
  
-@@ -6642,10 +7203,13 @@
+@@ -6663,10 +7224,13 @@
      class ParentStruct:
          def __init__(self, *, field1: builtins.str) -> None:
              '''
@@ -18478,7 +18842,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              }
  
          @builtins.property
-@@ -6674,10 +7238,14 @@
+@@ -6695,10 +7259,14 @@
          def __init__(self, *, field1: builtins.str, field2: builtins.str) -> None:
              '''
              :param field1: 
@@ -18493,7 +18857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
                  "field2": field2,
              }
  
-@@ -6728,10 +7296,14 @@
+@@ -6749,10 +7317,14 @@
      ) -> None:
          '''
          :param readonly_string: -
@@ -18508,7 +18872,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="method")
      def method(self) -> None:
          return typing.cast(None, jsii.invoke(self, "method", []))
-@@ -6746,10 +7318,13 @@
+@@ -6767,10 +7339,13 @@
      def mutable_property(self) -> typing.Optional[jsii.Number]:
          return typing.cast(typing.Optional[jsii.Number], jsii.get(self, "mutableProperty"))
  
@@ -18522,7 +18886,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.enum(jsii_type="jsii-calc.StableEnum")
  class StableEnum(enum.Enum):
-@@ -6765,10 +7340,13 @@
+@@ -6786,10 +7361,13 @@
  class StableStruct:
      def __init__(self, *, readonly_property: builtins.str) -> None:
          '''
@@ -18536,7 +18900,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -6805,10 +7383,13 @@
+@@ -6826,10 +7404,13 @@
      def static_variable(cls) -> builtins.bool:  # pyright: ignore [reportGeneralTypeIssues,reportRedeclaration]
          return typing.cast(builtins.bool, jsii.sget(cls, "staticVariable"))
  
@@ -18550,7 +18914,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class StaticHelloParent(
      metaclass=jsii.JSIIMeta,
-@@ -6843,19 +7424,25 @@
+@@ -6864,19 +7445,25 @@
  class Statics(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.Statics"):
      def __init__(self, value: builtins.str) -> None:
          '''
@@ -18576,7 +18940,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justMethod")
      def just_method(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justMethod", []))
-@@ -6892,19 +7479,25 @@
+@@ -6913,19 +7500,25 @@
          '''
          return typing.cast("Statics", jsii.sget(cls, "instance"))
  
@@ -18602,7 +18966,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="value")
      def value(self) -> builtins.str:
-@@ -6960,10 +7553,13 @@
+@@ -6981,10 +7574,13 @@
      def you_see_me(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "youSeeMe"))
  
@@ -18616,7 +18980,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructA",
-@@ -6986,10 +7582,15 @@
+@@ -7007,10 +7603,15 @@
  
          :param required_string: 
          :param optional_number: 
@@ -18632,7 +18996,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_number is not None:
              self._values["optional_number"] = optional_number
-@@ -7047,10 +7648,15 @@
+@@ -7068,10 +7669,15 @@
          :param optional_boolean: 
          :param optional_struct_a: 
          '''
@@ -18648,7 +19012,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if optional_boolean is not None:
              self._values["optional_boolean"] = optional_boolean
-@@ -7102,10 +7708,14 @@
+@@ -7123,10 +7729,14 @@
          See: https://github.com/aws/aws-cdk/issues/4302
  
          :param scope: 
@@ -18663,7 +19027,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if props is not None:
              self._values["props"] = props
-@@ -7148,10 +7758,14 @@
+@@ -7169,10 +7779,14 @@
      ) -> jsii.Number:
          '''
          :param _positional: -
@@ -18678,7 +19042,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="roundTrip")
      @builtins.classmethod
      def round_trip(
-@@ -7166,10 +7780,13 @@
+@@ -7187,10 +7801,13 @@
          :param _positional: -
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -18692,7 +19056,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          )
  
          return typing.cast("TopLevelStruct", jsii.sinvoke(cls, "roundTrip", [_positional, input]))
-@@ -7186,10 +7803,13 @@
+@@ -7207,10 +7824,13 @@
          struct: typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -18706,7 +19070,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="isStructB")
      @builtins.classmethod
      def is_struct_b(
-@@ -7197,18 +7817,24 @@
+@@ -7218,18 +7838,24 @@
          struct: typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]],
      ) -> builtins.bool:
          '''
@@ -18731,7 +19095,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.StructWithCollectionOfUnionts",
-@@ -7222,10 +7848,13 @@
+@@ -7243,10 +7869,13 @@
          union_property: typing.Sequence[typing.Mapping[builtins.str, typing.Union[typing.Union["StructA", typing.Dict[builtins.str, typing.Any]], typing.Union["StructB", typing.Dict[builtins.str, typing.Any]]]]],
      ) -> None:
          '''
@@ -18745,7 +19109,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -7262,10 +7891,14 @@
+@@ -7283,10 +7912,14 @@
      ) -> None:
          '''
          :param foo: An enum value.
@@ -18760,7 +19124,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if bar is not None:
              self._values["bar"] = bar
-@@ -7321,10 +7954,16 @@
+@@ -7342,10 +7975,16 @@
          :param default: 
          :param assert_: 
          :param result: 
@@ -18777,7 +19141,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if assert_ is not None:
              self._values["assert_"] = assert_
-@@ -7394,10 +8033,13 @@
+@@ -7415,10 +8054,13 @@
      @parts.setter
      def parts(
          self,
@@ -18791,7 +19155,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.SupportsNiceJavaBuilderProps",
-@@ -7413,10 +8055,14 @@
+@@ -7434,10 +8076,14 @@
      ) -> None:
          '''
          :param bar: Some number, like 42.
@@ -18806,7 +19170,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if id is not None:
              self._values["id"] = id
-@@ -7465,10 +8111,13 @@
+@@ -7486,10 +8132,13 @@
          '''
          :param id_: some identifier of your choice.
          :param bar: Some number, like 42.
@@ -18820,7 +19184,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          jsii.create(self.__class__, self, [id_, props])
  
      @builtins.property
-@@ -7546,17 +8195,23 @@
+@@ -7567,17 +8216,23 @@
      @jsii.member(jsii_name="modifyOtherProperty")
      def modify_other_property(self, value: builtins.str) -> None:
          '''
@@ -18844,7 +19208,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="readA")
      def read_a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.invoke(self, "readA", []))
-@@ -7576,17 +8231,23 @@
+@@ -7597,17 +8252,23 @@
      @jsii.member(jsii_name="virtualMethod")
      def virtual_method(self, n: jsii.Number) -> jsii.Number:
          '''
@@ -18868,7 +19232,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readonlyProperty")
      def readonly_property(self) -> builtins.str:
-@@ -7597,46 +8258,61 @@
+@@ -7618,46 +8279,61 @@
      def a(self) -> jsii.Number:
          return typing.cast(jsii.Number, jsii.get(self, "a"))
  
@@ -18930,7 +19294,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class TestStructWithEnum(
      metaclass=jsii.JSIIMeta,
-@@ -7719,10 +8395,15 @@
+@@ -7740,10 +8416,15 @@
          '''
          :param required: This is a required field.
          :param second_level: A union to really stress test our serialization.
@@ -18946,7 +19310,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "second_level": second_level,
          }
          if optional is not None:
-@@ -7813,10 +8494,13 @@
+@@ -7834,10 +8515,13 @@
  
      def __init__(self, operand: "_scope_jsii_calc_lib_c61f082f.NumericValue") -> None:
          '''
@@ -18960,7 +19324,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="operand")
      def operand(self) -> "_scope_jsii_calc_lib_c61f082f.NumericValue":
-@@ -7847,10 +8531,14 @@
+@@ -7868,10 +8552,14 @@
      ) -> None:
          '''
          :param bar: 
@@ -18975,7 +19339,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
          if foo is not None:
              self._values["foo"] = foo
-@@ -7887,10 +8575,13 @@
+@@ -7908,10 +8596,13 @@
  
      def __init__(self, delegate: typing.Mapping[builtins.str, typing.Any]) -> None:
          '''
@@ -18989,7 +19353,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.python.classproperty
      @jsii.member(jsii_name="reflector")
      def REFLECTOR(
-@@ -7935,10 +8626,13 @@
+@@ -7956,10 +8647,13 @@
  ):
      def __init__(self, obj: "IInterfaceWithProperties") -> None:
          '''
@@ -19003,7 +19367,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="justRead")
      def just_read(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.invoke(self, "justRead", []))
-@@ -7949,17 +8643,23 @@
+@@ -7970,17 +8664,23 @@
          ext: "IInterfaceWithPropertiesExtension",
      ) -> builtins.str:
          '''
@@ -19027,7 +19391,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="obj")
      def obj(self) -> "IInterfaceWithProperties":
-@@ -7969,25 +8669,34 @@
+@@ -7990,25 +8690,34 @@
  class VariadicInvoker(metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.VariadicInvoker"):
      def __init__(self, method: "VariadicMethod") -> None:
          '''
@@ -19062,7 +19426,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="asArray")
      def as_array(
          self,
-@@ -7996,10 +8705,14 @@
+@@ -8017,10 +8726,14 @@
      ) -> typing.List[jsii.Number]:
          '''
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
@@ -19077,7 +19441,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VariadicTypeUnion(
      metaclass=jsii.JSIIMeta,
-@@ -8007,19 +8720,25 @@
+@@ -8028,19 +8741,25 @@
  ):
      def __init__(self, *union: typing.Union["StructA", "StructB"]) -> None:
          '''
@@ -19103,7 +19467,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VirtualMethodPlayground(
      metaclass=jsii.JSIIMeta,
-@@ -8031,38 +8750,53 @@
+@@ -8052,38 +8771,53 @@
      @jsii.member(jsii_name="overrideMeAsync")
      def override_me_async(self, index: jsii.Number) -> jsii.Number:
          '''
@@ -19157,7 +19521,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class VoidCallback(
      metaclass=jsii.JSIIAbstractClass,
-@@ -8124,10 +8858,13 @@
+@@ -8145,10 +8879,13 @@
          '''
          return typing.cast(typing.Optional[builtins.str], jsii.get(self, "dontReadMe"))
  
@@ -19171,7 +19535,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  class WithPrivatePropertyInConstructor(
      metaclass=jsii.JSIIMeta,
-@@ -8137,10 +8874,13 @@
+@@ -8158,10 +8895,13 @@
  
      def __init__(self, private_field: typing.Optional[builtins.str] = None) -> None:
          '''
@@ -19185,7 +19549,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="success")
      def success(self) -> builtins.bool:
-@@ -8181,10 +8921,13 @@
+@@ -8202,10 +8942,13 @@
      @jsii.member(jsii_name="abstractMethod")
      def abstract_method(self, name: builtins.str) -> builtins.str:
          '''
@@ -19199,7 +19563,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, AbstractClass).__jsii_proxy_class__ = lambda : _AbstractClassProxy
  
-@@ -8200,10 +8943,14 @@
+@@ -8221,10 +8964,14 @@
          '''Creates a BinaryOperation.
  
          :param lhs: Left-hand side operand.
@@ -19214,7 +19578,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="toString")
      def to_string(self) -> builtins.str:
          '''String representation of the value.'''
-@@ -8247,10 +8994,13 @@
+@@ -8268,10 +9015,13 @@
      def rung(self) -> builtins.bool:
          return typing.cast(builtins.bool, jsii.get(self, "rung"))
  
@@ -19228,7 +19592,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.data_type(
      jsii_type="jsii-calc.ChildStruct982",
-@@ -8261,10 +9011,14 @@
+@@ -8282,10 +9032,14 @@
      def __init__(self, *, foo: builtins.str, bar: jsii.Number) -> None:
          '''
          :param foo: 
@@ -19243,7 +19607,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar": bar,
          }
  
-@@ -8305,37 +9059,49 @@
+@@ -8326,37 +9080,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -19293,7 +19657,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(INonInternalInterface)
  class ClassThatImplementsThePrivateInterface(
-@@ -8350,37 +9116,49 @@
+@@ -8371,37 +9137,49 @@
      def a(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "a"))
  
@@ -19343,7 +19707,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IInterfaceWithProperties)
  class ClassWithPrivateConstructorAndAutomaticProperties(
-@@ -8398,10 +9176,14 @@
+@@ -8419,10 +9197,14 @@
      ) -> "ClassWithPrivateConstructorAndAutomaticProperties":
          '''
          :param read_only_string: -
@@ -19358,7 +19722,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="readOnlyString")
      def read_only_string(self) -> builtins.str:
-@@ -8412,10 +9194,13 @@
+@@ -8433,10 +9215,13 @@
      def read_write_string(self) -> builtins.str:
          return typing.cast(builtins.str, jsii.get(self, "readWriteString"))
  
@@ -19372,7 +19736,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.implements(IIndirectlyImplemented)
  class FullCombo(BaseClass, metaclass=jsii.JSIIMeta, jsii_type="jsii-calc.FullCombo"):
-@@ -8530,10 +9315,13 @@
+@@ -8551,10 +9336,13 @@
  ):
      def __init__(self, property: builtins.str) -> None:
          '''
@@ -19386,7 +19750,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="bar")
      def bar(self) -> None:
          return typing.cast(None, jsii.invoke(self, "bar", []))
-@@ -8554,10 +9342,13 @@
+@@ -8575,10 +9363,13 @@
  
      def __init__(self, operand: "_scope_jsii_calc_lib_c61f082f.NumericValue") -> None:
          '''
@@ -19400,7 +19764,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="farewell")
      def farewell(self) -> builtins.str:
          '''Say farewell.'''
-@@ -8622,10 +9413,16 @@
+@@ -8643,10 +9434,16 @@
          :param id: some identifier.
          :param default_bar: the default value of \`\`bar\`\`.
          :param props: some props once can provide.
@@ -19417,7 +19781,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @builtins.property
      @jsii.member(jsii_name="id")
      def id(self) -> jsii.Number:
-@@ -8983,7 +9780,1573 @@
+@@ -9004,7 +9801,1573 @@
  
  import sys as _sys
  setattr(_sys.modules[__name__], "__getattr__", __getattr__)
@@ -21063,8 +21427,8 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/__init__.py	--runtime-type-checking
-@@ -47,10 +47,13 @@
-     def _unwrap(self, gen: "_IRandomNumberGenerator_9643a8b9") -> jsii.Number:
+@@ -64,10 +64,13 @@
+     def _unwrap(self, gen: "_jsii_calc_e856c20f.IRandomNumberGenerator") -> jsii.Number:
          '''Implement this functin to return \`\`gen.next()\`\`. It is extremely important that the \`\`donotimport\`\` submodule is NEVER explicitly loaded in the testing application (otherwise this test is void).
  
          :param gen: a VERY pseudo random number generator.
@@ -21077,7 +21441,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  # Adding a "__jsii_proxy_class__(): typing.Type" function to the abstract class
  typing.cast(typing.Any, Cdk16625).__jsii_proxy_class__ = lambda : _Cdk16625Proxy
  
-@@ -82,5 +85,11 @@
+@@ -99,5 +102,11 @@
      return [*__all__, *_SUBMODULES]
  
  import sys as _sys
@@ -21085,7 +21449,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  setattr(_sys.modules[__name__], "__dir__", __dir__)
 +
 +def _typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b(
-+    gen: _IRandomNumberGenerator_9643a8b9,
++    gen: _jsii_calc_e856c20f.IRandomNumberGenerator,
 +) -> None:
 +    """Type checking stubs"""
 +    pass
@@ -21094,7 +21458,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/cdk16625/donotimport/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/cdk16625/donotimport/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/cdk16625/donotimport/__init__.py	--runtime-type-checking
-@@ -35,10 +35,13 @@
+@@ -52,10 +52,13 @@
  
      def __init__(self, value: jsii.Number) -> None:
          '''
@@ -21108,7 +21472,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="next")
      def next(self) -> jsii.Number:
          '''Not quite random, but it'll do.
-@@ -51,5 +54,11 @@
+@@ -68,5 +71,11 @@
  __all__ = [
      "UnimportedSubmoduleType",
  ]
@@ -21157,7 +21521,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/composition/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/composition/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/composition/__init__.py	--runtime-type-checking
-@@ -56,30 +56,39 @@
+@@ -73,30 +73,39 @@
          '''A set of postfixes to include in a decorated .toString().'''
          return typing.cast(typing.List[builtins.str], jsii.get(self, "decorationPostfixes"))
  
@@ -21197,7 +21561,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.enum(
          jsii_type="jsii-calc.composition.CompositeOperation.CompositionStringStyle"
      )
-@@ -112,5 +121,23 @@
+@@ -129,5 +138,23 @@
  __all__ = [
      "CompositeOperation",
  ]
@@ -21559,7 +21923,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/intersection/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/intersection/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/intersection/__init__.py	--runtime-type-checking
-@@ -35,10 +35,13 @@
+@@ -52,10 +52,13 @@
      @builtins.classmethod
      def accepts_intersection(cls, param: '_ISomething_IFriendly') -> None:
          '''
@@ -21573,7 +21937,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="acceptsPropWithIntersection")
      @builtins.classmethod
      def accepts_prop_with_intersection(cls, *, param: '_ISomething_IFriendly') -> None:
-@@ -76,10 +79,13 @@
+@@ -93,10 +96,13 @@
  class IntersectionProps:
      def __init__(self, *, param: '_ISomething_IFriendly') -> None:
          '''
@@ -21587,7 +21951,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -106,10 +112,23 @@
+@@ -123,10 +129,23 @@
      "IntersectionProps",
  ]
  
@@ -21670,7 +22034,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/jsii4894/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/jsii4894/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/jsii4894/__init__.py	--runtime-type-checking
-@@ -62,10 +62,13 @@
+@@ -79,10 +79,13 @@
          '''
          :param some_type: 
          '''
@@ -21684,7 +22048,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -92,5 +95,12 @@
+@@ -109,5 +112,12 @@
      "NonPascalCaseTest",
      "NonPascalCaseTestProps",
  ]
@@ -21787,7 +22151,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2647/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2647/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2647/__init__.py	--runtime-type-checking
-@@ -35,10 +35,13 @@
+@@ -53,10 +53,13 @@
          '''
          :param very: -
  
@@ -21801,7 +22165,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
      @jsii.member(jsii_name="hello")
      def hello(self) -> builtins.str:
          '''Say hello!'''
-@@ -52,5 +55,11 @@
+@@ -70,5 +73,11 @@
  __all__ = [
      "ExtendAndImplement",
  ]
@@ -21818,7 +22182,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/methods/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/methods/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/methods/__init__.py	--runtime-type-checking
-@@ -33,23 +33,41 @@
+@@ -51,23 +51,41 @@
          _bar: typing.Mapping[builtins.str, typing.Union["_scope_jsii_calc_base_734f0262.BaseProps", typing.Dict[builtins.str, typing.Any]]],
      ) -> None:
          '''
@@ -21865,7 +22229,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2689/structs/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2689/structs/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2689/structs/__init__.py	--runtime-type-checking
-@@ -34,10 +34,14 @@
+@@ -52,10 +52,14 @@
      ) -> None:
          '''
          :param base_map: 
@@ -21880,7 +22244,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "numbers": numbers,
          }
  
-@@ -70,5 +74,13 @@
+@@ -88,5 +92,13 @@
  __all__ = [
      "MyStruct",
  ]
@@ -21931,7 +22295,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/module2692/submodule2/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/module2692/submodule2/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/module2692/submodule2/__init__.py	--runtime-type-checking
-@@ -27,10 +27,13 @@
+@@ -44,10 +44,13 @@
  class Bar:
      def __init__(self, *, bar2: builtins.str) -> None:
          '''
@@ -21945,7 +22309,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -67,10 +70,15 @@
+@@ -84,10 +87,15 @@
          '''
          :param bar2: 
          :param bar1: 
@@ -21961,7 +22325,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              "bar1": bar1,
              "foo2": foo2,
          }
-@@ -109,5 +117,21 @@
+@@ -126,5 +134,21 @@
      "Bar",
      "Foo",
  ]
@@ -22078,7 +22442,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/__init__.py	--runtime-type-checking
-@@ -44,10 +44,13 @@
+@@ -59,10 +59,13 @@
  
          :param foo: 
  
@@ -22092,12 +22456,12 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -112,10 +115,13 @@
-     def all_types(self) -> typing.Optional["_AllTypes_b08307c5"]:
-         return typing.cast(typing.Optional["_AllTypes_b08307c5"], jsii.get(self, "allTypes"))
+@@ -127,10 +130,13 @@
+     def all_types(self) -> typing.Optional["_jsii_calc_e856c20f.AllTypes"]:
+         return typing.cast(typing.Optional["_jsii_calc_e856c20f.AllTypes"], jsii.get(self, "allTypes"))
  
      @all_types.setter
-     def all_types(self, value: typing.Optional["_AllTypes_b08307c5"]) -> None:
+     def all_types(self, value: typing.Optional["_jsii_calc_e856c20f.AllTypes"]) -> None:
 +        if __debug__:
 +            type_hints = typing.get_type_hints(_typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
@@ -22106,7 +22470,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  __all__ = [
      "Default",
-@@ -160,5 +166,18 @@
+@@ -175,5 +181,18 @@
      return [*__all__, *_SUBMODULES]
  
  import sys as _sys
@@ -22121,7 +22485,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 +    pass
 +
 +def _typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1(
-+    value: typing.Optional[_AllTypes_b08307c5],
++    value: typing.Optional[_jsii_calc_e856c20f.AllTypes],
 +) -> None:
 +    """Type checking stubs"""
 +    pass
@@ -22130,9 +22494,9 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/submodule/back_references/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/submodule/back_references/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/submodule/back_references/__init__.py	--runtime-type-checking
-@@ -27,10 +27,13 @@
+@@ -44,10 +44,13 @@
  class MyClassReference:
-     def __init__(self, *, reference: "_MyClass_a2fdc0b6") -> None:
+     def __init__(self, *, reference: "_submodule_f946ba2c.MyClass") -> None:
          '''
          :param reference: 
          '''
@@ -22144,7 +22508,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          }
  
      @builtins.property
-@@ -54,5 +57,12 @@
+@@ -71,5 +74,12 @@
  __all__ = [
      "MyClassReference",
  ]
@@ -22153,7 +22517,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 +
 +def _typecheckingstub__e7f53d1efa418d6ee29ababd1c2660c1d3d9a5d3de3ad874b2d0cd7c6481139b(
 +    *,
-+    reference: _MyClass_a2fdc0b6,
++    reference: _submodule_f946ba2c.MyClass,
 +) -> None:
 +    """Type checking stubs"""
 +    pass
@@ -22270,7 +22634,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
 exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/jsii_calc/union/__init__.py.diff 1`] = `
 --- python/src/jsii_calc/union/__init__.py	--no-runtime-type-checking
 +++ python/src/jsii_calc/union/__init__.py	--runtime-type-checking
-@@ -27,10 +27,13 @@
+@@ -44,10 +44,13 @@
          param: typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", "IResolvable", "Resolvable"],
      ) -> None:
          '''
@@ -22284,7 +22648,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
  @jsii.interface(jsii_type="jsii-calc.union.IResolvable")
  class IResolvable(typing_extensions.Protocol):
-@@ -63,7 +66,13 @@
+@@ -80,7 +83,13 @@
      "Resolvable",
  ]
  

--- a/packages/jsii-pacmak/test/targets/python/type-name.test.ts
+++ b/packages/jsii-pacmak/test/targets/python/type-name.test.ts
@@ -206,11 +206,9 @@ describe(toTypeName, () => {
     {
       name: 'User Type (Local, Submodule)',
       input: { fqn: `${assembly.name}.submodule.${SUBMODULE_TYPE}` },
-      pythonType: `"_${SUBMODULE_TYPE}_72dbc9ef"`,
+      pythonType: `"_submodule_b81e7cf1.${SUBMODULE_TYPE}"`,
       requiredImports: {
-        '.submodule': new Set([
-          `${SUBMODULE_TYPE} as _${SUBMODULE_TYPE}_72dbc9ef`,
-        ]),
+        [`${LOCAL_MODULE}.submodule as _submodule_b81e7cf1`]: new Set(['']),
       },
     },
     {
@@ -218,11 +216,9 @@ describe(toTypeName, () => {
       input: {
         fqn: `${assembly.name}.submodule.${SUBMODULE_TYPE}.${SUBMODULE_NESTED_TYPE}`,
       },
-      pythonType: `"_${SUBMODULE_TYPE}_72dbc9ef.${SUBMODULE_NESTED_TYPE}"`,
+      pythonType: `"_submodule_b81e7cf1.${SUBMODULE_TYPE}.${SUBMODULE_NESTED_TYPE}"`,
       requiredImports: {
-        '.submodule': new Set([
-          `${SUBMODULE_TYPE} as _${SUBMODULE_TYPE}_72dbc9ef`,
-        ]),
+        [`${LOCAL_MODULE}.submodule as _submodule_b81e7cf1`]: new Set(['']),
       },
     },
     {
@@ -238,11 +234,9 @@ describe(toTypeName, () => {
     {
       name: 'User Type (Local, Parent)',
       input: { fqn: `${assembly.name}.other.${OTHER_SUBMODULE_TYPE}` },
-      pythonType: `"_${OTHER_SUBMODULE_TYPE}_78b5948e"`,
+      pythonType: `"_other_d480fe3b.${OTHER_SUBMODULE_TYPE}"`,
       requiredImports: {
-        '..other': new Set([
-          `${OTHER_SUBMODULE_TYPE} as _${OTHER_SUBMODULE_TYPE}_78b5948e`,
-        ]),
+        [`${LOCAL_MODULE}.other as _other_d480fe3b`]: new Set(['']),
       },
       inSubmodule: `${assembly.name}.submodule`,
     },


### PR DESCRIPTION
## Problem

Every generated `init.py` file has import statements at the top that look like this, for example

```
from .aws_iam import IGrantable as _IGrantable_ef567890
from .aws_kms import IKey as _IKey_abc12345
...
```

and cross-module imports that could look like this. for example
```
import scope.jsii_calc_base
...
```

These load immediately whenever each module loads, which in turn load their own dependencies. This causes a huge cascade of imports at module load time. A large chunk of these imports only exist to satisfy type annotations however, or runtime type checks, and therefore this creates a need for optimization. 

## Solution

Cross-module imports are now deferred using a `typing.TYPE_CHECKING` split plus a lazy import proxy. Instead of importing each symbol eagerly, the generator emits:

```python
class _LazyImport:
    def __init__(self, module_name: str) -> None:
        self._module_name = module_name
        self._module: typing.Any = None
    def __getattr__(self, name: str) -> typing.Any:
        if self._module is None:
            import importlib
            self._module = importlib.import_module(self._module_name)
        return getattr(self._module, name)

if typing.TYPE_CHECKING:
    import jsii_calc.composition as _composition_4f38e801
    import scope.jsii_calc_lib as _scope_jsii_calc_lib_c61f082f
else:
    _composition_4f38e801 = _LazyImport("jsii_calc.composition")
    _scope_jsii_calc_lib_c61f082f = _LazyImport("scope.jsii_calc_lib")
```

mypy and pyright evaluate the if statement, so they see the real module imports and resolve all types normally. At runtime, the `else:` branch executes instead, binding each module alias to a `_LazyImport` proxy. The actual `importlib.import_module()` call is deferred until the first attribute access through the proxy's `__getattr__`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
