### PR TITLE
chore: route workflow context values through env instead of inline

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -20,6 +20,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - run: gh pr review --approve ${{ github.event.pull_request.number }} -R ${{ github.repository }}
+    - run: gh pr review --approve "$PR_NUMBER" -R "$REPO"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -24,9 +24,12 @@ jobs:
     - name: Manage regression label
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
       run: |
-        if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
-          gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
+        if [ "$IS_REGRESSION" == "true" ]; then
+          gh issue edit "$ISSUE_NUMBER" --add-label "potential-regression" -R "$REPO"
         else
-          gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}
+          gh issue edit "$ISSUE_NUMBER" --remove-label "potential-regression" -R "$REPO"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,16 +153,21 @@ jobs:
       # Determine a prerelease version (depending on whether this is a PR or Push event)
       - name: Standard Version (PR)
         if: github.event_name == 'pull_request'
+        env:
+          GIT_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |-
           npx standard-version                                                                                          \
-            --compareUrlFormat='{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...${{ github.sha }}'          \
-            --prerelease=dev.${{ github.event.pull_request.number }}                                                    \
+            --compareUrlFormat="{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...${GIT_SHA}"                 \
+            --prerelease="dev.${PR_NUMBER}"                                                                             \
             --skip.commit
       - name: Standard Version (Nightly)
         if: github.event_name == 'push'
+        env:
+          GIT_SHA: ${{ github.sha }}
         run: |-
           npx standard-version                                                                                          \
-            --compareUrlFormat='{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...${{ github.sha }}'          \
+            --compareUrlFormat="{{host}}/{{owner}}/{{repository}}/compare/{{previousTag}}...${GIT_SHA}"                 \
             --prerelease=dev.$(date -u +'%Y%m%d')                                                                       \
             --skip.commit
       # Now we'll be preparing a release package (with the "real" version)


### PR DESCRIPTION
Updates three GitHub Actions workflows to pass `${{ github.* }}` context values through `env:` variables and reference them as quoted shell variables, rather than interpolating them inline into shell scripts.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
