### PR TITLE
fix: interface from un-imported submodule raises KeyError under lazy loading

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/_reference_map.py
+++ b/packages/@jsii/python-runtime/src/jsii/_reference_map.py
@@ -92,6 +92,30 @@ def _try_import_type_module(class_fqn: str) -> bool:
     return False
 
 
+def _obtain_interface(fqn: str) -> Any:
+    """Look up an interface by FQN, triggering lazy loading if necessary.
+
+    With lazy cross-module imports, a behavioral interface may live in a
+    submodule that has not been imported yet, so it is not registered in
+    ``_interfaces``. Importing the containing module triggers registration as a
+    side effect; then we retry the lookup.
+
+    Returns the interface class. Raises ValueError if the interface cannot be
+    found after attempting lazy resolution.
+    """
+    iface = _interfaces.get(fqn)
+    if iface is not None:
+        return iface
+
+    _try_import_type_module(fqn)
+
+    iface = _interfaces.get(fqn)
+    if iface is not None:
+        return iface
+
+    raise ValueError(f"Unknown interface: {fqn}")
+
+
 class _FakeReference:
     def __init__(self, ref: str) -> None:
         self.__jsii_ref__ = ref
@@ -167,6 +191,14 @@ class _ReferenceMap:
             return _enums[class_fqn]
         elif class_fqn == "Object":
             # If any one interface is a struct, all of them are guaranteed to be (Kernel invariant)
+            # With lazy loading, the struct/interface types may live in
+            # submodules that have not been imported yet. Trigger lazy
+            # registration before deciding whether this is a struct or a
+            # behavioral interface, and before dereferencing _data_types.
+            if ref.interfaces is not None:
+                for fqn in ref.interfaces:
+                    if fqn not in _data_types and fqn not in _interfaces:
+                        _try_import_type_module(fqn)
             if ref.interfaces is not None and any(
                 fqn in _data_types for fqn in ref.interfaces
             ):
@@ -210,7 +242,7 @@ class _ReferenceMap:
         return self._refs[id]
 
     def build_interface_proxies_for_ref(self, ref: ObjRef) -> List[Any]:
-        ifaces = [_interfaces[fqn] for fqn in ref.interfaces or []]
+        ifaces = [_obtain_interface(fqn) for fqn in ref.interfaces or []]
         classes = [iface.__jsii_proxy_class__() for iface in ifaces]
 
         # If there's no classes, use an Opaque reference to make sure the

--- a/packages/@jsii/python-runtime/tests/test_compliance.py
+++ b/packages/@jsii/python-runtime/tests/test_compliance.py
@@ -1389,6 +1389,64 @@ def test_interface_can_be_used_when_not_expressedly_loaded():
     assert submodule in sys.modules
 
 
+def test_byref_struct_can_be_used_when_not_expressedly_loaded():
+    """
+    Verifies that a struct (data type) serialized by-reference, whose type lives
+    in a submodule that was never explicitly imported, can be resolved by the
+    runtime.
+
+    Data types are sometimes serialized by-reference (see aws/jsii#400), in
+    which case they arrive as an anonymous ``Object`` whose ``ref.interfaces``
+    names the struct's FQN. ``resolve()`` decides between the struct path and
+    the behavioral-interface path by checking ``fqn in _data_types``. With lazy
+    loading, a struct from an un-imported submodule is not registered there yet,
+    so without an on-demand import the check is False, execution wrongly falls
+    into the interface branch, and resolution fails with
+    ``ValueError: Unknown interface: <struct fqn>``. ``resolve()`` now imports
+    unregistered ``ref.interfaces`` FQNs before that decision.
+
+    The ``jsii_calc.module2692.submodule1`` submodule (which declares the struct
+    ``Bar``) must NEVER be explicitly imported by this test, otherwise it is
+    void.
+    """
+    import sys
+    from jsii import _reference_map
+    from jsii._kernel.types import ObjRef
+
+    struct_fqn = "jsii-calc.module2692.submodule1.Bar"
+    submodule = "jsii_calc.module2692.submodule1"
+
+    # Precondition: the submodule has not been imported, so the struct is not
+    # yet registered as a data type.
+    assert struct_fqn not in _reference_map._data_types
+
+    # A by-reference struct's properties are read back from the kernel via
+    # kernel.get(). The bug under test is in resolve()'s struct-vs-interface
+    # decision (whether the submodule is imported on demand BEFORE that
+    # decision), which happens before any property read, so a minimal fake
+    # kernel that returns property values is sufficient to exercise it without
+    # standing up a real kernel-backed object.
+    class _FakeKernel:
+        def get(self, _ref, _name):
+            return "value-from-kernel"
+
+    # Simulate the kernel returning a by-reference struct: an anonymous object
+    # whose interfaces names the struct FQN.
+    ref = ObjRef(ref="Object@90126", interfaces=[struct_fqn])
+
+    # This must NOT raise ValueError("Unknown interface: ..."): the runtime
+    # imports the submodule on demand (registering Bar as a data type),
+    # recognizes it as a struct, and rebuilds it by reading its properties.
+    result = _reference_map.resolve_reference(_FakeKernel(), ref)
+    assert result is not None
+
+    # The on-demand import should have registered the struct as a data type, and
+    # the resolved value should be an instance of it (not an interface proxy).
+    assert struct_fqn in _reference_map._data_types
+    assert submodule in sys.modules
+    assert isinstance(result, _reference_map._data_types[struct_fqn])
+
+
 def test_stripped_deprecated_member_can_be_received():
     assert InterfaceFactory.create() is not None
 

--- a/packages/@jsii/python-runtime/tests/test_compliance.py
+++ b/packages/@jsii/python-runtime/tests/test_compliance.py
@@ -1345,6 +1345,50 @@ def test_class_can_be_used_when_not_expressedly_loaded():
     Subject().test()
 
 
+def test_interface_can_be_used_when_not_expressedly_loaded():
+    """
+    Verifies that a value whose dynamic type is a *behavioral interface* from a
+    submodule that was never explicitly imported can be resolved by the runtime.
+
+    With lazy cross-module imports (see jsii-pacmak), a submodule is not loaded
+    until first accessed, so its interfaces are not registered with the runtime.
+    When the kernel returns an object tagged with such an interface FQN, the
+    reference map must import the containing submodule on demand to resolve the
+    interface proxy. Previously ``build_interface_proxies_for_ref`` did a bare
+    ``_interfaces[fqn]`` lookup and raised ``KeyError`` for unregistered
+    interfaces (mirrors the aws-cdk-lib shape where, e.g., ``aws_codebuild``
+    returns an ``aws_codestarnotifications`` interface).
+
+    The ``jsii_calc.module2700`` submodule (which declares the behavioral
+    interface ``IFoo``) must NEVER be explicitly imported by this test,
+    otherwise it is void.
+    """
+    import sys
+    from jsii import _reference_map
+    from jsii._kernel.types import ObjRef
+
+    iface_fqn = "jsii-calc.module2700.IFoo"
+    submodule = "jsii_calc.module2700"
+
+    # Precondition: the submodule has not been imported, so its interface is
+    # not yet registered. (Other tests run in the same process, so only assert
+    # the registration state, which is what the code path depends on.)
+    assert iface_fqn not in _reference_map._interfaces
+
+    # Simulate the kernel returning an anonymous object that implements a
+    # behavioral interface from the un-imported submodule.
+    ref = ObjRef(ref="Object@90125", interfaces=[iface_fqn])
+
+    # This must NOT raise: the runtime imports jsii_calc.module2700 on demand,
+    # which registers IFoo, then builds the interface proxy.
+    proxy = _reference_map.resolve_reference(jsii.kernel, ref)
+    assert proxy is not None
+
+    # The on-demand import should have registered the interface.
+    assert iface_fqn in _reference_map._interfaces
+    assert submodule in sys.modules
+
+
 def test_stripped_deprecated_member_can_be_received():
     assert InterfaceFactory.create() is not None
 


### PR DESCRIPTION
When we made sibling module imports lazy here(https://github.com/aws/jsii/pull/5172), the imports were deferred behind a `_LazyImport` proxy:

```python
if typing.TYPE_CHECKING:
    import aws_cdk.aws_codestarnotifications as _x
else:
    _x = _LazyImport("aws_cdk.aws_codestarnotifications")
```

As a result, a sibling submodule's types are now not registered with the runtime until that submodule is first touched. This is fine for classes/structs/enums, because they have an on-demand fallback that imports the containing submodule and retries.

Behavioral interfaces have no such fallback. `build_interface_proxies_for_ref` does a bare lookup:

```python
ifaces = [_interfaces[fqn] for fqn in ref.interfaces or []]
```

When the kernel returns a value whose dynamic type is a behavioral interface that lives in a submodule the user never imported, that FQN is not in `_interfaces` and the call raises an uncaught `KeyError`. This happens both when a method's declared return type is such an interface and when an anonymous object implementing such an interface is returned.

I solve this by routing the interface resolution through a new `_obtain_interface` helper that reuses the same on-demand import machinery already used for classes/structs/enums. When an interface FQN is not yet registered, it imports the containing submodule (which registers the type as a side effect) and retries, raising a Value Error if it still cannot be resolved:

```python
def _obtain_interface(fqn: str) -> Any:
    iface = _interfaces.get(fqn)
    if iface is not None:
        return iface
    _try_import_type_module(fqn)
    iface = _interfaces.get(fqn)
    if iface is not None:
        return iface
    raise ValueError(f"Unknown interface: {fqn}")
```

There is another related edge case in the same area. When an anonymous object comes back (`class_fqn == "Object"`), `resolve()` first has to decide whether it is a struct or a behavioral interface, by checking whether any of `ref.interfaces` is a known data type:

```python
if ref.interfaces is not None and any(fqn in _data_types for fqn in ref.interfaces):
    ...  # struct path
else:
    ...  # interface path
```

Runtimje tries checking whether the object is in the listed structs. Since it was never registered, it assumes its an interface and then we get a `ValueError: Unknown interface`

To cover this, I load the type's submodule before that struct-vs-interface check runs, so the registry is accurate by the time the decision is made

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
