### PR TITLE
feat: make runtime typechecks optional (DO NOT MERGE YET)

### DIFF
--- a/packages/@jsii/python-runtime/src/jsii/__init__.py
+++ b/packages/@jsii/python-runtime/src/jsii/__init__.py
@@ -14,6 +14,10 @@ from ._runtime import (
     kernel,
     proxy_for,
 )
+from ._type_checking import (
+    runtime_type_checking_enabled,
+    set_runtime_type_checking,
+)
 from . import python
 
 # JS doesn't have distinct float or integer types, but we do. So we'll define our own

--- a/packages/@jsii/python-runtime/src/jsii/_type_checking.py
+++ b/packages/@jsii/python-runtime/src/jsii/_type_checking.py
@@ -10,7 +10,44 @@ lazily on first call to :func:`check_type`. This means:
   ``check_type`` is never called and typeguard is never imported at all.
 """
 
+import os
 import typing
+
+# Whether jsii runtime type checking is enabled. Defaults to off (opt-in): the
+# kernel enforces the same constraints on the wire, so the generated Python-side
+# checks are an ergonomic aid (a native ``TypeError`` raised at the call site, in
+# Python vocabulary) rather than an additional safety mechanism. The value is
+# seeded once from the environment at import time -- matching the static-field
+# semantics of the Java/.NET ``Configuration`` toggles -- and can be changed at
+# runtime via :func:`set_runtime_type_checking`. Because generated code imports
+# the ``runtime_type_checking_enabled`` *function* (not its return value), a
+# later call to :func:`set_runtime_type_checking` is observed on subsequent
+# checks.
+_ENABLED: bool = os.environ.get("JSII_RUNTIME_TYPE_CHECKING", "").lower() in (
+    "1",
+    "true",
+    "on",
+)
+
+
+def runtime_type_checking_enabled() -> bool:
+    """Return whether jsii runtime type checking is currently enabled.
+
+    Defaults to ``False``. Enable it by setting the ``JSII_RUNTIME_TYPE_CHECKING``
+    environment variable (to ``1``, ``true``, or ``on``) before import, or by
+    calling :func:`set_runtime_type_checking` at runtime.
+    """
+    return _ENABLED
+
+
+def set_runtime_type_checking(enabled: bool) -> None:
+    """Enable or disable jsii runtime type checking for the current process.
+
+    Takes effect for all subsequent jsii method/constructor/property calls.
+    """
+    global _ENABLED
+    _ENABLED = bool(enabled)
+
 
 # Resolved typeguard-backed implementation, populated on first call to
 # ``check_type`` and reused thereafter. Caching here (rather than hot-patching

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -737,7 +737,7 @@ class TestRuntimeTypeCheckingToggle:
         # typeguard 2.x raises TypeError; 3.x/4.x raise typeguard.TypeCheckError.
         if TYPEGUARD_MAJOR_VERSION == 2:
             return TypeError
-        return typeguard.TypeCheckError  # type:ignore
+        return typeguard.TypeCheckError  # type: ignore
 
     def test_toggle_round_trips(self):
         jsii.set_runtime_type_checking(True)
@@ -777,9 +777,9 @@ class TestRuntimeTypeCheckingToggle:
         """
         jsii.set_runtime_type_checking(False)
         with pytest.raises(
-            typeguard.TypeCheckError,  # type:ignore
+            typeguard.TypeCheckError,  # type: ignore
             match=re.escape("no method named 'your_turn'"),
         ):
             jsii_calc.ConsumerCanRingBell().implemented_by_object_literal(
-                PythonInvalidBellRinger()  # type:ignore
+                PythonInvalidBellRinger()  # type: ignore
             )

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -19,6 +19,21 @@ class PythonInvalidBellRinger:
         bell.ring()
 
 
+@pytest.fixture(autouse=True)
+def _enable_runtime_type_checking():
+    """Runtime type checking is opt-in (off by default) since the toggle was added.
+
+    The assertions in this module exercise the checks, so enable them for the
+    duration of each test and restore the prior state afterwards.
+    """
+    previous = jsii.runtime_type_checking_enabled()
+    jsii.set_runtime_type_checking(True)
+    try:
+        yield
+    finally:
+        jsii.set_runtime_type_checking(previous)
+
+
 @pytest.mark.skipif(TYPEGUARD_MAJOR_VERSION != 2, reason="requires typeguard 2.x")
 class TestRuntimeTypeCheckingTypeGuardV2:
 
@@ -712,3 +727,29 @@ class TestRuntimeTypeCheckingTypeGuardV4:
             jsii_calc.ConsumerCanRingBell().implemented_by_object_literal(
                 PythonInvalidBellRinger()  # type: ignore
             )
+
+
+class TestRuntimeTypeCheckingToggle:
+    """Verifies the opt-in toggle that gates runtime type checking."""
+
+    def test_toggle_round_trips(self):
+        jsii.set_runtime_type_checking(True)
+        assert jsii.runtime_type_checking_enabled() is True
+        jsii.set_runtime_type_checking(False)
+        assert jsii.runtime_type_checking_enabled() is False
+
+    def test_no_call_site_typeerror_when_disabled(self):
+        """With checking disabled, the Python-side check does not fire.
+
+        An invalid value is still rejected -- but by the kernel on the wire (as a
+        ``RuntimeError``), not as a call-site ``TypeError`` from ``check_type``.
+        """
+        jsii.set_runtime_type_checking(False)
+        with pytest.raises(Exception) as excinfo:
+            jsii_calc.Calculator(initial_value="nope")  # type: ignore
+        assert not isinstance(excinfo.value, TypeError)
+
+    def test_call_site_typeerror_when_enabled(self):
+        jsii.set_runtime_type_checking(True)
+        with pytest.raises(TypeError):
+            jsii_calc.Calculator(initial_value="nope")  # type: ignore

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -760,3 +760,26 @@ class TestRuntimeTypeCheckingToggle:
         jsii.set_runtime_type_checking(True)
         with pytest.raises(self.check_type_error):
             jsii_calc.Calculator(initial_value="nope")  # type: ignore
+
+    @pytest.mark.skipif(
+        TYPEGUARD_MAJOR_VERSION != 4,
+        reason="structural protocol conformance checks require typeguard 4.x",
+    )
+    def test_interface_conformance_checked_even_when_disabled(self):
+        """Interface-conformance checks run regardless of the toggle.
+
+        The kernel cannot validate that a by-reference host object structurally
+        conforms to the expected interface (it is passed by reference and would
+        only fail later, during a callback, if a member is missing). The
+        generated Python-side conformance check is therefore the only upfront
+        guard, so it is emitted ungated (``if __debug__``) and must fire even
+        when runtime type checking is disabled.
+        """
+        jsii.set_runtime_type_checking(False)
+        with pytest.raises(
+            typeguard.TypeCheckError,  # type:ignore
+            match=re.escape("no method named 'your_turn'"),
+        ):
+            jsii_calc.ConsumerCanRingBell().implemented_by_object_literal(
+                PythonInvalidBellRinger()  # type:ignore
+            )

--- a/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
+++ b/packages/@jsii/python-runtime/tests/test_runtime_type_checking.py
@@ -732,24 +732,31 @@ class TestRuntimeTypeCheckingTypeGuardV4:
 class TestRuntimeTypeCheckingToggle:
     """Verifies the opt-in toggle that gates runtime type checking."""
 
+    @property
+    def check_type_error(self):
+        # typeguard 2.x raises TypeError; 3.x/4.x raise typeguard.TypeCheckError.
+        if TYPEGUARD_MAJOR_VERSION == 2:
+            return TypeError
+        return typeguard.TypeCheckError  # type:ignore
+
     def test_toggle_round_trips(self):
         jsii.set_runtime_type_checking(True)
         assert jsii.runtime_type_checking_enabled() is True
         jsii.set_runtime_type_checking(False)
         assert jsii.runtime_type_checking_enabled() is False
 
-    def test_no_call_site_typeerror_when_disabled(self):
+    def test_no_call_site_error_when_disabled(self):
         """With checking disabled, the Python-side check does not fire.
 
         An invalid value is still rejected -- but by the kernel on the wire (as a
-        ``RuntimeError``), not as a call-site ``TypeError`` from ``check_type``.
+        ``RuntimeError``), not as a call-site check error from ``check_type``.
         """
         jsii.set_runtime_type_checking(False)
         with pytest.raises(Exception) as excinfo:
             jsii_calc.Calculator(initial_value="nope")  # type: ignore
-        assert not isinstance(excinfo.value, TypeError)
+        assert not isinstance(excinfo.value, self.check_type_error)
 
-    def test_call_site_typeerror_when_enabled(self):
+    def test_call_site_error_when_enabled(self):
         jsii.set_runtime_type_checking(True)
-        with pytest.raises(TypeError):
+        with pytest.raises(self.check_type_error):
             jsii_calc.Calculator(initial_value="nope")  # type: ignore

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -1814,7 +1814,9 @@ class PythonModule implements PythonType {
     code.line('import typing_extensions');
     code.line();
 
-    code.line('from jsii._type_checking import cached_type_hints, check_type');
+    code.line(
+      'from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled',
+    );
     code.line();
 
     // Determine if we need to write out the kernel load line.
@@ -3488,7 +3490,9 @@ function emitParameterTypeChecks(
     }
 
     if (!openedBlock) {
-      code.openBlock('if __debug__');
+      // Gate on both `__debug__` (so `python -O` elides the block entirely) and
+      // the opt-in runtime toggle (off by default; see jsii._type_checking).
+      code.openBlock('if __debug__ and runtime_type_checking_enabled()');
       code.line(
         `${typesVar} = ${context.typeCheckingHelper.getTypeHints(fqn, params)}`,
       );

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -15,7 +15,6 @@ import * as path from 'path';
 
 import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';
-import { isBehavioralInterfaceType } from '../type-visitor';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
 import { shell, subprocess, zip } from '../util';
@@ -35,6 +34,7 @@ import { die, toPythonIdentifier } from './python/util';
 import { toPythonVersionRange, toReleaseVersion } from './version-utils';
 import { assertSpecIsRosettaCompatible } from '../rosetta-assembly';
 import { topologicalSort } from '../toposort';
+import { isBehavioralInterfaceType } from '../type-visitor';
 
 import { TargetName } from './index';
 

--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 
 import { Generator, GeneratorOptions } from '../generator';
 import { warn } from '../logging';
+import { isBehavioralInterfaceType } from '../type-visitor';
 import { md2rst } from '../markdown';
 import { Target, TargetOptions } from '../target';
 import { shell, subprocess, zip } from '../util';
@@ -815,6 +816,13 @@ abstract class BaseMethod implements PythonBase {
         `${this.pythonParent.fqn ?? this.pythonParent.pythonName}#${
           this.pythonName
         }`,
+        this.parameters.some((p) =>
+          typeReferenceInvolvesBehavioralInterface(p.type, context),
+        ) ||
+          (this.liftedProp !== undefined &&
+            this.getLiftedProperties(context.resolver).some((p) =>
+              typeReferenceInvolvesBehavioralInterface(p.prop.type, context),
+            )),
       );
     }
     this.emitBody(
@@ -1094,6 +1102,7 @@ abstract class BaseProperty implements PythonBase {
           `${this.pythonParent.fqn ?? this.pythonParent.pythonName}#${
             this.pythonName
           }`,
+          typeReferenceInvolvesBehavioralInterface(this.type.type, context),
         );
         // In case of a static setter, the 'cls' type is the class type but because we use a custom
         // decorator to make the setter operate on classes instead of objects, pyright doesn't know about
@@ -1281,6 +1290,9 @@ class Struct extends BasePythonClassType {
         { ...context, runtimeTypeCheckKwargs: true },
         ['*', ...kwargs],
         `${this.fqn ?? this.pythonName}#__init__`,
+        members.some((m) =>
+          typeReferenceInvolvesBehavioralInterface(m.type.type, context),
+        ),
       );
     }
 
@@ -3452,11 +3464,53 @@ function openSignature(
  * @param params      the parameter signatures to be type-checked.
  * @params pythonName the name of the Python function being checked (qualified).
  */
+/**
+ * Determines whether a type reference involves a behavioral interface, either
+ * directly or nested within a collection or a type union.
+ *
+ * Parameters of such types require runtime type checking that cannot be elided
+ * by the opt-in toggle: the kernel cannot validate that a by-reference host
+ * object structurally conforms to the expected interface (it is passed by
+ * reference and would only fail later, during a callback, if a member is
+ * missing). The generated Python-side conformance check is therefore the only
+ * upfront guard, so it must always run.
+ */
+function typeReferenceInvolvesBehavioralInterface(
+  typeRef: spec.TypeReference | undefined,
+  context: EmitContext,
+): boolean {
+  if (typeRef == null) {
+    return false;
+  }
+  if (spec.isNamedTypeReference(typeRef)) {
+    let type: spec.Type | undefined;
+    try {
+      type = context.typeResolver(typeRef.fqn);
+    } catch {
+      return false;
+    }
+    return type != null && isBehavioralInterfaceType(type);
+  }
+  if (spec.isCollectionTypeReference(typeRef)) {
+    return typeReferenceInvolvesBehavioralInterface(
+      typeRef.collection.elementtype,
+      context,
+    );
+  }
+  if (spec.isUnionTypeReference(typeRef)) {
+    return typeRef.union.types.some((t) =>
+      typeReferenceInvolvesBehavioralInterface(t, context),
+    );
+  }
+  return false;
+}
+
 function emitParameterTypeChecks(
   code: CodeMaker,
   context: EmitContext,
   params: readonly string[],
   fqn: string,
+  alwaysCheck = false,
 ): boolean {
   if (!context.runtimeTypeChecking) {
     return false;
@@ -3490,9 +3544,19 @@ function emitParameterTypeChecks(
     }
 
     if (!openedBlock) {
-      // Gate on both `__debug__` (so `python -O` elides the block entirely) and
-      // the opt-in runtime toggle (off by default; see jsii._type_checking).
-      code.openBlock('if __debug__ and runtime_type_checking_enabled()');
+      // Always gate on `__debug__` (so `python -O` elides the block entirely).
+      // For most parameters, additionally gate on the opt-in runtime toggle
+      // (off by default; see jsii._type_checking). The exception is parameters
+      // whose type involves a behavioral interface: the kernel cannot validate
+      // that a by-reference host object structurally conforms to the expected
+      // interface (it would only fail later, during a callback, if a member is
+      // missing), so this is the only upfront conformance guard and must run
+      // regardless of the toggle.
+      code.openBlock(
+        alwaysCheck
+          ? 'if __debug__'
+          : 'if __debug__ and runtime_type_checking_enabled()',
+      );
       code.line(
         `${typesVar} = ${context.typeCheckingHelper.getTypeHints(fqn, params)}`,
       );

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/examples.test.js.snap
@@ -1312,7 +1312,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -1348,7 +1348,7 @@ class Foo:
         '''
         :param foo: -
         '''
-        if __debug__:
+        if __debug__ and runtime_type_checking_enabled():
             type_hints = cached_type_hints(_typecheckingstub__bf2f596592c027f75261089e0a96611ccca28179a004c918d9b1057b4e390db5)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
         self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -1389,7 +1389,7 @@ class FooBar:
         :param foo: -
         :param bar: -
         '''
-        if __debug__:
+        if __debug__ and runtime_type_checking_enabled():
             type_hints = cached_type_hints(_typecheckingstub__0cb0385f4239a994a5509c1ac8d143d10f8400893975d4519442a0d7baf1b5d4)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -1440,7 +1440,7 @@ class Baz(Foo, FooBar):
         :param bar: -
         :param baz: -
         '''
-        if __debug__:
+        if __debug__ and runtime_type_checking_enabled():
             type_hints = cached_type_hints(_typecheckingstub__98e5f88ba6c94001e15cc6f3ce78d86bd3610eea1b79954536d33da0dee53b2d)
             check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
             check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -1530,7 +1530,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
@@ -2732,7 +2732,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -2756,7 +2756,7 @@ class Namespace1(metaclass=jsii.JSIIMeta, jsii_type="testpkg.Namespace1"):
             '''
             :param bar: -
             '''
-            if __debug__:
+            if __debug__ and runtime_type_checking_enabled():
                 type_hints = cached_type_hints(_typecheckingstub__2a8df629360a764124e23427f4b4bb1422fef01e5b6dcd040a2f64d477f476d9)
                 check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
             self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -2860,7 +2860,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/prerelease-identifiers.test.js.snap
@@ -500,7 +500,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 import bar._jsii
@@ -1019,7 +1019,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 import bar._jsii
@@ -1517,7 +1517,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
@@ -2013,7 +2013,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -2573,7 +2573,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__e721760a6f0cb2ba909986665323a1f1f880769c379ae1f2ad0dbadf80ee9016)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(None, jsii.invoke(self, "foo", [obj]))
@@ -2791,7 +2791,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__bed3b5b08c611933987ef5d9dfc131289e09ebcd26286417337c3708ca054e9f)
 +            check_type(argname="argument reflectable", value=reflectable, expected_type=type_hints["reflectable"])
          return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
@@ -17214,7 +17214,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_object.setter
      def mutable_object(self, value: "IMutableObjectLiteral") -> None:
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__3afbef7e05ef43a18b9260b86660c09b15be66fabeae128c9a9f99b729da7143)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableObject", value) # pyright: ignore[reportArgumentType]
@@ -17256,7 +17256,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Optional[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", typing.List[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", "AbstractClass"]]]],
      ) -> None:
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__ec229cc92e04670f4dca9546759b3b39ee813eb1aa18057135bb155d08971e6a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -17270,7 +17270,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union_property: 
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__481b1113b85e6dc9d7ba31c3ef5654e3550abac1edef9204348ab0f9554f61c1)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
@@ -17298,7 +17298,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param delegate: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__5c5defc6d683ee91707f8b7770d8d2fb11d381b9c928d7e5d6e2c5c495395f38)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
@@ -17312,7 +17312,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__1df814299f3f9720be108d84bdfd61bc591699a79a3c8ac6d450bfb0a9610278)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
@@ -17326,7 +17326,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__2f08bd2d56e856071db5f777b63fe2577f9e96dbfcd91e4044d0eda2d26f9017)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
@@ -17340,7 +17340,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__4a2b7f0a05298ddaec112cb088cc71cfa2856aaa1d8414a5157d581b6d5a7293)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
@@ -17354,7 +17354,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__f751da3f5766ea4973eb2d89086565259f0a3cd626425a7eec723afd7b64f392)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
@@ -17367,7 +17367,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__cca04fe4a4c41a0034087ab0c574d1d2f1d0427d87a806fc660446b6a7e5290a)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
@@ -17380,7 +17380,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__7bde53b867de290d21a419baa46b8e833a0d394835a1ce2be3b429179b2ddce5)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
@@ -17393,7 +17393,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__988e53d92b16fb4b7224c654f985a074cbfa7dd5f567df005b41522641ad92ac)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
@@ -17406,7 +17406,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__1d786308546ae61deacb465c6f501fe7e0be028973494548b57e0480759ed460)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
@@ -17420,7 +17420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__83037a3f429b90a38d2d9532a347144030578d83f68817b1a5677ebcd1b38e12)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
@@ -17433,7 +17433,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__139bf4e63e56bef32e364c5972e055de5cba153d49cc821740fba1d51f73ef70)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
@@ -17784,7 +17784,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param clock: your implementation of \`\`WallClock\`\`.
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__2a7f203302b2610301f1b36f34453db0f5572f2e02b0bc4c9933fd670e594222)
 +            check_type(argname="argument clock", value=clock, expected_type=type_hints["clock"])
          jsii.create(self.__class__, self, [clock])
@@ -17971,7 +17971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param friendly: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__d17f0544be961cba6cabfbb40f28c196963de107fcaef9c56d8227bdcb359431)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
@@ -17999,7 +17999,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bell: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__d127476ce3b6e59ff9f375f547c1b6e1826d7a3969612c0605ebd0017d2b985d)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
@@ -18449,7 +18449,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param generator: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__3c1812783ba0b3b2146a3dd9609a6e12af404502ff5fbb9b9a9be49bf576122b)
 +            check_type(argname="argument generator", value=generator, expected_type=type_hints["generator"])
          jsii.create(self.__class__, self, [generator])
@@ -18459,7 +18459,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param gen: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__151b90e9765ce9a05ae13e568f4ba7c9e36e34c1cd991c5c1ee0249869fd4cce)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
@@ -18473,7 +18473,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @generator.setter
      def generator(self, value: "IRandomNumberGenerator") -> None:
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__0f5a1cc548d3db6e156cec5671bc04b980132e529c77f3bb5aaa58427db35e7c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "generator", value) # pyright: ignore[reportArgumentType]
@@ -18515,7 +18515,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param delegate: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__da93d15e57e6e2a1857cd7df156fb2a55ec91715c97323f20268def40f72137c)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
@@ -18573,7 +18573,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__ca8d417ddf787890441d6903718eebaf7fde3508b3466202724fdac3a17ba79b)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
@@ -18662,7 +18662,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param friendly: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__edbbf85a7c4217635da7418d28aa61c4e11f7a0c1e9c960528ed4e7bee1ad541)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
@@ -19359,7 +19359,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__73d1545891c65d400938add489402441cb083c61d214ad7a922b6417d3984732)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          jsii.create(self.__class__, self, [obj])
@@ -19373,7 +19373,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param ext: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__60f3870a6dceb3773397b75ec3f3b664f38c2cc3d2f37dc055262663d12f41a8)
 +            check_type(argname="argument ext", value=ext, expected_type=type_hints["ext"])
          return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
@@ -21366,7 +21366,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param option: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__132536bffc9129421b4ae0a6539d0bbfdc1c52c3de007c4546d2f2626ba8c31e)
 +            check_type(argname="argument option", value=option, expected_type=type_hints["option"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "consume", [option]))
@@ -21433,7 +21433,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param gen: a VERY pseudo random number generator.
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(jsii.Number, jsii.invoke(self, "unwrap", [gen]))
@@ -22640,7 +22640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: -
          '''
-+        if __debug__ and runtime_type_checking_enabled():
++        if __debug__:
 +            type_hints = cached_type_hints(_typecheckingstub__62dfa3c0a0a719fea295807df31fd40fd66b0e76cf44d9f742ffb421f8e4ca77)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))

--- a/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
+++ b/packages/jsii-pacmak/test/generated-code/__snapshots__/target-python.test.js.snap
@@ -339,7 +339,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -497,7 +497,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 import scope.jsii_calc_base_of_base._jsii
@@ -539,7 +539,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
          :param foo: -
          :param bar: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e2d8a566db7d86eb1cb511cb869273dae39a21b3ad7041359aabb7bd283dcfef)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -554,7 +554,7 @@ exports[`Generated code for "@scope/jsii-calc-base": <runtime-type-check-diff>/p
          '''
          :param args: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__66400f6ebe2f9a3fbb550342b894bebf4f5368890843f3917e2b903f62d48b38)
 +            check_type(argname="argument args", value=args, expected_type=typing.Tuple[type_hints["args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*args]))
@@ -922,7 +922,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -1036,7 +1036,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 __jsii_assembly__ = jsii.JSIIAssembly.load(
@@ -1079,7 +1079,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
          '''
          :param _args: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__740535cda6ecbc578919a2921dd1fa0b87c5dd735a2acd391963310cdf59f47c)
 +            check_type(argname="argument _args", value=_args, expected_type=typing.Tuple[type_hints["_args"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(None, jsii.sinvoke(cls, "consume", [*_args]))
@@ -1093,7 +1093,7 @@ exports[`Generated code for "@scope/jsii-calc-base-of-base": <runtime-type-check
          '''
          :param foo: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c314d9d6951cb6f41a208c5feb55cc9d30da774b67f6d47cb4fa13215b96f2b9)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -1472,7 +1472,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -2133,7 +2133,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 import scope.jsii_calc_base._jsii
@@ -2177,7 +2177,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -2445,7 +2445,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -2561,7 +2561,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__46512218b53da06690990919b41a88d6c2379b11ef0a3243cf6d60add5197ae2)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
@@ -2573,7 +2573,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e721760a6f0cb2ba909986665323a1f1f880769c379ae1f2ad0dbadf80ee9016)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(None, jsii.invoke(self, "foo", [obj]))
@@ -2587,7 +2587,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__969bc4b33aa2d0684b20d440803d81dfda55aa9fa6398ac40f1afafc2114db5a)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
@@ -2602,7 +2602,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__31f7eac552107efa0a4275f6798b003fcc3b6e74e0a463ae709af8b660b91dc4)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument right", value=right, expected_type=type_hints["right"])
@@ -2617,7 +2617,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9f2d965a28491c2347ed53f3f21b6d1e134bd8c506672f5715c44023bddab720)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(builtins.str, jsii.invoke(self, "foo", [_]))
@@ -2631,7 +2631,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__de81edc65427ea9129fd035388008307a6cae942eefc63cb3d9fd8b42956da06)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
@@ -2647,7 +2647,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__82b4e5e8f3b46996124a87aac13a874f61bf9660a45a062bafa08046c027da63)
 +            check_type(argname="argument optional1", value=optional1, expected_type=type_hints["optional1"])
 +            check_type(argname="argument optional2", value=optional2, expected_type=type_hints["optional2"])
@@ -2663,7 +2663,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__adff4f4d0383c32ffdeb0bca92ae1ea2ebe0b2ea8d9bf5f5433287cc06e55e07)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
@@ -2748,7 +2748,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
              :stability: deprecated
              '''
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__7073f0b0063a9ba1ceb949a9aefe7e3af5a1acbcf19b5013a8c15b7f3495c1ed)
 +                check_type(argname="argument name", value=name, expected_type=type_hints["name"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -2762,7 +2762,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
              :stability: deprecated
              '''
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__5c03ed6e0d395f6fa262d12c7831dd2893af2098bf580a0c602a20f92c1ad24b)
 +                check_type(argname="argument name", value=name, expected_type=type_hints["name"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -2776,7 +2776,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__301126f287c0bfbbd3cb015833c5e0b2ced77e73d25597215c917612b67c3331)
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
@@ -2791,7 +2791,7 @@ exports[`Generated code for "@scope/jsii-calc-lib": <runtime-type-check-diff>/py
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__bed3b5b08c611933987ef5d9dfc131289e09ebcd26286417337c3708ca054e9f)
 +            check_type(argname="argument reflectable", value=reflectable, expected_type=type_hints["reflectable"])
          return typing.cast(typing.Mapping[builtins.str, typing.Any], jsii.invoke(self, "asMap", [reflectable]))
@@ -3361,7 +3361,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ._jsii import *
@@ -12346,7 +12346,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 import scope.jsii_calc_base._jsii
@@ -12446,7 +12446,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -12544,7 +12544,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -12650,7 +12650,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -12724,7 +12724,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -12798,7 +12798,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -12934,7 +12934,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -12984,7 +12984,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -13196,7 +13196,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13258,7 +13258,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13311,7 +13311,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -13430,7 +13430,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -13549,7 +13549,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13627,7 +13627,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13689,7 +13689,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13823,7 +13823,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -13949,7 +13949,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14064,7 +14064,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14134,7 +14134,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14179,7 +14179,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14256,7 +14256,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14317,7 +14317,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14394,7 +14394,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14460,7 +14460,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14524,7 +14524,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14619,7 +14619,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14672,7 +14672,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14734,7 +14734,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -14866,7 +14866,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -14954,7 +14954,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15210,7 +15210,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15263,7 +15263,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -15303,7 +15303,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -15343,7 +15343,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15383,7 +15383,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15453,7 +15453,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15592,7 +15592,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -15769,7 +15769,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -15846,7 +15846,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -16049,7 +16049,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -16117,7 +16117,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -16215,7 +16215,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ...._jsii import *
@@ -16268,7 +16268,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -16330,7 +16330,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from ..._jsii import *
@@ -16389,7 +16389,7 @@ import jsii
 import publication
 import typing_extensions
 
-from jsii._type_checking import cached_type_hints, check_type
+from jsii._type_checking import cached_type_hints, check_type, runtime_type_checking_enabled
 
 
 from .._jsii import *
@@ -16536,7 +16536,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param seed: a \`\`string\`\`.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8348af6419fc01178f78ba59cea59d0c7437626169866d772f4e957d09e6e13a)
 +            check_type(argname="argument seed", value=seed, expected_type=type_hints["seed"])
          return typing.cast(builtins.str, jsii.invoke(self, "workItAll", [seed]))
@@ -16550,7 +16550,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param str: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__06c06b97e36be962012901c4c1f542b3f51b377154f91bf1154d1bd475221829)
 +            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
          return typing.cast(builtins.str, jsii.invoke(self, "someMethod", [str]))
@@ -16562,7 +16562,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @_property.setter
      def _property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__0f076015f51de68c2d0e6902c0d199c9058ad0bff9c11f58b2aae99578ece6ae)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value) # pyright: ignore[reportArgumentType]
@@ -16576,7 +16576,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param inp: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__81a2d86a9598fa10dde4af8bd70d369967edc6febb332dc788702f6aea07f33c)
 +            check_type(argname="argument inp", value=inp, expected_type=type_hints["inp"])
          return typing.cast(None, jsii.invoke(self, "anyIn", [inp]))
@@ -16590,7 +16590,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__56056c33132184bd4ad46f69c534777112c49b9a987cc7b962d4026cf550998c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast("StringEnum", jsii.invoke(self, "enumMethod", [value]))
@@ -16604,7 +16604,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @any_array_property.setter
      def any_array_property(self, value: typing.List[typing.Any]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1ab9ae75c746f751d2bf2ac254bcd1bee8eae7281ec936e222c9f29765fdcfa4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyArrayProperty", value) # pyright: ignore[reportArgumentType]
@@ -16616,7 +16616,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @any_map_property.setter
      def any_map_property(self, value: typing.Mapping[builtins.str, typing.Any]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f88e356a91a703923e622c02850435cc7f632a66f49ca79f00d42590d2928a5e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyMapProperty", value) # pyright: ignore[reportArgumentType]
@@ -16628,7 +16628,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @any_property.setter
      def any_property(self, value: typing.Any) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d81f1a89ccd850ccdb0b96a43000dfcde30f3542bf797051c754610d641f2316)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "anyProperty", value) # pyright: ignore[reportArgumentType]
@@ -16640,7 +16640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @array_property.setter
      def array_property(self, value: typing.List[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__0c663902e9a8a1db9aff59eb8642a68c944dc2e3385744098d2b51ecf2e2e11f)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "arrayProperty", value) # pyright: ignore[reportArgumentType]
@@ -16652,7 +16652,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @boolean_property.setter
      def boolean_property(self, value: builtins.bool) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__106a83d3c77dbb6dbc6fcd706bca888d57ec37cd4beedf7dcc9d7d4428f44845)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "booleanProperty", value) # pyright: ignore[reportArgumentType]
@@ -16664,7 +16664,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @date_property.setter
      def date_property(self, value: datetime.datetime) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5e62ea2f9629943c1138cad77629f47906644279c178b9436e4303e5a5f74c8a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dateProperty", value) # pyright: ignore[reportArgumentType]
@@ -16676,7 +16676,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @enum_property.setter
      def enum_property(self, value: "AllTypesEnum") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f0d83d5dde352e12690bd34359b2272194b20ad0d4585d4cd235a62a68413cc7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "enumProperty", value) # pyright: ignore[reportArgumentType]
@@ -16688,7 +16688,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @json_property.setter
      def json_property(self, value: typing.Mapping[typing.Any, typing.Any]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8cddc5c03b0b87366a7bf274aedf92ced502b23fe811780c7f8c3da532cba3fc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "jsonProperty", value) # pyright: ignore[reportArgumentType]
@@ -16702,7 +16702,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Mapping[builtins.str, "_scope_jsii_calc_lib_c61f082f.Number"],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ce34799b1443789feb28cffe434f5bcbb9cb940065992aa75dbb30eb89cd78e6)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mapProperty", value) # pyright: ignore[reportArgumentType]
@@ -16714,7 +16714,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @number_property.setter
      def number_property(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c8fb4d044e2e7432d7e661aafdb286ebf21dfe5a82b9908dee57945f6892a63e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "numberProperty", value) # pyright: ignore[reportArgumentType]
@@ -16726,7 +16726,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @string_property.setter
      def string_property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4e3dc199e54a9fbd40ceb20cecf887aa2aeca670e9ba223707466d9670eec9b9)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringProperty", value) # pyright: ignore[reportArgumentType]
@@ -16740,7 +16740,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.List[typing.Union[jsii.Number, "_scope_jsii_calc_lib_c61f082f.NumericValue"]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4a9e87035008a2c1b649b911c8cfc02f2723230d8ced957948b2948c76caf61a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionArrayProperty", value) # pyright: ignore[reportArgumentType]
@@ -16754,7 +16754,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Mapping[builtins.str, typing.Union[builtins.str, jsii.Number, "_scope_jsii_calc_lib_c61f082f.Number"]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__62ebee42e1871545bc2e82cfb9c7fe43b5a607c8f662caff89dda0f0ed99a3df)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionMapProperty", value) # pyright: ignore[reportArgumentType]
@@ -16768,7 +16768,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Union[builtins.str, jsii.Number, "_scope_jsii_calc_lib_c61f082f.Number", "Multiply"],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c9be2756a18e8a40eb03cf55231201574f76abf02996a73d0d75fefd1393473d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -16780,7 +16780,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @unknown_array_property.setter
      def unknown_array_property(self, value: typing.List[typing.Any]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e49729a44c21aef8c75584ff0991ddba3ee45184cacf816eb1a6a13b99e99ecc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownArrayProperty", value) # pyright: ignore[reportArgumentType]
@@ -16794,7 +16794,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Mapping[builtins.str, typing.Any],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f8de6b30de9bfa884f9de02e2abe57e9394fb7a387b5691f858b7b98817b1db7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownMapProperty", value) # pyright: ignore[reportArgumentType]
@@ -16806,7 +16806,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @unknown_property.setter
      def unknown_property(self, value: typing.Any) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__901c3574a81e006fdf36f73e34f66b34f65ada4bddcb11cd15a51d6e3d9b59e4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unknownProperty", value) # pyright: ignore[reportArgumentType]
@@ -16818,7 +16818,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @optional_enum_value.setter
      def optional_enum_value(self, value: typing.Optional["StringEnum"]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__705bed55c0dbc20a3a1bad9a21931270f0c285e5b3b276e13bca645ffa7ccb0f)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "optionalEnumValue", value) # pyright: ignore[reportArgumentType]
@@ -16832,7 +16832,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _p1: -
          :param _p2: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__99730dd857f01c8e93755d3e4f1e04f44efd2e63487e37db32f0fae8d36c618e)
 +            check_type(argname="argument _p1", value=_p1, expected_type=type_hints["_p1"])
 +            check_type(argname="argument _p2", value=_p2, expected_type=type_hints["_p2"])
@@ -16844,7 +16844,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param with_param: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7f25304a2274ca1691dbe05a223f32126250948b15187c5095780e5c9af08c2a)
 +            check_type(argname="argument with_param", value=with_param, expected_type=type_hints["with_param"])
          return typing.cast(builtins.str, jsii.invoke(self, "getFoo", [with_param]))
@@ -16856,7 +16856,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _y: -
          :param _z: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__12f6979e6d88948e4aebfe8c25ed814c21d19b4b549d6bc2db4620794e706238)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
@@ -16870,7 +16870,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _x: -
          :param _y: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ca978ab380897c8607252c370202d45bc72e8b5cdc52549bb53b870299333d52)
 +            check_type(argname="argument _x", value=_x, expected_type=type_hints["_x"])
 +            check_type(argname="argument _y", value=_y, expected_type=type_hints["_y"])
@@ -16885,7 +16885,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param scope: 
          :param props: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__35fb7428c2ad70583f7b280c07cec184905b51e8e896efe6cc88eaf83a6f65c3)
 +            check_type(argname="argument scope_", value=scope_, expected_type=type_hints["scope_"])
          props_ = StructParameterType(scope=scope, props=props)
@@ -16899,7 +16899,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param prop_b: the second property to read.
          :param result_prop: the property to write into.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2e74ece926d1cff82c3a42c02b35b0b5b4427369dfc17caf49b658e36503a986)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
 +            check_type(argname="argument prop_a", value=prop_a, expected_type=type_hints["prop_a"])
@@ -16916,7 +16916,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param mult: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__49537950cbbeb6e2c62cb1b8a079cc9bb5cc6d06d95cf2229128539d2be886a3)
 +            check_type(argname="argument mult", value=mult, expected_type=type_hints["mult"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMe", [mult]))
@@ -16930,7 +16930,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__408890be1949f7684db536e79081b85d00d72250ca9eb19c74db6ad226564784)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
@@ -16945,7 +16945,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :return: \`\`value\`\`
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__67894f861ef38d2769b440d2fe71f549cb9e333247b385c5d6ae862b2eb04fc5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Any, jsii.invoke(self, "giveItBack", [value]))
@@ -16959,7 +16959,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__106b87a3d0b194bda7cee057654f752c82d9a92a3775bcc3b2dc5cf7814ba84d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "add", [value]))
@@ -16970,7 +16970,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b0e9a9c8546dd024e1568b2e6d11bd847e53548d624f33afffdffacc77fe01ef)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "mul", [value]))
@@ -16984,7 +16984,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c62707f1a80d6bc26c0b74205f8892c1777e6ed97359263df05628018d8ef6fc)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "pow", [value]))
@@ -16998,7 +16998,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @curr.setter
      def curr(self, value: "_scope_jsii_calc_lib_c61f082f.NumericValue") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c74abb191c66f86aed2c139ec3e50b0442b6d3bdcd41beb06db17c9b3c5d93d0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "curr", value) # pyright: ignore[reportArgumentType]
@@ -17011,7 +17011,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @max_value.setter
      def max_value(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1af5d9bb897bd9bfc2029e92d33fc306fc090e2d0a9bc0bd70fb01762e798fe6)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "maxValue", value) # pyright: ignore[reportArgumentType]
@@ -17025,7 +17025,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Optional[typing.Union["Add", "Multiply", "Power"]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__349b2a1dce95cb7ff4c5a7772d81772697767c5f4e7e5fd709847ff5e526c3c1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -17039,7 +17039,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param initial_value: The initial value of the calculator. NOTE: Any number works here, it's fine. Default: 0
          :param maximum_value: The maximum value the calculator can store. Default: none
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__21033948ed66f89716ed818c4cf9e5a38a9252e042231e1e8e1672356d403bef)
 +            check_type(argname="argument initial_value", value=initial_value, expected_type=type_hints["initial_value"])
 +            check_type(argname="argument maximum_value", value=maximum_value, expected_type=type_hints["maximum_value"])
@@ -17054,7 +17054,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union_property: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9e749834c2e46eee6370de7b60daabbff6e5c16febe9775b98a2b961b0d4e335)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
@@ -17068,7 +17068,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e7f581418e6e26364831457496bacb64b7288f54694b8296434edb222bd0d2ec)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "staticMethodWithMapOfUnionsParam", [param]))
@@ -17081,7 +17081,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__18b42b0b9ab2c741a765cd484124f00630ab522985b8c69e3e99b6902795911e)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.invoke(self, "methodWithMapOfUnionsParam", [param]))
@@ -17095,7 +17095,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.List[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__80b80f78c4ac7fda46ac2aec7ab826a87bef3eaaba64661c90f346972800baf5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -17109,7 +17109,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param map: -
          :param array: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7eb49cfb1282d7f1bd28096ff0407c0806693194f02f5c053936f99756a2a8fd)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
@@ -17124,7 +17124,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @static_array.setter # type: ignore[no-redef]
      def static_array(cls, value: typing.List[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__964903eb68623806c91fc9026cacfdc726cfbb287698530724c5a9938a7bb2ca)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticArray", value) # pyright: ignore[reportArgumentType]
@@ -17136,7 +17136,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @static_map.setter # type: ignore[no-redef]
      def static_map(cls, value: typing.Mapping[builtins.str, builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8dd7203701e4915203e4778820ee40fe6bdd6f0bb2855c200f375606277e06c8)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticMap", value) # pyright: ignore[reportArgumentType]
@@ -17148,7 +17148,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @array.setter
      def array(self, value: typing.List[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c0c76fec28076841e36c26581c26385de1e984d96e91ea434a61c4bf36c9b4d9)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "array", value) # pyright: ignore[reportArgumentType]
@@ -17160,7 +17160,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @map.setter
      def map(self, value: typing.Mapping[builtins.str, builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5461a3c7bb81040765e4ca2e9effb12cc7f5fb018e5e1b8b21501a3f9cd6a8b3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "map", value) # pyright: ignore[reportArgumentType]
@@ -17174,7 +17174,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param obj_prop: 
          :param record_prop: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__11d94174b1d488125abef65967a384ceb599f4948eca6cb9be3d55e1979fb64f)
 +            check_type(argname="argument array", value=array, expected_type=type_hints["array"])
 +            check_type(argname="argument record", value=record, expected_type=type_hints["record"])
@@ -17190,7 +17190,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param int: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c017a39e0da5d21f3a9acbfd00f6a5c84eb4cad306148504e7c835359d35537e)
 +            check_type(argname="argument int", value=int, expected_type=type_hints["int"])
          jsii.create(self.__class__, self, [int])
@@ -17200,7 +17200,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param assert_: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7a756cab89b47a2ae4c08f36162482b60fdf963b8ba638917a63c5e110b4d33e)
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
          return typing.cast(builtins.str, jsii.invoke(self, "import", [assert_]))
@@ -17214,7 +17214,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_object.setter
      def mutable_object(self, value: "IMutableObjectLiteral") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3afbef7e05ef43a18b9260b86660c09b15be66fabeae128c9a9f99b729da7143)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableObject", value) # pyright: ignore[reportArgumentType]
@@ -17228,7 +17228,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union_property: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__0b8f0f729686dad01c8555a3b1bc47509e495bd18f1560ef045b558884b2a1fb)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          jsii.create(self.__class__, self, [union_property])
@@ -17242,7 +17242,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.List[typing.Union[typing.Mapping[builtins.str, typing.Union["StructA", "StructB"]], typing.List[typing.Union["StructA", "StructB"]]]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a8a15eb37393d5188c71779e29278367f7b3600c6dd48bdbcd502cdf510c3c15)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -17256,7 +17256,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Optional[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", typing.List[typing.Union["_scope_jsii_calc_lib_c61f082f.IFriendly", "AbstractClass"]]]],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ec229cc92e04670f4dca9546759b3b39ee813eb1aa18057135bb155d08971e6a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unionProperty", value) # pyright: ignore[reportArgumentType]
@@ -17270,7 +17270,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__481b1113b85e6dc9d7ba31c3ef5654e3550abac1edef9204348ab0f9554f61c1)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
@@ -17284,7 +17284,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param consumer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5676fcb3395f1db1a013537fa52220553e5e418c2a9d97aa2f9541c00ffe259e)
 +            check_type(argname="argument consumer", value=consumer, expected_type=type_hints["consumer"])
          jsii.create(self.__class__, self, [consumer])
@@ -17298,7 +17298,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param delegate: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5c5defc6d683ee91707f8b7770d8d2fb11d381b9c928d7e5d6e2c5c495395f38)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
@@ -17312,7 +17312,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1df814299f3f9720be108d84bdfd61bc591699a79a3c8ac6d450bfb0a9610278)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByObjectLiteral", [ringer]))
@@ -17326,7 +17326,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2f08bd2d56e856071db5f777b63fe2577f9e96dbfcd91e4044d0eda2d26f9017)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPrivateClass", [ringer]))
@@ -17340,7 +17340,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4a2b7f0a05298ddaec112cb088cc71cfa2856aaa1d8414a5157d581b6d5a7293)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticImplementedByPublicClass", [ringer]))
@@ -17354,7 +17354,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f751da3f5766ea4973eb2d89086565259f0a3cd626425a7eec723afd7b64f392)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "staticWhenTypedAsClass", [ringer]))
@@ -17367,7 +17367,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cca04fe4a4c41a0034087ab0c574d1d2f1d0427d87a806fc660446b6a7e5290a)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByObjectLiteral", [ringer]))
@@ -17380,7 +17380,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7bde53b867de290d21a419baa46b8e833a0d394835a1ce2be3b429179b2ddce5)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPrivateClass", [ringer]))
@@ -17393,7 +17393,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__988e53d92b16fb4b7224c654f985a074cbfa7dd5f567df005b41522641ad92ac)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "implementedByPublicClass", [ringer]))
@@ -17406,7 +17406,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param ringer: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1d786308546ae61deacb465c6f501fe7e0be028973494548b57e0480759ed460)
 +            check_type(argname="argument ringer", value=ringer, expected_type=type_hints["ringer"])
          return typing.cast(builtins.bool, jsii.invoke(self, "whenTypedAsClass", [ringer]))
@@ -17420,7 +17420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__83037a3f429b90a38d2d9532a347144030578d83f68817b1a5677ebcd1b38e12)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(builtins.str, jsii.invoke(self, "consumeAnotherPublicInterface", [obj]))
@@ -17433,7 +17433,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__139bf4e63e56bef32e364c5972e055de5cba153d49cc821740fba1d51f73ef70)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(typing.Any, jsii.invoke(self, "consumeNonInternalInterface", [obj]))
@@ -17447,7 +17447,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param obj_prop: 
          :param record_prop: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2be181b08e5a2c0e1e3f3a84732a423af31039117701d35431ee251d343ca9d5)
 +            check_type(argname="argument array_prop", value=array_prop, expected_type=type_hints["array_prop"])
 +            check_type(argname="argument obj_prop", value=obj_prop, expected_type=type_hints["obj_prop"])
@@ -17463,7 +17463,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param data: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__dd941dcba8415b4b4dbb95bc3f55ac3404bdaf303822dfc7093fb615dc66b2cf)
 +            check_type(argname="argument data", value=data, expected_type=type_hints["data"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderArbitrary", [data]))
@@ -17473,7 +17473,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param map: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9008dfc97234c0f2895caaa88d20a94de081c3cd97c38f9a012f13cdae75fbd6)
 +            check_type(argname="argument map", value=map, expected_type=type_hints["map"])
          return typing.cast(builtins.str, jsii.invoke(self, "renderMap", [map]))
@@ -17487,7 +17487,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg2: -
          :param arg3: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__019e6ec86ae7ee325dc404a7025eaf0edcb164e166535a831bccf6658adfbb10)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
@@ -17503,7 +17503,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f64945b01dd806fcd872f369983e1fa6b3db8811cb0682ac6adf88aebb0aabda)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
@@ -17518,7 +17518,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3aef3220b38be7daf4208453b1766d9eafb6a74bd51dfb351d21235a205afa34)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -17532,7 +17532,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cdee1d6893b4921a8d7cf0a9c957a543b69f7a98eb3cedd7ece84871fc81c767)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -17546,7 +17546,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param optional_any: 
          :param optional_array: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c544311353634d5a2f08144f0c184afbcb700d8304b9f49deae99f19e1e7b0af)
 +            check_type(argname="argument anumber", value=anumber, expected_type=type_hints["anumber"])
 +            check_type(argname="argument astring", value=astring, expected_type=type_hints["astring"])
@@ -17568,7 +17568,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param right: 
          :param bottom: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__865cdfdd094ca753189170221ee7d6a0e59c2c0bcfdeff3dc37bb87dd39515ca)
 +            check_type(argname="argument hoisted_top", value=hoisted_top, expected_type=type_hints["hoisted_top"])
 +            check_type(argname="argument left", value=left, expected_type=type_hints["left"])
@@ -17585,7 +17585,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param base_level_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cfa52ba952c3d4a7e6df7fba3f619bf3ac14c52e829cce862a5fa495e45d0e70)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -17599,7 +17599,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param base_level_property: 
          :param first_mid_level_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__354311bd3d60d2b3b4ea927d6a96bdf66aa6d1109c29bfcd96266051c7c30a5e)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
@@ -17614,7 +17614,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param base_level_property: 
          :param second_mid_level_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8074c5f38699399b9e6f8708c125bef5d7c89118c36ffcce8582d66cac2197da)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument second_mid_level_property", value=second_mid_level_property, expected_type=type_hints["second_mid_level_property"])
@@ -17629,7 +17629,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param second_mid_level_property: 
          :param top_level_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9384691e88dd3ab7e55516762b2076445d94bd6d9348db1b93f79de9f4ae0ea1)
 +            check_type(argname="argument base_level_property", value=base_level_property, expected_type=type_hints["base_level_property"])
 +            check_type(argname="argument first_mid_level_property", value=first_mid_level_property, expected_type=type_hints["first_mid_level_property"])
@@ -17646,7 +17646,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param new_value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5ae2124576c295a0c88fc75be0e57258f0f72e63c733e7493367b8558266510e)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(None, jsii.invoke(self, "changePrivatePropertyValue", [new_value]))
@@ -17660,7 +17660,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _optional_any: -
          :param _optional_string: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8ffaadb351f5c2c48a7368068d5c88e0c7836deefe0e13aa9fe53ac104052fd5)
 +            check_type(argname="argument _required_any", value=_required_any, expected_type=type_hints["_required_any"])
 +            check_type(argname="argument _optional_any", value=_optional_any, expected_type=type_hints["_optional_any"])
@@ -17676,7 +17676,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param optional: -
          :param things: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5af7b38b9b5c170ebd3e05c215e05f10e6843b03868850dad87a5a149b90e790)
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
 +            check_type(argname="argument things", value=things, expected_type=typing.Tuple[type_hints["things"], ...]) # pyright: ignore [reportGeneralTypeIssues]
@@ -17691,7 +17691,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param dont_set_me: .. epigraph:: Don't set this parameter. A parameter that shouldn't be set, with the annotation in a weird place.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__feb33b34fd05e771c7e47c132104c701042acfdf4eb6753873c4463e01f3cd9c)
 +            check_type(argname="argument dont_set_me", value=dont_set_me, expected_type=type_hints["dont_set_me"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
@@ -17705,7 +17705,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param example: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ae5d543014149876cec8b005abbb94c112981cccaf318870c7fe4e8353c2c675)
 +            check_type(argname="argument example", value=example, expected_type=type_hints["example"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -17719,7 +17719,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value_store: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c0d457497f870b36d210f01af9890c6624684d1e53da833858e801c18baf9fbb)
 +            check_type(argname="argument value_store", value=value_store, expected_type=type_hints["value_store"])
          jsii.create(self.__class__, self, [value_store])
@@ -17731,7 +17731,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @dynamic_property.setter
      def dynamic_property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4f40c12fae2ef2673f3f324c0c452f65c187c1b3e6552b86768465a2d20de051)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dynamicProperty", value) # pyright: ignore[reportArgumentType]
@@ -17743,7 +17743,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @value_store.setter
      def value_store(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9106fb2a86e944ce0c61537852ab2d310a8a53448c6946af051de0325a67fa1a)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueStore", value) # pyright: ignore[reportArgumentType]
@@ -17757,7 +17757,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param original_value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ad557fbd0532aa4220227645f5aae3e73ebae6b529cfe074430abf30d18cd5e9)
 +            check_type(argname="argument original_value", value=original_value, expected_type=type_hints["original_value"])
          jsii.create(self.__class__, self, [original_value])
@@ -17770,7 +17770,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :return: the old value that was set.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a4026611d197b83d9a37b973ba97c69254e674921a7d89d0eb57ac41a19b636e)
 +            check_type(argname="argument new_value", value=new_value, expected_type=type_hints["new_value"])
          return typing.cast(builtins.str, jsii.invoke(self, "overrideValue", [new_value]))
@@ -17784,7 +17784,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param clock: your implementation of \`\`WallClock\`\`.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2a7f203302b2610301f1b36f34453db0f5572f2e02b0bc4c9933fd670e594222)
 +            check_type(argname="argument clock", value=clock, expected_type=type_hints["clock"])
          jsii.create(self.__class__, self, [clock])
@@ -17798,7 +17798,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :return: \`\`word\`\`.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a90d161fb7d47a195a192cf987ac6968fc2c6fbe27005bdd7684478a3d956e66)
 +            check_type(argname="argument word", value=word, expected_type=type_hints["word"])
          return typing.cast(builtins.str, jsii.invoke(self, "repeat", [word]))
@@ -17812,7 +17812,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param opts: -
          :param key: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b87cc89f87e9b1c180227625f3aba9395da5a8b258a88e605d466edb9004d709)
 +            check_type(argname="argument opts", value=opts, expected_type=type_hints["opts"])
 +            check_type(argname="argument key", value=key, expected_type=type_hints["key"])
@@ -17827,7 +17827,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param option1: 
          :param option2: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d34e4f5dab670ec3ea298ec2cda50be32700f7f52dcef6a618ca9cb3706062ee)
 +            check_type(argname="argument option1", value=option1, expected_type=type_hints["option1"])
 +            check_type(argname="argument option2", value=option2, expected_type=type_hints["option2"])
@@ -17842,7 +17842,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :stability: experimental
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6a92c7223d00e7a0a2f0611cbb689671885b835bb26eedc8eb4a4d12e4ed5021)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
@@ -17857,7 +17857,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__52559292c6e04ad49e53e443b1a4c56149833b8f12876d779bb8860fcb231b41)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -17871,7 +17871,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :stability: experimental
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b0c8f4c6eca5af7072a4a7c737950b39e75c61a56c505deb94edc5cd0995ed7d)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -17885,7 +17885,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param success: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__dad018fa707514e8023df185b5e6e0a4b611bec563fe57abd9b81939b8833ebb)
 +            check_type(argname="argument success", value=success, expected_type=type_hints["success"])
          jsii.create(self.__class__, self, [success])
@@ -17899,7 +17899,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param boom: 
          :param prop: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__861a5ec03219f6c9fecd1b039faa2e53075227ff0d28f8eb66929909bc0c3096)
 +            check_type(argname="argument boom", value=boom, expected_type=type_hints["boom"])
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
@@ -17914,7 +17914,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :external: true
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__82149b1f61aca58419f6ba4c74c8bb1c5c241433707e64ea4626937b294d8fe5)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
@@ -17929,7 +17929,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8380ec30b1f8773df7b5b27be8811be79b04f1d17c8eca83f83927eb56cdfd34)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -17943,7 +17943,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :external: true
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8e8843a5fc914ec2c1e3baccdad526ea4d48eee37296f6812f3c0673ef86794f)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -17957,7 +17957,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param name: The name of the greetee. Default: world
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3dce87825e36304d54521ce5524aa7e230fa5d505b0abbc79101fd9014f2cbd9)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
@@ -17971,7 +17971,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param friendly: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d17f0544be961cba6cabfbb40f28c196963de107fcaef9c56d8227bdcb359431)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "betterGreeting", [friendly]))
@@ -17985,7 +17985,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @a.setter
      def a(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3eabfcad9a21b26024f4c1480ca127a3d6c6888067f0ae991d5922a49bfe81d4)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value) # pyright: ignore[reportArgumentType]
@@ -17999,7 +17999,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bell: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d127476ce3b6e59ff9f375f547c1b6e1826d7a3969612c0605ebd0017d2b985d)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
@@ -18013,7 +18013,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bell: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2c34aaac5945bdc61c4f56492dee5608e1852940835d94d3e991fed377db66f2)
 +            check_type(argname="argument bell", value=bell, expected_type=type_hints["bell"])
          return typing.cast(None, jsii.invoke(self, "yourTurn", [bell]))
@@ -18027,7 +18027,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e4d76200a6c5bdbdd51f208229da8bfd8f6f4c967af28e1e733579780e9d4a0e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -18041,7 +18041,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6e68d313f3254be7145220b211c66f45749aa8efc15aaf93d96330eb3cb7c6c7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -18055,7 +18055,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @private.setter
      def private(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8199a83e86f8a4cf29ddc53d2b2151c37c7fa10d29562b454127376d1867d6da)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value) # pyright: ignore[reportArgumentType]
@@ -18069,7 +18069,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a904d745cb9f037de717ed7a2b1d3a207493564662fdbe1d7c63e60a24f9bace)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -18083,7 +18083,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg1: -
          :param arg2: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5568c72c746dd5221cb6fb7b741ed7a3346c346d7a30863c5abe3d99ada53098)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
@@ -18098,7 +18098,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__858de6e8785f18ad264a158ca83a0fc1e0a6299efa9f77a0b31eaaffaa5b086c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value) # pyright: ignore[reportArgumentType]
@@ -18112,7 +18112,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @foo.setter
      def foo(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c571c6749392bc04e123a99b926edaf10b88be6b6d6b6a3937cae9893af5119e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value) # pyright: ignore[reportArgumentType]
@@ -18126,7 +18126,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @value.setter
      def value(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e0395944061fad9d5156b633dc20682ff9759ae0acb88df574b159f4919ab3a5)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "value", value) # pyright: ignore[reportArgumentType]
@@ -18140,7 +18140,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @b.setter
      def b(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9d1e4198ba3f4e6b6a6f4ce0a4a185223ec216368c0c3304c69b029aba13ca49)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value) # pyright: ignore[reportArgumentType]
@@ -18152,7 +18152,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @c.setter
      def c(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6774e195ab25dab5790e1d187eb30be56997804d5186753a9928f2575f81977b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value) # pyright: ignore[reportArgumentType]
@@ -18166,7 +18166,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @property.setter
      def property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__831f664cd567fd4e707fd175e9c9e13519f3ca587b792d7d5bc79f427589a802)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "property", value) # pyright: ignore[reportArgumentType]
@@ -18180,7 +18180,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__254a58386276f7b7d5a41dddd674375b8942c2cad4deb6c2d24b55d240d14350)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -18194,7 +18194,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__10bb8b026d6c8368d479cf0da8b27c049c5f9088f173a63624e515dd36607439)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value) # pyright: ignore[reportArgumentType]
@@ -18208,7 +18208,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @private.setter
      def private(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2df4d055b033cdfdf7ad915b451ddc787ad68fb64b7e02386a9d8e591c1657af)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "private", value) # pyright: ignore[reportArgumentType]
@@ -18222,7 +18222,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param bar: -
          :param goo: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b70592e4d080897239bf5f8b0de5b6b464cd9e888e39fca1082c04b5cbeca890)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -18238,7 +18238,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param count: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1d6e348a61ed27bfc8b7928365798b43e0130ca2b720c1105baca04fa093d194)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(typing.List["_scope_jsii_calc_lib_c61f082f.IDoublable"], jsii.sinvoke(cls, "makeInterfaces", [count]))
@@ -18252,7 +18252,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @prop_a.setter
      def prop_a(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__30ce308abdc1d2462c00bf7a4acc194ec05d61ddee24b2e79c674aa7034e5ffa)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propA", value) # pyright: ignore[reportArgumentType]
@@ -18264,7 +18264,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @prop_b.setter
      def prop_b(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__eef7c487e6f0c4d81dd633cf70121104ff8f3458fa52a418df64bcab9fe4bd3e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "propB", value) # pyright: ignore[reportArgumentType]
@@ -18278,7 +18278,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @while_.setter
      def while_(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a7654af9a241e67ad498c3eb33b98e6cdb1558487bb9b02dcce41f75334b76ad)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "while", value) # pyright: ignore[reportArgumentType]
@@ -18292,7 +18292,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__43f45c49ecee3d08351b82aa5cdc3548d9dafa534cd2d99da8b5c5c9188e9a54)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(typing.Optional[builtins.str], jsii.sinvoke(cls, "stringify", [value]))
@@ -18306,7 +18306,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              '''
              :param value: 
              '''
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__ef705a05998260349d35c748c557e65cf539d53e136eb9191250080bdce852c3)
 +                check_type(argname="argument value", value=value, expected_type=type_hints["value"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18320,7 +18320,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              '''
              if isinstance(prop, dict):
                  prop = LevelOne.PropBooleanValue(**prop)
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__2a9e65060bf85c3d49b79ada1f9394ae146c380a4212c190065e031098d570b8)
 +                check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18334,7 +18334,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(prop, dict):
              prop = LevelOne.PropProperty(**prop)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__479be5d5625f656c28cf12ffdc2cef9d6d74aae555551630f440fcb05351d261)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18348,7 +18348,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param public_load_balancer: Determines whether the Application Load Balancer will be internet-facing. Default: true
          :param public_tasks: Determines whether your Fargate Service will be assigned a public IP address. Default: false
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b3d89a25beb0ebd10c196d941aa924197ae9a2def08f1f414c190a2a6d943d9c)
 +            check_type(argname="argument container_port", value=container_port, expected_type=type_hints["container_port"])
 +            check_type(argname="argument cpu", value=cpu, expected_type=type_hints["cpu"])
@@ -18366,7 +18366,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7e73465ea858e34d4df8697d34f29a53ca3c3a41c47946382e5d49f498e3747d)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
@@ -18381,7 +18381,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param number_prop: When provided, must be > 0.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__04dae031a5097183ccda93eb91ec51a8a6fa1133134a6a398f1f05c581bc0091)
 +            check_type(argname="argument number_prop", value=number_prop, expected_type=type_hints["number_prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18395,7 +18395,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _param1: -
          :param optional: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__218107d38285901ff40e08163f0de0bac5d835bd64c21c0a735e8d72399ebe35)
 +            check_type(argname="argument _param1", value=_param1, expected_type=type_hints["_param1"])
 +            check_type(argname="argument optional", value=optional, expected_type=type_hints["optional"])
@@ -18406,7 +18406,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a109cd8429db09172895a3eb04ca7e9d5c92129c7ca7a50f85fa89b6f6ab366b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "giveMeUndefined", [value]))
@@ -18420,7 +18420,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @change_me_to_undefined.setter
      def change_me_to_undefined(self, value: typing.Optional[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7102c29a709c4297fb88615c74a3e42a584364ac4ccba5c1db42a65e05184d1b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "changeMeToUndefined", value) # pyright: ignore[reportArgumentType]
@@ -18434,7 +18434,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param array_with_three_elements_and_undefined_as_second_argument: 
          :param this_should_be_undefined: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ae8d47cabe4d36f88c891d250d7e792432b0d153223789ec3687e714ba92a5f3)
 +            check_type(argname="argument array_with_three_elements_and_undefined_as_second_argument", value=array_with_three_elements_and_undefined_as_second_argument, expected_type=type_hints["array_with_three_elements_and_undefined_as_second_argument"])
 +            check_type(argname="argument this_should_be_undefined", value=this_should_be_undefined, expected_type=type_hints["this_should_be_undefined"])
@@ -18449,7 +18449,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param generator: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3c1812783ba0b3b2146a3dd9609a6e12af404502ff5fbb9b9a9be49bf576122b)
 +            check_type(argname="argument generator", value=generator, expected_type=type_hints["generator"])
          jsii.create(self.__class__, self, [generator])
@@ -18459,7 +18459,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param gen: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__151b90e9765ce9a05ae13e568f4ba7c9e36e34c1cd991c5c1ee0249869fd4cce)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSameGenerator", [gen]))
@@ -18473,7 +18473,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @generator.setter
      def generator(self, value: "IRandomNumberGenerator") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__0f5a1cc548d3db6e156cec5671bc04b980132e529c77f3bb5aaa58427db35e7c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "generator", value) # pyright: ignore[reportArgumentType]
@@ -18487,7 +18487,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param values: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f5cb9f9511b0248cd4c0c4bec4eed9e75e7690012237fdb1b39b3f7b3bb0392e)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromArray", [values]))
@@ -18501,7 +18501,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param values: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ca5199647728e53a1ec89d4fd7dad9aeb7239f8c1213c51b4e2eda734daa4cf4)
 +            check_type(argname="argument values", value=values, expected_type=type_hints["values"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumFromMap", [values]))
@@ -18515,7 +18515,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param delegate: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__da93d15e57e6e2a1857cd7df156fb2a55ec91715c97323f20268def40f72137c)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
@@ -18529,7 +18529,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg2: -
          :param arg3: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5f6c5e5b55379123a8bd2bc457d9a5e9a0d34dd512b2bd2f59c6a5bec2a95f14)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
@@ -18545,7 +18545,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param field: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__26ecd0d4ea200acf388a8b91f17bfd3c09b6c7f8e0a84228b89c27ace672d0b1)
 +            check_type(argname="argument field", value=field, expected_type=type_hints["field"])
          self._values: typing.Dict[builtins.str, typing.Any] = {}
@@ -18559,7 +18559,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @_override_read_write.setter
      def _override_read_write(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__72ca8c3c148afe2b76dc14b63b8e2baf0bbf28802add3f88490cb5d3792825fb)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "overrideReadWrite", value) # pyright: ignore[reportArgumentType]
@@ -18573,7 +18573,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ca8d417ddf787890441d6903718eebaf7fde3508b3466202724fdac3a17ba79b)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          return typing.cast(jsii.Number, jsii.invoke(self, "test", [obj]))
@@ -18587,7 +18587,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param string_property: 
          :param struct_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__32a51b5d61d5ca58d33e8f6b9d9e1c4f16b39bf431a669250d4c290de0bbf46f)
 +            check_type(argname="argument builtins", value=builtins, expected_type=type_hints["builtins"])
 +            check_type(argname="argument str", value=str, expected_type=type_hints["str"])
@@ -18602,7 +18602,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(struct_property, dict):
              struct_property = StructA(**struct_property)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c93d69c5c8307eec2d1c6e8d5f9892234fbdd24bb5cce3f5ea1e210276bc58c1)
 +            check_type(argname="argument boolean_property", value=boolean_property, expected_type=type_hints["boolean_property"])
 +            check_type(argname="argument string_property", value=string_property, expected_type=type_hints["string_property"])
@@ -18618,7 +18618,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param scope: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ae63c91319764cabd02536ac5b03026eb3f4071497b2a04adf93ca02985507ae)
 +            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
          return typing.cast("_scope_jsii_calc_lib_c61f082f.Number", jsii.invoke(self, "useScope", [scope]))
@@ -18632,7 +18632,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param foo: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f6db465208dd616dc4f171643676a159b21fe5963ec9a3d1fd752e5cb291868d)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18646,7 +18646,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param dt: -
          :param ev: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__85c3ad65f24d8d5af99d7777a0379b793f45ac0e0e39714f279b8f2d58dbcfdb)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
 +            check_type(argname="argument dt", value=dt, expected_type=type_hints["dt"])
@@ -18662,7 +18662,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param friendly: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__edbbf85a7c4217635da7418d28aa61c4e11f7a0c1e9c960528ed4e7bee1ad541)
 +            check_type(argname="argument friendly", value=friendly, expected_type=type_hints["friendly"])
          return typing.cast(builtins.str, jsii.invoke(self, "sayHello", [friendly]))
@@ -18676,7 +18676,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param base: The base of the power.
          :param pow: The number of times to multiply.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__df4f41b4c003b9ba61f07f4d41a4059f167ea41c03ea29933966d2caeb831d8c)
 +            check_type(argname="argument base", value=base, expected_type=type_hints["base"])
 +            check_type(argname="argument pow", value=pow, expected_type=type_hints["pow"])
@@ -18691,7 +18691,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__235768085718ab33214221cff3145bb2a82c28916350f273995760a428a1aba3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "saveFoo", [value]))
@@ -18705,7 +18705,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.Optional["_scope_jsii_calc_lib_c61f082f.EnumFromScopedModule"],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__100c679fa10c1938fc087475a1e5fcdf7c2cbff383b1c02b1d09471cb4f23123)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "foo", value) # pyright: ignore[reportArgumentType]
@@ -18719,7 +18719,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(nested_struct, dict):
              nested_struct = NestedStruct(**nested_struct)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cf66d7b4f4a567aefacbafc24f61d33a942afde3d167676ed65ea82da95cd36e)
 +            check_type(argname="argument string_prop", value=string_prop, expected_type=type_hints["string_prop"])
 +            check_type(argname="argument nested_struct", value=nested_struct, expected_type=type_hints["nested_struct"])
@@ -18734,7 +18734,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg2: -
          :param arg3: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6db501e892de783af62ff728e59cc3155afc51ddc2dff77cce61ffe698e2e1f3)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
@@ -18746,7 +18746,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param arg: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5978f09aaa3317742377437d5735571f672119325c2b5d69f26153bae6764c85)
 +            check_type(argname="argument arg", value=arg, expected_type=type_hints["arg"])
          return typing.cast(None, jsii.invoke(self, "methodWithOptionalAnyArgument", [arg]))
@@ -18760,7 +18760,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param arg2: -
          :param arg3: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c894904fd4904d7e110da91df846a8ec0970051a274bba5ad95c2b7dc1125cc2)
 +            check_type(argname="argument arg1", value=arg1, expected_type=type_hints["arg1"])
 +            check_type(argname="argument arg2", value=arg2, expected_type=type_hints["arg2"])
@@ -18776,7 +18776,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param deeper_required_prop: It's long and required.
          :param deeper_optional_prop: It's long, but you'll almost never pass it.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e7383b9a36a10b88815e6c310c7b13c611260f5ccb143b75dac114873643350d)
 +            check_type(argname="argument deeper_required_prop", value=deeper_required_prop, expected_type=type_hints["deeper_required_prop"])
 +            check_type(argname="argument deeper_optional_prop", value=deeper_optional_prop, expected_type=type_hints["deeper_optional_prop"])
@@ -18791,7 +18791,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2ccde09a2986c421795069d44c46d9e2d7470609094b8b7177c6b154360f7435)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonInt", [value]))
@@ -18805,7 +18805,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__76cbdc0bba36d674ab013a40d091c1f3ccb139f10e78844ebc868bfa5d707ef8)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.bool, jsii.invoke(self, "isSingletonString", [value]))
@@ -18819,7 +18819,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param property: 
          :param yet_anoter_one: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1b795ca2a3052da38144d10d87f230e74bcfa497af1262580f53908be48f6710)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
 +            check_type(argname="argument yet_anoter_one", value=yet_anoter_one, expected_type=type_hints["yet_anoter_one"])
@@ -18834,7 +18834,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              '''
              :param field1: 
              '''
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__fc7308b88a257882ff36698ae2addc6565d7c0986fc18d31fa3b531d0f1e0e80)
 +                check_type(argname="argument field1", value=field1, expected_type=type_hints["field1"])
              self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18848,7 +18848,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
              :param field1: 
              :param field2: 
              '''
-+            if __debug__:
++            if __debug__ and runtime_type_checking_enabled():
 +                type_hints = cached_type_hints(_typecheckingstub__53ef72709089f8b082b5b1468b38f85fabbb62c51969f600a065ab63f749e32f)
 +                check_type(argname="argument field1", value=field1, expected_type=type_hints["field1"])
 +                check_type(argname="argument field2", value=field2, expected_type=type_hints["field2"])
@@ -18863,7 +18863,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param readonly_string: -
          :param mutable_number: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8c577a76d55e32f4b62a2a005d0c321bf9d0784b2f6cea5f10e297f3f79fc4bb)
 +            check_type(argname="argument readonly_string", value=readonly_string, expected_type=type_hints["readonly_string"])
 +            check_type(argname="argument mutable_number", value=mutable_number, expected_type=type_hints["mutable_number"])
@@ -18878,7 +18878,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @mutable_property.setter
      def mutable_property(self, value: typing.Optional[jsii.Number]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__737be2f0376e64bd8c0980aee9fc6afd796bb4d0cb3415eab28d054f15881752)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "mutableProperty", value) # pyright: ignore[reportArgumentType]
@@ -18892,7 +18892,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param readonly_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4bbf1eebbce12768b1d2ef90968ffdbe749e42ce8bcdaf4c8750314d2160c5ea)
 +            check_type(argname="argument readonly_property", value=readonly_property, expected_type=type_hints["readonly_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -18906,7 +18906,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @static_variable.setter # type: ignore[no-redef]
      def static_variable(cls, value: builtins.bool) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cf00e16ec45ebcadc1f7003eb344ecf452096a12a1a76ff0e15fce1066d716d2)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "staticVariable", value) # pyright: ignore[reportArgumentType]
@@ -18920,7 +18920,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__69df39c5fc3367bba974a46518d9122ce067721f56037ef6e1faedf479222822)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
@@ -18932,7 +18932,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param name: The name of the person to say hello to.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c4597464b7867e98bf0052f7808e080b75874d088aeac980865a4fc19e47a6d1)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "staticMethod", [name]))
@@ -18946,7 +18946,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @instance.setter # type: ignore[no-redef]
      def instance(cls, value: "Statics") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__748a4d0813e4a3ab750bd52215b9ff4dee315d39b160d47884780ea7c4b10daf)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "instance", value) # pyright: ignore[reportArgumentType]
@@ -18958,7 +18958,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @non_const_static.setter # type: ignore[no-redef]
      def non_const_static(cls, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5d0ed37ae4b7f5bd294a768da342f4735c6636e0197883a5727e46ed81deec69)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.sset(cls, "nonConstStatic", value) # pyright: ignore[reportArgumentType]
@@ -18972,7 +18972,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @you_see_me.setter
      def you_see_me(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__aa3b9a5342b6fe1366fac3279219c5bae15389881ddd050c544c1d0001853482)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "youSeeMe", value) # pyright: ignore[reportArgumentType]
@@ -18986,7 +18986,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param optional_number: 
          :param optional_string: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c9e4f6413d6ce49f4a289256d84d0fa97f7abac1877fc8d49f80f4a7d83a4972)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_number", value=optional_number, expected_type=type_hints["optional_number"])
@@ -19002,7 +19002,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(optional_struct_a, dict):
              optional_struct_a = StructA(**optional_struct_a)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4d335a3a7bbc35ed76509a5e85466d6d29221efebdd6dd4de639ef040628f332)
 +            check_type(argname="argument required_string", value=required_string, expected_type=type_hints["required_string"])
 +            check_type(argname="argument optional_boolean", value=optional_boolean, expected_type=type_hints["optional_boolean"])
@@ -19018,7 +19018,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param scope: 
          :param props: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7eb7b6caeb33bbd3740ca0fc027022df9d4fade4a7d1943a334f2869ab44bd98)
 +            check_type(argname="argument scope", value=scope, expected_type=type_hints["scope"])
 +            check_type(argname="argument props", value=props, expected_type=type_hints["props"])
@@ -19033,7 +19033,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param _positional: -
          :param inputs: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e3587fc6359e7cd1adf0bb70ed66e1cd69faa462a530e07c8d25a96b942cb943)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
 +            check_type(argname="argument inputs", value=inputs, expected_type=typing.Tuple[type_hints["inputs"], ...]) # pyright: ignore [reportGeneralTypeIssues]
@@ -19048,7 +19048,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b60fd8dad9496da93546e0555f2f8a7a34711e7160c06dc64a47f095f1539d02)
 +            check_type(argname="argument _positional", value=_positional, expected_type=type_hints["_positional"])
          input = TopLevelStruct(
@@ -19062,7 +19062,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param struct: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1c22dd35a08877498e4c2c0ed61e220c19d83da3b6a1e278dfcb7af4d76d2df8)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructA", [struct]))
@@ -19076,7 +19076,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param struct: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__bfb5d0235b42940b9a17c7bb3182f454c7652fdb031f8993719a701d42833623)
 +            check_type(argname="argument struct", value=struct, expected_type=type_hints["struct"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "isStructB", [struct]))
@@ -19087,7 +19087,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param which: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e3e3d0b072ef214d95806fb0366dd1f4a92b97932f845c9364616c9348bce502)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union["StructA", "StructB"], jsii.sinvoke(cls, "provideStruct", [which]))
@@ -19101,7 +19101,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__06173422e8b2a410ef992bee26115592516245e72f1a99397919d18bfebc1259)
 +            check_type(argname="argument union_property", value=union_property, expected_type=type_hints["union_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -19115,7 +19115,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param foo: An enum value.
          :param bar: Optional enum value (of type integer). Default: AllTypesEnum.YOUR_ENUM_VALUE
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9fac60639e71eb35a422d891e6b571b3ba2118da50de35e8ba784bbb73928be9)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -19130,7 +19130,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param result: 
          :param that: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__21b11cdfe2d95237cdddef417a67936ff8529ea3cef4bd7e80fe498f1e27527d)
 +            check_type(argname="argument default", value=default, expected_type=type_hints["default"])
 +            check_type(argname="argument assert_", value=assert_, expected_type=type_hints["assert_"])
@@ -19147,7 +19147,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          self,
          value: typing.List["_scope_jsii_calc_lib_c61f082f.NumericValue"],
      ) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e2e14d04b1a68f16d9aef0965aa4ffbc51af3cbd2d201ac6e236d861b10c2fbf)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "parts", value) # pyright: ignore[reportArgumentType]
@@ -19161,7 +19161,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__11e78aa6557af36be636eea7a1a9b1d6ebf38d63d876b270de65a5f23152b605)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
@@ -19176,7 +19176,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param bar: Some number, like 42.
          :param id: An \`\`id\`\` field here is terrible API design, because the constructor of \`\`SupportsNiceJavaBuilder\`\` already has a parameter named \`\`id\`\`. But here we are, doing it like we didn't care.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__46b91a4f1b85f01437aa8a6dda82c7c9e02f0b2ae5324f8c1591fa7ff74feaa0)
 +            check_type(argname="argument id_", value=id_, expected_type=type_hints["id_"])
          props = SupportsNiceJavaBuilderProps(bar=bar, id=id)
@@ -19190,7 +19190,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a961c6dee96c75a70470863d82c09136094c1d72d47aafe7f105c7733536dd4d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyOtherProperty", [value]))
@@ -19200,7 +19200,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f3d4d3109122672e8fa17c64fb60787d84a098ee0ee0857d4a10ffe5345a1908)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "modifyValueOfTheProperty", [value]))
@@ -19214,7 +19214,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param n: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ba36c4cb32b9551fe1c3e91bd834b2e97f7ee93d0b5919acfb1c4fd3d6161295)
 +            check_type(argname="argument n", value=n, expected_type=type_hints["n"])
          return typing.cast(jsii.Number, jsii.invoke(self, "virtualMethod", [n]))
@@ -19224,7 +19224,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7118412729d7ec6272cded791897b09f12ee70e1ca550853121f98ceb30ee0e7)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(None, jsii.invoke(self, "writeA", [value]))
@@ -19238,7 +19238,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @a.setter
      def a(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c361a6694d6564ff5c16af012cfaf94cac0a971928a1d0fb014c27f971287836)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value) # pyright: ignore[reportArgumentType]
@@ -19250,7 +19250,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @caller_is_property.setter
      def caller_is_property(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d5d44f6e3395b0db421bab95a6dd7d1560538c63f136025c6b216ffb01eae179)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "callerIsProperty", value) # pyright: ignore[reportArgumentType]
@@ -19262,7 +19262,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @other_property.setter
      def other_property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__64c8c65ae76fcafb4b6d28e75f8fd31efad60ab9e71d11cbd5877c28c45d8f70)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "otherProperty", value) # pyright: ignore[reportArgumentType]
@@ -19274,7 +19274,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @the_property.setter
      def the_property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__52ea95020be0094da769c873214a182768aa2de47b1c4c3dff43f1226edfe281)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "theProperty", value) # pyright: ignore[reportArgumentType]
@@ -19286,7 +19286,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @value_of_other_property.setter
      def value_of_other_property(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__21d6ffe465a7e42c257c8318bf2bee38ecbc6b1959e6e945e769e365afb3e55d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "valueOfOtherProperty", value) # pyright: ignore[reportArgumentType]
@@ -19300,7 +19300,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param second_level: A union to really stress test our serialization.
          :param optional: You don't have to pass this.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__74359fdf4e6a6505a1c0bc4c2c687826dde0a7696de75fc39f9ed57d89137f96)
 +            check_type(argname="argument required", value=required, expected_type=type_hints["required"])
 +            check_type(argname="argument second_level", value=second_level, expected_type=type_hints["second_level"])
@@ -19316,7 +19316,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param operand: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e31f878fe14747887a58683a15ca9c8ab54ec35cd6e3a665ad70dd53deadb573)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
@@ -19330,7 +19330,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param bar: 
          :param foo: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__223de5294ccc50da976adb8794cb8556981e31d63a2c8b249f7dfbd9e2d99eac)
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
@@ -19345,7 +19345,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param delegate: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__aaaf822e80c6473bff9b1da58151a278cd846ae0614db9af97bc57ea6f899ce2)
 +            check_type(argname="argument delegate", value=delegate, expected_type=type_hints["delegate"])
          jsii.create(self.__class__, self, [delegate])
@@ -19359,7 +19359,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param obj: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__73d1545891c65d400938add489402441cb083c61d214ad7a922b6417d3984732)
 +            check_type(argname="argument obj", value=obj, expected_type=type_hints["obj"])
          jsii.create(self.__class__, self, [obj])
@@ -19373,7 +19373,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param ext: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__60f3870a6dceb3773397b75ec3f3b664f38c2cc3d2f37dc055262663d12f41a8)
 +            check_type(argname="argument ext", value=ext, expected_type=type_hints["ext"])
          return typing.cast(builtins.str, jsii.invoke(self, "readStringAndNumber", [ext]))
@@ -19383,7 +19383,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__42edcb376aed0b6e6fec7d7df016bda9e3a31df0e47ecabb5465d1c84d16a414)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          return typing.cast(builtins.str, jsii.invoke(self, "writeAndRead", [value]))
@@ -19397,7 +19397,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param method: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6d238d6a2f6e464c570c3176db3d78d62e0be9908b705705c8f6d7b6b2385c54)
 +            check_type(argname="argument method", value=method, expected_type=type_hints["method"])
          jsii.create(self.__class__, self, [method])
@@ -19407,7 +19407,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param values: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__43f32dfb73f1a7fe9c86c00bbc381391db4812c13b5b72363ddcfcd57638c368)
 +            check_type(argname="argument values", value=values, expected_type=typing.Tuple[type_hints["values"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          return typing.cast(typing.List[jsii.Number], jsii.invoke(self, "asArray", [*values]))
@@ -19418,7 +19418,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param prefix: a prefix that will be use for all values returned by \`\`#asArray\`\`.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a33769c23320f9f6bce3e3a70c594135cf44ca5c9c6d1de1cae8cc62a99d49e9)
 +            check_type(argname="argument prefix", value=prefix, expected_type=typing.Tuple[type_hints["prefix"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*prefix])
@@ -19432,7 +19432,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param first: the first element of the array to be returned (after the \`\`prefix\`\` provided at construction time).
          :param others: other elements to be included in the array.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1c18f2c7d91dcdc13843ff1637ed95a1f1c1ed99384d6276ee493b0ca579b4a4)
 +            check_type(argname="argument first", value=first, expected_type=type_hints["first"])
 +            check_type(argname="argument others", value=others, expected_type=typing.Tuple[type_hints["others"], ...]) # pyright: ignore [reportGeneralTypeIssues]
@@ -19447,7 +19447,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param union: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f18ff2aa5c744d99cc2b37e705d6ed44823660f714c20539c148c9e34e123752)
 +            check_type(argname="argument union", value=union, expected_type=typing.Tuple[type_hints["union"], ...]) # pyright: ignore [reportGeneralTypeIssues]
          jsii.create(self.__class__, self, [*union])
@@ -19459,7 +19459,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @union.setter
      def union(self, value: typing.List[typing.Union["StructA", "StructB"]]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__01944feab2feb5a9fdf3d356f62de139685f520d3bb3a38ddc5c42d0b03963fe)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "union", value) # pyright: ignore[reportArgumentType]
@@ -19473,7 +19473,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param index: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5efa2ef42e261d5c38c59d5e216e587cb3005bbbb5b4a62e926087ee58478a36)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "overrideMeAsync", [index]))
@@ -19483,7 +19483,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param index: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ca8f2360b0292d0b5329ac52818673aece7fb01cf2f09567e60ff65b7728c9cc)
 +            check_type(argname="argument index", value=index, expected_type=type_hints["index"])
          return typing.cast(jsii.Number, jsii.invoke(self, "overrideMeSync", [index]))
@@ -19493,7 +19493,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param count: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5bc99fd66b59152ee7799cf716c91bec428d7091eb33ece69057f9ca9b9fdb19)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "parallelSumAsync", [count]))
@@ -19503,7 +19503,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param count: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__58451fb4813d1aa8877a55de41f1ef8bd30300048337edb2bcf16985abbb6f45)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.ainvoke(self, "serialSumAsync", [count]))
@@ -19513,7 +19513,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param count: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7ac4c09636b11fefb0a54fbd52b88fc2b4c5c356eb07189a0d2545601f3bef9c)
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
          return typing.cast(jsii.Number, jsii.invoke(self, "sumSync", [count]))
@@ -19527,7 +19527,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @dont_read_me.setter
      def dont_read_me(self, value: typing.Optional[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__54f5b2f0a61a7f2fafae719635a1408f7ff0a8f8a503e559bf0d6bc99772471f)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "dontReadMe", value) # pyright: ignore[reportArgumentType]
@@ -19541,7 +19541,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param private_field: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__01fcbc911a24b1fa352275e1273526114db562d2c278b742181eba6e8cb11ad4)
 +            check_type(argname="argument private_field", value=private_field, expected_type=type_hints["private_field"])
          jsii.create(self.__class__, self, [private_field])
@@ -19555,7 +19555,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param name: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__af1f574dee5c4eb581961518ccf32b4060094ed2f9b7e60bece1ed48e3fc45a1)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
          return typing.cast(builtins.str, jsii.invoke(self, "abstractMethod", [name]))
@@ -19569,7 +19569,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param lhs: Left-hand side operand.
          :param rhs: Right-hand side operand.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c0e59e6ea7e78215051bf4fe6b69de179aefb4116a344decdfaab4b6b15189b8)
 +            check_type(argname="argument lhs", value=lhs, expected_type=type_hints["lhs"])
 +            check_type(argname="argument rhs", value=rhs, expected_type=type_hints["rhs"])
@@ -19584,7 +19584,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @rung.setter
      def rung(self, value: builtins.bool) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__fa23831ecd0b539d7689616a0557240dc1a45f924fafe58c0d5f0ac464eecf94)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "rung", value) # pyright: ignore[reportArgumentType]
@@ -19598,7 +19598,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param foo: 
          :param bar: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__84a0b7e93c52a4977e9726c1186b64f57ff35c59c5bc0e7250da1d3236e70208)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
 +            check_type(argname="argument bar", value=bar, expected_type=type_hints["bar"])
@@ -19613,7 +19613,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @a.setter
      def a(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__720d53a768711730e792d129fcff6272627608d1d3942f42e3010e61a3463b31)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value) # pyright: ignore[reportArgumentType]
@@ -19625,7 +19625,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @b.setter
      def b(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5236e267a6763b672404dac13a3d5e50c03eb03d35fe2c18cbe7f649933301f1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value) # pyright: ignore[reportArgumentType]
@@ -19637,7 +19637,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @c.setter
      def c(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1bd3b16d1aaf127e7610a230095bced32c4c3ef1cadc73f6b24c76b3ebffdd8e)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value) # pyright: ignore[reportArgumentType]
@@ -19649,7 +19649,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @d.setter
      def d(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4e685d8185af60a2f5c9bcffe812224568fe893228304e510b4d989f92c19b90)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "d", value) # pyright: ignore[reportArgumentType]
@@ -19663,7 +19663,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @a.setter
      def a(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6499a25aa5ac6723e26c4c716dd2d62a1f9ecd75ae2a476d3213fa5fe8792a1d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "a", value) # pyright: ignore[reportArgumentType]
@@ -19675,7 +19675,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @b.setter
      def b(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5da75e226d085b0daac7742a86525ea697c77a044896ce80d48677f5fadb2d57)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "b", value) # pyright: ignore[reportArgumentType]
@@ -19687,7 +19687,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @c.setter
      def c(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__538f9410afd2d028ca599a233896016121b326bd90d69693e949aff75d72caf3)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "c", value) # pyright: ignore[reportArgumentType]
@@ -19699,7 +19699,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @e.setter
      def e(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ba8bf3471001981f03d1ad5b84a1b0a4a4d7d556c72734d25d96637a60ad2477)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "e", value) # pyright: ignore[reportArgumentType]
@@ -19713,7 +19713,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param read_only_string: -
          :param read_write_string: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__71399b17d07223b2b83f0d7b33d5172c49eb3d0cf3fe38d6059d4c9b7f471113)
 +            check_type(argname="argument read_only_string", value=read_only_string, expected_type=type_hints["read_only_string"])
 +            check_type(argname="argument read_write_string", value=read_write_string, expected_type=type_hints["read_write_string"])
@@ -19728,7 +19728,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @read_write_string.setter
      def read_write_string(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e308499c7b9268c91ee3dc9e4a9c975efdfaa0cd72bd877383c6c64e8f2768d0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "readWriteString", value) # pyright: ignore[reportArgumentType]
@@ -19742,7 +19742,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param property: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__148cd823b5de47723c8a76d0553f3ff6c880ba8ecec14b9a86bd89025a18f4d3)
 +            check_type(argname="argument property", value=property, expected_type=type_hints["property"])
          jsii.create(self.__class__, self, [property])
@@ -19756,7 +19756,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param operand: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e7aa949631662ae6f6ab2804e4a231fa264a1c879d86efa8267e53158c50e647)
 +            check_type(argname="argument operand", value=operand, expected_type=type_hints["operand"])
          jsii.create(self.__class__, self, [operand])
@@ -19770,7 +19770,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param props: some props once can provide.
          :param rest: a variadic continuation.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__2f90423a63bd0fc04016022e622b4bf01d35f365e38b15153d0a4d6fa014ee5b)
 +            check_type(argname="argument id", value=id, expected_type=type_hints["id"])
 +            check_type(argname="argument default_bar", value=default_bar, expected_type=type_hints["default_bar"])
@@ -21366,7 +21366,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param option: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__132536bffc9129421b4ae0a6539d0bbfdc1c52c3de007c4546d2f2626ba8c31e)
 +            check_type(argname="argument option", value=option, expected_type=type_hints["option"])
          return typing.cast(builtins.str, jsii.sinvoke(cls, "consume", [option]))
@@ -21377,7 +21377,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param which: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d461fff988e22833dcf37c5193332d48b9e455d605f2a1e708ab0d111a1659c7)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Any, jsii.sinvoke(cls, "privideAsAny", [which]))
@@ -21388,7 +21388,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param which: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f841b966136dfd090628b12290eedd178724cc8f332e05aba2b3a035f07dae50)
 +            check_type(argname="argument which", value=which, expected_type=type_hints["which"])
          return typing.cast(typing.Union["IOptionA", "IOptionB"], jsii.sinvoke(cls, "provide", [which]))
@@ -21433,7 +21433,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :param gen: a VERY pseudo random number generator.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__92f621cedc18f68d281c38191023e89bba6348836db623bc5d780630324b992b)
 +            check_type(argname="argument gen", value=gen, expected_type=type_hints["gen"])
          return typing.cast(jsii.Number, jsii.invoke(self, "unwrap", [gen]))
@@ -21464,7 +21464,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e2659669d69691129e05836f0722a48449fe2efe197706d9d59c10c141470a4b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.create(self.__class__, self, [value])
@@ -21495,7 +21495,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param source_path: A path that doesn't exist.
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5a067c851774273f33badeac9c167720ebde25d4301ab096dec54b2e615dc8a4)
 +            check_type(argname="argument source_path", value=source_path, expected_type=type_hints["source_path"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21527,7 +21527,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @decoration_postfixes.setter
      def decoration_postfixes(self, value: typing.List[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f546e09b5b6c86dfee3f946eff8913ea8feb763a4156fb8aad45ecc179c63e62)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPostfixes", value) # pyright: ignore[reportArgumentType]
@@ -21540,7 +21540,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @decoration_prefixes.setter
      def decoration_prefixes(self, value: typing.List[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__abce94053402e9d1fcf1605226fa2c285e1340ec8219cfd1061f917e876a9051)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "decorationPrefixes", value) # pyright: ignore[reportArgumentType]
@@ -21553,7 +21553,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @string_style.setter
      def string_style(self, value: "CompositeOperation.CompositionStringStyle") -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9dbbc353e0ea03d68edfa3977eadeb5446b56a89ffb921cb8406ba9fca0805b0)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "stringStyle", value) # pyright: ignore[reportArgumentType]
@@ -21596,7 +21596,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @name.setter
      def name(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__eeb0e2f6f15e62545344a73c109909bc39f12407f617cc17046a16d750ae9821)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "name", value) # pyright: ignore[reportArgumentType]
@@ -21610,7 +21610,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @add_unrelated_member.setter
      def add_unrelated_member(self, value: jsii.Number) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__1051efd4d7b2a018070aed93762af17bf3bf03922b4b69078c2531f572efa32b)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "addUnrelatedMember", value) # pyright: ignore[reportArgumentType]
@@ -21624,7 +21624,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @name.setter
      def name(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__18d2a95a2ddcf18b20a0a35b0f711b8001853317f5def313f18ec3acf6385a8c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "name", value) # pyright: ignore[reportArgumentType]
@@ -21638,7 +21638,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @name.setter
      def name(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__eef308cfe64fac2288066609c39fe09f5cb1de9aeb89d015b7e45c7a44428c91)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "name", value) # pyright: ignore[reportArgumentType]
@@ -21651,7 +21651,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @unique.setter
      def unique(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b5604f917bc4b1fd9354007ab09f68bce80b3018ff4042fde2d310649dc3087d)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "unique", value) # pyright: ignore[reportArgumentType]
@@ -21708,7 +21708,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @prop.setter
      def prop(self, value: builtins.str) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__4b95d284137921c7cbf29a9e3a15da0a5cf9dda87efad87aa9ed601662f00b2c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "prop", value) # pyright: ignore[reportArgumentType]
@@ -21739,7 +21739,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(homonymous, dict):
              homonymous = Homonymous(**homonymous)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a201923592702b83e439b8af921b7eae6f1b86b0eeeffb6c2b506d66a57d4c3a)
 +            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21753,7 +21753,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param numeric_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b7814834f12f5cbacf39dd7bdb11da208ae4c429011eff511d21e10d621cf9d5)
 +            check_type(argname="argument numeric_property", value=numeric_property, expected_type=type_hints["numeric_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21792,7 +21792,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(homonymous, dict):
              homonymous = Homonymous(**homonymous)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__56bad81fb024ccb6a97af9b4edcb748a4d5e34e81491c4222bb761bc0e5890b6)
 +            check_type(argname="argument homonymous", value=homonymous, expected_type=type_hints["homonymous"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21806,7 +21806,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param string_property: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__57e873ae26cc34d45d619900518aa9fbc9f512fa9ca964387f9bcd933e461123)
 +            check_type(argname="argument string_property", value=string_property, expected_type=type_hints["string_property"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21845,7 +21845,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @bar.setter
      def bar(self, value: typing.Optional[builtins.str]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3319085b675e83451882dd81f7704e88da2e392266f9d5188ecb22725f3f71bb)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "bar", value) # pyright: ignore[reportArgumentType]
@@ -21859,7 +21859,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param foo: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5c05b45db7e873d4164cc7295b5d2800ba4bed1813d4a2d57aad8cedb292186d)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21897,7 +21897,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param foo: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cc86cfd2ea53d0ae81d6d80ed07db33f3ca7b140e37166ba1d572a8ed2a78d2c)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21929,7 +21929,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a36fd0053d186cf16119b874974d4b9825317b52ccd23075a83b521970a1f420)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "acceptsIntersection", [param]))
@@ -21943,7 +21943,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__c15dc791f3df60b50382a570589911c44374231249b9f320e007beea4de43c1b)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -21986,7 +21986,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param name: 
          :param count: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9754f0ac616c8a4339db020e52a796e65577c9909ed5e25d0c696417da04377c)
 +            check_type(argname="argument name", value=name, expected_type=type_hints["name"])
 +            check_type(argname="argument count", value=count, expected_type=type_hints["count"])
@@ -22001,7 +22001,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param receiver: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__37c9a298f20a606212f074bd150ba5bc37e38a4cc1f9b2672facafd80734afc1)
 +            check_type(argname="argument receiver", value=receiver, expected_type=type_hints["receiver"])
          return typing.cast(builtins.bool, jsii.sinvoke(cls, "callAbstract", [receiver]))
@@ -22040,7 +22040,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          if isinstance(some_type, dict):
              some_type = _scope_jsii_calc_lib_custom_submodule_name_c61f082f.ClassWithNONPASCALCASEDName.SomeType(**some_type)
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7303ee79d186b33b0bfda2001105f495ddcaf7ff505dc8e171a74f9536581765)
 +            check_type(argname="argument some_type", value=some_type, expected_type=type_hints["some_type"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22072,7 +22072,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param _: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d62f783e4108a6327009d506f8ae7f5aca2734de07314ffd120f24d3e918f697)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          jsii.create(self.__class__, self, [_])
@@ -22083,7 +22083,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param _: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f35c91dda02ec538c4e5ee9182aaa01ba14f837c78951f48bb0abd1a866a4d5c)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.sinvoke(cls, "bar", [_]))
@@ -22093,7 +22093,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param _: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__dd74e61269fd21c6a0b0983199f27c5d4df8a4447ff77e770890f58f6c9b6969)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
          return typing.cast(None, jsii.invoke(self, "foo", [_]))
@@ -22107,7 +22107,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param __: -
          :param ___: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__9923f6393d8cfb578b5baa739d6fea52e5a24d59447e020e0b36222d4ca9e2dc)
 +            check_type(argname="argument _", value=_, expected_type=type_hints["_"])
 +            check_type(argname="argument __", value=__, expected_type=type_hints["__"])
@@ -22157,7 +22157,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :stability: deprecated
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__3b33906576528227344dbb0f079876c5dccd08a32f3dbaa0acdc3f444c5fe448)
 +            check_type(argname="argument very", value=very, expected_type=type_hints["very"])
          jsii.create(self.__class__, self, [very])
@@ -22188,7 +22188,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param _bar: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__cfbe1bc46497cbad551fc80c4d304742daa30493dee8c65b7119cafdeb06e9af)
 +            check_type(argname="argument _bar", value=_bar, expected_type=type_hints["_bar"])
          return typing.cast(None, jsii.invoke(self, "bar", [_bar]))
@@ -22201,7 +22201,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param _values: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__40045f17e26efacbabd3e103d903497e18761a611301d901fcdebc3cf8baaced)
 +            check_type(argname="argument _values", value=_values, expected_type=type_hints["_values"])
          return typing.cast(None, jsii.invoke(self, "foo", [_values]))
@@ -22235,7 +22235,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param base_map: 
          :param numbers: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__71fe496245d27f33a2ded522fdf47757e7fb41b578fd3ec479cd5b45534588fc)
 +            check_type(argname="argument base_map", value=base_map, expected_type=type_hints["base_map"])
 +            check_type(argname="argument numbers", value=numbers, expected_type=type_hints["numbers"])
@@ -22269,7 +22269,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bar1: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__6602c05b71ef2e77c650dd283c33ba4543f756dbbca5d1c31752ee29f836b1f5)
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22301,7 +22301,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bar2: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__d9a43a9ecad39319deef77fa38822e65c584450447849fb04c34b767a8c0881d)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22315,7 +22315,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param bar1: 
          :param foo2: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__717272f96a16c5ea04b9406364f96f18d1c2b16b183b81ef7bae856ebd371a43)
 +            check_type(argname="argument bar2", value=bar2, expected_type=type_hints["bar2"])
 +            check_type(argname="argument bar1", value=bar1, expected_type=type_hints["bar1"])
@@ -22358,7 +22358,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param self: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__5cc662603963e69f50f446fe7bf40b3f3ccf17842ed59562f45f4eb63848155b)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          jsii.create(self_.__class__, self_, [self])
@@ -22368,7 +22368,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param self: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__7085240966e9682f4d0598c65f482b932ae1281420f2cead92f0036488d061d4)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
@@ -22382,7 +22382,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param self: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__8e4a50df1f139ac6d917c0954b0b6346aeeb47f16abae33b345a5aa2aa02fc99)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          return typing.cast(builtins.str, jsii.invoke(self_, "method", [self]))
@@ -22396,7 +22396,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param self: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__796022ef7b07de2b3997ff905b7451854b30a5e8e06145e4cc31e88f0ea8b0d0)
 +            check_type(argname="argument self", value=self, expected_type=type_hints["self"])
          self_._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22448,7 +22448,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
          :see: https://github.com/aws/jsii/issues/2637
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__a44c39bd2002b354344d30dcb1ae0e2dc7ef8f604c2d31c61616cbbfc6a6fc40)
 +            check_type(argname="argument foo", value=foo, expected_type=type_hints["foo"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22462,7 +22462,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
  
      @all_types.setter
      def all_types(self, value: typing.Optional["_jsii_calc_e856c20f.AllTypes"]) -> None:
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__bfa98c91ee81ff3f0ca8bdba51d8e53f57e5260e9d6071534e9caa5ba2ffaed1)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          jsii.set(self, "allTypes", value) # pyright: ignore[reportArgumentType]
@@ -22500,7 +22500,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param reference: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__e7f53d1efa418d6ee29ababd1c2660c1d3d9a5d3de3ad874b2d0cd7c6481139b)
 +            check_type(argname="argument reference", value=reference, expected_type=type_hints["reference"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22532,7 +22532,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param prop: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__ce6e4bc4b6c503e757ba9e0640368ea37840d2ca58311e6ec8b98cdcda077f48)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22546,7 +22546,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param bool: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__f4dc81f7243c5c317d71ab682231a51bf3c3a189d9be68c17b8d41246c0abef5)
 +            check_type(argname="argument bool", value=bool, expected_type=type_hints["bool"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22560,7 +22560,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          :param prop: 
          :param extra: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__b3b6b38208a14cadd94ba787e4091f753debb361ad5dd2ee9d037908f5677d8b)
 +            check_type(argname="argument prop", value=prop, expected_type=type_hints["prop"])
 +            check_type(argname="argument extra", value=extra, expected_type=type_hints["extra"])
@@ -22608,7 +22608,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param value: 
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__25c6f5775c01f503690c503a264eb256af186a94c0c65bd43d6a11942ff54b1c)
 +            check_type(argname="argument value", value=value, expected_type=type_hints["value"])
          self._values: typing.Dict[builtins.str, typing.Any] = {
@@ -22640,7 +22640,7 @@ exports[`Generated code for "jsii-calc": <runtime-type-check-diff>/python/src/js
          '''
          :param param: -
          '''
-+        if __debug__:
++        if __debug__ and runtime_type_checking_enabled():
 +            type_hints = cached_type_hints(_typecheckingstub__62dfa3c0a0a719fea295807df31fd40fd66b0e76cf44d9f742ffb421f8e4ca77)
 +            check_type(argname="argument param", value=param, expected_type=type_hints["param"])
          return typing.cast(None, jsii.sinvoke(cls, "unionType", [param]))


### PR DESCRIPTION
This pr puts Python's runtime type checks emitted by pacmak behind a toggle so they can be turned on and off, which mirrors the `Configuration.RuntimeTypeChecking` switch the Java and .NET runtimes already expose.

The kernel already has these type checks after the data is passed to it and deserialized. It validates every by-value type recursively and rejects bad input, irrespective of Python's checks. Therefore there is a redundancy that Python checks are performing and we can remove the duplication.

The generated guard now changes from:

```python
if __debug__:
    ...check_type(...)
```

to:

```python
if __debug__ and runtime_type_checking_enabled():
    ...check_type(...)
```

`__debug__` is kept as the outer condition so `python -O` still elides the block
entirely.

### Exception: behavioral interfaces stay always-on

Parameters, struct members, and setters whose type involves a behavioral interface (directly, or nested inside a collection or a type union) keep the ungated `if __debug__:` form and run regardless of the toggle.

This is deliberate because behavioral interface values seem to be passed by reference amnd the kernel does not explicitly check whether the incoming object structurally conforms to the expected interface (see aws/jsii#399/#400). The generated Python-side conformance check is therefore the only upfront guard for this case, so it must not be skippable. 

## Behavioral Changes
An invalid by-value argument is still rejected, but by the kernel, surfaced as a `RuntimeError` after the call crosses the boundary, rather than a typeguard `TypeError`/`TypeCheckError` raised synchronously at the call site. This is a behavioral change for the user. 

Currently the default for this feature is set to FALSE. I want to keep it TRUE. Under discussion.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
