### PR TITLE
fix(jsii-diff): ignore scripts when running `npm install`

### DIFF
--- a/packages/jsii-diff/lib/util.ts
+++ b/packages/jsii-diff/lib/util.ts
@@ -51,7 +51,12 @@ export async function downloadNpmPackage<T>(
       // This executes the shell, which is necessary: on Windows, npm is a .cmd file,
       // and only the shell and execute .bat/.cmd files. We have validated the package
       // name already to make sure it contains only safe characters.
-      await exec(`npm install --silent --prefix . ${pkg}`);
+      //
+      // `--ignore-scripts` prevents lifecycle scripts (preinstall/install/postinstall)
+      // of the downloaded package and its dependencies from executing. We only need the
+      // files on disk to read the assembly, so there is no reason to run arbitrary code
+      // from the package under comparison.
+      await exec(`npm install --silent --ignore-scripts --prefix . ${pkg}`);
     } catch (e: any) {
       // If this fails, might be because the package doesn't exist
       if (!isSubprocesFailedError(e)) {


### PR DESCRIPTION
We shouldn't need them for the purposes of assembly diffs. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
